### PR TITLE
Radio probe

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -720,6 +720,14 @@ service_is_tv(service_t *t)
     t->s_servicetype == ST_AC_HDTV;
 }
 
+/**
+ *
+ */
+int
+service_is_radio(service_t *t)
+{
+  return t->s_servicetype == ST_RADIO;
+}
 
 /**
  *

--- a/src/service.h
+++ b/src/service.h
@@ -516,6 +516,8 @@ const char *service_servicetype_txt(service_t *t);
 
 int service_is_tv(service_t *t);
 
+int service_is_radio(service_t *t);
+
 void service_destroy(service_t *t);
 
 void service_remove_subscriber(service_t *t, struct th_subscription *s,

--- a/src/serviceprobe.c
+++ b/src/serviceprobe.c
@@ -44,8 +44,8 @@ static pthread_cond_t serviceprobe_cond;
 void
 serviceprobe_enqueue(service_t *t)
 {
-  if(!service_is_tv(t))
-    return; /* Don't even consider non-tv channels */
+  if(!service_is_tv(t) && !service_is_radio(t))
+    return; /* Don't even consider non-tv/non-radio channels */
 
   if(t->s_sp_onqueue)
     return;
@@ -170,9 +170,11 @@ serviceprobe_thread(void *aux)
 	tvhlog(LOG_INFO, "serviceprobe", "%20s: mapped to channel \"%s\"",
 	       t->s_svcname, t->s_svcname);
 
-	channel_tag_map(ch, channel_tag_find_by_name("TV channels", 1), 1);
-	tvhlog(LOG_INFO, "serviceprobe", "%20s: joined tag \"%s\"",
-	       t->s_svcname, "TV channels");
+	if(service_is_tv(t)) {
+ 	  channel_tag_map(ch, channel_tag_find_by_name("TV channels", 1), 1);
+	  tvhlog(LOG_INFO, "serviceprobe", "%20s: joined tag \"%s\"",
+		 t->s_svcname, "TV channels");
+	}
 
 	switch(t->s_servicetype) {
 	case ST_SDTV:
@@ -182,6 +184,9 @@ serviceprobe_thread(void *aux)
 	case ST_HDTV:
 	case ST_AC_HDTV:
 	  str = "HDTV";
+	  break;
+	case ST_RADIO:
+	  str = "Radio";
 	  break;
 	default:
 	  str = NULL;


### PR DESCRIPTION
when doing a service probe, map services with the type ST_RADIO to a channel and tag it as "Radio".
