### PR TITLE
Dvr bugfix duplicates

### DIFF
--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -834,9 +834,9 @@ dvr_init(void)
     }
   }
 
-  dvr_autorec_init();
-
   dvr_db_load();
+
+  dvr_autorec_init();
 }
 
 /**


### PR DESCRIPTION
Hi,

I have noticed a small bug when starting tvheadend...

When tvheadend gets started and there is a valid epg-database (or EPG data is coming in from the dvb network really fast) it sometimes hits an epg-triggered autorec entry before the previously scheduled recordings from disk are read. The recordings from disk are shot directly into the recording-schedule (no checks on duplicates), so this causes duplicate entries (when the same entry has been processed by the EPG / Autorec combo before)...

This fix loads the recordings before the autorec-rules, and eliminates this situation...

I've done some scripting to make my pvr server sleep when it's got nothing to do, and schedule a wake-up 5 min. before a recording starts. I have also hooked into pm-suspend to perform custom actions before shutdown and after wakeup. This means I am effectively stopping / starting tvheadend on a (live production) system roughly 4-5 times per day. This is probably the reason I am seeing this much more often then anyone else...

Hope this (super-simple) fix helps, I have been running it on my live pvr for roughly 1 week without issues...

Love your work (tvheadend rocks), came down from GBPVR (windows-based) for it, first real alternative I saw (Myth was just to freaking hard to set-up)...

Best regards,

//Ton
