### PR TITLE
Xml charref fix

### DIFF
--- a/src/htsmsg_xml.c
+++ b/src/htsmsg_xml.c
@@ -637,7 +637,7 @@ htsmsg_xml_parse_cd0(xmlparser_t *xp,
     }
 
     if(cc == NULL) {
-      if(*src <= 32) {
+      if(*src < 32) {
 	src++;
 	continue;
       }


### PR DESCRIPTION
Hi Andoma,

Hi noticed a small issue where the XML parser eats 1 space just after a character entity reference. This commit should fix this.

Best regards,

-sbi
