### PR TITLE
fix bug: set a default creator name if an empty or no creator name is provided

### DIFF
--- a/src/htsp.c
+++ b/src/htsp.c
@@ -529,7 +529,7 @@ htsp_method_addDvrEntry(htsp_connection_t *htsp, htsmsg_t *in)
 
     // get the optional attributes
     if (htsmsg_get_u32(in, "priority", &iPriority))
-      iPriority = 0;
+      iPriority = DVR_PRIO_NORMAL;
 
     if ((strDescription = htsmsg_get_str(in, "description")) == NULL)
       strDescription = "";


### PR DESCRIPTION
Set a default creator name if an empty or no creator name is provided when adding a DVR entry without an EPG event. Adding an entry with an empty creator name causes the GUI not to display any DVR entry at all.
