### PR TITLE
Implement new function in dvr_db (and the respective new HTSP function), which actually does (in a single function) what dvr_entry_cancel and dvr_entry_delete functions do at the moment

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -278,6 +278,8 @@ void dvr_extra_time_post_set(dvr_config_t *cfg, int d);
 
 void dvr_entry_delete(dvr_entry_t *de);
 
+void dvr_entry_cancel_delete(dvr_entry_t *de);
+
 /**
  * Query interface
  */

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1196,3 +1196,29 @@ dvr_entry_delete(dvr_entry_t *de)
   dvr_entry_remove(de);
 }
 
+/**
+ *
+ */
+void
+dvr_entry_cancel_delete(dvr_entry_t *de)
+{
+  switch(de->de_sched_state) {
+  case DVR_SCHEDULED:
+    dvr_entry_remove(de);
+    break;
+
+  case DVR_RECORDING:
+    de->de_dont_reschedule = 1;
+    dvr_stop_recording(de, SM_CODE_ABORTED);
+  case DVR_COMPLETED:
+    dvr_entry_delete(de);
+    break;
+
+  case DVR_MISSED_TIME:
+    dvr_entry_remove(de);
+    break;
+
+  default:
+    abort();
+  }
+}

--- a/src/htsp.c
+++ b/src/htsp.c
@@ -609,15 +609,15 @@ htsp_method_updateDvrEntry(htsp_connection_t *htsp, htsmsg_t *in)
 }
 
 /**
- * delete a Dvrentry
+ * cancel a Dvrentry
  */
-static htsmsg_t * 
-htsp_method_deleteDvrEntry(htsp_connection_t *htsp, htsmsg_t *in)
+static htsmsg_t *
+htsp_method_cancelDvrEntry(htsp_connection_t *htsp, htsmsg_t *in)
 {
   htsmsg_t *out;
   uint32_t dvrEntryId;
   dvr_entry_t *de;
-    
+
   if(htsmsg_get_u32(in, "id", &dvrEntryId))
     return htsp_error("Missing argument 'id'");
 
@@ -629,7 +629,32 @@ htsp_method_deleteDvrEntry(htsp_connection_t *htsp, htsmsg_t *in)
   //create response
   out = htsmsg_create_map();
   htsmsg_add_u32(out, "success", 1);
-  
+
+  return out;
+}
+
+/**
+ * delete a Dvrentry
+ */
+static htsmsg_t *
+htsp_method_deleteDvrEntry(htsp_connection_t *htsp, htsmsg_t *in)
+{
+  htsmsg_t *out;
+  uint32_t dvrEntryId;
+  dvr_entry_t *de;
+
+  if(htsmsg_get_u32(in, "id", &dvrEntryId))
+    return htsp_error("Missing argument 'id'");
+
+  if( (de = dvr_entry_find_by_id(dvrEntryId)) == NULL)
+    return htsp_error("id not found");
+
+  dvr_entry_cancel_delete(de);
+
+  //create response
+  out = htsmsg_create_map();
+  htsmsg_add_u32(out, "success", 1);
+
   return out;
 }
 
@@ -1000,6 +1025,7 @@ struct {
   { "subscriptionChangeWeight", htsp_method_change_weight, ACCESS_STREAMING},
   { "addDvrEntry", htsp_method_addDvrEntry, ACCESS_RECORDER},
   { "updateDvrEntry", htsp_method_updateDvrEntry, ACCESS_RECORDER},
+  { "cancelDvrEntry", htsp_method_cancelDvrEntry, ACCESS_RECORDER},
   { "deleteDvrEntry", htsp_method_deleteDvrEntry, ACCESS_RECORDER},
   { "epgQuery", htsp_method_epgQuery, ACCESS_STREAMING},
 


### PR DESCRIPTION
Implement dvr_entry_cancel_delete in dvr_db and deleteDvrEntry/cancelDvrEntry in HTSP in order to provide HTSP clients the ability to delete the actual recording files along with a dvr entry.
This shouldn't break any of the current functionality, as it is a totally new function.
In addition to this pull request, I am sending another one to opdenkamp, so that the XBMC tvheadent client can use this function when deleting a recording (not timer), instead of function dvr_entry_cancel
