### PR TITLE
Fallback to Latin1 charset when ISO6937 is not supported.

### DIFF
--- a/src/dvb/dvb_support.c
+++ b/src/dvb/dvb_support.c
@@ -64,6 +64,9 @@ dvb_conversion_init(void)
 
   convert_utf8   = dvb_iconv_open("UTF-8");
   convert_latin1 = dvb_iconv_open("ISO6937");
+  if(convert_latin1 == (iconv_t)(-1)) {
+    convert_latin1 = dvb_iconv_open("ISO_8859-1");
+  }
 }
 
 


### PR DESCRIPTION
Hi andoma,

From our chat on IRC last night, this is my very naive charset fallback patch. Tested, working on OpenWRT trunk r27126, running on a D-Link DIR-825, Anysee E30TCPlus.

I've found some interesting info on charset support for DVB in the patch for LinuxTV dvb-apps:
http://www.mail-archive.com/linux-media@vger.kernel.org/msg29914.html
I think it might be possible to optimize that so it can be used in tvheadend also, to support more charsets.

I wonder if in the end it might be possible to include some kind of ISO6937 converter in tvheadend itself.
This is because I think the chances of such a thing being included in OpenWRT's libiconv stub are very slim, given the natural bloat aversion the embedded people have (the converter would be included in .all. builds of OpenWRT, even those which have to boot from as little as 2MB of Flash, etc.).

The chance of an ISO6937 converter being included in GNU libiconv, which OpenWRT can optionally use, are virtually zilch, I think, as the maintainers seem to have a _very_ strong aversion against supporting such a "specialized" encoding... :( See some very spicy discussion on their mailinglist about it.

Kind regards, Alain
