### PR TITLE
fix initial scaning with s2api for drivers that won't default to a delivery system

### DIFF
--- a/src/dvb/dvb_preconf.c
+++ b/src/dvb/dvb_preconf.c
@@ -64,6 +64,7 @@ dvb_mux_preconf_add(th_dvb_adapter_t *tda, const struct mux *m, int num,
       break;
       
     case FE_QPSK:
+      dmc.dmc_fe_delsys = SYS_DVBS;
       dmc.dmc_fe_params.u.qpsk.symbol_rate = m->symrate;
       dmc.dmc_fe_params.u.qpsk.fec_inner   = m->fec;
 


### PR DESCRIPTION
Set dvb-s as default delivery system, so that it is used for muxes of the initial tuning list
