### PR TITLE
Fix memory leak in queue size protection

### DIFF
--- a/src/htsp.c
+++ b/src/htsp.c
@@ -1496,7 +1496,7 @@ const static char frametypearray[PKT_NTYPES] = {
 static void
 htsp_stream_deliver(htsp_subscription_t *hs, th_pkt_t *pkt)
 {
-  htsmsg_t *m = htsmsg_create_map(), *n;
+  htsmsg_t *m, *n;
   htsp_msg_t *hm;
   htsp_connection_t *htsp = hs->hs_htsp;
   int64_t ts;
@@ -1508,13 +1508,12 @@ htsp_stream_deliver(htsp_subscription_t *hs, th_pkt_t *pkt)
 
     hs->hs_dropstats[pkt->pkt_frametype]++;
 
-    // destroy the already created htsmsg to avoid memory leaks
-    htsmsg_destroy(m);
-
     /* Queue size protection */
     pkt_ref_dec(pkt);
     return;
   }
+
+  m = htsmsg_create_map();
  
   htsmsg_add_str(m, "method", "muxpkt");
   htsmsg_add_u32(m, "subscriptionId", hs->hs_sid);


### PR DESCRIPTION
I think this needs no additional explanation.
