### PR TITLE
Add pidfile option

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -157,6 +157,8 @@ usage(const char *argv0)
   printf(" -c <directory>  Alternate configuration path.\n"
 	 "                 Defaults to [$HOME/.hts/tvheadend]\n");
   printf(" -f              Fork and daemonize\n");
+  printf(" -p <pidfile>    Write pid to <pidfile> instead of /var/run/tvheadend.pid,\n"
+        "                 only works with -f\n");
   printf(" -u <username>   Run as user <username>, only works with -f\n");
   printf(" -g <groupname>  Run as group <groupname>, only works with -f\n");
   printf(" -C              If no useraccount exist then create one with\n"
@@ -228,6 +230,7 @@ main(int argc, char **argv)
   int c;
   int forkaway = 0;
   FILE *pidfile;
+  const char *pidpath = "/var/run/tvheadend.pid";
   struct group *grp;
   struct passwd *pw;
   const char *usernam = NULL;
@@ -246,7 +249,7 @@ main(int argc, char **argv)
   // make sure the timezone is set
   tzset();
 
-  while((c = getopt(argc, argv, "Aa:fu:g:c:Chdr:j:s")) != -1) {
+  while((c = getopt(argc, argv, "Aa:fp:u:g:c:Chdr:j:s")) != -1) {
     switch(c) {
     case 'a':
       adapter_mask = 0x0;
@@ -273,6 +276,9 @@ main(int argc, char **argv)
       break;
     case 'f':
       forkaway = 1;
+      break;
+    case 'p':
+      pidpath = optarg;
       break;
     case 'u':
       usernam = optarg;
@@ -314,8 +320,7 @@ main(int argc, char **argv)
     if(daemon(0, 0)) {
       exit(2);
     }
-
-    pidfile = fopen("/var/run/tvheadend.pid", "w+");
+    pidfile = fopen(pidpath, "w+");
     if(pidfile != NULL) {
       fprintf(pidfile, "%d\n", getpid());
       fclose(pidfile);


### PR DESCRIPTION
Add -p <pidfile> option, so that the pid file can be specified when running as a daemon,
useful when not running from root.
