### PR TITLE
Fix emm updates for seca cards.

### DIFF
--- a/src/cwc.c
+++ b/src/cwc.c
@@ -677,6 +677,7 @@ cwc_detect_card_type(cwc_t *cwc)
     cwc->cwc_card_type = CARD_SECA;
     tvhlog(LOG_INFO, "cwc", "%s: seca card",
 	   cwc->cwc_hostname);
+    break;
   case 0x4a:
     cwc->cwc_card_type = CARD_DRE;
     tvhlog(LOG_INFO, "cwc", "%s: dre card",


### PR DESCRIPTION
emm updates did not work after adding support for dre cards.

The update: https://github.com/andoma/tvheadend/commit/82d18a387243b858bd354d14e613c87b4b4f11b1#src/cwc.c was added one line to early so seca cards did not get updated anymore. 

Cheers

William van de Velde
