### PR TITLE
UK Emley Moor Values.

### DIFF
--- a/src/linuxtv_muxes.h
+++ b/src/linuxtv_muxes.h
@@ -7826,7 +7826,7 @@ static const struct mux muxes_DVBT_uk_EmleyMoor[] = {
  	{.freq = 658000000, .bw = 0, .constellation = 3, .fechp = 2, .feclp = 0, .tmode = 1, .guard = 0, .hierarchy = 0},
  	{.freq = 714000000, .bw = 0, .constellation = 3, .fechp = 2, .feclp = 0, .tmode = 1, .guard = 0, .hierarchy = 0},
  	{.freq = 722000000, .bw = 0, .constellation = 3, .fechp = 2, .feclp = 0, .tmode = 1, .guard = 0, .hierarchy = 0},
- 	{.freq = 690000000, .bw = 0, .constellation = 3, .fechp = 2, .feclp = 0, .tmode = 1, .guard = 0, .hierarchy = 0},
+ 	{.freq = 690000000, .bw = 0, .constellation = 3, .fechp = 3, .feclp = 0, .tmode = 1, .guard = 0, .hierarchy = 0},
  };
 
 static const struct mux muxes_DVBT_uk_Fenham[] = {


### PR DESCRIPTION
Based on values supplied by http://www.ukfree.tv/txdetail.php?a=SE222128.

Error correction is incorrect for 960000000 on the website.

w_scan reports:
# T[2] <freq> <bw> <fec_hi> <fec_lo> <mod> <tm> <guard> <hi> [# comment]
# ------------------------------------------------------------------------------

T 482000000 8MHz  2/3 NONE    QAM64   8k 1/32 NONE  # East Yorks & Lincs
T 730000000 8MHz  3/4 NONE    QAM64   8k 1/32 NONE
T 785833000 8MHz  3/4 NONE    QAM64   8k 1/32 NONE
T 506000000 8MHz  2/3 NONE    QAM64   8k 1/32 NONE  # East Yorks & Lincs
T 545833000 8MHz  2/3 NONE    QAM64   8k 1/32 NONE
T 658000000 8MHz  2/3 NONE    QAM64   8k 1/32 NONE  # Yorkshire
T 690000000 8MHz  3/4 NONE    QAM64   8k 1/32 NONE  # Yorkshire
T 682000000 8MHz  2/3 NONE    QAM64   8k 1/32 NONE  # Yorkshire
T 714000000 8MHz  2/3 NONE    QAM64   8k 1/32 NONE  # Yorkshire
T 722000000 8MHz  2/3 NONE    QAM64   8k 1/32 NONE  # Yorkshire
