### PR TITLE
DVB: turn the stream (and LNB) off when idle

### DIFF
--- a/src/dvb/diseqc.c
+++ b/src/dvb/diseqc.c
@@ -112,3 +112,13 @@ diseqc_setup(int frontend_fd, int switch_pos, int voltage_18, int hiband,
 }
 
 
+int diseqc_voltage_off(int frontend_fd)
+{
+        fe_sec_voltage_t v = SEC_VOLTAGE_OFF;
+        int err;
+
+	if ((err = ioctl(frontend_fd, FE_SET_VOLTAGE, v)))
+		return err;
+
+        return 0;
+}

--- a/src/dvb/diseqc.h
+++ b/src/dvb/diseqc.h
@@ -21,5 +21,6 @@ extern int diseqc_send_msg(int fd, fe_sec_voltage_t v, struct diseqc_cmd **cmd,
 int diseqc_setup(int frontend_fd, int switch_pos, int voltage_18, int hiband,
 		 int diseqc_ver);
 
-#endif
+int diseqc_voltage_off(int frontend_fd);
 
+#endif

--- a/src/dvb/dvb.h
+++ b/src/dvb/dvb.h
@@ -164,6 +164,7 @@ typedef struct th_dvb_adapter {
   uint32_t tda_autodiscovery;
   uint32_t tda_idlescan;
   uint32_t tda_qmon;
+  uint32_t tda_off;
   uint32_t tda_nitoid;
   uint32_t tda_diseqc_version;
   char *tda_displayname;
@@ -230,6 +231,8 @@ void dvb_adapter_set_idlescan(th_dvb_adapter_t *tda, int on);
 void dvb_adapter_set_qmon(th_dvb_adapter_t *tda, int on);
 
 void dvb_adapter_set_dump_muxes(th_dvb_adapter_t *tda, int on);
+
+void dvb_adapter_set_off(th_dvb_adapter_t *tda, int on);
 
 void dvb_adapter_set_nitoid(th_dvb_adapter_t *tda, int nitoid);
 
@@ -321,6 +324,8 @@ int dvb_transport_get_signal_status(struct service *t,
 int dvb_fe_tune(th_dvb_mux_instance_t *tdmi, const char *reason);
 
 void dvb_fe_stop(th_dvb_mux_instance_t *tdmi);
+
+void dvb_fe_turn_off(th_dvb_adapter_t *tda);
 
 
 /**

--- a/src/dvb/dvb_fe.c
+++ b/src/dvb/dvb_fe.c
@@ -511,3 +511,18 @@ dvb_fe_tune(th_dvb_mux_instance_t *tdmi, const char *reason)
   dvb_adapter_notify(tda);
   return 0;
 }
+
+/**
+ *
+ */
+void dvb_fe_turn_off(th_dvb_adapter_t *tda)
+{
+  lock_assert(&global_lock);
+  if (!tda->tda_off)
+    return;
+  if (tda->tda_mux_current)
+    dvb_fe_stop(tda->tda_mux_current);
+  if (tda->tda_type == FE_QPSK)
+    diseqc_voltage_off(tda->tda_fe_fd);
+  tvhlog(LOG_DEBUG, "dvb", "\"%s\" is off", tda->tda_rootpath);
+}

--- a/src/webui/extjs_dvb.c
+++ b/src/webui/extjs_dvb.c
@@ -151,6 +151,7 @@ extjs_dvbadapter(http_connection_t *hc, const char *remain, void *opaque)
     htsmsg_add_u32(r, "idlescan", tda->tda_idlescan);
     htsmsg_add_u32(r, "qmon", tda->tda_qmon);
     htsmsg_add_u32(r, "dumpmux", tda->tda_dump_muxes);
+    htsmsg_add_u32(r, "off", tda->tda_off);
     htsmsg_add_u32(r, "nitoid", tda->tda_nitoid);
     htsmsg_add_str(r, "diseqcversion", 
 		   ((const char *[]){"DiSEqC 1.0 / 2.0",
@@ -171,6 +172,9 @@ extjs_dvbadapter(http_connection_t *hc, const char *remain, void *opaque)
 
     s = http_arg_get(&hc->hc_req_args, "qmon");
     dvb_adapter_set_qmon(tda, !!s);
+
+    s = http_arg_get(&hc->hc_req_args, "off");
+    dvb_adapter_set_off(tda, !!s);
 
     s = http_arg_get(&hc->hc_req_args, "dumpmux");
     dvb_adapter_set_dump_muxes(tda, !!s);

--- a/src/webui/static/app/dvb.js
+++ b/src/webui/static/app/dvb.js
@@ -1055,7 +1055,7 @@ tvheadend.dvb_adapter_general = function(adapterData, satConfStore) {
     var confreader = new Ext.data.JsonReader({
 	root: 'dvbadapters'
     }, ['name', 'automux', 'idlescan', 'diseqcversion', 'qmon',
-	'dumpmux', 'nitoid']);
+	'dumpmux', 'off', 'nitoid']);
 
     
     function saveConfForm () {
@@ -1094,6 +1094,10 @@ tvheadend.dvb_adapter_general = function(adapterData, satConfStore) {
 					 'option enabled can consume a lot ' +
 					 'of diskspace. You have been warned');
 	    }
+	}),
+	new Ext.form.Checkbox({
+	    fieldLabel: 'Turn off adapter when idle',
+	    name: 'off'
 	}),
 	{
 	    fieldLabel: 'NIT-o Network ID',


### PR DESCRIPTION
Be green, this saves about 4-5 watts for my configuration for one LNB. Also, it saves CPU ticks by calling the dvb_fe_stop() for other - non-satellite - adapters.
