### PR TITLE
Some streaming mkv fixes

### DIFF
--- a/src/dvr/mkmux.h
+++ b/src/dvr/mkmux.h
@@ -24,6 +24,8 @@ typedef struct mk_mux mk_mux_t;
 struct streaming_start;
 struct dvr_entry;
 struct th_pkt;
+struct channel;
+struct event;
 
 mk_mux_t *mk_mux_create(const char *filename,
 			const struct streaming_start *ss,
@@ -32,9 +34,11 @@ mk_mux_t *mk_mux_create(const char *filename,
 
 mk_mux_t *mk_mux_stream_create(int fd,
 			       const struct streaming_start *ss,
-			       const event_t *e);
+			       const struct channel *ch);
 
 int mk_mux_write_pkt(mk_mux_t *mkm, struct th_pkt *pkt);
+
+int mk_mux_append_meta(mk_mux_t *mkm, struct event *e);
 
 void mk_mux_close(mk_mux_t *mk_mux);
 


### PR DESCRIPTION
- Comply with "mkcalidator --live". ERR150 can still reported but should be okey.
- Avoid seeking on sockets.
- Minimize cluster size.
