### PR TITLE
cwc: improve EMM handling for multiple readers with same CAS system

### DIFF
--- a/src/cwc.c
+++ b/src/cwc.c
@@ -1180,14 +1180,15 @@ cwc_emm_cache_lookup(cwc_t *cwc, uint32_t crc)
  *
  */
 void
-cwc_emm(uint8_t *data, int len)
+cwc_emm(uint8_t *data, int len, uint16_t caid)
 {
   cwc_t *cwc;
 
   pthread_mutex_lock(&cwc_mutex);
 
   TAILQ_FOREACH(cwc, &cwcs, cwc_link) {
-    if(cwc->cwc_forward_emm && cwc->cwc_writer_running) {
+    if(cwc->cwc_caid == caid &&
+       cwc->cwc_forward_emm && cwc->cwc_writer_running) {
       switch (cwc->cwc_card_type) {
       case CARD_CONAX:
 	cwc_emm_conax(cwc, data, len);

--- a/src/cwc.h
+++ b/src/cwc.h
@@ -23,6 +23,6 @@ void cwc_init(void);
 
 void cwc_service_start(struct service *t);
 
-void cwc_emm(uint8_t *data, int len);
+void cwc_emm(uint8_t *data, int len, uint16_t caid);
 
 #endif /* CWC_H_ */

--- a/src/dvb/dvb_tables.c
+++ b/src/dvb/dvb_tables.c
@@ -828,7 +828,7 @@ static int
 dvb_ca_callback(th_dvb_mux_instance_t *tdmi, uint8_t *ptr, int len,
 		uint8_t tableid, void *opaque)
 {
-  cwc_emm(ptr, len);
+  cwc_emm(ptr, len, (uintptr_t)opaque);
   return 0;
 }
 
@@ -841,6 +841,7 @@ dvb_cat_callback(th_dvb_mux_instance_t *tdmi, uint8_t *ptr, int len,
 {
   int tag, tlen;
   uint16_t pid;
+  uintptr_t caid;
 
   if((ptr[2] & 1) == 0) {
     /* current_next_indicator == next, skip this */
@@ -856,13 +857,13 @@ dvb_cat_callback(th_dvb_mux_instance_t *tdmi, uint8_t *ptr, int len,
     len -= 2;
     switch(tag) {
     case DVB_DESC_CA:
-      //      caid = ( ptr[0]         << 8) | ptr[1];
+      caid = ( ptr[0]         << 8) | ptr[1];
       pid  = ((ptr[2] & 0x1f) << 8) | ptr[3];
 
       if(pid == 0)
 	break;
 
-      tdt_add(tdmi, NULL, dvb_ca_callback, NULL, "CA", 
+      tdt_add(tdmi, NULL, dvb_ca_callback, (void *)caid, "CA", 
 	      TDT_INC_TABLE_HDR, pid, NULL);
       break;
 


### PR DESCRIPTION
Add CAID filter to identify the correct reader for EMM messages. Previous
code sent all EMMs to all readers with different CAIDs but same CAS system.
