### PR TITLE
cwc: Add Bulcrypt support.

### DIFF
--- a/src/psi.c
+++ b/src/psi.c
@@ -878,7 +878,9 @@ static struct strtab caidnametab[] = {
   { "GI",               0x4700 }, 
   { "Telemann",         0x4800 },
   { "DRECrypt",         0x4ae0 },
-  { "DRECrypt2",        0x4ae1 }
+  { "DRECrypt2",        0x4ae1 },
+  { "Bulcrypt",         0x4aee },
+  { "Bulcrypt",         0x5581 },
 };
 
 const char *


### PR DESCRIPTION
This patch adds Bulcrypt support. Bulcrypt is CAS created by bulgarian satellite operator Bulsatcom and it is used in Bulgaria, Serbia and couple of other places. Bulcrypt support was submitted to OSCAM and I expect it to be merged any day now.
