### PR TITLE
Minor fixes to htsmsg handling

### DIFF
--- a/src/htsmsg.c
+++ b/src/htsmsg.c
@@ -258,6 +258,7 @@ htsmsg_add_msg(htsmsg_t *msg, const char *name, htsmsg_t *sub)
 
   assert(sub->hm_data == NULL);
   TAILQ_MOVE(&f->hmf_msg.hm_fields, &sub->hm_fields, hmf_link);
+  f->hmf_msg.hm_islist = sub->hm_islist;
   free(sub);
 }
 
@@ -275,6 +276,7 @@ htsmsg_add_msg_extname(htsmsg_t *msg, const char *name, htsmsg_t *sub)
 
   assert(sub->hm_data == NULL);
   TAILQ_MOVE(&f->hmf_msg.hm_fields, &sub->hm_fields, hmf_link);
+  f->hmf_msg.hm_islist = sub->hm_islist;
   free(sub);
 }
 

--- a/src/htsmsg_json.c
+++ b/src/htsmsg_json.c
@@ -233,7 +233,10 @@ htsmsg_json_parse_object(const char *s, const char **endp)
 
   r = htsmsg_create_map();
   
-  while(1) {
+  while(*s > 0 && *s < 33)
+    s++;
+
+  if(*s != '}') while(1) {
 
     if((name = htsmsg_json_parse_string(s, &s2)) == NULL) {
       htsmsg_destroy(r);


### PR DESCRIPTION
the htsmsg_add_msg() mod allows some post hts_settings_load() modifications, which I've used to do config migration for my new EPG stuff.

the json mod simply makes things a little more robust should someone insert an empty map (which I happened to have done in my config).

I can live without the changes, but they makes things easier and both seem sensible.
