### PR TITLE
dvb: added extra priority per adapter

### DIFF
--- a/src/dvb/dvb.h
+++ b/src/dvb/dvb.h
@@ -205,6 +205,8 @@ typedef struct th_dvb_adapter {
   int tda_unc_is_delta;  /* 1 if we believe FE_READ_UNCORRECTED_BLOCKS
 			  * return dela values */
 
+  uint32_t tda_extrapriority; // extra priority for choosing the best adapter/service
+
 } th_dvb_adapter_t;
 
 
@@ -246,6 +248,8 @@ void dvb_adapter_notify(th_dvb_adapter_t *tda);
 htsmsg_t *dvb_adapter_build_msg(th_dvb_adapter_t *tda);
 
 htsmsg_t *dvb_fe_opts(th_dvb_adapter_t *tda, const char *which);
+
+void dvb_adapter_set_extrapriority(th_dvb_adapter_t *tda, int extrapriority);
 
 /**
  * DVB Multiplex

--- a/src/dvb/dvb_adapter.c
+++ b/src/dvb/dvb_adapter.c
@@ -86,6 +86,7 @@ tda_save(th_dvb_adapter_t *tda)
   htsmsg_add_u32(m, "dump_muxes", tda->tda_dump_muxes);
   htsmsg_add_u32(m, "nitoid", tda->tda_nitoid);
   htsmsg_add_u32(m, "diseqc_version", tda->tda_diseqc_version);
+  htsmsg_add_u32(m, "extrapriority", tda->tda_extrapriority);
   hts_settings_save(m, "dvbadapters/%s", tda->tda_identifier);
   htsmsg_destroy(m);
 }
@@ -232,6 +233,23 @@ dvb_adapter_set_diseqc_version(th_dvb_adapter_t *tda, unsigned int v)
   tda_save(tda);
 }
 
+/**
+ *
+ */
+void
+dvb_adapter_set_extrapriority(th_dvb_adapter_t *tda, int extrapriority)
+{
+  lock_assert(&global_lock);
+
+  if(tda->tda_extrapriority == extrapriority)
+    return;
+
+  tvhlog(LOG_NOTICE, "dvb", "Adapter \"%s\" extra priority \"%d\" changed to \"%d\"",
+         tda->tda_displayname, tda->tda_extrapriority, extrapriority);
+
+  tda->tda_extrapriority = extrapriority;
+  tda_save(tda);
+}
 
 /**
  *
@@ -383,6 +401,7 @@ dvb_adapter_init(uint32_t adapter_mask)
       htsmsg_get_u32(c, "dump_muxes", &tda->tda_dump_muxes);
       htsmsg_get_u32(c, "nitoid", &tda->tda_nitoid);
       htsmsg_get_u32(c, "diseqc_version", &tda->tda_diseqc_version);
+      htsmsg_get_u32(c, "extrapriority", &tda->tda_extrapriority);
     }
     htsmsg_destroy(l);
   }

--- a/src/service.c
+++ b/src/service.c
@@ -231,7 +231,7 @@ service_start(service_t *t, unsigned int weight, int force_start)
 static int
 dvb_extra_prio(th_dvb_adapter_t *tda)
 {
-  return tda->tda_hostconnection * 10;
+  return tda->tda_extrapriority + tda->tda_hostconnection * 10;
 }
 
 /**
@@ -285,10 +285,19 @@ servicecmp(const void *A, const void *B)
   service_t *a = *(service_t **)A;
   service_t *b = *(service_t **)B;
 
-  int q = service_get_quality(a) - service_get_quality(b);
+  /* only check quality if both adapters have the same prio
+   *
+   * there needs to be a much more sophisticated algorithm to take priority and quality into account
+   * additional, it may be problematic, since a higher priority value lowers the ranking
+   *
+   */
+  if (dvb_extra_prio(a->s_dvb_mux_instance->tdmi_adapter) == dvb_extra_prio(b->s_dvb_mux_instance->tdmi_adapter)) {
 
-  if(q != 0)
-    return q; /* Quality precedes priority */
+    int q = service_get_quality(a) - service_get_quality(b);
+
+    if(q != 0)
+      return q; /* Quality precedes priority */
+  }
 
   return service_get_prio(a) - service_get_prio(b);
 }
@@ -335,6 +344,9 @@ service_find(channel_t *ch, unsigned int weight, const char *loginfo,
       continue;
     }
     vec[cnt++] = t;
+    tvhlog(LOG_DEBUG, "Service",
+    		"%s: Adding adapter \"%s\" for service \"%s\"",
+    		 loginfo, t->s_dvb_mux_instance->tdmi_identifier, service_nicename(t));
   }
 
   /* Sort services, lower priority should come come earlier in the vector
@@ -358,6 +370,9 @@ service_find(channel_t *ch, unsigned int weight, const char *loginfo,
   /* First, try all services without stealing */
   for(i = off; i < cnt; i++) {
     t = vec[i];
+    tvhlog(LOG_DEBUG, "Service", "%s: Probing adapter \"%s\" without stealing for service \"%s\"",
+	     loginfo, t->s_dvb_mux_instance->tdmi_identifier, service_nicename(t));
+
     if(t->s_status == SERVICE_RUNNING) 
       return t;
     if((r = service_start(t, 0, 0)) == 0)
@@ -372,6 +387,9 @@ service_find(channel_t *ch, unsigned int weight, const char *loginfo,
 
   for(i = off; i < cnt; i++) {
     t = vec[i];
+    tvhlog(LOG_DEBUG, "Service", "%s: Probing adapter \"%s\" with weight %d for service \"%s\"",
+	     loginfo, t->s_dvb_mux_instance->tdmi_identifier, weight, service_nicename(t));
+
     if((r = service_start(t, weight, 0)) == 0)
       return t;
     *errorp = r;

--- a/src/webui/extjs_dvb.c
+++ b/src/webui/extjs_dvb.c
@@ -156,6 +156,7 @@ extjs_dvbadapter(http_connection_t *hc, const char *remain, void *opaque)
 		   ((const char *[]){"DiSEqC 1.0 / 2.0",
 				       "DiSEqC 1.1 / 2.1"})
 		   [tda->tda_diseqc_version % 2]);
+    htsmsg_add_u32(r, "extrapriority", tda->tda_extrapriority);
  
     out = json_single_record(r, "dvbadapters");
   } else if(!strcmp(op, "save")) {
@@ -184,6 +185,9 @@ extjs_dvbadapter(http_connection_t *hc, const char *remain, void *opaque)
       else if(!strcmp(s, "DiSEqC 1.1 / 2.1"))
 	dvb_adapter_set_diseqc_version(tda, 1);
     }
+
+    if((s = http_arg_get(&hc->hc_req_args, "extrapriority")) != NULL)
+      dvb_adapter_set_extrapriority(tda, atoi(s));
 
     out = htsmsg_create_map();
     htsmsg_add_u32(out, "success", 1);

--- a/src/webui/static/app/dvb.js
+++ b/src/webui/static/app/dvb.js
@@ -1106,7 +1106,7 @@ tvheadend.dvb_adapter_general = function(adapterData, satConfStore) {
     var confreader = new Ext.data.JsonReader({
 	root: 'dvbadapters'
     }, ['name', 'automux', 'idlescan', 'diseqcversion', 'qmon',
-	'dumpmux', 'nitoid']);
+	'dumpmux', 'nitoid','extrapriority']);
 
     
     function saveConfForm () {
@@ -1149,6 +1149,11 @@ tvheadend.dvb_adapter_general = function(adapterData, satConfStore) {
 	{
 	    fieldLabel: 'NIT-o Network ID',
 	    name: 'nitoid',
+	    width: 50
+	},
+	{
+	    fieldLabel: 'Extra priority',
+	    name: 'extrapriority',
 	    width: 50
 	}
     ];


### PR DESCRIPTION
This small patch adds the option to priorize DVB adapters, it fixes https://www.lonelycoder.com/redmine/issues/343.

I'm using it nearly a year and there is also some positive feedback over at xbmc http://forum.xbmc.org/showthread.php?tid=131574.
