### PR TITLE
replaced dvb dependend priority code with generic one

### DIFF
--- a/src/service.h
+++ b/src/service.h
@@ -557,6 +557,8 @@ const char *service_nicename(service_t *t);
 
 const char *service_component_nicename(elementary_stream_t *st);
 
+const char *service_adapter_nicename(service_t *t);
+
 const char *service_tss2text(int flags);
 
 static inline int service_tss_is_error(int flags)


### PR DESCRIPTION
erroneously assumed that there is always a DVB adapter available. which is not and therefore caused segfaults when evaluating IPTV or V4L sources for a service.

this is fixed, for logging purposes I introduced a "service_adapter_nicename" method to show the adapter in use - I'm not sure if this is the best solution and if there is already an existing way to get the adaptername.
