### PR TITLE
epggrab pthread initialization

### DIFF
--- a/src/epggrab.c
+++ b/src/epggrab.c
@@ -39,9 +39,9 @@
 #include "service.h"
 
 /* Thread protection */
-int                   epggrab_confver;
+static int                   epggrab_confver;
 pthread_mutex_t       epggrab_mutex;
-pthread_cond_t        epggrab_cond;
+static pthread_cond_t        epggrab_cond;
 
 /* Config */
 uint32_t              epggrab_interval;
@@ -346,6 +346,9 @@ void epggrab_init ( void )
   extern TAILQ_HEAD(, epggrab_ota_mux) ota_mux_all;
   TAILQ_INIT(&ota_mux_all);
 
+  pthread_mutex_init(&epggrab_mutex, NULL);
+  pthread_cond_init(&epggrab_cond, NULL);
+  
   /* Initialise modules */
   eit_init();
   xmltv_init();
@@ -362,5 +365,6 @@ void epggrab_init ( void )
   pthread_attr_init(&tattr);
   pthread_attr_setdetachstate(&tattr, PTHREAD_CREATE_DETACHED);
   pthread_create(&tid, &tattr, _epggrab_internal_thread, NULL);
+  pthread_attr_destroy(&tattr);
 }
 


### PR DESCRIPTION
tvheadend segfaults after clicking the "map dvb services to channels" button after some services have been discovered. it happens only when parameters are empty (network="", provider="", service=""). i have traced the problem to pthread_cond_wait() in serviceprobe.c (about line 131):

 while((sm = TAILQ_FIRST(&sq.sq_queue)) == NULL)
    pthread_cond_wait(&sq.sq_cond, &sq.sq_mutex);

but am still unsure why. anyway, this PR is for epggrab initialization which I thought may be corrupting something somewhere. but its not. :|
