### PR TITLE
Fix to scan Dishnet sats

### DIFF
--- a/src/dvb/dvb_tables.c
+++ b/src/dvb/dvb_tables.c
@@ -1021,6 +1021,11 @@ dvb_table_add_default_dvb(th_dvb_mux_instance_t *tdmi)
 
   fp = dvb_fparams_alloc();
   fp->filter.filter[0] = 0x42;
+  if (tdmi->tdmi_network != NULL) {
+    if(strstr(tdmi->tdmi_network,"EchoStar")!=NULL) {
+	fp->filter.filter[0] = 0x46;
+    }
+  }
   fp->filter.mask[0] = 0xff;
   tdt_add(tdmi, fp, dvb_sdt_callback, NULL, "sdt", 
 	  TDT_QUICKREQ | TDT_CRC, 0x11, NULL);


### PR DESCRIPTION
Dishnet does not send table_id 0x42 in the SDT.  This patch allows scanning 0x46 - much slower for getting the results but does work.  It determines if its looking at a DN sat by looking for 'EchoStar' in the sat identifier, otherwise it has no affect.
