### PR TITLE
Stype fixes for Sky TV, Bell and Dish networks

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -750,6 +750,13 @@ static struct strtab stypetab[] = {
   { "SDTV",         ST_SDTV },
   { "Radio",        ST_RADIO },
   { "HDTV",         ST_HDTV },
+  { "HDTV",	    ST_EX_HDTV },
+  { "SDTV",         ST_EX_SDTV },
+  { "HDTV",         ST_EP_HDTV },
+  { "HDTV",	    ST_ET_HDTV },
+  { "SDTV",	    ST_DN_SDTV },
+  { "HDTV",        ST_DN_HDTV },
+  { "SDTV",         ST_SK_SDTV },
   { "SDTV-AC",      ST_AC_SDTV },
   { "HDTV-AC",      ST_AC_HDTV },
 };
@@ -769,6 +776,13 @@ service_is_tv(service_t *t)
   return 
     t->s_servicetype == ST_SDTV    ||
     t->s_servicetype == ST_HDTV    ||
+    t->s_servicetype == ST_EX_HDTV ||
+    t->s_servicetype == ST_EX_SDTV ||
+    t->s_servicetype == ST_EP_HDTV ||
+    t->s_servicetype == ST_ET_HDTV ||
+    t->s_servicetype == ST_DN_SDTV ||
+    t->s_servicetype == ST_DN_HDTV ||
+    t->s_servicetype == ST_SK_SDTV ||
     t->s_servicetype == ST_AC_SDTV ||
     t->s_servicetype == ST_AC_HDTV;
 }

--- a/src/service.h
+++ b/src/service.h
@@ -318,6 +318,13 @@ typedef struct service {
     ST_HDTV       = 0x11,   /* HDTV (MPEG2) */
     ST_AC_SDTV    = 0x16,   /* Advanced codec SDTV */
     ST_AC_HDTV    = 0x19,   /* Advanced codec HDTV */
+    ST_EX_HDTV	  = 0x91,   /* Bell TV HDTV */
+    ST_EX_SDTV	  = 0x96,   /* Bell TV SDTV */
+    ST_EP_HDTV    = 0xA0,   /* Bell TV tiered HDTV */
+    ST_ET_HDTV    = 0xA6,   /* Bell TV tiered HDTV */
+    ST_DN_SDTV	   = 0xA8,   /* DN advanced SDTV */
+    ST_DN_HDTV    = 0xA4,    /* DN HDTV */
+    ST_SK_SDTV	  = 0xd3    /* SKY TV SDTV */
   } s_servicetype;
 
 

--- a/src/serviceprobe.c
+++ b/src/serviceprobe.c
@@ -180,9 +180,16 @@ serviceprobe_thread(void *aux)
 	switch(t->s_servicetype) {
 	case ST_SDTV:
 	case ST_AC_SDTV:
+	case ST_EX_SDTV:
+	case ST_DN_SDTV:
+	case ST_SK_SDTV:
 	  str = "SDTV";
 	  break;
 	case ST_HDTV:
+	case ST_EX_HDTV:
+	case ST_EP_HDTV:
+	case ST_ET_HDTV:
+	case ST_DN_HDTV:
 	case ST_AC_HDTV:
 	  str = "HDTV";
 	  break;


### PR DESCRIPTION
Added custom service types for Sky TV, Bell and Dish networks.
