### PR TITLE
Small patch to allow sid to be assigned as channel numbers controlled by...

### DIFF
--- a/src/dvb/dvb.h
+++ b/src/dvb/dvb.h
@@ -23,6 +23,8 @@
 #include <linux/dvb/frontend.h>
 #include "htsmsg.h"
 
+// temporary assignment until GUI can be determined
+#define CHANTOSID 1
 
 #define DVB_VER_INT(maj,min) (((maj) << 16) + (min))
 

--- a/src/dvb/dvb_transport.c
+++ b/src/dvb/dvb_transport.c
@@ -266,8 +266,11 @@ dvb_transport_save(service_t *t)
   htsmsg_add_u32(m, "pmt", t->s_pmt_pid);
   htsmsg_add_u32(m, "stype", t->s_servicetype);
   htsmsg_add_u32(m, "scrambled", t->s_scrambled);
-  htsmsg_add_u32(m, "channel", t->s_channel_number);
-
+  if(CHANTOSID) {
+    htsmsg_add_u32(m, "channel", t->s_dvb_service_id);
+  } else {
+    htsmsg_add_u32(m, "channel", t->s_channel_number);
+  }
   if(t->s_provider != NULL)
     htsmsg_add_str(m, "provider", t->s_provider);
 


### PR DESCRIPTION
This patch allows the assignment of the SID to channel number.  It is a preferred method of managing channels in NA.  
It is controlled by a flag variable in dvb.h called CHANTOSID.  If set to 1, then it applies, otherwise has no affect.  Can be added to front-end as a switch but didn't pursue this.  
