### PR TITLE
cwc: try reconnecting even if no subscribtion is active

### DIFF
--- a/src/cwc.c
+++ b/src/cwc.c
@@ -1175,7 +1175,9 @@ cwc_thread(void *aux)
 	continue; // Retry immediately
       d = 3;
     } else {
-      d = 60;
+      if(attempts == 1)
+        continue; // Retry immediately
+      d = 3;
     }
 
     ts.tv_sec = time(NULL) + d;


### PR DESCRIPTION
If there are active subscription, Tvheadend will attempt to reconnect
immediately and then retry every three seconds.
If no subscription is active a reconnection attempt is performed
every minute.

It's better to always have all cwcs connected, so
this changes the behaviour when no subscription is active. 

patch taken from OpenELEC. thanks to @romanlum 
