### PR TITLE
Add python 2.7 to build dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: tvheadend
 Section: video
 Priority: extra
 Maintainer: Andreas Öman <andreas@lonelycoder.com>
-Build-Depends: debhelper (>= 7.0.50), pkg-config, libavahi-client-dev, libssl-dev, zlib1g-dev
+Build-Depends: debhelper (>= 7.0.50), pkg-config, libavahi-client-dev, libssl-dev, zlib1g-dev, python2.7
 Standards-Version: 3.7.3
 
 Package: tvheadend


### PR DESCRIPTION
The tarfile module (needed for defualt build) is only installed with the
standard python package, thus it's not possible to build the package on
system with a minimal python installation, e.g. launchpad.
