### PR TITLE
Added support for DBS Bandstacked LNBFs

### DIFF
--- a/src/dvb/dvb.h
+++ b/src/dvb/dvb.h
@@ -24,8 +24,6 @@
 #include <pthread.h>
 #include "htsmsg.h"
 
-#define BANDSTACKED_NA_LNB 1
-
 #define DVB_VER_INT(maj,min) (((maj) << 16) + (min))
 
 #define DVB_VER_ATLEAST(maj, min) \

--- a/src/dvb/dvb_fe.c
+++ b/src/dvb/dvb_fe.c
@@ -466,7 +466,7 @@ dvb_fe_tune(th_dvb_mux_instance_t *tdmi, const char *reason)
       	dvb_lnb_get_frequencies(sc->sc_lnb, &lowfreq, &hifreq, &switchfreq);
     }
 
-    if (switchfreq == BANDSTACKED_NA_LNB) {
+    if(!strcmp(sc->sc_id, "DBS Bandstacked")) {
       hiband = 0;
       if(tdmi->tdmi_conf.dmc_polarisation == POLARISATION_HORIZONTAL ||
          tdmi->tdmi_conf.dmc_polarisation == POLARISATION_CIRCULAR_LEFT)

--- a/src/dvb/dvb_satconf.c
+++ b/src/dvb/dvb_satconf.c
@@ -317,7 +317,7 @@ dvb_lnb_get_frequencies(const char *id, int *f_low, int *f_hi, int *f_switch)
   } else if(!strcmp(id, "DBS Bandstacked")) {
     *f_low    = 11250000;
     *f_hi     = 14350000;
-    *f_switch = BANDSTACKED_NA_LNB; /* special case for Bandstacked LNB */
+    *f_switch = 0;
   } else if(!strcmp(id, "Standard")) {
     *f_low    = 10000000;
     *f_hi     = 0;


### PR DESCRIPTION
This patch adds support for DBS Bandstacked LNBFs that are typical in North America.

I've added a new entry to the lnblist called "DBS Bandstacked" with the following frequenies:

lo - 11250000
hi - 14350000
switch = BANDSTACKED_NA_LNB (special flag/constant defined in dvb.h)

The tuning code (dvb_fe_tune) has also been modified to check this special value and adjust the frequencies accordingly.
