### PR TITLE
Exposed episode repeat status to EPG

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -74,6 +74,10 @@ typedef enum {
   DVR_PRIO_UNIMPORTANT,
 } dvr_prio_t;
 
+typedef enum {
+  DVR_REPEATS_ALLEPISODES,
+  DVR_REPEATS_NEWONLY
+} dvr_repeats_t;
 
 LIST_HEAD(dvr_rec_stream_list, dvr_rec_stream);
 
@@ -219,6 +223,7 @@ typedef struct dvr_autorec_entry {
   channel_tag_t *dae_channel_tag;
   LIST_ENTRY(dvr_autorec_entry) dae_channel_tag_link;
 
+  dvr_repeats_t dae_repeats;
   dvr_prio_t dae_pri;
 
   struct dvr_entry_list dae_spawns;
@@ -336,7 +341,8 @@ void dvr_query_sort(dvr_query_result_t *dqr);
 void dvr_autorec_add(const char *dvr_config_name,
                      const char *title, const char *channel,
 		     const char *tag, epg_genre_t *content_type,
-		     const char *creator, const char *comment);
+		     const char *creator, const char *comment,
+                     dvr_repeats_t repeats);
 
 void dvr_autorec_add_series_link(const char *dvr_config_name,
                                  epg_broadcast_t *event,
@@ -354,8 +360,10 @@ dvr_autorec_entry_t *autorec_entry_find(const char *id, int create);
 /**
  *
  */
-dvr_prio_t dvr_pri2val(const char *s);
+dvr_repeats_t dvr_repeats2val(const char *s);
+const char *dvr_val2repeats(dvr_repeats_t v);
 
+dvr_prio_t dvr_pri2val(const char *s);
 const char *dvr_val2pri(dvr_prio_t v);
 
 #endif /* DVR_H  */

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1365,6 +1365,23 @@ dvr_get_filesize(dvr_entry_t *de)
 /**
  *
  */
+static struct strtab repeatstab[] = {
+  { "allepisodes",  DVR_REPEATS_ALLEPISODES },
+  { "newonly",      DVR_REPEATS_NEWONLY },
+};
+
+dvr_repeats_t
+dvr_repeats2val(const char *s)
+{
+  return str2val_def(s, repeatstab, DVR_REPEATS_ALLEPISODES);
+}
+
+const char *
+dvr_val2repeats(dvr_repeats_t v)
+{
+  return val2str(v, repeatstab) ?: "invalid";
+}
+
 static struct strtab priotab[] = {
   { "important",   DVR_PRIO_IMPORTANT },
   { "high",        DVR_PRIO_HIGH },

--- a/src/epg.h
+++ b/src/epg.h
@@ -473,9 +473,9 @@ void epg_query_sort(epg_query_result_t *eqr);
 /* Query routines */
 void epg_query0(epg_query_result_t *eqr, struct channel *ch,
                 struct channel_tag *ct, epg_genre_t *genre, const char *title,
-                const char *lang);
+                const char *lang, int repeats);
 void epg_query(epg_query_result_t *eqr, const char *channel, const char *tag,
-	       epg_genre_t *genre, const char *title, const char *lang);
+	       epg_genre_t *genre, const char *title, const char *lang, int repeats);
 
 
 /* ************************************************************************

--- a/src/htsp.c
+++ b/src/htsp.c
@@ -724,7 +724,7 @@ htsp_method_epgQuery(htsp_connection_t *htsp, htsmsg_t *in)
   }
 
   //do the query
-  epg_query0(&eqr, ch, ct, eg, query, NULL);
+  epg_query0(&eqr, ch, ct, eg, query, NULL, 0);
   c = eqr.eqr_entries;
 
   // create reply

--- a/src/webui/simpleui.c
+++ b/src/webui/simpleui.c
@@ -87,7 +87,7 @@ page_simple(http_connection_t *hc,
 
   if(s != NULL) {
     
-    epg_query(&eqr, NULL, NULL, NULL, s, lang);
+    epg_query(&eqr, NULL, NULL, NULL, s, lang, 0);
     epg_query_sort(&eqr);
 
     c = eqr.eqr_entries;

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -13,6 +13,15 @@ tvheadend.weekdays = new Ext.data.SimpleStore({
     ]
 });
 
+// Repeats
+tvheadend.dvrrepeats = new Ext.data.SimpleStore({
+    fields: ['identifier', 'name'],            
+    id: 0,                                     
+    data: [                                    
+        ['allepisodes',   'All Episodes'],
+        ['newonly',       'New Episodes Only']
+    ]                                          
+});        
 
 // This should be loaded from tvheadend
 tvheadend.dvrprio = new Ext.data.SimpleStore({
@@ -26,6 +35,8 @@ tvheadend.dvrprio = new Ext.data.SimpleStore({
 	['unimportant', 'Unimportant']
     ]
 });
+
+
 
 // For the container configuration
 tvheadend.containers = new Ext.data.SimpleStore({
@@ -541,6 +552,20 @@ tvheadend.autoreceditor = function() {
             increment: 10,
             format: 'H:i'
         })
+        }, {                                                               
+            header: "Repeats",                                            
+            dataIndex: 'repeats',
+            width: 100,                                                    
+            renderer: function(value, metadata, record, row, col, store) { 
+                return tvheadend.dvrrepeats.getById(value).data.name;         
+            },                                                             
+            editor: new fm.ComboBox({                                      
+                store: tvheadend.dvrrepeats,                                  
+                triggerAction: 'all',                                      
+                mode: 'local',                                             
+                valueField: 'identifier',                                  
+                displayField: 'name'                                       
+            })                    
 	}, {
 	    header: "Priority",
 	    dataIndex: 'pri',
@@ -650,7 +675,7 @@ tvheadend.dvr = function() {
     
     tvheadend.autorecRecord = Ext.data.Record.create([
 	'enabled','title', 'brand', 'channel','tag','creator','contenttype','comment',
-	'weekdays', 'pri', 'approx_time', 'config_name'
+	'weekdays', 'repeats', 'pri', 'approx_time', 'config_name'
     ]);
     
 


### PR DESCRIPTION
This PR exposes the "repeat" status of an episode and displays it on the EPG.

Fortunately the EPG structure already had an is_repeat variable and was already being captured from xmltv data... (I'm not sure about the other EPG sources though)

There is also a checkbox added to filter only new episodes (ie. non-repeats).

However, this does not modify the auto-record feature so this PR only shows repeat status for informational purposes but can be extended to support auto-record as well... (that's the main goal)
