### PR TITLE
Added Argentina to Country List

### DIFF
--- a/src/muxes.c
+++ b/src/muxes.c
@@ -50,6 +50,7 @@ static const struct {
 } tldlist[] = {
   {"auto", "--Generic--"},
   {"ad", "Andorra"},
+  {"ar", "Argentina"},
   {"at", "Austria"},
   {"au", "Australia"},
   {"ax", "Aland Islands"},


### PR DESCRIPTION
Please add this simple commit to have Argentina included in the Country List.

This way we can have tvheadend ready to read the file /usr/share/tvheadend/data/dvb-scan/dvb-t/ar-Argentina, which (currently doesn't exist) I'm going to submit to dvb-apps using this content:
http://linuxtv.org/wiki/index.php/ISDB-T_Frequency_Table

Thanks in advance,
Hernán.-
