### PR TITLE
service: audio/subtitle filter by default language(s)

### DIFF
--- a/src/config2.c
+++ b/src/config2.c
@@ -24,18 +24,26 @@
 
 static htsmsg_t *config;
 
+static const char *PATHFMT = "config";
+static const char *KEY_LANGUAGE = "language";
+static const char *KEY_MUXCONFPATH = "muxconfpath";
+static const char *KEY_FILTER_AUDIO_SUBTITLE = "filteraudiosubtitle";
+
 void config_init ( void )
 {
-  config = hts_settings_load("config");
+  config = hts_settings_load(PATHFMT);
   if (!config) {
-    tvhlog(LOG_WARNING, "config", "no configuration, loading defaults");
+    tvhlog(LOG_WARNING, PATHFMT, "no configuration, loading defaults");
     config = htsmsg_create_map();
+    htsmsg_add_str(config, KEY_LANGUAGE, "");
+    htsmsg_add_str(config, KEY_MUXCONFPATH, "");
+    htsmsg_add_str(config, KEY_FILTER_AUDIO_SUBTITLE, "false");
   }
 }
 
 void config_save ( void )
 {
-  hts_settings_save(config, "config");
+  hts_settings_save(config, PATHFMT);
 }
 
 htsmsg_t *config_get_all ( void )
@@ -45,15 +53,15 @@ htsmsg_t *config_get_all ( void )
 
 const char *config_get_language ( void )
 {
-  return htsmsg_get_str(config, "language");
+  return htsmsg_get_str(config, KEY_LANGUAGE);
 }
 
 int config_set_language ( const char *lang )
 {
   const char *c = config_get_language();
   if (!c || strcmp(c, lang)) {
-    if (c) htsmsg_delete_field(config, "language");
-    htsmsg_add_str(config, "language", lang);
+    if (c) htsmsg_delete_field(config, KEY_LANGUAGE);
+    htsmsg_add_str(config, KEY_LANGUAGE, lang);
     return 1;
   }
   return 0;
@@ -61,15 +69,31 @@ int config_set_language ( const char *lang )
 
 const char *config_get_muxconfpath ( void )
 {
-  return htsmsg_get_str(config, "muxconfpath");
+  return htsmsg_get_str(config, KEY_MUXCONFPATH);
 }
 
 int config_set_muxconfpath ( const char *path )
 {
   const char *c = config_get_muxconfpath();
   if (!c || strcmp(c, path)) {
-    if (c) htsmsg_delete_field(config, "muxconfpath");
-    htsmsg_add_str(config, "muxconfpath", path);
+    if (c) htsmsg_delete_field(config, KEY_MUXCONFPATH);
+    htsmsg_add_str(config, KEY_MUXCONFPATH, path);
+    return 1;
+  }
+  return 0;
+}
+
+const char *config_get_filteraudiosubtitle ( void )
+{
+  return htsmsg_get_str(config, KEY_FILTER_AUDIO_SUBTITLE);
+}
+
+int config_set_filteraudiosubtitle ( const char *path )
+{
+  const char *c = config_get_muxconfpath();
+  if (!c || strcmp(c, path)) {
+    if (c) htsmsg_delete_field(config, KEY_FILTER_AUDIO_SUBTITLE);
+    htsmsg_add_str(config, KEY_FILTER_AUDIO_SUBTITLE, path);
     return 1;
   }
   return 0;

--- a/src/config2.h
+++ b/src/config2.h
@@ -36,4 +36,8 @@ const char *config_get_language    ( void );
 int         config_set_language    ( const char *str )
   __attribute__((warn_unused_result));
 
+const char *config_get_filteraudiosubtitle    ( void );
+int         config_set_filteraudiosubtitle    ( const char *str )
+  __attribute__((warn_unused_result));
+
 #endif /* __TVH_CONFIG__H__ */

--- a/src/webui/extjs.c
+++ b/src/webui/extjs.c
@@ -1,6 +1,6 @@
 /*
  *  tvheadend, EXTJS based interface
- *  Copyright (C) 2008 Andreas Öman
+ *  Copyright (C) 2008 Andreas ï¿½man
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -1771,6 +1771,8 @@ extjs_config(http_connection_t *hc, const char *remain, void *opaque)
       save |= config_set_muxconfpath(str);
     if ((str = http_arg_get(&hc->hc_req_args, "language")))
       save |= config_set_language(str);
+    if ((str = http_arg_get(&hc->hc_req_args, "filteraudiosubtitle")))
+      save |= config_set_filteraudiosubtitle(str);
     if (save) config_save();
     pthread_mutex_unlock(&global_lock);
     out = htsmsg_create_map();

--- a/src/webui/static/app/config.js
+++ b/src/webui/static/app/config.js
@@ -1,10 +1,19 @@
+tvheadend.filteraudiosubtitle = new Ext.data.SimpleStore({
+    fields: ['identifier', 'name'],
+    id: 0,
+    data: [
+		['false', 'Disabled'],
+		['true', 'Enabled']
+    ]
+});
+
 tvheadend.miscconf = function() {
 	/*
 	 * Basic Config
 	 */
 	var confreader = new Ext.data.JsonReader({
 		root : 'config'
-	}, [ 'muxconfpath', 'language' ]);
+	}, [ 'muxconfpath', 'language', 'filteraudiosubtitle' ]);
 
 	/* ****************************************************************
 	 * Form Fields
@@ -21,6 +30,20 @@ tvheadend.miscconf = function() {
 		name : 'language',
 		allowBlank : true
 	});
+	
+	var filteraudiosubtitle = new Ext.form.ComboBox({
+		fieldLabel: 'Filter audio/subtitle by language',
+    	hiddenName: 'filteraudiosubtitle',
+    	store: tvheadend.filteraudiosubtitle,
+    	valueField: 'identifier',
+    	displayField: 'name',
+    	editable: false,
+		forceSelection: true,
+		mode:'local',
+		valueNotFoundText: 'Disabled',
+		triggerAction: 'all',
+    	width: 150
+  });
 
 	/* ****************************************************************
 	 * Form
@@ -46,13 +69,13 @@ tvheadend.miscconf = function() {
 		border : false,
 		bodyStyle : 'padding:15px',
 		labelAlign : 'left',
-		labelWidth : 150,
+		labelWidth : 190,
 		waitMsgTarget : true,
 		reader : confreader,
 		layout : 'form',
 		defaultType : 'textfield',
 		autoHeight : true,
-		items : [ language, dvbscanPath ],
+		items : [ language, dvbscanPath, filteraudiosubtitle ],
 		tbar : [ saveButton, '->', helpButton ]
 	});
 


### PR DESCRIPTION
This PR adds a config setting to enable/disable an audio/subtitle filter.
It filters the audio/subtitle stream by default language(s) within service_build_stream_start.
