### PR TITLE
webui: set auto scrolling to true for general tv adapter panel

### DIFF
--- a/src/webui/static/app/dvb.js
+++ b/src/webui/static/app/dvb.js
@@ -1229,6 +1229,7 @@ tvheadend.dvb_adapter_general = function(adapterData, satConfStore) {
 	var panel = new Ext.Panel({
 		title : 'General',
 		layout : 'column',
+		autoScroll : true,
 		items : [ toolpanel, confform, infoPanel ]
 	});
 


### PR DESCRIPTION
Without this you can't scroll down to the save button of this panel.
