### PR TITLE
Fix version for launchpad builds using recipes

### DIFF
--- a/support/version
+++ b/support/version
@@ -7,7 +7,11 @@
 FILE=$1
 
 # Calculate version
-VER=$(cd $(dirname $0); git describe --dirty 2> /dev/null | sed "s/-\([0-9]*\)-\(g[0-9a-f]*\)/.\1~\2/")
+if [ -d ".git" ]; then
+    VER=$(cd $(dirname $0); git describe --dirty 2> /dev/null | sed "s/-\([0-9]*\)-\(g[0-9a-f]*\)/.\1~\2/")
+else
+    VER=$(head -1 $(dirname $0)/../debian/changelog | awk '{ print $2 }' | tr -d '()' | cut -d '-' -f 1)
+fi
 
 # Output
 if [ -z "$FILE" ]; then


### PR DESCRIPTION
Git operations are not allowed in launchpad, thus the version number
must be extracted from the changeleg.
