### PR TITLE
xmltv_load_grabbers - only call closedir when opendir was successfull

### DIFF
--- a/src/epggrab/module/xmltv.c
+++ b/src/epggrab/module/xmltv.c
@@ -667,8 +667,8 @@ static void _xmltv_load_grabbers ( void )
             free(outbuf);
           }
         }
+        closedir(dir);
       }
-      closedir(dir);
       tmp = strtok(NULL, ":");
     }
     free(path);


### PR DESCRIPTION
I'm working on an android build and it crashes here if opendir returns NULL. Not sure if this is also an issue on other systems.
