### PR TITLE
Plug some memory leaks in mkv streaming

### DIFF
--- a/src/avc.c
+++ b/src/avc.c
@@ -186,8 +186,6 @@ avc_convert_pkt(th_pkt_t *src)
   pkt->pkt_header = NULL;
   pkt->pkt_payload = NULL;
 
-  pkt->pkt_payload = malloc(sizeof(pktbuf_t));
-  pkt->pkt_payload->pb_refcount=1;
   if (src->pkt_header) {
     sbuf_t headers;
     sbuf_init(&headers);


### PR DESCRIPTION
This commit closes two memory leaks in mkv streaming.

The first one was in avc_convert_pkt (pretty obvious if you take a closer look). Valgrind log below:

```
==18963== 1,853,928 bytes in 77,247 blocks are definitely lost in loss record 303 of 303
==18963==    at 0x4C2B6CD: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18963==    by 0x428E18: avc_convert_pkt (avc.c:189)
==18963==    by 0x435BA7: globalheaders_input (globalheaders.c:170)
==18963==    by 0x435191: normalize_ts.isra.1 (tsfix.c:212)
==18963==    by 0x411C6D: streaming_pad_deliver (streaming.c:298)
==18963==    by 0x41AD9C: parser_deliver.isra.4 (parsers.c:1407)
==18963==    by 0x41B2D5: parse_h264 (parsers.c:1243)
==18963==    by 0x41AB50: parse_sc (parsers.c:339)
==18963==    by 0x41D82E: ts_recv_packet0 (tsdemux.c:126)
==18963==    by 0x41DA3F: ts_recv_packet1 (tsdemux.c:260)
==18963==    by 0x427B4C: iptv_thread (iptv_input.c:116)
==18963==    by 0x5C41E99: start_thread (pthread_create.c:308)
```

The second one was in the mkv muxer and occurred only when there was an error. Valgrind logs below:

```
==18754== 363,773 (200 direct, 363,573 indirect) bytes in 5 blocks are definitely lost in loss record 317 of 319
==18754==    at 0x4C2B6CD: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18754==    by 0x425C39: htsbuf_append (htsbuf.c:110)
==18754==    by 0x43ACCF: ebml_append_id (ebml.c:39)
==18754==    by 0x43AE50: ebml_append_bin (ebml.c:71)
==18754==    by 0x43AF67: ebml_append_uint (ebml.c:90)
==18754==    by 0x43C78A: mk_mux_write_pkt (mkmux.c:732)
==18754==    by 0x4452BC: tvh_muxer_write_pkt (muxer_tvh.c:125)
==18754==    by 0x43D8C1: http_stream_run.isra.1 (webui.c:201)
==18754==    by 0x43DCFB: http_stream (webui.c:614)
==18754==    by 0x4086BC: http_exec (http.c:343)
==18754==    by 0x408A82: http_cmd_get (http.c:374)
==18754==    by 0x408C21: process_request (http.c:454)
```

```
==18754== 329,077 (160 direct, 328,917 indirect) bytes in 4 blocks are definitely lost in loss record 316 of 319
==18754==    at 0x4C2B6CD: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18754==    by 0x425C39: htsbuf_append (htsbuf.c:110)
==18754==    by 0x43C6B9: mk_mux_write_pkt (mkmux.c:759)
==18754==    by 0x4452BC: tvh_muxer_write_pkt (muxer_tvh.c:125)
==18754==    by 0x43D8C1: http_stream_run.isra.1 (webui.c:201)
==18754==    by 0x43DCFB: http_stream (webui.c:614)
==18754==    by 0x4086BC: http_exec (http.c:343)
==18754==    by 0x408A82: http_cmd_get (http.c:374)
==18754==    by 0x408C21: process_request (http.c:454)
==18754==    by 0x408FFF: http_serve (http.c:748)
==18754==    by 0x4074A8: tcp_server_start (tcp.c:401)
==18754==    by 0x5C41E99: start_thread (pthread_create.c:308)
```

There are still some smaller memory leaks (in range of a few 10kB). I'll take a look at them when I have some more time.
