### PR TITLE
Streaming queue size protection

### DIFF
--- a/src/streaming.h
+++ b/src/streaming.h
@@ -73,6 +73,8 @@ void streaming_queue_init(streaming_queue_t *sq, int reject_filter);
 
 void streaming_queue_clear(struct streaming_message_queue *q);
 
+int streaming_queue_size(struct streaming_message_queue *q);
+
 void streaming_queue_deinit(streaming_queue_t *sq);
 
 void streaming_target_connect(streaming_pad_t *sp, streaming_target_t *st);


### PR DESCRIPTION
Now that all memory leaks in http streaming are cleared there is only one major memory issue left. HTSP streaming has a queue size protection but HTTP streaming doesn't. 

When there are clients on a slow connection or if the server has connection problems the streaming queue size can increase indefinitely and sooner or later cause out of memory problems on the server.

This can be very easily simulated with VLC. Just start a HTTP stream and press play/pause in 5-10 seconds intervals. You will see the memory usage of tvheadend increase at the bit rate of the stream.

Here is a massif heap profile of tvheadend (marked is the highest memory usage --> cca. 140Mb):
![Tvheadend without queue size protection](https://dl.dropbox.com/u/8261657/without_queue_size_protection.png)

Here is a massif heap profile of tvheadend with the queue size protection from these PR (marked is the highest memory usage --> cca. 9Mb):
![Tvheadend with queue size protection](https://dl.dropbox.com/u/8261657/with_queue_size_protection.png)

Both heap profiles were recorded with the same stream, same player and similar play/pause intervals.

I'm not sure if this is the best solution for this problem. I just wanted to point out that there is a problem.
