### PR TITLE
Fix some compile errors

### DIFF
--- a/src/trap.c
+++ b/src/trap.c
@@ -67,6 +67,7 @@ sappend(char *buf, size_t l, const char *fmt, ...)
 /**
  *
  */
+#if ENABLE_EXECINFO
 static int
 add2lineresolve(const char *binary, void *addr, char *buf0, size_t buflen)
 {
@@ -126,6 +127,7 @@ add2lineresolve(const char *binary, void *addr, char *buf0, size_t buflen)
   close(fd[0]);
   return 0;
 }
+#endif /* ENABLE_EXECINFO */
 
 
 
@@ -133,8 +135,8 @@ static void
 traphandler(int sig, siginfo_t *si, void *UC)
 {
   ucontext_t *uc = UC;
-  char buf[200];
 #if ENABLE_EXECINFO
+  char buf[200];
   static void *frames[MAXFRAMES];
   int nframes = backtrace(frames, MAXFRAMES);
   Dl_info dli;


### PR DESCRIPTION
While building package for OpenWRT there were several compile errors: SHA_\* -> SHA1_\* and unused variables and functions.
