### PR TITLE
Stype fix for NET POA Cabo network

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -763,6 +763,7 @@ static struct strtab stypetab[] = {
   { "SDTV",         ST_DN_SDTV },
   { "HDTV",         ST_DN_HDTV },
   { "SDTV",         ST_SK_SDTV },
+  { "SDTV",         ST_NE_SDTV },
   { "SDTV-AC",      ST_AC_SDTV },
   { "HDTV-AC",      ST_AC_HDTV },
 };
@@ -789,6 +790,7 @@ service_is_tv(service_t *t)
     t->s_servicetype == ST_DN_SDTV ||
     t->s_servicetype == ST_DN_HDTV ||
     t->s_servicetype == ST_SK_SDTV ||
+    t->s_servicetype == ST_NE_SDTV ||
     t->s_servicetype == ST_AC_SDTV ||
     t->s_servicetype == ST_AC_HDTV;
 }

--- a/src/service.h
+++ b/src/service.h
@@ -324,6 +324,7 @@ typedef struct service {
     ST_HDTV       = 0x11,   /* HDTV (MPEG2) */
     ST_AC_SDTV    = 0x16,   /* Advanced codec SDTV */
     ST_AC_HDTV    = 0x19,   /* Advanced codec HDTV */
+    ST_NE_SDTV    = 0x80,   /* NET POA - Cabo SDTV */
     ST_EX_HDTV    = 0x91,   /* Bell TV HDTV */
     ST_EX_SDTV    = 0x96,   /* Bell TV SDTV */
     ST_EP_HDTV    = 0xA0,   /* Bell TV tiered HDTV */

--- a/src/serviceprobe.c
+++ b/src/serviceprobe.c
@@ -198,6 +198,7 @@ serviceprobe_thread(void *aux)
           case ST_EX_SDTV:
           case ST_DN_SDTV:
           case ST_SK_SDTV:
+          case ST_NE_SDTV:
             str = "SDTV";
             break;
           case ST_HDTV:


### PR DESCRIPTION
Some services in NET POA Cabo (Brazil) have a service type of 0x80. They are standard SDTV services.
