### PR TITLE
Added prefrerred CA pid support

### DIFF
--- a/src/channels.c
+++ b/src/channels.c
@@ -294,16 +294,26 @@ channels_load(void)
 {
   htsmsg_t *l, *c;
   htsmsg_field_t *f;
+  channel_t *ch; 
+  int cnt;
 
   if((l = hts_settings_load("channels")) != NULL) {
     HTSMSG_FOREACH(f, l) {
       if((c = htsmsg_get_map_by_field(f)) == NULL)
-	continue;
+    continue;
       channel_load_one(c, atoi(f->hmf_name));
     }
     htsmsg_destroy(l);
   }
-}
+  cnt = 0;
+  RB_FOREACH(ch, &channel_name_tree, ch_name_link) {
+    cnt++;
+    if (ch->ch_number == cnt) continue;
+    ch->ch_number = cnt;
+    channel_save(ch);
+  }
+ 
+} 
 
 
 /**

--- a/src/dvb/dvb_adapter.c
+++ b/src/dvb/dvb_adapter.c
@@ -500,6 +500,7 @@ tda_add(int adapter_num)
   
   tda->tda_autodiscovery = tda->tda_type != FE_QPSK;
   tda->tda_idlescan = 1;
+  tda->tda_skip_checksubscr = 1;
 
   tda->tda_sat = tda->tda_type == FE_QPSK;
 

--- a/src/dvb/dvb_fe.c
+++ b/src/dvb/dvb_fe.c
@@ -100,7 +100,7 @@ dvb_fe_monitor(void *aux)
   int store = 0;
   int notify = 0;
 
-  gtimer_arm(&tda->tda_fe_monitor_timer, dvb_fe_monitor, tda, 1);
+  gtimer_arm(&tda->tda_fe_monitor_timer, dvb_fe_monitor, tda, 60);
 
   if(tdmi == NULL)
     return;

--- a/src/dvb/dvb_service.c
+++ b/src/dvb/dvb_service.c
@@ -259,6 +259,10 @@ dvb_service_load(th_dvb_mux_instance_t *tdmi, const char *tdmi_identifier)
     if(s && u32)
       service_map_channel(t, channel_find_by_name(s, 1, 0), 0);
 
+    if(htsmsg_get_u32(c, "prefcapid", &u32))
+      u32 = 0;
+    t->s_prefcapid = u32;
+
     /* HACK - force save for old config */
     if(old)
       dvb_service_save(t);
@@ -470,6 +474,8 @@ dvb_service_build_msg(service_t *t)
     htsmsg_add_str(m, "dvb_charset", t->s_dvb_charset);
 
   htsmsg_add_u32(m, "dvb_eit_enable", t->s_dvb_eit_enable);
+
+  htsmsg_add_u32(m, "prefcapid", t->s_prefcapid);
 
   return m;
 }

--- a/src/psi.c
+++ b/src/psi.c
@@ -308,10 +308,10 @@ psi_desc_ca(service_t *t, const uint8_t *buffer, int size)
     }
     break;
   case 0x4a00://DRECrypt
-    if (caid != 0x4aee) { // Bulcrypt
+    if (caid != 0x4aee && caid != 0x4ae1) { // Bulcrypt or Tricolor
       provid = size < 4 ? 0 : buffer[4];
-      break;
     }
+    break;
   default:
     provid = 0;
     break;

--- a/src/service.c
+++ b/src/service.c
@@ -933,6 +933,12 @@ service_set_enable(service_t *t, int enabled)
   subscription_reschedule();
 }
 
+void
+service_set_prefcapid(service_t *t, uint32_t prefcapid)
+{
+  t->s_prefcapid = prefcapid;
+  t->s_config_save(t);
+}
 
 static pthread_mutex_t pending_save_mutex;
 static pthread_cond_t pending_save_cond;

--- a/src/service.h
+++ b/src/service.h
@@ -474,6 +474,7 @@ typedef struct service {
   int s_scrambled;
   int s_scrambled_seen;
   int s_caid;
+  uint16_t s_prefcapid;
 
   /**
    * PCR drift compensation. This should really be per-packet.
@@ -596,6 +597,8 @@ uint16_t service_get_encryption(service_t *t);
 void service_set_dvb_charset(service_t *t, const char *dvb_charset);
 
 void service_set_dvb_eit_enable(service_t *t, int dvb_eit_enable);
+
+void service_set_prefcapid(service_t *t, uint32_t prefcapid);
 
 int service_is_primary_epg (service_t *t);
 

--- a/src/serviceprobe.c
+++ b/src/serviceprobe.c
@@ -81,7 +81,7 @@ serviceprobe_thread(void *aux)
   int was_doing_work = 0;
   streaming_queue_t sq;
   streaming_message_t *sm;
-  //  transport_feed_status_t status;
+//  transport_feed_status_t status;
   int run;
   const char *err;
   channel_t *ch;
@@ -119,7 +119,7 @@ serviceprobe_thread(void *aux)
         t->s_sp_onqueue = 0;
         TAILQ_REMOVE(&serviceprobe_queue, t, s_sp_link);
         tvhlog(LOG_INFO, "serviceprobe", "%20s: could not subscribe",
-         t->s_svcname);
+        t->s_svcname);
         continue;
       }
     }

--- a/src/webui/extjs.c
+++ b/src/webui/extjs.c
@@ -1469,6 +1469,9 @@ service_update(htsmsg_t *in)
     if((chname = htsmsg_get_str(c, "channelname")) != NULL) 
       service_map_channel(t, channel_find_by_name(chname, 1, 0), 1);
 
+    if(!htsmsg_get_u32(c, "prefcapid", &u32))
+      service_set_prefcapid(t, u32);
+
     if((dvb_charset = htsmsg_get_str(c, "dvb_charset")) != NULL)
       service_set_dvb_charset(t, dvb_charset);
 
@@ -1799,6 +1802,9 @@ extjs_service_update(htsmsg_t *in)
 
     if(!htsmsg_get_u32(c, "enabled", &u32))
       service_set_enable(t, u32);
+
+    if(!htsmsg_get_u32(c, "prefcapid", &u32))
+      service_set_prefcapid(t, u32);
 
     if((chname = htsmsg_get_str(c, "channelname")) != NULL) 
       service_map_channel(t, channel_find_by_name(chname, 1, 0), 1);

--- a/src/webui/static/app/dvb.js
+++ b/src/webui/static/app/dvb.js
@@ -507,6 +507,11 @@ tvheadend.dvb_services = function(adapterId) {
 			width : 50,
 			hidden : true
 		}, {
+	    		header: "Preffered CA pid",
+			dataIndex: 'prefcapid',
+	    		width: 50,
+            		editor: new fm.TextField({allowBlank: true})
+	        },{
 			header : "PMT PID",
 			dataIndex : 'pmt',
 			width : 50,
@@ -521,7 +526,7 @@ tvheadend.dvb_services = function(adapterId) {
 	var store = new Ext.data.JsonStore({
 		root : 'entries',
 		fields : Ext.data.Record.create([ 'id', 'enabled', 'type', 'sid', 'pmt',
-			'pcr', 'svcname', 'network', 'provider', 'mux', 'channelname',
+			'pcr', 'svcname', 'network', 'provider', 'mux', 'channelname', 'prefcapid',
 			'dvb_charset', 'dvb_eit_enable' ]),
 		url : "dvb/services/" + adapterId,
 		autoLoad : true,


### PR DESCRIPTION
Added prefrerred CA pid field in user interface and use field value to store ECM only from stream which is answer ok
Tricolor provider with 0x4ae1 added to exceptions in psi.c file the same as Bulcrypt.
Channels are ordered alphabetically just after start for better managability in XBMC channel list.
