### PR TITLE
Settings: Close file pointer after the call to fb_size(fp)

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -195,11 +195,13 @@ hts_settings_load_one(const char *filename)
   mem    = malloc(fb_size(fp)+1);
   n      = fb_read(fp, mem, fb_size(fp));
   if (n >= 0) mem[n] = 0;
-  fb_close(fp);
 
   /* Decode */
   if(n == fb_size(fp))
     r = htsmsg_json_deserialize(mem);
+
+  /* Close */
+  fb_close(fp);
   free(mem);
 
   return r;


### PR DESCRIPTION
Another bug I noticed when porting tvheadend to android... the saved settings were loaded randomly (sometimes almost all of them, sometimes none). 

Even if on other platforms this isn't an issue it should still be fixed.
