### PR TITLE
Remove strong link between dvr_entry and channel

### DIFF
--- a/src/channels.c
+++ b/src/channels.c
@@ -344,6 +344,7 @@ int
 channel_rename(channel_t *ch, const char *newname)
 {
   service_t *t;
+  dvr_entry_t *de;
 
   lock_assert(&global_lock);
 
@@ -354,6 +355,14 @@ channel_rename(channel_t *ch, const char *newname)
 
   tvhlog(LOG_NOTICE, "channels", "Channel \"%s\" renamed to \"%s\"",
 	 ch->ch_name, newname);
+
+  LIST_FOREACH(de, &dvrentries, de_global_link)
+    if (!strcmp(ch->ch_name, de->de_channel_name)) {
+      free(de->de_channel_name);
+      de->de_channel_name = strdup(newname);
+      dvr_entry_notify(de);
+    }
+
 
   RB_REMOVE(&channel_name_tree, ch, ch_name_link);
   channel_set_name(ch, newname);

--- a/src/channels.h
+++ b/src/channels.h
@@ -58,8 +58,6 @@ typedef struct channel {
   int ch_number;  // User configurable number
   char *ch_icon;
 
-  struct dvr_entry_list ch_dvrs;
-  
   struct dvr_autorec_entry_list ch_autorecs;
 
   struct channel_tag_mapping_list ch_ctms;

--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -110,8 +110,7 @@ typedef struct dvr_entry {
   LIST_ENTRY(dvr_entry) de_global_link;
   int de_id;
   
-  channel_t *de_channel;
-  LIST_ENTRY(dvr_entry) de_channel_link;
+  char *de_channel_name;
 
   gtimer_t de_timer;
 

--- a/src/dvr/mkmux.c
+++ b/src/dvr/mkmux.c
@@ -480,8 +480,9 @@ _mk_build_metadata(const dvr_entry_t *de, const epg_broadcast_t *ebc)
   if (ebc)               ee = ebc->episode;
   else if (de->de_bcast) ee = de->de_bcast->episode;
 
-  if (de) ch = de->de_channel;
-  else    ch = ebc->channel;
+  if (de) {
+    ch = channel_find_by_name(de->de_channel_name, 0, 0);
+  } else    ch = ebc->channel;
 
   snprintf(datestr, sizeof(datestr),
 	   "%04d-%02d-%02d %02d:%02d:%02d",

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -515,9 +515,13 @@ htsp_build_dvrentry(dvr_entry_t *de, const char *method)
   const char *s = NULL, *error = NULL;
   const char *p;
   dvr_config_t *cfg;
+  channel_t *ch;
+  int ch_id = 0;
 
   htsmsg_add_u32(out, "id", de->de_id);
-  htsmsg_add_u32(out, "channel", de->de_channel->ch_id);
+  ch = channel_find_by_name(de->de_channel_name, 0, 0);
+  if (ch != NULL) ch_id = ch->ch_id;
+  htsmsg_add_u32(out, "channel", ch_id);
 
   htsmsg_add_s64(out, "start", de->de_start);
   htsmsg_add_s64(out, "stop", de->de_stop);

--- a/src/webui/extjs.c
+++ b/src/webui/extjs.c
@@ -1298,6 +1298,7 @@ extjs_dvrlist(http_connection_t *hc, const char *remain, void *opaque,
   const char *s;
   off_t fsize;
   char buf[100];
+  channel_t *ch;
 
   if((s = http_arg_get(&hc->hc_req_args, "start")) != NULL)
     start = atoi(s);
@@ -1332,10 +1333,11 @@ extjs_dvrlist(http_connection_t *hc, const char *remain, void *opaque,
 
     m = htsmsg_create_map();
 
-    if(de->de_channel != NULL) {
-      htsmsg_add_str(m, "channel", de->de_channel->ch_name);
-      if(de->de_channel->ch_icon != NULL)
-	htsmsg_add_str(m, "chicon", de->de_channel->ch_icon);
+    htsmsg_add_str(m, "channel", de->de_channel_name);
+    ch = channel_find_by_name(de->de_channel_name, 0, 0);
+    if(ch != NULL) {
+      if(ch->ch_icon != NULL)
+	htsmsg_add_str(m, "chicon", ch->ch_icon);
     }
 
     htsmsg_add_str(m, "config_name", de->de_config_name);

--- a/src/webui/simpleui.c
+++ b/src/webui/simpleui.c
@@ -322,7 +322,7 @@ page_pvrinfo(http_connection_t *hc, const char *remain, void *opaque)
 	      a.tm_hour, a.tm_min, b.tm_hour, b.tm_min);
 
   htsbuf_qprintf(hq, "<hr><b>\"%s\": \"%s\"</b><br><br>",
-	      de->de_channel->ch_name, lang_str_get(de->de_title, NULL));
+	      de->de_channel_name, lang_str_get(de->de_title, NULL));
   
   if((rstatus = val2str(de->de_sched_state, recstatustxt)) != NULL)
     htsbuf_qprintf(hq, "Recording status: %s<br>", rstatus);


### PR DESCRIPTION
Fixes:
- Recordings getting deleted if a channel gets deleted
- Upon channel rename, all recordings will also
  get the channel name updated.
