### PR TITLE
add separator in filename before 'onscreen' style of episode number

### DIFF
--- a/src/epg.c
+++ b/src/epg.c
@@ -1078,8 +1078,8 @@ size_t epg_episode_number_format
     if ( cfmt && num.e_cnt )
       i+= snprintf(&buf[i], len-i, cfmt, num.e_cnt);
   } else if ( num.text ) {
-    strncpy(buf, num.text, len);
-    i = strlen(buf);
+    if (pre) i += snprintf(&buf[i], len-i, "%s", pre);
+    i += snprintf(&buf[i], len-i, "%s", num.text);
   }
   return i;
 }


### PR DESCRIPTION
The 'onscreen' style of episode numbers are meant to be used as-is, but if there's no separator added when they're used in recording filenames you get something like this: Title.2012-12-29.02-4519.mkv instead of Title.2012-12-29.02-45.19.mkv (the episode number is 19 at the end).

Proposed change adds separator before episode number just like with other styles of episode numbers.
