### PR TITLE
fixed content type translation

### DIFF
--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -20,7 +20,7 @@ tvheadend.contentGroupLookupName = function(code) {
 	ret = "";
 	tvheadend.ContentGroupStore.each(function(r) {
 		if (r.data.code == code) ret = r.data.name;
-		else if (ret == "" && r.data.code == code & 0xF0) ret = r.data.name;
+		else if (ret == "" && r.data.code == (code & 0xF0)) ret = r.data.name;
 	});
 	return ret;
 }


### PR DESCRIPTION
Content 'subtypes' were not translated correctly in the webui.
For example "News/Current affairs" works fine but "news/weather report", "news magazine", "documentary", "discussion/interview/debate" don't display anything.
