### PR TITLE
Fix typo in dvr.js causing javascript error on webui

### DIFF
--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -129,7 +129,6 @@ tvheadend.dvrDetails = function(entry) {
 
 			success : function(response, options) {
 				win.close();
-				v
 			},
 
 			failure : function(response, options) {


### PR DESCRIPTION
"v is not defined" bug.

suspect this type of a stray v is causing UI to stop updating on changes on latest.
