### PR TITLE
DVB: Allow duplicate TSIDs to be scanned.

### DIFF
--- a/src/dvb/dvb_tables.c
+++ b/src/dvb/dvb_tables.c
@@ -496,7 +496,7 @@ dvb_pat_callback(th_dvb_mux_instance_t *tdmi, uint8_t *ptr, int len,
   // That might indicate that we have accedentally received a PAT
   // from another mux
   LIST_FOREACH(other, &tda->tda_muxes, tdmi_adapter_link)
-    if(other != tdmi && 
+    if(other == tdmi && 
        other->tdmi_conf.dmc_satconf == tdmi->tdmi_conf.dmc_satconf &&
        other->tdmi_transport_stream_id == tsid &&
        other->tdmi_network_id == tdmi->tdmi_network_id)


### PR DESCRIPTION
Satellites in North America often have many muxes with the same TSID.
Stopping scanning of duplicate TSIDs means several satellite configs
have to be created to be able to scan all the muxes on a single satellite.
