### PR TITLE
whitelist TBS 6981 card for SNR monitoring

### DIFF
--- a/src/dvb/dvb_adapter.c
+++ b/src/dvb/dvb_adapter.c
@@ -59,6 +59,7 @@ static void tda_init(th_dvb_adapter_t *tda);
 static const char* dvb_adapter_snr_whitelist[] = {
   "Sony CXD2820R",
   "stv090x",
+  "TBS 6981",
   NULL
 };
 


### PR DESCRIPTION
as discussed, here is PR that whitelists TBS 6981card

all TBS 6981 users will have to enable "options tbsfe dbm=1". look in README_TBS6981 for how-to.

amet
