### PR TITLE
fix compile errors with gcc 4.1.x and 4.2.x

### DIFF
--- a/src/capmt.c
+++ b/src/capmt.c
@@ -75,7 +75,13 @@
 #define CW_DUMP(buf, len, format, ...) \
   printf(format, __VA_ARGS__); int j; for (j = 0; j < len; ++j) printf("%02X ", buf[j]); printf("\n");
 
+#ifdef __GNUC__
+#include <features.h>
+#if __GNUC_PREREQ(4, 3)
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+#endif
+
 #define MAX_CA  4
 #define MAX_INDEX 64
 #define KEY_SIZE  8

--- a/src/main.c
+++ b/src/main.c
@@ -388,14 +388,14 @@ main(int argc, char **argv)
     { 'u', "user",      "Run as user",             OPT_STR,  &opt_user    },
     { 'g', "group",     "Run as group",            OPT_STR,  &opt_group   },
     { 'p', "pid",       "Alternate pid path",      OPT_STR,  &opt_pidpath },
-    { 'C', "firstrun",  "If no useraccount exist then create one with\n"
+    { 'C', "firstrun",  "If no user account exists then create one with\n"
 	                      "no username and no password. Use with care as\n"
 	                      "it will allow world-wide administrative access\n"
 	                      "to your Tvheadend installation until you edit\n"
 	                      "the access-control from within the Tvheadend UI",
       OPT_BOOL, &opt_firstrun },
 #if ENABLE_LINUXDVB
-    { 'a', "adapters",  "Use only specified DVB adapters",
+    { 'a', "adapters",  "Only use specified DVB adapters (comma separated)",
       OPT_STR, &opt_dvb_adapters },
 #endif
     {   0, NULL,         "Server Connectivity",    OPT_BOOL, NULL         },
@@ -474,13 +474,16 @@ main(int argc, char **argv)
   if (!opt_dvb_adapters) {
     adapter_mask = ~0;
   } else {
-    char *p, *r, *e;
+    char *p, *e;
+    char *r = NULL;
+    char *dvb_adapters = strdup(opt_dvb_adapters);
     adapter_mask = 0x0;
-    p = strtok_r((char*)opt_dvb_adapters, ",", &r);
+    p = strtok_r(dvb_adapters, ",", &r);
     while (p) {
       int a = strtol(p, &e, 10);
       if (*e != 0 || a < 0 || a > 31) {
         tvhlog(LOG_ERR, "START", "Invalid adapter number '%s'", p);
+        free(dvb_adapters);
         return 1;
       }
       adapter_mask |= (1 << a);
@@ -488,8 +491,10 @@ main(int argc, char **argv)
     }
     if (!adapter_mask) {
       tvhlog(LOG_ERR, "START", "No adapters specified!");
+      free(dvb_adapters);
       return 1;
     }
+    free(dvb_adapters);
   }
 #endif
   if (tvheadend_webroot) {


### PR DESCRIPTION
- tested with gcc 4.1.2, 4.2.1, 4.4.6, 4.6.3 and 4.7.2
- disable gcc ignore pragma for `-Warray-bounds` if gcc version < 4.3
  - when I took out the pragma tvheadend compiled fine in all the above compilers, but I assume some version of gcc is issuing a false-positive.
  - "-Warray-bounds" was [added in gcc 4.3](http://gcc.gnu.org/gcc-4.3/changes.html): 
- In main.c, `*r` is initialized to null due to a "uninitialized variable" warning in gcc when strtok_r is inlined.  See [gcc bug 26634](http://gcc.gnu.org/bugzilla/show_bug.cgi?id=26634).
- fixes typo in cmdline help for -C
- clarify usage of -a in help description

Here's the stderr output from gcc4.2.1 prior to this fix:

```
cc1: warnings being treated as errors
/home/acm/dev/tvheadend/src/main.c: In function ‘main’:
/home/acm/dev/tvheadend/src/main.c:479: warning: passing argument 1 of ‘__strtok_r_1c’ discards qualifiers from pointer target type
make: *** [build.linux/src/main.o] Error 1
cc1: warnings being treated as errors
/home/acm/dev/tvheadend/src/capmt.c:78: warning: unknown option after ‘#pragma GCC diagnostic’ kind
make: *** [build.linux/src/capmt.o] Error 1
make: Target `all' not remade because of errors.
```
