### PR TITLE
Fix creation of new channel in "Channels" tab when renaming IPTV service.

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -940,6 +940,16 @@ service_set_enable(service_t *t, int enabled)
 }
 
 void
+service_set_name(service_t *t, const char* name)
+{
+  if( !strcmp(t->s_ch->ch_name, name) )
+    return;
+
+  t->s_ch->ch_name = strdup(name);
+  t->s_config_save(t);
+}
+
+void
 service_set_prefcapid(service_t *t, uint32_t prefcapid)
 {
   if(t->s_prefcapid == prefcapid)

--- a/src/service.h
+++ b/src/service.h
@@ -602,6 +602,8 @@ void service_set_dvb_charset(service_t *t, const char *dvb_charset);
 
 void service_set_dvb_eit_enable(service_t *t, int dvb_eit_enable);
 
+void service_set_name(service_t *t, const char* name);
+
 void service_set_prefcapid(service_t *t, uint32_t prefcapid);
 
 int service_is_primary_epg (service_t *t);

--- a/src/webui/extjs.c
+++ b/src/webui/extjs.c
@@ -1566,6 +1566,11 @@ service_update(htsmsg_t *in)
     {
       if( t->s_ch == NULL)
         service_map_channel(t, channel_find_by_name(chname, 1, 0), 1);
+      else
+      {
+        channel_rename(t->s_ch,chname);
+        service_set_name(t,chname);
+      }
     } 
 
     if(!htsmsg_get_u32(c, "prefcapid", &u32))


### PR DESCRIPTION
This fix allows renaming of IPTV service without creating a new channel in "Channels" tab.
