### PR TITLE
capmt: fix crash while trying to open iptv channel with capmt enabled

### DIFF
--- a/src/capmt.c
+++ b/src/capmt.c
@@ -1018,6 +1018,10 @@ capmt_service_start(service_t *t)
     if (!capmt->capmt_enabled)
       continue;
 
+
+    if (!(t->s_dvb_mux_instance && t->s_dvb_mux_instance->tdmi_adapter))
+      continue;
+
     tvhlog(LOG_INFO, "capmt",
       "Starting capmt server for service \"%s\" on tuner %d", 
       t->s_svcname,


### PR DESCRIPTION
there is a crash in capmt.c while trying to watch an non-encrypted iptv channel

traceback: http://pastebin.com/Ucay9wz7

in general, capmt should be used ONLY with real dvb adapters, not iptv (no matter if it's encrypted or not)

this is a quick and dirty fix.
