### PR TITLE
Fix clean title

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -66,6 +66,7 @@ extern struct dvr_entry_list dvrentries;
 #define DVR_CLEAN_TITLE	        0x100
 #define DVR_TAG_FILES           0x200
 #define DVR_SKIP_COMMERCIALS    0x400
+#define DVR_ONLY_ASCII          0x800
 
 typedef enum {
   DVR_PRIO_IMPORTANT,

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -170,7 +170,6 @@ dvr_make_title(char *output, size_t outlen, dvr_entry_t *de)
 {
   struct tm tm;
   char buf[40];
-  int i;
   dvr_config_t *cfg = dvr_config_find_by_name_default(de->de_config_name);
 
   if(cfg->dvr_flags & DVR_CHANNEL_IN_TITLE)
@@ -199,19 +198,6 @@ dvr_make_title(char *output, size_t outlen, dvr_entry_t *de)
                                 output + strlen(output),
                                 outlen - strlen(output),
                                 ".", "S%02d", NULL, "E%02d", NULL);
-  }
-
-  if(cfg->dvr_flags & DVR_CLEAN_TITLE) {
-        for (i=0;i<strlen(output);i++) {
-                if (
-                        output[i]<32 ||
-                        output[i]>122 ||
-                        output[i]==34 ||
-                        output[i]==39 ||
-                        output[i]==92 ||
-                        output[i]==58
-                        ) output[i]='_';
-        }
   }
 }
 
@@ -1026,6 +1012,9 @@ dvr_init(void)
       if(!htsmsg_get_u32(m, "clean-title", &u32) && u32)
         cfg->dvr_flags |= DVR_CLEAN_TITLE;
 
+      if(!htsmsg_get_u32(m, "only-ascii", &u32) && u32)
+        cfg->dvr_flags |= DVR_ONLY_ASCII;
+
       if(!htsmsg_get_u32(m, "tag-files", &u32) && !u32)
         cfg->dvr_flags &= ~DVR_TAG_FILES;
 
@@ -1130,7 +1119,7 @@ dvr_config_create(const char *name)
   cfg->dvr_config_name = strdup(name);
   cfg->dvr_retention_days = 31;
   cfg->dvr_mc = MC_MATROSKA;
-  cfg->dvr_flags = DVR_TAG_FILES | DVR_SKIP_COMMERCIALS;
+  cfg->dvr_flags = DVR_TAG_FILES | DVR_SKIP_COMMERCIALS | DVR_ONLY_ASCII;
 
   /* series link support */
   cfg->dvr_sl_brand_lock   = 1; // use brand linking
@@ -1194,6 +1183,7 @@ dvr_save(dvr_config_t *cfg)
   htsmsg_add_u32(m, "title-dir", !!(cfg->dvr_flags & DVR_DIR_PER_TITLE));
   htsmsg_add_u32(m, "episode-in-title", !!(cfg->dvr_flags & DVR_EPISODE_IN_TITLE));
   htsmsg_add_u32(m, "clean-title", !!(cfg->dvr_flags & DVR_CLEAN_TITLE));
+  htsmsg_add_u32(m, "only-ascii", !!(cfg->dvr_flags & DVR_ONLY_ASCII));
   htsmsg_add_u32(m, "tag-files", !!(cfg->dvr_flags & DVR_TAG_FILES));
   htsmsg_add_u32(m, "skip-commercials", !!(cfg->dvr_flags & DVR_SKIP_COMMERCIALS));
   if(cfg->dvr_postproc != NULL)

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -21,6 +21,7 @@
 #include <assert.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <ctype.h>
 #include <libgen.h> /* basename */
 
 #include "htsstr.h"
@@ -117,6 +118,15 @@ dvr_rec_unsubscribe(dvr_entry_t *de, int stopcode)
   de->de_last_error = stopcode;
 }
 
+static const char UNCLEAN_CHARS[] = ":\\<>|*?'\"";
+static inline int is_unclean(char c)
+{
+  if (c < 32) return 1;
+  if (122 < c && c <= 127) return 1;
+  if (strchr(UNCLEAN_CHARS, c) != NULL) return 1;
+  return 0;
+}
+
 
 /**
  * Replace various chars with a dash
@@ -134,9 +144,8 @@ cleanupfilename(char *s, int dvr_flags)
             (s[i] == ' ' || s[i] == '\t'))
       s[i] = '-';	
 
-    else if((dvr_flags & DVR_CLEAN_TITLE) &&
-            ((s[i] < 32) || (s[i] > 122) ||
-             (strchr("/:\\<>|*?'\"", s[i]) != NULL)))
+    else if(((dvr_flags & DVR_CLEAN_TITLE) && is_unclean(s[i])) ||
+            ((dvr_flags & DVR_ONLY_ASCII) && !isascii(s[i])))
       s[i] = '-';
   }
 }

--- a/src/webui/extjs.c
+++ b/src/webui/extjs.c
@@ -1259,6 +1259,7 @@ extjs_dvr(http_connection_t *hc, const char *remain, void *opaque)
     htsmsg_add_u32(r, "titleDirs", !!(cfg->dvr_flags & DVR_DIR_PER_TITLE));
     htsmsg_add_u32(r, "episodeInTitle", !!(cfg->dvr_flags & DVR_EPISODE_IN_TITLE));
     htsmsg_add_u32(r, "cleanTitle", !!(cfg->dvr_flags & DVR_CLEAN_TITLE));
+    htsmsg_add_u32(r, "onlyAscii", !!(cfg->dvr_flags & DVR_ONLY_ASCII));
     htsmsg_add_u32(r, "tagFiles", !!(cfg->dvr_flags & DVR_TAG_FILES));
     htsmsg_add_u32(r, "commSkip", !!(cfg->dvr_flags & DVR_SKIP_COMMERCIALS));
 
@@ -1299,6 +1300,8 @@ extjs_dvr(http_connection_t *hc, const char *remain, void *opaque)
       flags |= DVR_CHANNEL_IN_TITLE;
     if(http_arg_get(&hc->hc_req_args, "cleanTitle") != NULL)
       flags |= DVR_CLEAN_TITLE;
+    if(http_arg_get(&hc->hc_req_args, "onlyAscii") != NULL)
+      flags |= DVR_ONLY_ASCII;
     if(http_arg_get(&hc->hc_req_args, "dateInTitle") != NULL)
       flags |= DVR_DATE_IN_TITLE;
     if(http_arg_get(&hc->hc_req_args, "timeInTitle") != NULL)

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -729,7 +729,7 @@ tvheadend.dvrsettings = function() {
 	}, [ 'storage', 'postproc', 'retention', 'dayDirs', 'channelDirs',
 		'channelInTitle', 'container', 'dateInTitle', 'timeInTitle',
 		'preExtraTime', 'postExtraTime', 'whitespaceInTitle', 'titleDirs',
-		'episodeInTitle', 'cleanTitle', 'tagFiles', 'commSkip' ]);
+		'episodeInTitle', 'cleanTitle', 'onlyAscii', 'tagFiles', 'commSkip' ]);
 
 	var confcombo = new Ext.form.ComboBox({
 		store : tvheadend.configNames,
@@ -813,6 +813,9 @@ tvheadend.dvrsettings = function() {
 		}), new Ext.form.Checkbox({
 			fieldLabel : 'Remove all unsafe characters from filename',
 			name : 'cleanTitle'
+		}), new Ext.form.Checkbox({
+			fieldLabel : 'Only allow ASCII characters in filename',
+			name : 'onlyAscii'
 		}), new Ext.form.Checkbox({
 			fieldLabel : 'Replace whitespace in title with \'-\'',
 			name : 'whitespaceInTitle'


### PR DESCRIPTION
No longer treat any character >= 127 as illegal when clean title is set.
These may be relevant unicode characters in utf-8.
Also add <, > and ? as illegal characters.
