### PR TITLE
documentation updates

### DIFF
--- a/docs/html/config_access.html
+++ b/docs/html/config_access.html
@@ -6,7 +6,7 @@ wide open.
 <img src="docresources/accessconfig.png">
 
 <p>
-When Tvheadend verifies access is scan thru all the enabled access control entries.
+When Tvheadend verifies access is scan through all the enabled access control entries.
 The permission flags are combined for all matching access entries.
 An access entry is said to match if the username / password matches and the IP source
 address of the requesting peer is within the prefix.
@@ -42,7 +42,7 @@ The columns have the following functions:
   <dt>Username
   <dd>
   Name of user, if no username is needed for match it should contain a
-  single asterix (*).
+  single asterisk (*).
 
   <dt>Password
   <dd>

--- a/docs/html/config_channels.html
+++ b/docs/html/config_channels.html
@@ -3,7 +3,7 @@
  <img src="docresources/channeltab.png">
 
  <div>
- The channels are listed / edited  in a grid. 
+ The channels are listed / edited in a grid. 
 
  <ul>
   <li>To edit a cell, double-click on it. After a cell is changed it
@@ -37,7 +37,7 @@
       player.
 
   <dt>EPG Grab Source
-  <dd>Name of the Internet based EPG provider (typically XMLTV) channel
+  <dd>Name of the Internet-based EPG provider (typically XMLTV) channel
       that should be used to update this channels EPG info.
       By default Tvheadend tries to match the name itself, but sometimes
       it might not match correctly in which case you can do the mapping

--- a/docs/html/config_dvb.html
+++ b/docs/html/config_dvb.html
@@ -53,7 +53,7 @@
   This will attempt to close all available device handles. This can be 
   necessary to allow some devices to go into low power states.
   <br/>
-  However this option has been known to cause problems with some multi tuner
+  However, this option has been known to cause problems with some multi-tuner
   DVB cards. If you have signal problems, try disabling this option.
   <br/>
   Note: this option has no effect if idle scanning is enabled.
@@ -110,8 +110,8 @@
   <dt>Turn off LNB when idle
   <dd>
   This option can be enabled to disable the power to the LNB when the adapter
-  is not in use. This can reduce power consumption, however for poorly shieled
-  multi tuner setups you may some inteference when the LNB is re-enabled.
+  is not in use. This can reduce power consumption, however for poorly shielded
+  multi-tuner setups you may have some interference when the LNB is re-enabled.
 
  </dl>
 </dl>
@@ -143,25 +143,25 @@
       temporary broken
 
   <dt>Network
-  <dd>Network name as given in the DVB stream. Can not be changed
+  <dd>Network name as given in the DVB stream. Cannot be changed
 
   <dt>Frequency
-  <dd>Center frequency for the mux. Can not be changed
+  <dd>Center frequency for the mux. Cannot be changed
 
   <dt>Modulation
-  <dd>Information about the modulation used on the mux. Can not be changed
+  <dd>Information about the modulation used on the mux. Cannot be changed
     
   <dt>Polarisation
-  <dd>Information about the polarisation used on the mux. Can not be changed
+  <dd>Information about the polarisation used on the mux. Cannot be changed
 
   <dt>Satellite config (DVB-S only)
-  <dd>The satellite configuration in use on this mux. Can not be changed.
+  <dd>The satellite configuration in use on this mux. Cannot be changed.
 
   <dt>Frontend status
-  <dd>The status of the frontend signal last time the mux was tuned. Can not be changed
+  <dd>The status of the frontend signal last time the mux was tuned. Cannot be changed
   
   <dt>Mux id
-  <dd>Unique ID for this mux in the dvb network. Can not be changed
+  <dd>Unique ID for this mux in the dvb network. Cannot be changed
 
   <dt>Quality
   <dd>Tvheadend's estimated quality for the mux.
@@ -180,7 +180,7 @@
       'Save changes' button. In order to change a Checkbox cell you only
       have to click once in it.
 
-  <li>Service can not be deleted since they are directly inherited /
+  <li>Service cannot be deleted since they are directly inherited /
       discovered from a mux they will reappear in just a few seconds
       should one delete them.
  </ul>
@@ -194,7 +194,7 @@
       temporary broken
 
   <dt>Service name
-  <dd>Service name as given in the DVB stream. Can not be changed
+  <dd>Service name as given in the DVB stream. Cannot be changed
 
   <dt>Play
   <dd>Open the VLC plugin window to play this service.
@@ -210,13 +210,13 @@
   charset to use when none is specified by the broadcaster.
 
   <dt>EPG
-  <dd>Uncheck this if EPG data should not be retreived for this service.
+  <dd>Uncheck this if EPG data should not be retrieved for this service.
 
   <dt>Type
-  <dd>Type of service. Can not be changed
+  <dd>Type of service. Cannot be changed
 
   <dt>Provider
-  <dd>Provider as given in the DVB stream. Can not be changed
+  <dd>Provider as given in the DVB stream. Cannot be changed
 
   <dt>Network
   <dd>Network name for the mux this service resides on
@@ -259,7 +259,7 @@
   <dd>Port number to select for this configuration (numbering begins at 0).
   <dd>In DiSEqC 1.0/2.0 mode, ports 0-3 are valid.
   <dd>In DiSEqC 1.1/2.1 mode, ports 0-63 are valid.
-  <dd>Use numbers 0-3 for LNBs behind first input on the uncommited switch,
+  <dd>Use numbers 0-3 for LNBs behind first input on the uncommitted switch,
       then 4-7 and so on to support up to 64 ports using DiSEqC 1.1/2.1.
   
   <dt>LNB type

--- a/docs/html/config_epggrab.html
+++ b/docs/html/config_epggrab.html
@@ -1,28 +1,51 @@
 <div class="hts-doc-text">
 
  <p>
- This tab is used to configure EPG grabbing capabilities. TVheadend supports
- a variety of different EPG grabbing mechanisms. These fall into 3 broad
- categories, within which there are a variety of specific grabber 
- implementations.
+ This tab is used to configure the Electronic Program Guide (EPG) grabbing
+ capabilities. Tvheadend supports a variety of different EPG grabbing
+ mechanisms. These fall into 3 broad categories, within which there are a
+ variety of specific grabber implementations.
  </p>
 
  <h2>Grabber Types</h2>
  <ul>
-  <li>Over-the-Air (OTA) - These grabbers receive EPG data directly from the DVB network. This is often the easiest way to get up and running and does provide timely updates should scheduling change. However the information isn't always as rich as some of the other grabbers.
-  <li>Internal - These are grabbers which can be internally initiated from within TVheadend using a very simple scheduler. These are typically Internet based services. This can be a quick way to get richer EPG data where you don't have decent OTA support.
-  <li>External - These provide the option to run grabber scripts externally and to send data into TVheadend via Unix domain sockets. It provides the ability to run more complex configurations using things like cronjob's, script chains, etc.
+  <li>Over-the-Air (OTA) - These grabbers receive EPG data directly from the
+  DVB network. This is often the easiest way to get up and running and does
+  provide timely updates should scheduling change. However, the information
+  isn't always as rich as some of the other grabbers.
+  <li>Internal - These are grabbers which can be internally initiated from
+  within Tvheadend using a very simple scheduler. These are typically
+  Internet-based services. This can be a quick way to get richer EPG data
+  where you don't have decent OTA support.
+  <li>External - These provide the option to run grabber scripts externally and
+  to send data into Tvheadend via Unix domain sockets. It provides the ability
+  to run more complex configurations using things like cronjob's, script
+  chains, etc.
  </ul>
 
  <h2>Grabber Modules</h2>
  <ul>
-  <li>EIT    - This is a DVB standards compatible EIT grabber. Typically it will
-  retrieve now/next information, though on some networks there may be more
+  <li>EIT    - This is a DVB standards compatible EIT grabber. Typically it
+  will retrieve now/next information, though on some networks there may be more
   extensive data published.
-  <li>Freesat/view - This is an extended version of EIT that is used by the Free-to-air DVB providers in the UK. It includes additional information such as series links and episode identifiers.
-  <li>OpenTV - This is a proprietary OTA EPG grabber. Its known to be used on the SKY networks, but others may use it. You need two configuration files to define settings for your particular network, if you don't see yours listed please visit IRC #hts for help.
-  <li>XMLTV  - This is am Internet based suite of scripts, for more information about XMLTV please visit <a href="http://www.xmltv.org">http://www.xmltv.org</a>. To make use of the internal XMLTV grabber you typically require the xmltv-utils package to be installed. If you install new grabbers you will need to restart TVheadend to pick these up as they're loaded at startup. If you see no XMLTV grabbers listed then most probably XMLTV is not properly installed and in the PATH.
-  <li>PyEPG  - This is another Internet based scraper. It currently only supports the Atlas UK system (for which you need a key), but it does provide a very rich EPG data set. For more information see <a href='http://github.com/adamsutton/PyEPG'>http://github.com/adamsutton/PyEPG</a>.</li>
+  <li>Freesat/view - This is an extended version of EIT that is used by the
+  Free-to-air DVB providers in the UK. It includes additional information such
+  as series links and episode identifiers.
+  <li>OpenTV - This is a proprietary OTA EPG grabber. It's known to be used on
+  the SKY networks, but others may use it. You need two configuration files to
+  define settings for your particular network, if you don't see yours listed
+  please visit IRC #hts for help.
+  <li>XMLTV  - This is am Internet-based suite of scripts, for more information
+  about XMLTV please visit <a href="http://www.xmltv.org">http://www.xmltv.org</a>.
+  To make use of the internal XMLTV grabber you typically require the xmltv-utils
+  package to be installed. If you install new grabbers you will need to
+  restart Tvheadend to pick these up as they're loaded at startup. If you see
+  no XMLTV grabbers listed then most probably XMLTV is not properly installed
+  and in the PATH.
+  <li>PyEPG  - This is another Internet-based scraper. It currently only
+  supports the Atlas UK system (for which you need a key), but it does provide
+  a very rich EPG data set. For more information see
+  <a href='http://github.com/adamsutton/PyEPG'>http://github.com/adamsutton/PyEPG</a>.</li>
  </ul>
 
  <h2>Configuration options</h2>
@@ -46,7 +69,7 @@
   <dd>Select which internal grabber to use.
 
   <dt>Grab interval
-  <dd>Time period between grabs. Value and unit are indepdently set.
+  <dd>Time period between grabs. Value and unit are independently set.
  </dl>
  
  <h3>Over-the-air Grabbers</h3>

--- a/docs/html/config_timeshift.html
+++ b/docs/html/config_timeshift.html
@@ -14,7 +14,7 @@
       you cannot rewind the buffer (it always begins on the currently playing
       frame).
 
-      Without this option there will be a permanent, cicular, buffer upto
+      Without this option there will be a permanent, circular, buffer up to
       the limits defined below.
 
   <dt>Storage Path:

--- a/docs/html/epg.html
+++ b/docs/html/epg.html
@@ -62,7 +62,7 @@ sorted based on start time.
  [Record series] button that will record all entries in the series.
  <p>
  For events without any series link information, a [Autorec] button will be
- provided to create a pseudo series link using hte Autorec feature.
+ provided to create a pseudo series link using the Autorec feature.
  <p>
  <img src="docresources/epg2.png">
  <p>

--- a/docs/html/features.html
+++ b/docs/html/features.html
@@ -16,7 +16,7 @@
    <dt>Multicasted IPTV.
    <dd>
    Both raw transport streams in UDP and transport stream in RTP in UDP 
-   is supported. The precense of RTP is autodetected.
+   is supported. The presence of RTP is autodetected.
    </dd>
    <dt>Analog TV
    <dd>

--- a/docs/html/install.html
+++ b/docs/html/install.html
@@ -38,7 +38,7 @@ Parts of this documentation is also available in the Tvheadend man page.
  access to all features / settings</b> in the web user interface. If
  this is the first time you setup Tvheadend you are most encouraged to
  enter the web user interface, selected the 'Configuration' + 'Access Control'
- tab and make reasonable changes. Futher help / documentation can be obtained
+ tab and make reasonable changes. Further help / documentation can be obtained
  inside the web interface.
 
  <dt>Settings storage
@@ -47,7 +47,7 @@ Parts of this documentation is also available in the Tvheadend man page.
 
  <dt>Logging
  <dd>
- All activity inside tvheadend is logged to syslog using log facility.
+ All activity inside Tvheadend is logged to syslog using log facility.
  Also, if logged in to the web interface you will receive the same log in the bottom
  tab (System log).
 

--- a/docs/html/overview.html
+++ b/docs/html/overview.html
@@ -4,7 +4,7 @@
 
 <center>
 <h1>HTS Tvheadend 3.2</h1>
-&copy; 2006 - 2012, Andreas Öman, et al.<br><br>
+&copy; 2006 - 2013, Andreas Öman, et al.<br><br>
 <img style="padding: 0px" src="docresources/tvheadendlogo.png">
 </center>
 

--- a/docs/html/sysreq.html
+++ b/docs/html/sysreq.html
@@ -1,16 +1,17 @@
 <div class="hts-doc-text">
 <p>
-If you want to build tvheadend from source, please visit 
-<a href="http://trac.lonelycoder.com/hts/wiki/howtobuildhts">this</a> page.
-Please notice that wiki development site only reflects the work
+If you want to build Tvheadend from source, please visit
+<a href="https://www.lonelycoder.com/redmine/projects/tvheadend/wiki/Building">this</a> page.
+Please note: that wiki development site only reflects the work
 in HEAD (-current). It should not deviate much should you want to
 build a released version from source, but you never know.
 <p>
 
-Tvheadend is part of the <b>HTS</b> project hosted at
-<a href="http://hts.lonelycoder.com/">http://hts.lonelycoder.com/</a>.
+Tvheadend is part of the <b>HTS</b> project and is hosted at
+<a
+href="https://www.lonelycoder.com/redmine/projects/tvheadend">https://www.lonelycoder.com/redmine/projects/tvheadend</a>.
 
 <p>
-It functions primarily as a TV backend for the Showtime Media player but
+It functions primarily as a TV backend for the Showtime Media player, but
 can be used standalone for other purposes.
 </div>


### PR DESCRIPTION
breakout documentation updates from PR #252.  Added a few additional clean-ups.

scope of changes:
- fix typos/misspellings in documentation
- fix broken link on how to build Tvheadend
- standardize on most commonly used capitalization of "Tvheadend"
- update copyright year to 2013
- break up the handful of run-on lines
