### PR TITLE
Add command for explicitly renaming files for finished recordings.

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -260,6 +260,8 @@ void dvr_entry_notify(dvr_entry_t *de);
 
 void dvr_entry_save(dvr_entry_t *de);
 
+htsmsg_t *dvr_entry_rename_file(dvr_entry_t *de, const char *filename);
+
 const char *dvr_entry_status(dvr_entry_t *de);
 
 const char *dvr_entry_schedstatus(dvr_entry_t *de);

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -18,6 +18,7 @@
 
 #include <pthread.h>
 #include <sys/stat.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <assert.h>
 #include <string.h>
@@ -647,6 +648,63 @@ dvr_entry_save(dvr_entry_t *de)
   htsmsg_destroy(m);
 }
 
+htsmsg_t *dvr_entry_rename_file(dvr_entry_t *de, const char *filename)
+{
+  htsmsg_t *res = htsmsg_create_map();
+  if (de->de_filename == NULL) {
+    htsmsg_add_u32(res, "status", 1);
+    htsmsg_add_str(res, "message", "no filename defined for recording");
+    return res;
+  }
+
+  if (!strcmp(de->de_filename, filename)) {
+    htsmsg_add_u32(res, "status", 0);
+    htsmsg_add_str(res, "message", "nothing to do - filename already set to this");
+    return res;
+  }
+
+  dvr_config_t *cfg = dvr_config_find_by_name_default(de->de_config_name);
+  if (cfg == NULL || cfg->dvr_storage == NULL) {
+    htsmsg_add_u32(res, "status", 1);
+    htsmsg_add_str(res, "message", "no storage path defined");
+    return res;
+  }
+
+  if (strncmp(filename, cfg->dvr_storage, strlen(cfg->dvr_storage))) {
+    htsmsg_add_u32(res, "status", 2);
+    htsmsg_add_str(res, "message", "may not link outside of storage path");
+    htsmsg_add_str(res, "filename", filename);
+    htsmsg_add_str(res, "storage", cfg->dvr_storage);
+    return res;
+  }
+
+  if (strstr(filename, "/../")) {
+    htsmsg_add_u32(res, "status", 3);
+    htsmsg_add_str(res, "message", "may not use relative paths");
+    return res;
+  }
+
+  int fd = open(filename, O_RDONLY);
+  if (fd < 0) {
+    htsmsg_add_u32(res, "status", 4);
+    htsmsg_add_str(res, "message", "file not found");
+    return res;
+  }
+  close(fd);
+
+  tvhlog(LOG_INFO, "dvr", "renamed entry %d from \"%s\" to \"%s\"",
+         de->de_id, de->de_filename, filename);
+
+  free(de->de_filename);
+  de->de_filename = strdup(filename);
+
+  dvr_entry_save(de);
+  htsp_dvr_entry_update(de);
+  dvr_entry_notify(de);
+
+  htsmsg_add_u32(res, "status", 0);
+  return res;
+}
 
 /**
  *

--- a/src/webui/extjs.c
+++ b/src/webui/extjs.c
@@ -1218,6 +1218,22 @@ extjs_dvr(http_connection_t *hc, const char *remain, void *opaque)
     out = htsmsg_create_map();
     htsmsg_add_u32(out, "success", 1);
 
+  } else if(!strcmp(op, "entryFile")) {
+    s = http_arg_get(&hc->hc_req_args, "entryId");
+
+    if(s == NULL || (de = dvr_entry_find_by_id(atoi(s))) == NULL) {
+      pthread_mutex_unlock(&global_lock);
+      return HTTP_STATUS_BAD_REQUEST;
+    }
+
+    s = http_arg_get(&hc->hc_req_args, "filename");
+    if (s == NULL) {
+      pthread_mutex_unlock(&global_lock);
+      return HTTP_STATUS_BAD_REQUEST;
+    }
+
+    out = dvr_entry_rename_file(de, s);
+
   } else if(!strcmp(op, "createAutoRec")) {
     epg_genre_t genre, *eg = NULL;
     if ((s = http_arg_get(&hc->hc_req_args, "contenttype"))) {


### PR DESCRIPTION
This is useful for post process scripts that wants to transcode
recordings and thus changes file endings.

Example usage:
$ curl 'localhost:9981/dvr?op=entryFile&entryId=1&filename=foo.mkv'
