### PR TITLE
[PATCH] Detect usage of dvb-scan data automatically

### DIFF
--- a/configure
+++ b/configure
@@ -19,7 +19,7 @@ OPTIONS=(
   "cwc:yes"
   "v4l:yes"
   "linuxdvb:yes"
-  "dvbscan:yes"
+  "dvbscan:auto"
   "timeshift:yes"
   "imagecache:auto"
   "avahi:auto"
@@ -178,12 +178,22 @@ fi
 #
 # DVB scan
 #
-if enabled linuxdvb && enabled dvbscan; then
-  printf "${TAB}" "fetching dvb-scan files ..."
-  "${ROOTDIR}/support/getmuxlist"
-  if [ $? -ne 0 ]; then
-    echo "fail"
-    die "Failed to fetch dvb-scan data (use --disable-dvbscan)"
+if enabled linuxdvb && enabled_or_auto dvbscan; then
+  if [ ! -d /usr/share/dvb/ ]; then
+    if [ ! -d ${ROOTDIR}/data/dvb-scan ]; then
+      printf "${TAB}" "Fetching dvb-scan files... "
+      "${ROOTDIR}/support/getmuxlist"
+      if [ $? -ne 0 ]; then
+        echo "fail"
+        die "Failed to fetch dvb-scan data (use --disable-dvbscan)"
+      fi
+      enable dvbscan
+      echo "done"
+    fi
+  else
+    echo -n "Found '/usr/share/dvb/' using '/usr/share/dvb/ "
+    disable dvbscan
+    echo "done"
   fi
   echo "ok"
 fi


### PR DESCRIPTION
If /usr/share/dvb exists allready (from a dependancy or other package)
it is not needed to fetch the git tree, since it should be identical.

This should accompany https://github.com/tvheadend/tvheadend/commit/7a52ff434c8287d0f1a68d709cb41d0c4678c737#support/getmuxlist

We have talked about this in https://github.com/tvheadend/tvheadend/pull/168

So (maybe in a different form?) this should be used now. the dtv tables should be under active maintenance now (I am official maintainer of that specific git repo).
