### PR TITLE
Fix capmt for multi-frontend adapters

### DIFF
--- a/src/capmt.c
+++ b/src/capmt.c
@@ -620,6 +620,8 @@ capmt_thread(void *aux)
 #if ENABLE_LINUXDVB
         th_dvb_adapter_t *tda;
         TAILQ_FOREACH(tda, &dvb_adapters, tda_global_link) {
+          if (!tda->tda_enabled)
+            continue;
           if (tda->tda_rootpath) {          //if rootpath is NULL then can't rely on tda_adapter_num because it is always 0
             if (tda->tda_adapter_num > MAX_CA) {
               tvhlog(LOG_ERR, "capmt", "adapter number > MAX_CA");


### PR DESCRIPTION
With multi-frontend-adapters, tvheadend tries to open multiple udp sockets on the same port(one for each frontend on the same adapter, as the port number is 9000 + adapter_num), making it impossible to use capmt with such adapters.

This simple patch fixes it by checking if the "adapter" is enabled before opening any UDP sockets for it.
