### PR TITLE
Fixes the 'llabs' implicit declaration warning when using old gcc versions

### DIFF
--- a/src/tvhtime.c
+++ b/src/tvhtime.c
@@ -1,3 +1,5 @@
+#define _ISOC9X_SOURCE
+
 #include <time.h>
 #include <sys/ipc.h>
 #include <sys/shm.h>


### PR DESCRIPTION
This behaviour is described on the Bug #1634 (although the bug ticket is not related to it).
