### PR TITLE
Character Encoding Additions

### DIFF
--- a/data/conf/charset
+++ b/data/conf/charset
@@ -105,6 +105,20 @@
 		"description": "Astra 19.2E TVP"
 	},
 	{
+		"tsid": 3218,
+		"onid": 3,
+		"charset": "ISO8859-5",
+		"sid": 0,
+		"description": "Astra 23.5E Satellite BG 12051.00 V"
+	},
+	{
+		"tsid": 3226,
+		"onid": 3,
+		"charset": "ISO8859-5",
+		"sid": 0,
+		"description": "Astra 23.5E Satellite BG 12207.00 V"
+	},
+	{
 		"tsid": 8100,
 		"onid": 156,
 		"charset": "PL_AUTO",


### PR DESCRIPTION
I have updated several channels based on the overrides from hardware boxes. I included only the once that appeared in all lists are should not create problems among different sat platform. 

From the stuff I didn't  include so far and would need to do a bit more digging as of what encoding needs to be specified and if it is needed at all are those lists also include number of entries like 
0x02BF  0x0600      #   11804.00    V   UPC DIRECT
but hence they do not specify the encoding I wait for an answer in few forums what listing them in the file with no set encoding is done for. Probably assumes ISO8859-1 but would have to know for sure first.

There are also entries like 
0x0001/0x0440       ISO8859-1   # Astra/12168 canalsat
which go through out Digital+, CanalSat, MTV Networks on the Astra 19.2E, but some checking is required first are they still required. If so I would think using http://en.wikipedia.org/wiki/ISO/IEC_8859-15 as an override would be more appropriate anyways as it includes € sing and few others more likely used than those from ISO8859-1
