### PR TITLE
Add Autobuild templates for ARM Hard Float platform

### DIFF
--- a/Autobuild/lucid-armhf.sh
+++ b/Autobuild/lucid-armhf.sh
@@ -1,0 +1,3 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --arch=armhf"
+DEBDIST=lucid
+source Autobuild/debian.sh

--- a/Autobuild/precise-armhf.sh
+++ b/Autobuild/precise-armhf.sh
@@ -1,0 +1,3 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --arch=armhf"
+DEBDIST=precise
+source Autobuild/debian.sh


### PR DESCRIPTION
Hi,

I started to use your project on a BeagleBone Black, it compiles perfectly. So I think it could be nice to add Autobuild templates for ARM Hard Float (especially there are more and more people using RasperryPi and BeagleBone to run TV Headend :) ).

Tested it on Ubuntu 13.04.

Have a good day!
