### PR TITLE
Subtitle in filename

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -67,6 +67,7 @@ extern struct dvr_entry_list dvrentries;
 #define DVR_TAG_FILES           0x200
 #define DVR_SKIP_COMMERCIALS    0x400
 #define DVR_SUBTITLE_IN_TITLE	0x800
+#define DVR_EPISODE_BEFORE_DATE	0x1000
 
 typedef enum {
   DVR_PRIO_IMPORTANT,

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -181,6 +181,22 @@ dvr_make_title(char *output, size_t outlen, dvr_entry_t *de)
   snprintf(output + strlen(output), outlen - strlen(output),
 	   "%s", lang_str_get(de->de_title, NULL));
 
+  if(cfg->dvr_flags & DVR_EPISODE_BEFORE_DATE) {
+	  if(cfg->dvr_flags & DVR_EPISODE_IN_TITLE) {
+		if(de->de_bcast && de->de_bcast->episode)  
+		  epg_episode_number_format(de->de_bcast->episode,
+									output + strlen(output),
+									outlen - strlen(output),
+									".", "S%02d", NULL, "E%02d", NULL);
+	  }
+  }
+
+  if(cfg->dvr_flags & DVR_SUBTITLE_IN_TITLE) {
+    if(de->de_bcast && de->de_bcast->episode && de->de_bcast->episode->subtitle)  
+	  snprintf(output + strlen(output), outlen - strlen(output),
+		   ".%s", lang_str_get(de->de_bcast->episode->subtitle, NULL));
+  }
+
   localtime_r(&de->de_start, &tm);
   
   if(cfg->dvr_flags & DVR_DATE_IN_TITLE) {
@@ -193,18 +209,22 @@ dvr_make_title(char *output, size_t outlen, dvr_entry_t *de)
     snprintf(output + strlen(output), outlen - strlen(output), ".%s", buf);
   }
 
-  if(cfg->dvr_flags & DVR_SUBTITLE_IN_TITLE) {
-    if(de->de_bcast && de->de_bcast->episode && de->de_bcast->episode->subtitle)  
-	  snprintf(output + strlen(output), outlen - strlen(output),
-		   "-%s", lang_str_get(de->de_bcast->episode->subtitle, NULL));
-  }
-
   if(cfg->dvr_flags & DVR_EPISODE_IN_TITLE) {
     if(de->de_bcast && de->de_bcast->episode)  
       epg_episode_number_format(de->de_bcast->episode,
                                 output + strlen(output),
                                 outlen - strlen(output),
                                 ".", "S%02d", NULL, "E%02d", NULL);
+  }
+
+  if(!(cfg->dvr_flags & DVR_EPISODE_BEFORE_DATE)) {
+	  if(cfg->dvr_flags & DVR_EPISODE_IN_TITLE) {
+		if(de->de_bcast && de->de_bcast->episode)  
+		  epg_episode_number_format(de->de_bcast->episode,
+									output + strlen(output),
+									outlen - strlen(output),
+									".", "S%02d", NULL, "E%02d", NULL);
+	  }
   }
 
   if(cfg->dvr_flags & DVR_CLEAN_TITLE) {
@@ -1038,7 +1058,13 @@ dvr_init(void)
       if(!htsmsg_get_u32(m, "skip-commercials", &u32) && !u32)
         cfg->dvr_flags &= ~DVR_SKIP_COMMERCIALS;
 
-      tvh_str_set(&cfg->dvr_postproc, htsmsg_get_str(m, "postproc"));
+      if(!htsmsg_get_u32(m, "subtitle-in-title", &u32) && u32)
+        cfg->dvr_flags |= DVR_SUBTITLE_IN_TITLE;
+
+      if(!htsmsg_get_u32(m, "episode-before-date", &u32) && u32)
+        cfg->dvr_flags |= DVR_EPISODE_BEFORE_DATE;
+
+		tvh_str_set(&cfg->dvr_postproc, htsmsg_get_str(m, "postproc"));
     }
 
     htsmsg_destroy(l);
@@ -1202,6 +1228,8 @@ dvr_save(dvr_config_t *cfg)
   htsmsg_add_u32(m, "clean-title", !!(cfg->dvr_flags & DVR_CLEAN_TITLE));
   htsmsg_add_u32(m, "tag-files", !!(cfg->dvr_flags & DVR_TAG_FILES));
   htsmsg_add_u32(m, "skip-commercials", !!(cfg->dvr_flags & DVR_SKIP_COMMERCIALS));
+  htsmsg_add_u32(m, "subtitle-in-title", !!(cfg->dvr_flags & DVR_SUBTITLE_IN_TITLE));
+  htsmsg_add_u32(m, "episode-before-date", !!(cfg->dvr_flags & DVR_EPISODE_BEFORE_DATE));
   if(cfg->dvr_postproc != NULL)
     htsmsg_add_str(m, "postproc", cfg->dvr_postproc);
 

--- a/src/webui/extjs.c
+++ b/src/webui/extjs.c
@@ -1260,6 +1260,7 @@ extjs_dvr(http_connection_t *hc, const char *remain, void *opaque)
     htsmsg_add_u32(r, "tagFiles", !!(cfg->dvr_flags & DVR_TAG_FILES));
     htsmsg_add_u32(r, "commSkip", !!(cfg->dvr_flags & DVR_SKIP_COMMERCIALS));
     htsmsg_add_u32(r, "subtitleInTitle", !!(cfg->dvr_flags & DVR_SUBTITLE_IN_TITLE));
+    htsmsg_add_u32(r, "episodeBeforeDate", !!(cfg->dvr_flags & DVR_EPISODE_BEFORE_DATE));
 
     out = json_single_record(r, "dvrSettings");
 
@@ -1314,6 +1315,8 @@ extjs_dvr(http_connection_t *hc, const char *remain, void *opaque)
       flags |= DVR_SKIP_COMMERCIALS;
     if(http_arg_get(&hc->hc_req_args, "subtitleInTitle") != NULL)
       flags |= DVR_SUBTITLE_IN_TITLE;
+    if(http_arg_get(&hc->hc_req_args, "episodeBeforeDate") != NULL)
+      flags |= DVR_EPISODE_BEFORE_DATE;
 
 
     dvr_flags_set(cfg,flags);

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -729,7 +729,7 @@ tvheadend.dvrsettings = function() {
 	}, [ 'storage', 'postproc', 'retention', 'dayDirs', 'channelDirs',
 		'channelInTitle', 'container', 'dateInTitle', 'timeInTitle',
 		'preExtraTime', 'postExtraTime', 'whitespaceInTitle', 'titleDirs',
-		'episodeInTitle', 'cleanTitle', 'tagFiles', 'commSkip' 'subtitleInTitle']);
+		'episodeInTitle', 'cleanTitle', 'tagFiles', 'commSkip', 'subtitleInTitle', 'episodeBeforeDate']);
 
 	var confcombo = new Ext.form.ComboBox({
 		store : tvheadend.configNames,
@@ -825,6 +825,9 @@ tvheadend.dvrsettings = function() {
 		}), new Ext.form.Checkbox({
 			fieldLabel : 'Include subtitle in filename',
 			name : 'subtitleInTitle'
+		}), new Ext.form.Checkbox({
+			fieldLabel : 'Put episode in filename before date and time',
+			name : 'episodeBeforeDate'
 		}), {
 			width : 300,
 			fieldLabel : 'Post-processor command',


### PR DESCRIPTION
Hello,
I've add option to include subtitle (from EPG) in filename of recording.
Also I think, that sometimes it's better when episode number is before date and time in filename, so I've also added option for this.
My changes are based on 3.4 release (last stable), because I use it on my "production" htpc. If needed I can port it to another branch (master?).
