### PR TITLE
Preprocessor command to generate filename

### DIFF
--- a/docs/html/config_dvr.html
+++ b/docs/html/config_dvr.html
@@ -84,19 +84,25 @@
       or an error occurred. Use the %e error formatting string to check
       for errors, the error string is empty if recording finished
       successfully.
-      <br><br>
-      Support format strings:<br>
+
+  <dt>External filename program
+  <dd>Command run to generate a filename. The command is executed before starting
+      recording. The command should write to standard output. Trailing new line
+      marker is ignored but no other safety checks are made unless removing of
+      unsafe characters is enabled.
+
+  <dt>Post-processor and external filename program format strings
       <table class="hts-doc-text" border="0">
-        <tr><th>Format</th><th>Description</th><th>Example value</th></tr>
-        <tr><td>%f</td><td>Full path to recording</td><td>/home/user/Videos/News.mkv</td></tr>
-        <tr><td>%b</td><td>Basename of recording</td><td>News.mkv</td></tr>
-        <tr><td>%c</td><td>Channel name</td><td>BBC world</td></tr>
-        <tr><td>%C</td><td>Who created this recording</td><td>user</td></tr>
-        <tr><td>%t</td><td>Program title</td><td>News</td></tr>
-        <tr><td>%d</td><td>Program description</td><td>News and stories...</td></tr>
-        <tr><td>%e</td><td>Error message</td><td>Aborted by user</td></tr>
-        <tr><td>%S</td><td>Start time stamp of recording, UNIX epoch</td><td>1224421200</td></tr>
-        <tr><td>%E</td><td>Stop time stamp of recording, UNIX epoch</td><td>1224426600</td></tr>
+        <tr><th>Format</th><th>Description</th><th>Example value</th><th>Notice</th></tr>
+        <tr><td>%f</td><td>Full path to recording</td><td>/home/user/Videos/News.mkv</td><td>Post-processor only</td></tr>
+        <tr><td>%b</td><td>Basename of recording</td><td>News.mkv</td><td>Post-processor only</td></tr>
+        <tr><td>%c</td><td>Channel name</td><td>BBC world</td><td></td></tr>
+        <tr><td>%C</td><td>Who created this recording</td><td>user</td><td></td></tr>
+        <tr><td>%t</td><td>Program title</td><td>News</td><td></td></tr>
+        <tr><td>%d</td><td>Program description</td><td>News and stories...</td><td></td></tr>
+        <tr><td>%e</td><td>Error message</td><td>Aborted by user</td><td>Useful only for post-processor</td></tr>
+        <tr><td>%S</td><td>Start time stamp of recording, UNIX epoch</td><td>1224421200</td><td></td></tr>
+        <tr><td>%E</td><td>Stop time stamp of recording, UNIX epoch</td><td>1224426600</td><td></td></tr>
       </table>
       <br>
       Example usage: /path/to/ffmpeg -i %f -vcodec libx264 -acodec copy "/path/with white space/%b"<br>

--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -48,12 +48,18 @@ typedef struct dvr_config {
   /* Duplicate detect */
   int dvr_dup_detect_episode;
 
+  int dvr_filename_mode;
+  char *dvr_filename_external;
+
   LIST_ENTRY(dvr_config) config_link;
 } dvr_config_t;
 
 extern struct dvr_config_list dvrconfigs;
 
 extern struct dvr_entry_list dvrentries;
+
+#define DVR_FILENAMEMODE_BASIC		1
+#define DVR_FILENAMEMODE_EXTERNAL	2
 
 #define DVR_DIR_PER_DAY		0x1
 #define DVR_DIR_PER_CHANNEL	0x2
@@ -334,6 +340,10 @@ void dvr_flags_set(dvr_config_t *cfg, int flags);
 void dvr_extra_time_pre_set(dvr_config_t *cfg, int d);
 
 void dvr_extra_time_post_set(dvr_config_t *cfg, int d);
+
+void dvr_filename_mode_set(dvr_config_t *cfg, int mode);
+
+void dvr_filename_external_set(dvr_config_t *cfg, const char *external);
 
 void dvr_entry_delete(dvr_entry_t *de);
 

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1088,6 +1088,9 @@ dvr_init(void)
       htsmsg_get_u32(m, "retention-days", &cfg->dvr_retention_days);
       tvh_str_set(&cfg->dvr_storage, htsmsg_get_str(m, "storage"));
 
+      htsmsg_get_s32(m, "filename_mode", &cfg->dvr_filename_mode);
+      tvh_str_set(&cfg->dvr_filename_external, htsmsg_get_str(m, "filename_external"));
+
       if(!htsmsg_get_u32(m, "day-dir", &u32) && u32)
         cfg->dvr_flags |= DVR_DIR_PER_DAY;
 
@@ -1232,6 +1235,9 @@ dvr_config_create(const char *name)
   /* dup detect */
   cfg->dvr_dup_detect_episode = 1; // detect dup episodes
 
+  cfg->dvr_filename_mode = DVR_FILENAMEMODE_BASIC;
+  cfg->dvr_filename_external = NULL;
+
   LIST_INSERT_HEAD(&dvrconfigs, cfg, config_link);
 
   return LIST_FIRST(&dvrconfigs);
@@ -1274,6 +1280,9 @@ dvr_save(dvr_config_t *cfg)
   htsmsg_add_u32(m, "retention-days", cfg->dvr_retention_days);
   htsmsg_add_u32(m, "pre-extra-time", cfg->dvr_extra_time_pre);
   htsmsg_add_u32(m, "post-extra-time", cfg->dvr_extra_time_post);
+  htsmsg_add_u32(m, "filename_mode", cfg->dvr_filename_mode);
+  if(cfg->dvr_filename_external != NULL)
+    htsmsg_add_str(m, "filename_external", cfg->dvr_filename_external);
   htsmsg_add_u32(m, "day-dir",          !!(cfg->dvr_flags & DVR_DIR_PER_DAY));
   htsmsg_add_u32(m, "channel-dir",      !!(cfg->dvr_flags & DVR_DIR_PER_CHANNEL));
   htsmsg_add_u32(m, "channel-in-title", !!(cfg->dvr_flags & DVR_CHANNEL_IN_TITLE));
@@ -1402,6 +1411,34 @@ dvr_extra_time_post_set(dvr_config_t *cfg, int d)
     return;
 
   cfg->dvr_extra_time_post = d;
+  dvr_save(cfg);
+}
+
+
+/**
+ *
+ */
+void
+dvr_filename_mode_set(dvr_config_t *cfg, int mode)
+{
+  if(cfg->dvr_filename_mode == mode)
+    return;
+
+  cfg->dvr_filename_mode = mode;
+  dvr_save(cfg);
+}
+
+
+/**
+ *
+ */
+void
+dvr_filename_external_set(dvr_config_t *cfg, const char *external)
+{
+  if(cfg->dvr_filename_external != NULL && !strcmp(cfg->dvr_filename_external, external))
+    return;
+
+  tvh_str_set(&cfg->dvr_filename_external, !strcmp(external, "") ? NULL : external);
   dvr_save(cfg);
 }
 

--- a/src/webui/extjs.c
+++ b/src/webui/extjs.c
@@ -1255,6 +1255,9 @@ extjs_dvr(http_connection_t *hc, const char *remain, void *opaque)
     htsmsg_add_u32(r, "retention", cfg->dvr_retention_days);
     htsmsg_add_u32(r, "preExtraTime", cfg->dvr_extra_time_pre);
     htsmsg_add_u32(r, "postExtraTime", cfg->dvr_extra_time_post);
+    htsmsg_add_u32(r, "filename_mode", cfg->dvr_filename_mode);
+    if(cfg->dvr_filename_external != NULL)
+      htsmsg_add_str(r, "filename_external", cfg->dvr_filename_external);
     htsmsg_add_u32(r, "dayDirs",        !!(cfg->dvr_flags & DVR_DIR_PER_DAY));
     htsmsg_add_u32(r, "channelDirs",    !!(cfg->dvr_flags & DVR_DIR_PER_CHANNEL));
     htsmsg_add_u32(r, "channelInTitle", !!(cfg->dvr_flags & DVR_CHANNEL_IN_TITLE));
@@ -1296,6 +1299,10 @@ extjs_dvr(http_connection_t *hc, const char *remain, void *opaque)
    if((s = http_arg_get(&hc->hc_req_args, "postExtraTime")) != NULL)
      dvr_extra_time_post_set(cfg,atoi(s));
 
+    if((s = http_arg_get(&hc->hc_req_args, "filename_mode")) != NULL)
+      dvr_filename_mode_set(cfg,atoi(s));
+    if((s = http_arg_get(&hc->hc_req_args, "filename_external")) != NULL)
+      dvr_filename_external_set(cfg,s);
     if(http_arg_get(&hc->hc_req_args, "dayDirs") != NULL)
       flags |= DVR_DIR_PER_DAY;
     if(http_arg_get(&hc->hc_req_args, "channelDirs") != NULL)


### PR DESCRIPTION
Adds a possibility to use an external program to generate a filename for a recording.

Uses the same format as the post-processor command. Filename should be written to standard output. Possible trailing '\n' is ignored in the filename but no other safety checks are made. If the external program fails or writes nothing, filename is generated by the basic internal method.
