### PR TITLE
Description tag fix

### DIFF
--- a/src/muxer/tvh/mkmux.c
+++ b/src/muxer/tvh/mkmux.c
@@ -603,6 +603,10 @@ _mk_build_metadata(const dvr_entry_t *de, const epg_broadcast_t *ebc)
     ls = ee->description;
   else if (ee && ee->summary)
     ls = ee->summary;
+  else if (ebc && ebc->description)
+    ls = ebc->description;
+  else if (ebc && ebc->summary)
+    ls = ebc->summary;
   if (ls) {
     lang_str_ele_t *e;
     RB_FOREACH(e, ls, link)


### PR DESCRIPTION
Fixes description tag writing in a matroska container (bug tracker #1689). This is the simplest way to fix the issue.

Observations:
- const dvr_entry_t *de = NULL (always and so it's useless)
  - muxer_tvh.c:178: mk_mux_write_meta(tm->tm_ref, NULL, eb)
- Why those description/summary string pointers are stored in multiple places?
  - struct epg_episode, struct epg_broadcast, struct dvr_entry
