### PR TITLE
Fix dvbs2

### DIFF
--- a/src/dvb/dvb.h
+++ b/src/dvb/dvb.h
@@ -426,6 +426,7 @@ int dvb_mux_str2fec(const char *str);
 int dvb_mux_str2mode(const char *str);
 int dvb_mux_str2guard(const char *str);
 int dvb_mux_str2hier(const char *str);
+int dvb_mux_str2rolloff(const char *str);
 
 void dvb_mux_save(th_dvb_mux_instance_t *tdmi);
 

--- a/src/dvb/dvb_multiplex.c
+++ b/src/dvb/dvb_multiplex.c
@@ -401,10 +401,10 @@ dvb_mux_find_by_identifier(const char *identifier)
 
 #if DVB_API_VERSION >= 5
 static struct strtab rollofftab[] = {
-  { "ROLLOFF_35",   ROLLOFF_35 },
-  { "ROLLOFF_20",   ROLLOFF_20 },
-  { "ROLLOFF_25",   ROLLOFF_25 },
-  { "ROLLOFF_AUTO", ROLLOFF_AUTO }
+  { "35",   ROLLOFF_35 },
+  { "20",   ROLLOFF_20 },
+  { "25",   ROLLOFF_25 },
+  { "AUTO", ROLLOFF_AUTO }
 };
 
 static struct strtab delsystab[] = {
@@ -601,6 +601,11 @@ int dvb_mux_str2guard(const char *str)
 int dvb_mux_str2hier(const char *str)
 {
   return str2val(str, hiertab);
+}
+
+int dvb_mux_str2rolloff(const char *str)
+{
+  return str2val(str, rollofftab);
 }
 
 /**

--- a/src/dvb/dvb_preconf.c
+++ b/src/dvb/dvb_preconf.c
@@ -62,6 +62,7 @@ dvb_mux_preconf_add(th_dvb_adapter_t *tda, const network_t *net,
     case FE_QPSK:
 #if DVB_API_VERSION >= 5
       dmc.dmc_fe_delsys                    = m->delsys;
+      dmc.dmc_fe_rolloff                   = m->rolloff;
 #endif
       dmc.dmc_fe_params.u.qpsk.symbol_rate = m->symrate;
       dmc.dmc_fe_params.u.qpsk.fec_inner   = m->fec;

--- a/src/muxes.c
+++ b/src/muxes.c
@@ -145,7 +145,7 @@ static int _muxes_load_dvbt ( mux_t *mux, const char *line )
 
 static int _muxes_load_dvbs ( mux_t *mux, const char *line )
 {
-  char fec[20], qam[20], hier[20];
+  char fec[20], qam[20], rolloff[20];
   int r, v2 = 0;
 
   if (*line == '2') {
@@ -162,13 +162,15 @@ static int _muxes_load_dvbs ( mux_t *mux, const char *line )
 
   r = sscanf(line, "%u %c %u %s %s %s",
 	           &mux->freq, &mux->polarisation, &mux->symrate,
-             fec, hier, qam);
+             fec, rolloff, qam);
   if (r != (4+v2)) return 1;
   
   if ((mux->fec             = dvb_mux_str2fec(fec)) == -1)   return 1;
   if (v2) {
-    if ((mux->hierarchy     = dvb_mux_str2hier(hier)) == -1) return 1;
-    if ((mux->constellation = dvb_mux_str2qamnew(qam)) == -1) return 1;
+#if DVB_API_VERSION >= 5
+    if ((mux->rolloff       = dvb_mux_str2rolloff(rolloff)) == -1) return 1;
+#endif
+    if ((mux->constellation = dvb_mux_str2qamnew(qam))   == -1) return 1;
   }
 
   return 0;

--- a/src/muxes.h
+++ b/src/muxes.h
@@ -32,6 +32,7 @@ typedef struct mux {
  short tmode;
  short guard;
  short hierarchy;
+ short rolloff;
  char polarisation;
 } mux_t;
 


### PR DESCRIPTION
When not using auto-detect to find muxes, DVB-S2 gets skipped on load. This is due to the 5th field being incorrectly used as hierachy, when in fact, it is rolloff. Additionally, if it would have passed as such, the delivery system never gets set to DVB-S2.

Finally, in scan files, there is no such think as PSK_8, it's 8PSK.
