### PR TITLE
mkbundle: follow symlinks

### DIFF
--- a/support/mkbundle
+++ b/support/mkbundle
@@ -40,7 +40,7 @@ if opts.deps:
 root  = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '..'))
 ents  = {}
 for path in args:
-  for (p, ds, fs) in os.walk(path):
+  for (p, ds, fs) in os.walk(path, followlinks=True):
     p = os.path.abspath(p)
     n = p.replace(root+'/', '')
     t = ents


### PR DESCRIPTION
some resources are now symlinked to vendor/ so when built with --enable-bundle webif fails to load due to resources not compiled in.

from python os.wak() docs:

```
By default, walk() will not walk down into symbolic links that resolve to directories. 
Set followlinks to True to visit directories pointed to by symlinks, 
on systems that support them
```

actual error

```
...
2013-09-24 18:55:32.243 [  ERROR] webui: failed to open src/webui/static/extjs/resources/css/ext-all-notheme.css
2013-09-24 18:55:32.243 [  ERROR] HTTP: 127.0.0.1: /static/extjs/resources/css/ext-all-notheme.css -- 500
2013-09-24 18:55:32.243 [  ERROR] webui: failed to open src/webui/static/extjs/resources/css/xtheme-blue.css
2013-09-24 18:55:32.243 [  ERROR] HTTP: 127.0.0.1: /static/extjs/resources/css/xtheme-blue.css -- 500
...
```
