### PR TITLE
Option do add subtitle (from EPG) to recording filename

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -66,6 +66,8 @@ extern struct dvr_entry_list dvrentries;
 #define DVR_CLEAN_TITLE	        0x100
 #define DVR_TAG_FILES           0x200
 #define DVR_SKIP_COMMERCIALS    0x400
+#define DVR_SUBTITLE_IN_TITLE	0x800
+#define DVR_EPISODE_BEFORE_DATE	0x1000
 
 typedef enum {
   DVR_PRIO_IMPORTANT,

--- a/src/webui/extjs.c
+++ b/src/webui/extjs.c
@@ -1306,6 +1306,8 @@ extjs_dvr(http_connection_t *hc, const char *remain, void *opaque)
     htsmsg_add_u32(r, "cleanTitle", !!(cfg->dvr_flags & DVR_CLEAN_TITLE));
     htsmsg_add_u32(r, "tagFiles", !!(cfg->dvr_flags & DVR_TAG_FILES));
     htsmsg_add_u32(r, "commSkip", !!(cfg->dvr_flags & DVR_SKIP_COMMERCIALS));
+    htsmsg_add_u32(r, "subtitleInTitle", !!(cfg->dvr_flags & DVR_SUBTITLE_IN_TITLE));
+    htsmsg_add_u32(r, "episodeBeforeDate", !!(cfg->dvr_flags & DVR_EPISODE_BEFORE_DATE));
 
     out = json_single_record(r, "dvrSettings");
 
@@ -1358,6 +1360,10 @@ extjs_dvr(http_connection_t *hc, const char *remain, void *opaque)
       flags |= DVR_TAG_FILES;
     if(http_arg_get(&hc->hc_req_args, "commSkip") != NULL)
       flags |= DVR_SKIP_COMMERCIALS;
+    if(http_arg_get(&hc->hc_req_args, "subtitleInTitle") != NULL)
+      flags |= DVR_SUBTITLE_IN_TITLE;
+    if(http_arg_get(&hc->hc_req_args, "episodeBeforeDate") != NULL)
+      flags |= DVR_EPISODE_BEFORE_DATE;
 
 
     dvr_flags_set(cfg,flags);

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -729,7 +729,7 @@ tvheadend.dvrsettings = function() {
 	}, [ 'storage', 'postproc', 'retention', 'dayDirs', 'channelDirs',
 		'channelInTitle', 'container', 'dateInTitle', 'timeInTitle',
 		'preExtraTime', 'postExtraTime', 'whitespaceInTitle', 'titleDirs',
-		'episodeInTitle', 'cleanTitle', 'tagFiles', 'commSkip' ]);
+		'episodeInTitle', 'cleanTitle', 'tagFiles', 'commSkip', 'subtitleInTitle', 'episodeBeforeDate']);
 
 	var confcombo = new Ext.form.ComboBox({
 		store : tvheadend.configNames,
@@ -822,6 +822,12 @@ tvheadend.dvrsettings = function() {
 		}), new Ext.form.Checkbox({
 			fieldLabel : 'Skip commercials',
 			name : 'commSkip'
+		}), new Ext.form.Checkbox({
+			fieldLabel : 'Include subtitle in filename',
+			name : 'subtitleInTitle'
+		}), new Ext.form.Checkbox({
+			fieldLabel : 'Put episode in filename before date and time',
+			name : 'episodeBeforeDate'
 		}), {
 			width : 300,
 			fieldLabel : 'Post-processor command',


### PR DESCRIPTION
My EPG source (XMLTV) supports subtitles and episode numbers.
They are shown correct in web UI, but there is no possibility to use them in recording filename.
So, for TV serie, I have many recordings with the same title (TV serie title) but I don't know which file is which episode.

The second issue is that currently episode number is added at the end of filename (after date and time). I think reverse order (first episode number and then date and time) is better / more natural.

So I've made patch, which adds in web ui: Configuration, Recording, Digital Video Recorder two new options (checkboxes): 
1. Include subtitle in filename
2. Put episode in filename before date and time
