### PR TITLE
programs with non zero and equal episode numbers are considered duplicates

### DIFF
--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -427,11 +427,23 @@ dvr_entry_create_by_event(const char *config_name,
                            creator, dae, pri);
 }
 
+/**
+ * Considered a duplicate if it has episode numbers and it is equal to an existing recording
+ */
 static int _dvr_duplicate_event ( epg_broadcast_t *e )
 {
   dvr_entry_t *de;
+  epg_episode_num_t empty_epnum;
+
+  memset(&empty_epnum, 0, sizeof(empty_epnum));
+  if (epg_episode_number_cmp(&empty_epnum, &e->episode->epnum) == 0)
+    return 0;
+
   LIST_FOREACH(de, &dvrentries, de_global_link) {
-    if (de->de_bcast && (de->de_bcast->episode == e->episode)) return 1;
+    if (de->de_bcast && epg_episode_number_cmp(&de->de_bcast->episode->epnum, &e->episode->epnum) == 0)
+    {
+      return 1;
+    }
   }
   return 0;
 }


### PR DESCRIPTION
Not sure you want this but here goes:
After getting tired of removing dups i tried this change, it seem to have worked fine for me so far (i use XMLTV).
I was a bit perplexed to see that the exisiting code did compare two episode struct pointers but perhaps it make sense for those who understand the tvheadend innards well.
Off topic: I wish tvheadend was written in C++ to make it easy to understand, i guess C is needed for "small devices".
