### PR TITLE
Fix signal quality and SNR statistics in linuxdvb input

### DIFF
--- a/src/input/mpegts/linuxdvb/linuxdvb_frontend.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_frontend.c
@@ -568,10 +568,9 @@ linuxdvb_frontend_monitor ( void *aux )
       }
     }
     if(fe_properties[3].u.st.len > 0) {
-      /* note that decibel scale means 0.0001 dB units */
-      /* TODO: snr is not unsigned, but signed! */
+      /* note that decibel scale means 1 = 0.0001 dB units here */
       if(fe_properties[3].u.st.stat[0].scale == FE_SCALE_DECIBEL)
-        mmi->mmi_stats.snr = fe_properties[3].u.st.stat[0].uvalue;
+        mmi->mmi_stats.snr = fe_properties[3].u.st.stat[0].svalue * 0.0001;
       /* TODO: handle other scales */
     }
     /* Calculate PER from PRE_ERROR and TOTAL_BIT_COUNT */


### PR DESCRIPTION
The current code reports wrong signal quality and SNR values in my case. The SNR value is ten times too high, while the signal quality ranges from 0 to 65535%. This is caused by a difference between the DVB v3 and v5 ioctl's, and the support for different unit scales in v5 (see [1]). I have one of the more recently added demodulators (the DRXK), and when that was added they adopted the v5 API (with the new units).

The trend is to support the new v5 API, which reports SNR in 0.1 dBm and signal quality between 0x0000 and 0xFFFF [2]. My current fix is not suitable to solve the problem for other devices, I could rewrite it such that it attempts to fix this for both new devices (via v5 ioctls) and old devices (using the current code). Any suggestions?

[1] http://linuxtv.org/downloads/v4l-dvb-apis/FE_GET_SET_PROPERTY.html#frontend-stat-properties
[2] http://www.spinics.net/lists/linux-media/msg58505.html
