### PR TITLE
capmt: adjust for recent OSCam frame change

### DIFF
--- a/src/webui/static/app/capmteditor.js
+++ b/src/webui/static/app/capmteditor.js
@@ -25,7 +25,7 @@ tvheadend.capmteditor = function() {
 			fields: ['res','name'],
 			id: 0,
 			data: [
-				['2','Recent OSCam (svn rev >= 9063)'],
+				['2','Recent OSCam (svn rev >= 9095)'],
 				['1','Older OSCam'],
 				['0','Wrapper (capmt_ca.so)']
 			]


### PR DESCRIPTION
Additional byte describing adapter index was
added to the beginning of the frame.
It only affect tvh capmt mode 2.
