### PR TITLE
linuxdvb_frontend: fix signal strength and SNR for old API

### DIFF
--- a/src/input/mpegts/linuxdvb/linuxdvb_frontend.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_frontend.c
@@ -592,11 +592,11 @@ linuxdvb_frontend_monitor ( void *aux )
 #endif
   {
     if (!ioctl(lfe->lfe_fe_fd, FE_READ_SIGNAL_STRENGTH, &u16))
-      mmi->mmi_stats.signal = u16;
+      mmi->mmi_stats.signal = (u16 * 100) / 0xffff;
     if (!ioctl(lfe->lfe_fe_fd, FE_READ_BER, &u32))
       mmi->mmi_stats.ber = u32;
     if (!ioctl(lfe->lfe_fe_fd, FE_READ_SNR, &u16))
-      mmi->mmi_stats.snr = u16;
+      mmi->mmi_stats.snr = u16 / 10;
     if (!ioctl(lfe->lfe_fe_fd, FE_READ_UNCORRECTED_BLOCKS, &u32))
       mmi->mmi_stats.unc = u32;
   }


### PR DESCRIPTION
commit aed4f63 accidently removed the scale changes for the
signal strength and SNR if the old(er) API is used.

Signed-off-by: Peter Lieven pl@kamp.de
