### PR TITLE
Fallback to use ONID as CRID authority

### DIFF
--- a/src/epggrab/module/eit.c
+++ b/src/epggrab/module/eit.c
@@ -375,7 +375,7 @@ static int _eit_desc_crid
           if (defauth)
             snprintf(crid, clen, "crid://%s%s", defauth, buf);
           else
-            snprintf(crid, clen, "crid://%d%s", svc->s_dvb_mux->mm_onid, buf);
+            snprintf(crid, clen, "crid://onid-%d%s", svc->s_dvb_mux->mm_onid, buf);
         }
       }
 


### PR DESCRIPTION
This uses the network ID as a fallback for CRID authority. Useful for Canal Digital in Sweden, since they supply partial CRID data but doesn't have a CRID authority defined anywhere.
