### PR TITLE
Added long date columns to epg view

### DIFF
--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -250,13 +250,6 @@ tvheadend.epg = function() {
 		setMetaAttr(meta, record);
 
 		var dt = new Date(value);
-		return dt.format('l H:i');
-	}
-
-	function renderDateFull(value, meta, record, rowIndex, colIndex, store) {
-		setMetaAttr(meta, record);
-
-		var dt = new Date(value);
 		return dt.format('D, M d, H:i');
 	}
 
@@ -317,24 +310,11 @@ tvheadend.epg = function() {
 		renderer : renderDate
 	}, {
 		width : 100,
-		id : 'lstart',
-		header : "Start (long)",
-		dataIndex : 'start',
-		renderer : renderDateFull
-	}, {
-		width : 100,
 		hidden : true,
 		id : 'end',
 		header : "End",
 		dataIndex : 'end',
 		renderer : renderDate
-	}, {
-		width : 100,
-		hidden : true,
-		id : 'lend',
-		header : "End (long)",
-		dataIndex : 'end',
-		renderer : renderDateFull
 	}, {
 		width : 100,
 		id : 'duration',


### PR DESCRIPTION
Hi folks,

epg data for e.g. 14 days ahead sometimes leads to difficulties to schedule the correct entry from the epg grid, since only the weekday is shown. So I added some "longer" formatted column. Maybe this is useful?

Apologies, I'm quite new to both tvheadend and git. :) Just learning... and maybe I'm able to contribut? ;-)

Thanks,
Dietmar.
