### PR TITLE
support/configure.inc: fix crosscompiling

### DIFF
--- a/support/configure.inc
+++ b/support/configure.inc
@@ -265,8 +265,6 @@ int main() {
 EOF
   $CC $CFLAGS $LDFLAGS $TMPDIR/$$.c -o $TMPDIR/$$.bin $opt &> /dev/null
   RET=$?
-  [ $RET -eq 0 ] && $TMPDIR/$$.bin
-  RET=$?
   rm -f $TMPDIR/$$.{c,bin}
   return $RET
 }


### PR DESCRIPTION
--cc= can be whatever. there should be no check if generated
binaries can run while crosscompiling.
