### PR TITLE
Power off LNB when idle

### DIFF
--- a/src/input/mpegts/linuxdvb/linuxdvb_private.h
+++ b/src/input/mpegts/linuxdvb/linuxdvb_private.h
@@ -126,6 +126,11 @@ struct linuxdvb_satconf
   gtimer_t               ls_diseqc_timer;
   int                    ls_diseqc_idx;
   int                    ls_diseqc_repeats;
+
+  /*
+   * LNB settings
+   */
+  int                    ls_lnb_poweroff;
   
   /*
    * Satconf elements


### PR DESCRIPTION
Try to reduce power, when no streams are captured from DVB-S/S2 devices.
