### PR TITLE
Neither stream nor file should require 0777 use 0644 instead.

### DIFF
--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -377,7 +377,7 @@ pass_muxer_open_file(muxer_t *m, const char *filename)
   int fd;
   pass_muxer_t *pm = (pass_muxer_t*)m;
 
-  fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0777);
+  fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
   if(fd < 0) {
     pm->pm_error = errno;
     tvhlog(LOG_ERR, "pass", "%s: Unable to create file, open failed -- %s",

--- a/src/muxer/tvh/mkmux.c
+++ b/src/muxer/tvh/mkmux.c
@@ -1041,7 +1041,7 @@ mk_mux_open_file(mk_mux_t *mkm, const char *filename)
 {
   int fd;
 
-  fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0777);
+  fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
   if(fd < 0) {
     mkm->error = errno;
     tvhlog(LOG_ERR, "mkv", "%s: Unable to create file, open failed -- %s",


### PR DESCRIPTION
Closes #1962.

There is no reason to make any stream or file executable.
