### PR TITLE
The sbuf allocation cleanups and fixups for memory leaks

### DIFF
--- a/src/htsbuf.c
+++ b/src/htsbuf.c
@@ -51,6 +51,15 @@ htsbuf_queue_alloc(unsigned int maxsize)
   return hq;
 }
 
+/**
+ *
+ */
+void
+htsbuf_queue_free(htsbuf_queue_t *hq)
+{
+  htsbuf_queue_flush(hq);
+  free(hq);
+}
 
 /**
  *

--- a/src/htsbuf.h
+++ b/src/htsbuf.h
@@ -45,6 +45,8 @@ void htsbuf_queue_init(htsbuf_queue_t *hq, unsigned int maxsize);
 
 htsbuf_queue_t *htsbuf_queue_alloc(unsigned int maxsize);
 
+void htsbuf_queue_free(htsbuf_queue_t *hq);
+
 void htsbuf_queue_flush(htsbuf_queue_t *hq);
 
 void htsbuf_vqprintf(htsbuf_queue_t *hq, const char *fmt, va_list ap);

--- a/src/input/mpegts/mpegts_service.c
+++ b/src/input/mpegts/mpegts_service.c
@@ -241,6 +241,9 @@ mpegts_service_stop(service_t *t)
   /* Stop */
   if (i)
     i->mi_close_service(i, s);
+
+  /* Save some memory */
+  sbuf_free(&s->s_tsbuf);
 }
 
 /*

--- a/src/input/mpegts/tsdemux.c
+++ b/src/input/mpegts/tsdemux.c
@@ -297,6 +297,9 @@ ts_remux(mpegts_service_t *t, const uint8_t *src)
   pktbuf_t *pb;
   sbuf_t *sb = &t->s_tsbuf;
 
+  if (sb->sb_data == NULL)
+    sbuf_init_fixed(sb, TS_REMUX_BUFSIZE);
+
   sbuf_append(sb, src, 188);
 
   if(sb->sb_ptr < TS_REMUX_BUFSIZE) 
@@ -312,7 +315,7 @@ ts_remux(mpegts_service_t *t, const uint8_t *src)
 
   service_set_streaming_status_flags((service_t*)t, TSS_PACKETS);
 
-  sbuf_reset(sb);
+  sbuf_reset(sb, TS_REMUX_BUFSIZE);
 }
 
 /*

--- a/src/muxer/muxer_tvh.c
+++ b/src/muxer/muxer_tvh.c
@@ -210,7 +210,7 @@ tvh_muxer_destroy(muxer_t *m)
   tvh_muxer_t *tm = (tvh_muxer_t*)m;
 
   if(tm->tm_ref)
-    free(tm->tm_ref);
+    mk_mux_destroy(tm->tm_ref);
 
   free(tm);
 }

--- a/src/muxer/tvh/mkmux.c
+++ b/src/muxer/tvh/mkmux.c
@@ -1064,7 +1064,7 @@ mk_mux_open_file(mk_mux_t *mkm, const char *filename)
 int
 mk_mux_init(mk_mux_t *mkm, const char *title, const streaming_start_t *ss)
 {
-  htsbuf_queue_t q;
+  htsbuf_queue_t q, *a;
 
   getuuid(mkm->uuid);
 
@@ -1081,10 +1081,14 @@ mk_mux_init(mk_mux_t *mkm, const char *title, const streaming_start_t *ss)
   ebml_append_master(&q, 0x1a45dfa3, mk_build_ebmlheader(mkm));
   
   mkm->segment_header_pos = q.hq_size;
-  htsbuf_appendq(&q, mk_build_segment_header(0));
+  a = mk_build_segment_header(0);
+  htsbuf_appendq(&q, a);
+  htsbuf_queue_free(a);
 
   mkm->segment_pos = q.hq_size;
-  htsbuf_appendq(&q, mk_build_segment(mkm, ss));
+  a = mk_build_segment(mkm, ss);
+  htsbuf_appendq(&q, a);
+  htsbuf_queue_free(a);
  
   mk_write_queue(mkm, &q);
 

--- a/src/parsers/parser_avc.c
+++ b/src/parsers/parser_avc.c
@@ -27,7 +27,7 @@ avc_find_startcode(const uint8_t *p, const uint8_t *end)
   int i;
 	
   uint32_t sc=0xFFFFFFFF;
-  size_t len = (end -p)+1;
+  size_t len = end - p;
   for (i=0;i<len;i++)
     {
       sc = (sc <<8) | p[i];
@@ -138,10 +138,14 @@ isom_write_avcc(sbuf_t *sb, const uint8_t *data, int len)
       }
       if(!sps_count || !pps_count) {
 	free(start);
-	if (sps_count)
+	if (sps_count) {
 	  free(sps_array);
-	if (pps_count)
+          free(sps_size_array);
+        }
+	if (pps_count) {
 	  free(pps_array);
+          free(pps_size_array);
+        }
 	return -1;
       }
 
@@ -163,10 +167,14 @@ isom_write_avcc(sbuf_t *sb, const uint8_t *data, int len)
       }
       free(start);
 
-      if (sps_count)
+      if (sps_count) {
 	free(sps_array);
-      if (pps_count)
+        free(sps_size_array);
+      }
+      if (pps_count) {
 	free(pps_array);
+        free(pps_size_array);
+      }
     } else {
       sbuf_append(sb, data, len);
     }

--- a/src/tvheadend.h
+++ b/src/tvheadend.h
@@ -583,13 +583,32 @@ static inline int64_t ts_rescale_i(int64_t ts, int tb)
 
 void sbuf_init(sbuf_t *sb);
 
+void sbuf_init_fixed(sbuf_t *sb, int len);
+
 void sbuf_free(sbuf_t *sb);
 
-void sbuf_reset(sbuf_t *sb);
+void sbuf_reset(sbuf_t *sb, int max_len);
 
-void sbuf_err(sbuf_t *sb);
+void sbuf_reset_and_alloc(sbuf_t *sb, int len);
 
-void sbuf_alloc(sbuf_t *sb, int len);
+static inline void sbuf_steal_data(sbuf_t *sb)
+{
+  sb->sb_data = NULL;
+  sb->sb_ptr = sb->sb_size = 0;
+}
+
+static inline void sbuf_err(sbuf_t *sb)
+{
+  sb->sb_err = 1;
+}
+
+void sbuf_alloc_(sbuf_t *sb, int len);
+
+static inline void sbuf_alloc(sbuf_t *sb, int len)
+{
+  if (sb->sb_ptr + len >= sb->sb_size)
+    sbuf_alloc_(sb, len);
+}
 
 void sbuf_append(sbuf_t *sb, const void *data, int len);
 


### PR DESCRIPTION
This is an attempt to fix the nonoptimal memory allocations. The old
code tries to allocate new chunks based on maximum packet value, but
the streams contain mostly short chunks. Also, in some cases, we know
the fixed sbuf size, so use it.

I found also some memory leaks in parse_avc.c and mkmux.c .
