### PR TITLE
The sbuf allocation cleanups

### DIFF
--- a/src/input/mpegts/mpegts_service.c
+++ b/src/input/mpegts/mpegts_service.c
@@ -241,6 +241,9 @@ mpegts_service_stop(service_t *t)
   /* Stop */
   if (i)
     i->mi_close_service(i, s);
+
+  /* Save some memory */
+  sbuf_free(&s->s_tsbuf);
 }
 
 /*

--- a/src/input/mpegts/tsdemux.c
+++ b/src/input/mpegts/tsdemux.c
@@ -297,6 +297,9 @@ ts_remux(mpegts_service_t *t, const uint8_t *src)
   pktbuf_t *pb;
   sbuf_t *sb = &t->s_tsbuf;
 
+  if (sb->sb_data == NULL)
+    sbuf_init_fixed(sb, TS_REMUX_BUFSIZE);
+
   sbuf_append(sb, src, 188);
 
   if(sb->sb_ptr < TS_REMUX_BUFSIZE) 
@@ -312,7 +315,7 @@ ts_remux(mpegts_service_t *t, const uint8_t *src)
 
   service_set_streaming_status_flags((service_t*)t, TSS_PACKETS);
 
-  sbuf_reset(sb);
+  sbuf_reset(sb, TS_REMUX_BUFSIZE);
 }
 
 /*

--- a/src/tvheadend.h
+++ b/src/tvheadend.h
@@ -583,13 +583,32 @@ static inline int64_t ts_rescale_i(int64_t ts, int tb)
 
 void sbuf_init(sbuf_t *sb);
 
+void sbuf_init_fixed(sbuf_t *sb, int len);
+
 void sbuf_free(sbuf_t *sb);
 
-void sbuf_reset(sbuf_t *sb);
+void sbuf_reset(sbuf_t *sb, int max_len);
 
-void sbuf_err(sbuf_t *sb);
+void sbuf_reset_and_alloc(sbuf_t *sb, int len);
 
-void sbuf_alloc(sbuf_t *sb, int len);
+static inline void sbuf_steal_data(sbuf_t *sb)
+{
+  sb->sb_data = NULL;
+  sb->sb_ptr = sb->sb_size = 0;
+}
+
+static inline void sbuf_err(sbuf_t *sb)
+{
+  sb->sb_err = 1;
+}
+
+void sbuf_alloc_(sbuf_t *sb, int len);
+
+static inline void sbuf_alloc(sbuf_t *sb, int len)
+{
+  if (sb->sb_ptr + len >= sb->sb_size)
+    sbuf_alloc_(sb, len);
+}
 
 void sbuf_append(sbuf_t *sb, const void *data, int len);
 


### PR DESCRIPTION
This is an attempt to fix the nonoptimal memory allocations. The old
code tries to allocate new chunks based on maximum packet value, but
the streams contain mostly short chunks. Also, in some cases, we know
the fixed sbuf size, so use it.
