### PR TITLE
eit.c: move invalid tsid messages from tvhwarn() to tvhtrace()

### DIFF
--- a/src/epggrab/module/eit.c
+++ b/src/epggrab/module/eit.c
@@ -599,7 +599,7 @@ _eit_callback
         mm->mm_onid != onid) {
       if (mm->mm_onid != MPEGTS_ONID_NONE &&
           mm->mm_tsid != MPEGTS_TSID_NONE)
-        tvhwarn("eit",
+        tvhtrace("eit",
                 "invalid tsid found tid 0x%02X, onid:tsid %d:%d != %d:%d",
                 tableid, mm->mm_onid, mm->mm_tsid, onid, tsid);
       mm = NULL;


### PR DESCRIPTION
I'm getting these messages here - it seems like a broken feed.
