### PR TITLE
Fix linkage error with --disable-cwc

### DIFF
--- a/src/descrambler/descrambler.c
+++ b/src/descrambler/descrambler.c
@@ -118,8 +118,10 @@ descrambler_init ( void )
 void
 descrambler_done ( void )
 {
+#if ENABLE_CWC
   capmt_done();
   cwc_done();
+#endif
 }
 
 void


### PR DESCRIPTION
When configuring the project without CWC, there is an error at link time, because the de-init is not enclosed in #if #endif preprocessor block
