### PR TITLE
Fix config.h duplication - rename new config.[ch] to cfg.[ch]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ SRCS =  src/version.c \
   src/tvhpoll.c \
 	src/huffman.c \
 	src/filebundle.c \
-	src/config.c \
+	src/cfg.c \
 	src/lang_codes.c \
 	src/lang_str.c \
 	src/imagecache.c \

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -18,7 +18,7 @@
 
 #include "tvheadend.h"
 #include "settings.h"
-#include "config.h"
+#include "cfg.h"
 #include "uuid.h"
 
 #include <string.h>

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -18,8 +18,8 @@
 
 // TODO: expand this, possibly integrate command line
 
-#ifndef __TVH_CONFIG__H__
-#define __TVH_CONFIG__H__
+#ifndef __TVH_CFG__H__
+#define __TVH_CFG__H__
 
 #include "htsmsg.h"
 
@@ -37,4 +37,4 @@ const char *config_get_language    ( void );
 int         config_set_language    ( const char *str )
   __attribute__((warn_unused_result));
 
-#endif /* __TVH_CONFIG__H__ */
+#endif /* __TVH_CFG__H__ */

--- a/src/input/mpegts/scanfile.c
+++ b/src/input/mpegts/scanfile.c
@@ -19,7 +19,7 @@
 #include "tvheadend.h"
 #include "dvb.h"
 #include "filebundle.h"
-#include "config.h"
+#include "cfg.h"
 #include "scanfile.h"
 
 #include <sys/types.h>

--- a/src/lang_codes.c
+++ b/src/lang_codes.c
@@ -20,7 +20,7 @@
 #include <stdlib.h>
 
 #include "lang_codes.h"
-#include "config.h"
+#include "cfg.h"
 
 /* **************************************************************************
  * Code list

--- a/src/main.c
+++ b/src/main.c
@@ -54,7 +54,7 @@
 #include "service.h"
 #include "trap.h"
 #include "settings.h"
-#include "config.h"
+#include "cfg.h"
 #include "idnode.h"
 #include "imagecache.h"
 #include "timeshift.h"

--- a/src/webui/extjs.c
+++ b/src/webui/extjs.c
@@ -42,7 +42,7 @@
 #include "epg.h"
 #include "muxer.h"
 #include "epggrab/private.h"
-#include "config.h"
+#include "cfg.h"
 #include "lang_codes.h"
 #include "imagecache.h"
 #include "timeshift.h"


### PR DESCRIPTION
The config.h is generated in the build directory.
