### PR TITLE
Fix the uninitialized variable access detected by valgrind

### DIFF
--- a/src/descrambler/ffdecsa/FFdecsa.c
+++ b/src/descrambler/ffdecsa/FFdecsa.c
@@ -361,6 +361,7 @@ static void block_decypher_group (
   int i,g,count_all=GROUP_PARALLELISM;
 
   roff=GROUP_PARALLELISM*56;
+  memset(r + roff, 0, sizeof(r) - roff);
 
 #define FASTTRASP1
 #ifndef FASTTRASP1

--- a/src/input/mpegts/linuxdvb/linuxdvb_frontend.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_frontend.c
@@ -508,6 +508,7 @@ linuxdvb_frontend_monitor ( void *aux )
 
   /* Statistics - New API */
 #if DVB_VER_ATLEAST(5,10)
+  memset(&fe_properties, 0, sizeof(fe_properties));
   fe_properties[0].cmd = DTV_STAT_SIGNAL_STRENGTH;
 
   /* BER */
@@ -974,7 +975,7 @@ linuxdvb_frontend_tune0
   /* S2 tuning */
 #if DVB_API_VERSION >= 5
   struct dtv_property cmds[20];
-  struct dtv_properties cmdseq = { .num = 0, .props = cmds };
+  struct dtv_properties cmdseq;
   
   /* Clear Q */
   static struct dtv_property clear_p[] = {
@@ -990,6 +991,9 @@ linuxdvb_frontend_tune0
   if (freq == (uint32_t)-1)
     freq = p.frequency;
 
+  memset(&cmdseq, 0, sizeof(cmdseq));
+  cmdseq.props = cmds;
+  memset(&cmds, 0, sizeof(cmds));
   
   /* Tune */
 #define S2CMD(c, d)\


### PR DESCRIPTION
- in linuxdvb the structure member alignment causes these complaints
- in FFdecsa - probably the batch processing is the culprit
