### PR TITLE
Add support for seca3 emm updates

### DIFF
--- a/src/descrambler/cwc.c
+++ b/src/descrambler/cwc.c
@@ -1402,12 +1402,12 @@ cwc_emm_seca(cwc_t *cwc, struct cs_card_data *pcard, uint8_t *data, int len)
 {
   int match = 0;
 
-  if (data[0] == 0x82) {
+  if (data[0] == 0x82) {                    //unique emm
     if (memcmp(&data[3], &pcard->cwc_ua[2], 6) == 0) {
       match = 1;
     }
   } 
-  else if (data[0] == 0x84) {
+  else if (data[0] == 0x84) {               //shared emm
     /* XXX this part is untested but should do no harm */
     int i;
     for (i=0; i < pcard->cwc_num_providers; i++) {
@@ -1416,6 +1416,9 @@ cwc_emm_seca(cwc_t *cwc, struct cs_card_data *pcard, uint8_t *data, int len)
         break;
       }
     }
+  }
+  else if (data[0] == 0x83) {               //global emm -> seca3
+    match = 1;
   }
 
   if (match)


### PR DESCRIPTION
This should fix updates with 'canal digitaal' and 'tv vlaanderen' smartcards.
