### PR TITLE
Optimize the PIDs filtering

### DIFF
--- a/src/descrambler/capmt.c
+++ b/src/descrambler/capmt.c
@@ -1074,6 +1074,8 @@ capmt_service_start(service_t *s)
         tvhlog(LOG_DEBUG, "capmt",
           "New caid 0x%04X for service \"%s\"", c->caid, t->s_dvb_svcname);
 
+        mpegts_table_register_caid(((mpegts_service_t *)s)->s_dvb_mux, c->caid);
+
         /* add it to list */
         cce             = calloc(1, sizeof(capmt_caid_ecm_t));
         cce->cce_caid   = c->caid;

--- a/src/descrambler/cwc.c
+++ b/src/descrambler/cwc.c
@@ -2031,6 +2031,8 @@ cwc_service_start(service_t *t)
 
     if (ct) continue;
 
+    mpegts_table_register_caid(((mpegts_service_t *)t)->s_dvb_mux, pcard->cwc_caid);
+
     ct                   = calloc(1, sizeof(cwc_service_t));
     tvhcsa_init(&ct->cs_csa);
     ct->cs_cwc           = cwc;

--- a/src/input/mpegts.h
+++ b/src/input/mpegts.h
@@ -140,10 +140,12 @@ struct mpegts_table
    */
   int mt_flags;
 
-#define MT_CRC      0x1
-#define MT_FULL     0x2
-#define MT_QUICKREQ 0x4
-#define MT_RECORD   0x8
+#define MT_CRC      0x01
+#define MT_FULL     0x02
+#define MT_QUICKREQ 0x04
+#define MT_RECORD   0x08
+#define MT_SKIPSUBS 0x10
+#define MT_SCANSUBS 0x20
 
   /**
    * Cycle queue
@@ -169,6 +171,7 @@ struct mpegts_table
   int mt_complete;
   int mt_incomplete;
   int mt_finished;
+  int mt_subscribed;
 
   int mt_count;
 
@@ -696,6 +699,8 @@ void mpegts_input_close_pid
 
 void mpegts_table_dispatch
   (const uint8_t *sec, size_t r, void *mt);
+static inline void mpegts_table_grab
+  (mpegts_table_t *mt) { mt->mt_refcount++; }
 void mpegts_table_release_
   (mpegts_table_t *mt);
 static inline void mpegts_table_release
@@ -710,6 +715,7 @@ mpegts_table_t *mpegts_table_add
 void mpegts_table_flush_all
   (mpegts_mux_t *mm);
 void mpegts_table_destroy ( mpegts_table_t *mt );
+void mpegts_table_register_caid ( mpegts_mux_t *mm, uint16_t caid );
 
 mpegts_service_t *mpegts_service_create0
   ( mpegts_service_t *ms, const idclass_t *class, const char *uuid,

--- a/src/input/mpegts/dvb_psi.c
+++ b/src/input/mpegts/dvb_psi.c
@@ -592,7 +592,8 @@ dvb_pat_callback
       int save = 0;
       if ((s = mpegts_service_find(mm, sid, pid, 1, &save))) {
         mpegts_table_add(mm, DVB_PMT_BASE, DVB_PMT_MASK, dvb_pmt_callback,
-                         NULL, "pmt", MT_CRC | MT_QUICKREQ, pid);
+                         NULL, "pmt", MT_CRC | MT_QUICKREQ | MT_SCANSUBS,
+                         pid);
 
         if (save)
           service_request_save((service_t*)s, 1);
@@ -660,7 +661,7 @@ dvb_cat_callback
                  (uint16_t)caid, (uint16_t)caid, pid, pid);
         if(pid != 0)
           mpegts_table_add(mm, 0, 0, dvb_ca_callback,
-                           (void*)caid, "ca", MT_FULL, pid);
+                           (void*)caid, "ca", MT_FULL | MT_SKIPSUBS, pid);
         break;
       default:
         break;

--- a/src/input/mpegts/mpegts_input.c
+++ b/src/input/mpegts/mpegts_input.c
@@ -678,8 +678,8 @@ mpegts_input_table_dispatch ( mpegts_mux_t *mm, mpegts_table_feed_t *mtf )
 
   /* Collate - tables may be removed during callbacks */
   LIST_FOREACH(mt, &mm->mm_tables, mt_link) {
+    mpegts_table_grab(mt);
     vec[i++] = mt;
-    mt->mt_refcount++;
   }
   assert(i == len);
 


### PR DESCRIPTION
I worked on similar thing like @adamsutton  , but I chose different method - the all PMTs are scanned only at the initial mux scan. Also, only really used CA PIDs are subscribed/opened in my implementation (works with cwc - capmt requires all caids :( ).
