### PR TITLE
Restored ability to subscribe to a channel via HTTP using the channel name.

### DIFF
--- a/src/webui/webui.c
+++ b/src/webui/webui.c
@@ -613,6 +613,8 @@ page_http_playlist(http_connection_t *hc, const char *remain, void *opaque)
     ch = channel_find_by_id(atoi(components[1]));
   else if(nc == 2 && !strcmp(components[0], "channelnumber"))
     ch = channel_find_by_number(atoi(components[1]));
+  else if(nc == 2 && !strcmp(components[0], "channelname"))
+    ch = channel_find_by_name(components[1]);
   else if(nc == 2 && !strcmp(components[0], "channel"))
     ch = channel_find(components[1]);
   else if(nc == 2 && !strcmp(components[0], "dvrid"))
@@ -885,6 +887,8 @@ http_stream(http_connection_t *hc, const char *remain, void *opaque)
     ch = channel_find_by_id(atoi(components[1]));
   } else if(!strcmp(components[0], "channelnumber")) {
     ch = channel_find_by_number(atoi(components[1]));
+  } else if(!strcmp(components[0], "channelname")) {
+    ch = channel_find_by_name(components[1]);
   } else if(!strcmp(components[0], "channel")) {
     ch = channel_find(components[1]);
   } else if(!strcmp(components[0], "service")) {


### PR DESCRIPTION
 Example with a channel called `Rai 1`:
`http://host:port/stream/channelname/Rai+1` and `http://host:port/playlist/channelname/Rai+1`.
