### PR TITLE
Check manual priority of adapter before weighting.

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -1120,15 +1120,16 @@ service_refresh_channel(service_t *t)
 
 
 /**
- * Weight then prio?
+ * Priority Then Weight
  */
 static int
 si_cmp(const service_instance_t *a, const service_instance_t *b)
 {
   int r;
-  r = a->si_weight - b->si_weight;
+  r = a->si_prio - b->si_prio;
+
   if (!r)
-    r = a->si_prio - b->si_prio;
+    r = a->si_weight - b->si_weight;
   return r;
 }
 


### PR DESCRIPTION
To me it seems most likely that if someone has manually adjusted the priority of an adapter it is probably for good reason and should therefore take precedence over weighting. I have a two PCI-e tuner cards, one DVB-T2 and one DVB-S2. The DVB-T2 card was always favoured regardless of priority settings but the signal on this card is less reliable so it would be good if manual priority took precedence.
