### PR TITLE
Fix: timer for grace period was in ms when the rotor returned its waitin...

### DIFF
--- a/src/input/mpegts/linuxdvb/linuxdvb_satconf.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_satconf.c
@@ -643,7 +643,7 @@ linuxdvb_satconf_ele_tune ( linuxdvb_satconf_ele_t *lse )
 
     /* Pending */
     if (r != 0) {
-      gtimer_arm_ms(&ls->ls_diseqc_timer, linuxdvb_satconf_ele_tune_cb, lse, r);
+      gtimer_arm(&ls->ls_diseqc_timer, linuxdvb_satconf_ele_tune_cb, lse, r);
       ls->ls_diseqc_idx = i + 1;
       return 0;
     }


### PR DESCRIPTION
...g period in seconds.

the rotor was not given enough time to move between satellites after looking at the code I finaly found that the rotor function was returning 120 seconds and was passing it to the gtimer to use as milliseconds so the motor was unable to move.
