### PR TITLE
Removed unnecessary mutex unlock in timeshift_filemgr.c

### DIFF
--- a/src/timeshift/timeshift_filemgr.c
+++ b/src/timeshift/timeshift_filemgr.c
@@ -73,6 +73,8 @@ static void* timeshift_reaper_callback ( void *p )
         tvhlog(LOG_ERR, "timeshift", "failed to remove %s [e=%s]",
                dpath, strerror(errno));
 
+    pthread_mutex_lock(&timeshift_reaper_lock);
+
     /* Free memory */
     while ((ti = TAILQ_FIRST(&tsf->iframes))) {
       TAILQ_REMOVE(&tsf->iframes, ti, link);


### PR DESCRIPTION
The unnecessary mutex unlock leads to a crash when lock-elision (like on Intel Haswell processors
is active). The mutex is automatically locked/unlocked by the pthread_cond_wait.
