### PR TITLE
dvr.js: Add 'all' option to paging length to address limitations of only...

### DIFF
--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -413,20 +413,20 @@ tvheadend.dvrschedule = function(title, iconCls, dvrStore) {
         width: 50,
         mode : 'local',
         store: new Ext.data.ArrayStore({
-            fields: ['perpage'],
-            data  : [['10'],['20'],['30'],['40'],['50'],['60'],['70'],['80'],['90'],['100']]
+            fields: ['perpage','value'],
+            data  : [['10',10],['20',20],['30',30],['40',40],['50',50],['75',75],['100',100],['All',9999999999]]
         }),
         value : '20',
         listWidth : 40,
         triggerAction : 'all',
         displayField : 'perpage',
-        valueField : 'perpage',
+        valueField : 'value',
         editable : true,
         forceSelection : true,
         listeners : {
             scope: this,
             'select' : function(combo, record) {
-                bbar.pageSize = parseInt(record.get('perpage'), 10);
+                bbar.pageSize = parseInt(record.get('value'), 10);
                 bbar.doLoad(bbar.cursor);
             }
         }


### PR DESCRIPTION
... sorting current page

This is in response to the conversation in PR #399 regarding only being able to sort the current page and not the whole data set. It simply adds an "all" option to the page length (actually, a page length of 9,999,999,999 - that should be big enough for most user) that the user can select prior to sort.
