### PR TITLE
osx: fix non-blocking tcp connect

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -98,6 +98,11 @@ tcp_connect(const char *hostname, int port, const char *bindaddr,
   r = connect(fd, ai->ai_addr, ai->ai_addrlen);
   freeaddrinfo(ai);
 
+#if defined(PLATFORM_DARWIN)
+  if (timeout < 0)
+    timeout = 1;
+#endif
+
   if(r == -1) {
     if(errno == EINPROGRESS && timeout < 0) {
       err = 0;


### PR DESCRIPTION
I need some guidance here. TCP connection fails on OSX unless I apply this workaround.
Seems that OSX doesn't like writing to socket before poll() says it is ready.

What is the meaning of timeout=-1?
