### PR TITLE
RTSP: only skip leading zeros if the next character is also zero

### DIFF
--- a/src/rtsp.c
+++ b/src/rtsp.c
@@ -119,7 +119,7 @@ rtsp_setup_decode( http_client_t *hc, int satip )
     if (p == NULL)
       return -EIO;
     /* zero is valid stream id per specification */
-    while (*p && (*p == '0' || *p < ' '))
+    while (*p && ((*p == '0' && *(p + 1) == '0') || *p < ' '))
       p++;
     if (p[0] == '0' && p[1] == '\0') {
       hc->hc_rtsp_stream_id = 0;


### PR DESCRIPTION
If com.ses.streamID is zero then the SETUP decode fails as it attempts to skip all leading zeros which results in the entire stream ID being skipped resulting in a failure.  Instead only skip leading zeros if the next character is also a zero.
