### PR TITLE
Compile fixes

### DIFF
--- a/src/input/mpegts/linuxdvb/linuxdvb_switch.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_switch.c
@@ -117,7 +117,7 @@ static int
 linuxdvb_switch_tune
   ( linuxdvb_diseqc_t *ld, dvb_mux_t *lm, linuxdvb_satconf_ele_t *sc, int fd )
 {
-  int i, com, r1 = 0, r2 = 0;
+  int i, com = 0, r1 = 0, r2 = 0;
   int pol, band;
   linuxdvb_switch_t *ls = (linuxdvb_switch_t*)ld;
 


### PR DESCRIPTION
This fixes building after https://github.com/tvheadend/tvheadend/commit/69921519763d79080cf11cc31238883681123a26, first two commits address

```
CC              src/input/mpegts/linuxdvb/linuxdvb_switch.o
src/input/mpegts/linuxdvb/linuxdvb_switch.c: In function 'linuxdvb_switch_tune':
src/input/mpegts/linuxdvb/linuxdvb_switch.c:150:11: error: 'linuxdvb_switch_t' has no member named 'lsuncomitted'
src/input/mpegts/linuxdvb/linuxdvb_switch.c:223:1: error: expected declaration or statement at end of input
```

Last commits afterwards addresses

```
src/input/mpegts/linuxdvb/linuxdvb_switch.c: In function 'linuxdvb_switch_tune':
src/input/mpegts/linuxdvb/linuxdvb_switch.c:161:31: error: 'com' may be used uninitialized in this function [-Werror=uninitialized]
cc1: all warnings being treated as errors
```
