### PR TITLE
webui: adjust signal strength to be < 100%

### DIFF
--- a/src/webui/static/app/status.js
+++ b/src/webui/static/app/status.js
@@ -196,7 +196,7 @@ tvheadend.status_streams = function() {
             if (r) {
                 r.data.subs = m.subs;
                 r.data.weight = m.weight;
-                r.data.signal = m.signal;
+                r.data.signal = m.signal / 1000;
                 r.data.ber = m.ber;
                 r.data.unc = m.unc;
                 r.data.snr = m.snr;


### PR DESCRIPTION
A quick hack to bring the signal strength reported back below 100% (versus the 4500% it could be at the moment). No, it's not right, because the adapters vary what they report - but it's no more wrong than the > 100% value and at least it makes sense!
