### PR TITLE
[webui] always reload the EPG store when the tab is activated

### DIFF
--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -296,14 +296,6 @@ tvheadend.epg = function() {
             }])
     });
 
-    /**
-     * Listener for DVR notifications. We want to update the EPG grid when a
-     * recording is finished/deleted etc. so the status icon gets updated.
-     */
-    tvheadend.comet.on('dvrdb', function() {
-        epgStore.reload();
-    });
-
     function setMetaAttr(meta, record) {
         var now = new Date;
         var start = record.get('start');
@@ -665,6 +657,11 @@ tvheadend.epg = function() {
     });
 
     panel.on('rowclick', rowclicked);
+    
+    // Always reload the store when the tab is activated
+    panel.on('beforeshow', function() {
+        this.store.reload();
+    });
 
     function rowclicked(grid, index) {
         new tvheadend.epgDetails(grid.getStore().getAt(index).data);


### PR DESCRIPTION
If we update the store when the tab is not activated the grid will be empty
once the tab is activated again. This fixes that plus fixes the issue where
the EPG data can be outdated if the web interface has been left open for a
long time and the active tab has been something other than the EPG tab.
