### PR TITLE
[webui] unify save/undo buttons

### DIFF
--- a/src/webui/static/app/tableeditor.js
+++ b/src/webui/static/app/tableeditor.js
@@ -108,7 +108,7 @@ tvheadend.tableEditor = function(title, dtable, cm, rec, plugins, store,
     var saveBtn = new Ext.Toolbar.Button({
         tooltip: 'Save any changes made (Changed cells have red borders)',
         iconCls: 'save',
-        text: "Save changes",
+        text: "Save",
         handler: saveChanges,
         disabled: true
     });
@@ -116,7 +116,7 @@ tvheadend.tableEditor = function(title, dtable, cm, rec, plugins, store,
     var rejectBtn = new Ext.Toolbar.Button({
         tooltip: 'Revert any changes made (Changed cells have red borders)',
         iconCls: 'undo',
-        text: "Revert changes",
+        text: "Undo",
         handler: function() {
             store.rejectChanges();
         },
@@ -151,6 +151,7 @@ tvheadend.tableEditor = function(title, dtable, cm, rec, plugins, store,
         selModel: selModel,
         stripeRows: true,
         tbar: [
+            saveBtn, rejectBtn, '-',
             {
                 tooltip: 'Create a new entry on the server. '
                         + 'The new entry is initially disabled so it must be enabled '
@@ -158,7 +159,7 @@ tvheadend.tableEditor = function(title, dtable, cm, rec, plugins, store,
                 iconCls: 'add',
                 text: 'Add entry',
                 handler: addRecord
-            }, '-', delButton, '-', saveBtn, rejectBtn, '->', {
+            }, '-', delButton, '->', {
                 text: 'Help',
                 handler: function() {
                     new tvheadend.help(title, helpContent);


### PR DESCRIPTION
This moves the Save and Undo buttons to the same position in the Autorec panel. This replicates the look-and-feel of other panels.
