### PR TITLE
[webui] fix status icon updates when a recording is scheduled/started fr...

### DIFF
--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -658,6 +658,17 @@ tvheadend.epg = function() {
 
     panel.on('rowclick', rowclicked);
     
+    /**
+     * Listener for DVR notifications. We want to update the EPG grid when a
+     * recording is finished/deleted etc. so the status icon gets updated. 
+     * Only do this when the tab is visible, otherwise it won't work as 
+     * expected.
+     */
+    tvheadend.comet.on('dvrdb', function() {
+        if (panel.isVisible())
+            epgStore.reload();
+    });
+    
     // Always reload the store when the tab is activated
     panel.on('beforeshow', function() {
         this.store.reload();


### PR DESCRIPTION
This should hopefully be the final fix for the EPG grid updates. Now the grid properly updates when a recording is triggered/scheduled from the grid (ie. the status icon on the row changes). Previously that would only happen if you switched away from the tab once.
