### PR TITLE
Fix autorec channel tags after the migration of tags to the idnode system

### DIFF
--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -560,7 +560,7 @@ _dvr_autorec_add(const char *config_name,
     dae->dae_title = strdup(title);
   }
 
-  if(tag != NULL && (ct = channel_tag_find_by_name(tag, 0)) != NULL) {
+  if(tag != NULL && (ct = channel_tag_find_by_uuid(tag)) != NULL) {
     LIST_INSERT_HEAD(&ct->ct_autorecs, dae, dae_channel_tag_link);
     dae->dae_channel_tag = ct;
   }

--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -49,6 +49,17 @@ tvheadend.channelLookupName = function(key) {
     return channelString;
 };
 
+tvheadend.tagLookupName = function(key) {
+    tagString = "";
+
+    var index = tvheadend.channelTags.find('key', key);
+
+    if (index !== -1)
+        var tagString = tvheadend.channelTags.getAt(index).get('val');
+
+    return tagString;
+};
+
 // Store for duration filters - EPG, autorec dialog and autorec rules in the DVR grid
 // NB: 'no max' is defined as 9999999s, or about 3 months...
 
@@ -637,7 +648,7 @@ tvheadend.epg = function() {
                 : "<i>Don't care</i>";
         var channel = epgStore.baseParams.channel ? tvheadend.channelLookupName(epgStore.baseParams.channel)
                 : "<i>Don't care</i>";
-        var tag = epgStore.baseParams.tag ? epgStore.baseParams.tag
+        var tag = epgStore.baseParams.tag ? tvheadend.tagLookupName(epgStore.baseParams.tag)
                 : "<i>Don't care</i>";
         var contenttype = epgStore.baseParams.contenttype ? tvheadend.contentGroupLookupName(epgStore.baseParams.contenttype)
                 : "<i>Don't care</i>";


### PR DESCRIPTION
Commit 3c088cb271d9cb3c27389eb2a18e604487aaadfe ("channel: tags - move to idnode system ") introduced a bug, in that the web UI started to show the UUID (hex string) value instead of the tag name, plus that wasn't then passed through to the autorec routine properly. This hopefully fixes both of those.

BTW, I take no responsibility for my appalling lack of git skills, so apologies in advance if we get a gazillion commits for a handful of changed lines...
