### PR TITLE
FIX: DVB-Scan during config

### DIFF
--- a/support/getmuxlist
+++ b/support/getmuxlist
@@ -11,8 +11,9 @@ DIR=$1
 if [ -d "${DIR}/.git" ]; then
   LAST=$(pwd)
   cd "${DIR}" || exit 1
-  git pull > /dev/null 2>&1 || exit 1
+  git fetch > /dev/null 2>&1 || exit 1
   git reset --hard > /dev/null 2>&1 || exit 1
+  git pull > /dev/null 2>&1 || exit 1
   cd "${LAST}" || exit 1
 # Fetch
 elif [ ! -d "${DIR}" ]; then


### PR DESCRIPTION
when configure tries to update the mux lists through git it would cause a fail if anything had been changed in the Data/dvb-scan folder

changed the inital git pull to a git fetch and added git pull after the git reset to make sure they have the latest files
