### PR TITLE
It seems kevent isn't working for this on freebsd, so disable for now...

### DIFF
--- a/src/input/mpegts/satip/satip_frontend.c
+++ b/src/input/mpegts/satip/satip_frontend.c
@@ -1274,6 +1274,7 @@ fast_exit:
           break;
       }
     }
+#if !defined(PLATFORM_FREEBSD) // temporary, until kevent is fixed properly
     /* for sure - the second sequence */
     r = rtsp_teardown(rtsp, (char *)rtcp, NULL);
     if (r < 0) {
@@ -1295,6 +1296,7 @@ fast_exit:
           break;
       }
     }
+#endif
   }
 
 done:


### PR DESCRIPTION
until we can do a proper fix.

The drawback is this may not be so good for some fewer sat>ip hardware which has bugs or does not conform to the sat>ip spec. So probably not much bad, since few users on freebsd anyway.

For issue #2261
