### PR TITLE
dvr: added option for automatic timer update window

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -36,6 +36,7 @@ typedef struct dvr_config {
   char *dvr_postproc;
   int dvr_extra_time_pre;
   int dvr_extra_time_post;
+  uint32_t dvr_update_window;
 
   muxer_container_type_t dvr_mc;
   muxer_config_t         dvr_muxcnf;
@@ -360,6 +361,8 @@ void dvr_extra_time_post_set(dvr_config_t *cfg, int d);
 void dvr_entry_delete(dvr_entry_t *de);
 
 void dvr_entry_cancel_delete(dvr_entry_t *de);
+
+void dvr_update_window_set(dvr_config_t *cfg, int minutes);
 
 /**
  * Query interface

--- a/src/webui/extjs.c
+++ b/src/webui/extjs.c
@@ -1131,6 +1131,7 @@ extjs_dvr(http_connection_t *hc, const char *remain, void *opaque)
     if(cfg->dvr_postproc != NULL)
       htsmsg_add_str(r, "postproc", cfg->dvr_postproc);
     htsmsg_add_u32(r, "retention", cfg->dvr_retention_days);
+    htsmsg_add_u32(r, "updateWindow", cfg->dvr_update_window);
     htsmsg_add_u32(r, "preExtraTime", cfg->dvr_extra_time_pre);
     htsmsg_add_u32(r, "postExtraTime", cfg->dvr_extra_time_post);
     htsmsg_add_u32(r, "dayDirs",        !!(cfg->dvr_flags & DVR_DIR_PER_DAY));
@@ -1187,6 +1188,9 @@ extjs_dvr(http_connection_t *hc, const char *remain, void *opaque)
 
     if((s = http_arg_get(&hc->hc_req_args, "retention")) != NULL)
       dvr_retention_set(cfg,atoi(s));
+
+    if((s = http_arg_get(&hc->hc_req_args, "updateWindow")) != NULL)
+      dvr_update_window_set(cfg,atoi(s));
 
     if((s = http_arg_get(&hc->hc_req_args, "preExtraTime")) != NULL)
       dvr_extra_time_pre_set(cfg,atoi(s));

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -929,7 +929,7 @@ tvheadend.dvrsettings = function() {
         'channelInTitle', 'container', 'cache', 'charset', 'dateInTitle', 'timeInTitle',
         'preExtraTime', 'postExtraTime', 'whitespaceInTitle', 'titleDirs',
         'episodeInTitle', 'cleanTitle', 'tagFiles', 'commSkip', 'subtitleInTitle',
-        'episodeBeforeDate', 'rewritePAT', 'rewritePMT', 'episodeDuplicateDetection']);
+        'episodeBeforeDate', 'rewritePAT', 'rewritePMT', 'episodeDuplicateDetection', 'updateWindow']);
 
     var confcombo = new Ext.form.ComboBox({
         store: tvheadend.configNames,
@@ -1000,6 +1000,12 @@ tvheadend.dvrsettings = function() {
         width: 350,
         fieldLabel: 'Post-processor command',
         name: 'postproc'
+    });
+
+    var updateWindow = new Ext.form.NumberField({
+        allowDecimals: false,
+        fieldLabel: 'Automatic timer update threshold (minutes)',
+        name: 'updateWindow'
     });
 
     /* Recording File Options */
@@ -1139,7 +1145,7 @@ tvheadend.dvrsettings = function() {
         autoHeight: true,
         collapsible: true,
         animCollapse: true,
-        items: [recordingContainer, cacheScheme, logRetention, timeBefore, timeAfter, postProcessing]
+        items: [recordingContainer, cacheScheme, logRetention, timeBefore, timeAfter, postProcessing, updateWindow]
     });
 
     /* Sub-Panel - File Output */


### PR DESCRIPTION
I'm experiencing a lot of troubles through automatic timer updates similar to https://tvheadend.org/issues/1818 . Therefore i have added a new dvr option which allows to configure the time window for autamtic timer updates which is currently hard coded to one day.
