### PR TITLE
Align condition when to show epg progress bar with bold face

### DIFF
--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -244,7 +244,7 @@ tvheadend.epg = function() {
         var now = new Date;
         var start = record.get('start');
 
-        if (now.getTime() > start.getTime()) {
+        if (now.getTime() >= start.getTime()) {
             meta.attr = 'style="font-weight:bold;"';
         }
     }
@@ -302,7 +302,7 @@ tvheadend.epg = function() {
                 var now = new Date();
 
                 // Only render a progress bar for currently running programmes
-                if (now <= end && now >= start)
+                if (now >= start)
                     return (now - start) / 1000 / duration * 100;
                 else
                     return "";


### PR DESCRIPTION
Currently running programmes (bold) should always show the progress bar to avoid an inconstitent user experience.
