### PR TITLE
[webui] enable any match mode for combo boxes

### DIFF
--- a/src/webui/static/app/idnode.js
+++ b/src/webui/static/app/idnode.js
@@ -370,6 +370,50 @@ tvheadend.idnode_editor_field = function(f, create)
             };
             st.on('load', fn);
         }
+        
+        // any match mode
+        r.doQuery = function(q, forceAll){
+	        q = Ext.isEmpty(q) ? '' : q;
+	        var qe = {
+	        query: q,
+		        forceAll: forceAll,
+		        combo: this,
+		        cancel:false
+	        };
+	         
+	        if (this.fireEvent('beforequery', qe) === false || qe.cancel)
+	        	return false;
+	        
+	        q = qe.query;
+	        forceAll = qe.forceAll;
+	        if (forceAll === true || (q.length >= this.minChars)) {
+		        if (this.lastQuery !== q) {
+		        	this.lastQuery = q;
+			        if (this.mode == 'local') {
+			        	this.selectedIndex = -1;
+				        if (forceAll) {
+				        	this.store.clearFilter();
+				        }
+				        else {
+				        	this.store.filter(this.displayField, q, true); // supply the anyMatch option
+				        }
+				        this.onLoad();
+			        }
+			        else {
+				        this.store.baseParams[this.queryParam] = q;
+				        this.store.load({
+				        	params: this.getParams(q)
+				        });
+				        this.expand();
+			        }
+		        }
+		        else {
+			        this.selectedIndex = -1;
+			        this.onLoad();
+		        }
+	        }
+        };
+        
         return r;
         /* TODO: listeners for regexp?
          listeners       : { 


### PR DESCRIPTION
This enables the any match mode for combo boxes in the idnode.js which fix the issue that you can't search only for a service name within the service combo box.
