### PR TITLE
fixed: keep a state per section in cwc. don't mark as forbidden when only one section fails

### DIFF
--- a/src/descrambler.h
+++ b/src/descrambler.h
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include "queue.h"
+#include "descrambler/descrambler_types.h"
 
 struct service;
 struct elementary_stream;
@@ -38,17 +39,13 @@ struct mpegts_mux;
  *
  * Created/Destroyed on per-transport basis upon transport start/stop
  */
+
 typedef struct th_descrambler {
   LIST_ENTRY(th_descrambler) td_service_link;
 
   char *td_nicename;
 
-  enum {
-    DS_UNKNOWN,
-    DS_RESOLVED,
-    DS_FORBIDDEN,
-    DS_IDLE
-  } td_keystate;
+  cwc_keystate_t td_keystate;
 
   struct service *td_service;
   struct tvhcsa  *td_csa;

--- a/src/descrambler/cwc.h
+++ b/src/descrambler/cwc.h
@@ -19,7 +19,10 @@
 #ifndef CWC_H_
 #define CWC_H_
 
+#include "descrambler_types.h"
+
 struct mpegts_mux;
+struct th_descrambler;
 
 void cwc_init(void);
 
@@ -29,5 +32,8 @@ void cwc_service_start(struct service *t);
 
 void cwc_caid_update(struct mpegts_mux *mux,
                      uint16_t caid, uint16_t pid, int valid);
+
+cwc_keystate_t cwc_keystate(struct th_descrambler *th);
+void cwc_set_keystate(struct th_descrambler *th, cwc_keystate_t state);
 
 #endif /* CWC_H_ */

--- a/src/descrambler/descrambler_types.h
+++ b/src/descrambler/descrambler_types.h
@@ -1,0 +1,18 @@
+/*
+ * descrambler_types.h
+ *
+ *  Created on: Sep 6, 2014
+ *      Author: Lars Op den Kamp
+ */
+
+#ifndef DESCRAMBLER_TYPES_H_
+#define DESCRAMBLER_TYPES_H_
+
+typedef enum {
+  DS_UNKNOWN,
+  DS_IDLE,
+  DS_FORBIDDEN,
+  DS_RESOLVED
+} cwc_keystate_t;
+
+#endif /* DESCRAMBLER_TYPES_H_ */


### PR DESCRIPTION
When there are multiple sections and one of them fails to decrypt, then the whole service got marked as 'DS_FORBIDDEN'. This gets corrected a bit later when a valid ecm reply comes in after the invalid ones, but in case the invalid one comes in after the valid reply, then decryption will stop completely.

This fixes the issue by keeping a state per section.
