### PR TITLE
api_epg.c: initialize safeptr to NULL

### DIFF
--- a/src/api/api_epg.c
+++ b/src/api/api_epg.c
@@ -29,7 +29,8 @@ static htsmsg_t *
 api_epg_get_list ( const char *s )
 {
   htsmsg_t *m = NULL;
-  char *r, *saveptr;
+  char *r;
+  char *saveptr = NULL;
   if (s && s[0] != '\0') {
     s = r = strdup(s);
     r = strtok_r(r, ";", &saveptr);


### PR DESCRIPTION
Fix compiler warning:
src/api/api_epg.c:37:14: Error: >>safeptr<< may be used unitialized in this function
