### PR TITLE
WebUI: Correct 'All' paging in idnode grids

### DIFF
--- a/src/webui/static/app/idnode.js
+++ b/src/webui/static/app/idnode.js
@@ -1331,7 +1331,7 @@ tvheadend.idnode_grid = function(panel, conf)
                 id: 0,
                 fields: ['key', 'val'],
                 data: [[25, '25'], [50, '50'], [100, '100'],
-                    [200, '200'], [9999999999, 'All']]
+                    [200, '200'], [999999999, 'All']]
             }),
             value: 50,
             mode: 'local',


### PR DESCRIPTION
The 'all' page size was set to 9,999,999,999, which is larger than the unsigned int 32 value of 4,294,967,295 and was thus overflowing and getting ignored.

I've just taken it down to 999,999,999 instead - still big enough for the most greedy of service lists, I hope!
