### PR TITLE
WEB UI: EPG: Fix the channel tag passing to autorec (completes fix to ...

### DIFF
--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -862,7 +862,7 @@ tvheadend.epg = function() {
         };
         if (params.title) conf.title = params.title;
         if (params.channel) conf.channel = params.channel;
-        if (params.tag) conf.tag = params.channelTag;
+        if (params.channelTag) conf.tag = params.channelTag;
         if (params.contentType) conf.content_type = params.contentType;
         if (params.durationMin) conf.minduration = params.durationMin;
         if (params.durationMax) conf.maxduration = params.durationMax;


### PR DESCRIPTION
... #2340)

Incorrect parameter checked in the js (params.tag vs params.channelTag) meaning that conf.tag is never set and thus never makes it to the autorec rules.
