### PR TITLE
tvhdhomerun: check return values of setsockopt

### DIFF
--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c
@@ -128,11 +128,13 @@ tvhdhomerun_frontend_input_thread ( void *aux )
 
   /* enable broadcast */
   if(setsockopt(sockfd, SOL_SOCKET, SO_BROADCAST, (char *) &sock_opt, sizeof(sock_opt)) < 0) {
+    close(sockfd);
     tvhlog(LOG_ERR, "tvhdhomerun", "failed to enable broadcast on socket (%d)", errno);
     return NULL;
   }
 
   if(setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, (char *) &sock_opt, sizeof(sock_opt)) < 0) {
+    close(sockfd);
     tvhlog(LOG_ERR, "tvhdhomerun", "failed to set address reuse on socket (%d)", errno);
     return NULL;
   }
@@ -148,12 +150,14 @@ tvhdhomerun_frontend_input_thread ( void *aux )
   sock_addr.sin_port = 0;
   if(bind(sockfd, (struct sockaddr *) &sock_addr, sizeof(sock_addr)) != 0) {
     tvhlog(LOG_ERR, "tvhdhomerun", "failed bind socket: %d", errno);
+    close(sockfd);
     return NULL;
   }
 
   memset(&sock_addr, 0, sizeof(sock_addr));
   if(getsockname(sockfd, (struct sockaddr *) &sock_addr, &sockaddr_len) != 0) {
     tvhlog(LOG_ERR, "tvhdhomerun", "failed to getsockname: %d", errno);
+    close(sockfd);
     return NULL;
   }
 
@@ -227,7 +231,7 @@ tvhdhomerun_frontend_input_thread ( void *aux )
 
   sbuf_free(&sb);
   tvhpoll_destroy(efd);
-  shutdown(sockfd, SHUT_RD);
+  close(sockfd);
   return NULL;
 }
 


### PR DESCRIPTION
This is a very small fix for the case when _setsockopt_ fails to set socket options. The return value was never checked, which may lead to use-cases where the plugin fails silently. This introduces some helpful log messages for those cases. Note that setting the rx buffer is allowed to fail: without it the user will be getting continuity errors but for some cases this might work (SD streams).
