### PR TITLE
Fixes #2479. Double free of hdhomerun_debug_obj

### DIFF
--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
@@ -419,5 +419,4 @@ tvhdhomerun_device_destroy( tvhdhomerun_device_t *hd )
 #undef FREEM
 
   free(hd);
-  hdhomerun_debug_destroy(hdhomerun_debug_obj);
 }


### PR DESCRIPTION
https://tvheadend.org/issues/2479
