### PR TITLE
WebUI: idnode.js rollup improvements

### DIFF
--- a/src/webui/static/app/idnode.js
+++ b/src/webui/static/app/idnode.js
@@ -677,6 +677,7 @@ tvheadend.idnode_editor_form = function(d, meta, panel, conf)
                        autoWidth: true,
                        collapsible: conf.nocollapse ? false : true,
                        collapsed: conf.collapsed ? true : false,
+                       animCollapse: true,
                        items: conf.items
                    });
     }


### PR DESCRIPTION
Specifically:
1. Enable rolled up-or-not status when creating an idnode panel
2. Set readonly panels to be rolled up by default (saves vertical screen real estate)
3. Enable animated rollup in idnode panels for UI consistency (e.g. with configuration panels)
