### PR TITLE
http: fix streaming behind https reverse proxy and non-default webroot

### DIFF
--- a/src/webui/webui.c
+++ b/src/webui/webui.c
@@ -368,14 +368,10 @@ static char *
 http_get_hostpath(http_connection_t *hc)
 {  
   char buf[255];
-  const char *host = http_arg_get(&hc->hc_args, "Host");
-  const char *forwarded_host = http_arg_get(&hc->hc_args, "X-Forwarded-Host");
+  const char *host = http_arg_get(&hc->hc_args, "Host") ?: http_arg_get(&hc->hc_args, "X-Forwarded-Host");
   const char *proto = http_arg_get(&hc->hc_args, "X-Forwarded-Proto");
 
-  snprintf(buf, sizeof(buf), "%s://%s%s", 
-     proto ? proto : "http", 
-     forwarded_host ? forwarded_host : host,
-     tvheadend_webroot ? tvheadend_webroot : "");
+  snprintf(buf, sizeof(buf), "%s://%s%s", proto ?: "http", host, tvheadend_webroot ?: "");
 
   return strdup(buf);
 }


### PR DESCRIPTION
These set of changes fix the following problems concerning streaming behind a https reverse proxy and a non-default webroot:

Starting tvheadend with `--http_root /tvheadend` and accessing it via an nginx reverse proxy, using the following (proxy) configuration...

```
location /tvheadend {
    proxy_pass http://127.0.0.1:9981/tvheadend;
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_set_header Host externalhostname; 

    ## optionally, the following header can be used to override the hostname:
    # proxy_set_header X-Forwarded-Host someotherhost;
}
```

... I can successfully retrieve the channel playlist using `https://externalhostname/tvheadend/playlist/channels`.

However, the playlist contains wrong URLs, such as `http://externalhostname/stream/channelid/123`.

Instead, I would have expected the playlist to contain URLs like `https://externalhostname/tvheadend/stream/channelid/123`.
This includes obeying the used protocol (i.e., https instead of http) and the specified webroot (i.e., /tvheadend).

My changeset fixes these problems.
More precisely, it allows the reverse proxy to override both the protocol (i.e., using the `X-Forwarded-Proto` HTTP header) and the hostname (i.e., using the `Host` or the `X-Forwarded-Host` HTTP header).
