### PR TITLE
access: fix access_ticket_verify2() when using non-default webroot

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -153,11 +153,11 @@ access_ticket_verify2(const char *id, const char *resource)
   if((at = access_ticket_find(id)) == NULL)
     return NULL;
 
-  char at_resource_with_webroot[256];
-  strcat(at_resource_with_webroot, tvheadend_webroot ?: "");
-  strcat(at_resource_with_webroot, at->at_resource);
+  char buf[256];
+  strcpy(buf, tvheadend_webroot ?: "");
+  strcat(buf, at->at_resource);
 
-  if(strcmp(at->at_resource, resource) && strcmp(at_resource_with_webroot, resource))
+  if(strcmp(buf, resource))
     return NULL;
 
   return access_copy(at->at_access);


### PR DESCRIPTION
I have just found another issue related to a non-default webroot (the context of this problem is the same as in #563).
The problem is, that `access_ticket_verify2()` does not consider `tvheadend_webroot`.
For instance, a ticket might have been issued for the resource `/stream/channelid/123`, while a client will request the resource `/tvheadend/stream/channelid/123` (i.e., if tvheadend is started with `--http_root /tvheadend`).
As a result, `access_ticket_verify2()` will (wrongly) deny the request.
