### PR TITLE
dvb-psi: Fix LCN for UMKBW germany DVB-C

### DIFF
--- a/src/input/mpegts/dvb_psi.c
+++ b/src/input/mpegts/dvb_psi.c
@@ -1515,7 +1515,7 @@ dvb_nit_callback
         case 0x82:
           if (priv == 0) goto lcn;
         case 0x83:
-          if (priv == 0 || priv == 0x28 || priv == 0xa5) goto lcn;
+          if (priv == 0 || priv == 0x28 || priv == 0x29 || priv == 0xa5) goto lcn;
         case 0x86:
           if (priv == 0) goto lcn;
         case 0x93:


### PR DESCRIPTION
Checking for 0x29 in the private data field restores LCN handling for UnitymediaKabelBW DVB-C Germany.

Not sure if this is the correct way to fix this, just found out that during scanning muxes dtag always was 0x83 and the priv field was 0x29, which wasn't before and caused LCNs to be all zero.
