### PR TITLE
WebUI: Restore weekday name to Upcoming/Finished/Failed Recordings grids

### DIFF
--- a/src/webui/static/app/idnode.js
+++ b/src/webui/static/app/idnode.js
@@ -303,7 +303,7 @@ tvheadend.IdNodeField = function(conf)
             }
             return function(v) {
                 var dt = new Date(v * 1000);
-                return dt.toLocaleString();
+                return dt.toLocaleString(window.navigator.language, {weekday: 'short'}) + ' ' + dt.toLocaleString();
             }
         }
 


### PR DESCRIPTION
This is a simple change to restore the weekday to the lists of recordings - it used to be there, but dropped out sometime recently. I don't know about anyone else, but a slab of upcoming/finished recordings listed solely by date doesn't make as much sense to me as something that includes the day, 'cos that's how my head works.

So, we go from this:

![screen1](https://cloud.githubusercontent.com/assets/6093716/5518060/adce2878-890a-11e4-80f8-250678848673.png)

... to this:

![screen2](https://cloud.githubusercontent.com/assets/6093716/5518061/b3ee8f86-890a-11e4-98d0-33f68eb11d25.png)

**Thoughts and comments:**
1. It goes against 'universal date formatting' a little, but that's unavoidable: weekdays aren't included in any default dd-mm-yyyy hh:mm:ss -style representation.
2. This _SHOULD_ work in your locale, so you'd get Mon/Tue/Wed or Lun/Mard/Mecr or Mon/Dien/Wod or whatever your browser language is. 
3. Arguably, we could (probably...!) do the same with a renderer on the grid in dvr.js, but changing idnode.js does it for all instances in one go, which seems neater.
4. The column is getting a bit wide. I can personally live with that, as the day/date/hour is more important to me than the minutes/seconds - plus, you can always resize to your preference. Comment if someone violently disagrees, please.  
5. Following that thought, there is the argument to reformat the lot to something else (e.g. Mon, 22 Dec 14, 20:30), but now we're back into whether your locale uses yyyy-mm-dd, dd-mm-yyyy or mm-dd-yyyy so I think this is unnecessary.

I'd probably add the day of week into the info boxes as well if that's acceptable, i.e. this one:

![screen3](https://cloud.githubusercontent.com/assets/6093716/5518128/7dcfe338-890e-11e4-9ad7-6742f98ba39f.png)

(I want to fix that 'Undefined' error, so I'll do it as part of a separate dialog PR)
