### PR TITLE
WebUI: Increase CSS spacing on day of week in EPG/DVR info dialogs

### DIFF
--- a/src/webui/static/app/ext.css
+++ b/src/webui/static/app/ext.css
@@ -513,7 +513,7 @@
 
 .x-nice-dayofweek {
     display: inline-block;
-    width: 4em;
+    width: 6em;
 }
 
 .x-nice-date {


### PR DESCRIPTION
As it says, really - slight increase in the spacing for the weekday so that long days (e.g. Wednesday) don't crash into the date field.
