### PR TITLE
Issue 1625 - Option for Windows-compatible filenames (was: Filename: Umlaute and special characters)

### DIFF
--- a/docs/html/config_dvr.html
+++ b/docs/html/config_dvr.html
@@ -176,10 +176,17 @@
   <dd>If checked, insert the episode number before the data and time rather than after (assumes <i>Include date</i>, <i>Include time</i> and <i>Include episode</i> options are set).
 	  
   <dt>Remove all unsafe characters from filename
-  <dd>If checked, all characters that could possibly cause problems for filenaming will be removed.
+  <dd>If checked, all characters that could possibly cause problems for filenaming will be replaced with '_'.<br>
+  	  Applies to characters:<br>
+      * not supported by Windows characters: <i>/ : \ < > | * ? ' "</i><br>
+      * control characters (ASCII code below 32)<br>
+      * control and national characters (ASCII code above 122)<br> 
   
   <dt>Replace whitespace in title with '-'
-  <dd>If checked, all whitespace characters will be replaced with '-'.
+  <dd>If checked, whitespace characters (spaces and tabs) will be replaced with '-'.
+  
+  <dt>Use Windows-compatible filenames
+  <dd>If checked, special characters not supported by Windows like: <i>/ : \ < > | * ? ' "</i> will be replaced with '_'.
   
  </dl>
  Changes to any of these settings must be confirmed by pressing the 'Save configuration' button before taking effect.

--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -64,6 +64,7 @@ typedef struct dvr_config {
   int dvr_subtitle_in_title;
   int dvr_episode_before_date;
   int dvr_episode_duplicate;
+  int dvr_clean_samba_unsafe;
 
   /* Series link support */
   int dvr_sl_brand_lock;

--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -64,7 +64,7 @@ typedef struct dvr_config {
   int dvr_subtitle_in_title;
   int dvr_episode_before_date;
   int dvr_episode_duplicate;
-  int dvr_clean_samba_unsafe;
+  int dvr_windows_compatible_filenames;
 
   /* Series link support */
   int dvr_sl_brand_lock;

--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -727,6 +727,13 @@ const idclass_t dvr_config_class = {
       .off      = offsetof(dvr_config_t, dvr_whitespace_in_title),
       .group    = 5,
     },
+    {
+      .type     = PT_BOOL,
+      .id       = "clean-samba-unsafe",
+      .name     = "Replace Samba Unsafe Characters with '_'",
+      .off      = offsetof(dvr_config_t, dvr_clean_samba_unsafe),
+      .group    = 5,
+    },
     {}
   },
 };

--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -729,9 +729,9 @@ const idclass_t dvr_config_class = {
     },
     {
       .type     = PT_BOOL,
-      .id       = "clean-samba-unsafe",
-      .name     = "Replace Samba Unsafe Characters with '_'",
-      .off      = offsetof(dvr_config_t, dvr_clean_samba_unsafe),
+      .id       = "windows-compatible-filenames",
+      .name     = "Use Windows-compatible filenames",
+      .off      = offsetof(dvr_config_t, dvr_windows_compatible_filenames),
       .group    = 5,
     },
     {}

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -164,6 +164,9 @@ cleanup_filename(char *s, dvr_config_t *cfg)
             ((s[i] < 32) || (s[i] > 122) ||
              (strchr("/:\\<>|*?'\"", s[i]) != NULL)))
       s[i] = '_';
+    else if(cfg->dvr_clean_samba_unsafe &&
+             (strchr("/:\\<>|*?'\"", s[i]) != NULL))
+      s[i] = '_';
   }
 
   return s;

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -164,7 +164,7 @@ cleanup_filename(char *s, dvr_config_t *cfg)
             ((s[i] < 32) || (s[i] > 122) ||
              (strchr("/:\\<>|*?'\"", s[i]) != NULL)))
       s[i] = '_';
-    else if(cfg->dvr_clean_samba_unsafe &&
+    else if(cfg->dvr_windows_compatible_filenames &&
              (strchr("/:\\<>|*?'\"", s[i]) != NULL))
       s[i] = '_';
   }


### PR DESCRIPTION
See: https://tvheadend.org/issues/1625
When filename created by DVR contains both national characters (umlate or ąęłóśź) and special characters (like colon : ), file created by DVR is not accesible from Windows by Samba sharing.
It is possible to remove ALL unsafe characters, but it removes both special characters (it's OK) and national characters (it's not OK).

This pull request adds new option in DVR configuration, called "Replace Samba Unsafe Characters with '_'".
And when this option is checked, replaces unsafe characters / : \ < > | * ? ' " to _