### PR TITLE
accept "%c" placeholder for channel icons to use unmangled channel

### DIFF
--- a/docs/html/config_misc.html
+++ b/docs/html/config_misc.html
@@ -83,9 +83,13 @@
     <dd>If both a picon and a channel-specific (e.g. channelname.jpg) icon are defined, use the picon.</dd>
  
     <dt>Channel icon path</dt>
-    <dd>Path to an icon for this channel. This can be named however you wish, as a local (file://) or remote (http://) image.<br>
-	Example: file:///tmp/icons/%C.png (where %C is the channel nameon local storage where
-	is TVHeadend) or http://example.com/example.png to set icon from web page.</dd>
+    <dd>Path to an icon for this channel. This can be named however you wish, as a local (file://) or remote (http://) image. 
+        The following placeholders are available:<br>
+	<ul>
+		<li>%C - the transliterated channel name in ASCII (safe characters, no spaces etc.)</li>
+		<li>%c - the channel name (URL encoded ASCII)</li>
+	</ul>
+	Example: file:///tmp/icons/%C.png or http://example.com/%c.png</dd>
   
     <dt>Picon path</dt>
     <dd>Path to a directory (folder) containing your picon collection. This can be named however 

--- a/src/channels.c
+++ b/src/channels.c
@@ -645,17 +645,14 @@ channel_get_icon ( channel_t *ch )
         (chname = channel_get_name(ch)) != NULL && chname[0]) {
       const char *chi, *send, *sname, *s;
       chi = strdup(chicon);
-      send = strstr(chi, "%C");
-      if (send == NULL) {
-        buf[0] = '\0';
-        sname = "";
-      } else {
-        *(char *)send = '\0';
-        send += 2;
+
+      /* Check for and replace placeholders */
+      if ((send = strstr(chi, "%C"))) {
         sname = intlconv_utf8safestr(intlconv_charset_id("ASCII", 1, 1),
                                      chname, strlen(chname) * 2);
         if (sname == NULL)
           sname = strdup(chname);
+
         /* Remove problematic characters */
         s = sname;
         while (s && *s) {
@@ -665,6 +662,26 @@ channel_get_icon ( channel_t *ch )
           s++;
         }
       }
+      else if((send = strstr(chi, "%c"))) {
+        char *aname = intlconv_utf8safestr(intlconv_charset_id("ASCII", 1, 1),
+                                     chname, strlen(chname) * 2);
+
+        if (aname == NULL)
+          aname = strdup(chname);
+
+        sname = url_encode(aname);
+        free((char *)aname);
+      }
+      else {
+        buf[0] = '\0';
+        sname = "";
+      }
+
+      if (send) {
+        *(char *)send = '\0';
+        send += 2;
+      }
+
       snprintf(buf, sizeof(buf), "%s%s%s", chi, sname ?: "", send ?: "");
       if (send)
         free((char *)sname);

--- a/src/tvheadend.h
+++ b/src/tvheadend.h
@@ -711,6 +711,10 @@ int rmtree ( const char *path );
 
 char *regexp_escape ( const char *str );
 
+/* URL decoding */
+char to_hex(char code);
+char *url_encode(char *str);
+
 static inline int32_t deltaI32(int32_t a, int32_t b) { return (a > b) ? (a - b) : (b - a); }
 static inline uint32_t deltaU32(uint32_t a, uint32_t b) { return (a > b) ? (a - b) : (b - a); }
   

--- a/src/utils.c
+++ b/src/utils.c
@@ -25,6 +25,7 @@
 #include <sys/types.h>
 #include <dirent.h>
 #include <unistd.h>
+#include <ctype.h>
 #include "tvheadend.h"
 
 #if defined(PLATFORM_DARWIN)
@@ -588,3 +589,29 @@ regexp_escape(const char* str)
   *b = 0;
   return tmp;
 }
+
+/* Converts an integer value to its hex character
+   http://www.geekhideout.com/urlcode.shtml */
+char to_hex(char code) {
+  static char hex[] = "0123456789abcdef";
+  return hex[code & 15];
+}
+
+/* Returns a url-encoded version of str
+   IMPORTANT: be sure to free() the returned string after use
+   http://www.geekhideout.com/urlcode.shtml */
+char *url_encode(char *str) {
+  char *pstr = str, *buf = malloc(strlen(str) * 3 + 1), *pbuf = buf;
+  while (*pstr) {
+    if (isalnum(*pstr) || *pstr == '-' || *pstr == '_' || *pstr == '.' || *pstr == '~') 
+      *pbuf++ = *pstr;
+    /*else if (*pstr == ' ') 
+      *pbuf++ = '+';*/
+    else 
+      *pbuf++ = '%', *pbuf++ = to_hex(*pstr >> 4), *pbuf++ = to_hex(*pstr & 15);
+    pstr++;
+  }
+  *pbuf = '\0';
+  return buf;
+}
+

--- a/src/webui/static/app/config.js
+++ b/src/webui/static/app/config.js
@@ -140,13 +140,13 @@ tvheadend.miscconf = function(panel, index) {
 
     var chiconPath = new Ext.form.TextField({
         name: 'chiconpath',
-        fieldLabel: 'Channel icon path<br/>(e.g. file:///tmp/icons/%C.png or http://...)',
+        fieldLabel: 'Channel icon path (see Help)',
         width: 400
     });
 
     var piconPath = new Ext.form.TextField({
         name: 'piconpath',
-        fieldLabel: 'Picon path<br/>(e.g. file:///tmp/picons or http://...)',
+        fieldLabel: 'Picon path (see Help)',
         width: 400
     });
 


### PR DESCRIPTION
I have all my channel icons on a web server named exactly like the channel, e.g. "Yle TV1 HD.png". With this patch I don't have to do any renaming when mapping channels.

@perexg does tvheadend have a helper for URL-encoding strings? I'm not completely sure that the current approach works since the URL isn't escaped (spaces should be converted to %20 etc.).