### PR TITLE
Issue 1625 - Option for Windows-compatible filenames - trim trailing spaces and dots

### DIFF
--- a/docs/html/config_dvr.html
+++ b/docs/html/config_dvr.html
@@ -186,7 +186,9 @@
   <dd>If checked, whitespace characters (spaces and tabs) will be replaced with '-'.
   
   <dt>Use Windows-compatible filenames
-  <dd>If checked, special characters not supported by Windows like: <i>/ : \ < > | * ? ' "</i> will be replaced with '_'.
+  <dd>If checked:<br>
+      * special characters not supported by Windows like: <i>/ : \ < > | * ? ' "</i> will be replaced with '_'<br>
+      * trailing spaces ' ' and dots '.' will be removed
   
  </dl>
  Changes to any of these settings must be confirmed by pressing the 'Save configuration' button before taking effect.

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -151,7 +151,8 @@ cleanup_filename(char *s, dvr_config_t *cfg)
   if (s[0] == '.')
     s[0] = '_';
 
-  for (i = 0, len = strlen(s); i < len; i++) {
+  int len2 = strlen(s);
+  for (i = 0; i < len2; i++) {
 
     if(s[i] == '/')
       s[i] = '-';
@@ -167,6 +168,18 @@ cleanup_filename(char *s, dvr_config_t *cfg)
     else if(cfg->dvr_windows_compatible_filenames &&
              (strchr("/:\\<>|*?'\"", s[i]) != NULL))
       s[i] = '_';
+  }
+
+  if(cfg->dvr_windows_compatible_filenames) {
+    //trim trailing spaces and dots
+    for (i = len2 - 1; i >= 0; i--) {
+      if((s[i] == ' ') || (s[i] == '.')) {
+        s[i] = '\0';
+      }
+      else {
+          break;
+      }
+    }
   }
 
   return s;

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -135,6 +135,7 @@ static char *
 cleanup_filename(char *s, dvr_config_t *cfg)
 {
   int i, len = strlen(s);
+  int len2;
   char *s1;
 
   s1 = intlconv_utf8safestr(cfg->dvr_charset_id, s, len * 2);
@@ -151,7 +152,7 @@ cleanup_filename(char *s, dvr_config_t *cfg)
   if (s[0] == '.')
     s[0] = '_';
 
-  int len2 = strlen(s);
+  len2 = strlen(s);
   for (i = 0; i < len2; i++) {
 
     if(s[i] == '/')
@@ -173,11 +174,11 @@ cleanup_filename(char *s, dvr_config_t *cfg)
   if(cfg->dvr_windows_compatible_filenames) {
     //trim trailing spaces and dots
     for (i = len2 - 1; i >= 0; i--) {
-      if((s[i] == ' ') || (s[i] == '.')) {
-        s[i] = '\0';
+      if((s[i] != ' ') && (s[i] != '.')) {
+          break;
       }
       else {
-          break;
+        s[i] = '\0';
       }
     }
   }


### PR DESCRIPTION
Fix for: https://tvheadend.org/issues/1625#note-5