### PR TITLE
Update timeshift_filemgr.c

### DIFF
--- a/src/timeshift/timeshift_filemgr.c
+++ b/src/timeshift/timeshift_filemgr.c
@@ -208,7 +208,8 @@ timeshift_file_t *timeshift_filemgr_get ( timeshift_t *ts, int create )
       timeshift_filemgr_close(tsf_tl);
 
     /* Check period */
-    if (ts->max_time && tsf_hd && tsf_tl) {
+    if (!timeshift_unlimited_period &&
+        ts->max_time && tsf_hd && tsf_tl) {
       time_t d = (tsf_tl->time - tsf_hd->time) * TIMESHIFT_FILE_PERIOD;
       if (d > (ts->max_time+5)) {
         if (!tsf_hd->refcount) {


### PR DESCRIPTION
It seems that in currently the timeshift_unlimited_period boolean is completely ignored when it comes to taking action on removing files or reporting a full buffer. This small patch should fix that, so that when the timeshift_unlimited_period boolean is set to true, tvheadend no longer evaluates the period of the current timeshift.