### PR TITLE
Fix 519ec96

### DIFF
--- a/src/descrambler/capmt.c
+++ b/src/descrambler/capmt.c
@@ -916,6 +916,10 @@ capmt_stop_filter(capmt_t *capmt, int adapter, sbuf_t *sb, int offset)
 static void
 capmt_notify_server(capmt_t *capmt, capmt_service_t *ct, int force)
 {
+  /* flush out the greeting */
+  if (capmt->capmt_oscam == CAPMT_OSCAM_NET_PROTO)
+    capmt_flush_queue(capmt, 0);
+
   pthread_mutex_lock(&capmt->capmt_mutex);
   if (capmt_oscam_new(capmt)) {
     if (!LIST_EMPTY(&capmt->capmt_services))


### PR DESCRIPTION
When there was a further subscribing requests, the queued greeting could
be queued not as the first position in the queue, leading to problems
when subscribing the channel.
Now requesting to flush the queue in capmt_notify_server() to be sure
that the greeting go out to OSCam as a first command.