### PR TITLE
fastscan should add muxes

### DIFF
--- a/src/input/mpegts/dvb_psi.c
+++ b/src/input/mpegts/dvb_psi.c
@@ -1332,7 +1332,12 @@ dvb_nit_mux
     case DVB_DESC_TERR_DEL:
       if (discovery) {
         if (dtag == DVB_DESC_SAT_DEL)
-          mux = dvb_desc_sat_del(mm, onid, tsid, dptr, dlen, 0);
+        {
+          if (tableid == DVB_FASTSCAN_NIT_BASE)
+            mux = dvb_desc_sat_del(mm, onid, tsid, dptr, dlen, 1);
+          else
+            mux = dvb_desc_sat_del(mm, onid, tsid, dptr, dlen, 0);
+        }
         else if (dtag == DVB_DESC_CABLE_DEL)
           mux = dvb_desc_cable_del(mm, onid, tsid, dptr, dlen);
         else


### PR DESCRIPTION
This seems at least fix the autodiscovery issue with fastscan from here:
https://tvheadend.org/issues/2657#change-12390

I'm not sure if this fix is correct, but it seems working.

Forcing mux was only done for SDT fastscan and not for NIT fastscan.