### PR TITLE
use iso format for date in default timerec title

### DIFF
--- a/docs/html/dvr_timerec.html
+++ b/docs/html/dvr_timerec.html
@@ -56,14 +56,19 @@ When specified, this setting overrides the subdirectory rules specified by the D
 <p>
 <dt><b>Title</b>
 <dd>
-Not sure how this differs from **Name* *
+The title is used in the filename that is created for the recording
 <br>
 <br>
-The default format string suggests Time-[date]-[time]:
+The default format string suggests Time-[date]_[time]:
 <br>
 <br>
-%x The local date, formatted according to your locale settings
-%R The time in HH;MM format
+The escape-codes use <a href="http://man7.org/linux/man-pages/man3/strftime.3.html">strftime</a> format. Examples:
+<br>
+%F The date in ISO-format (e.g. 2015-02-28)
+<br>
+%R The time in 24h HH:MM format (e.g. 19:45)
+<br>
+%x The date, formatted according to your locale settings
 <p>
 <dt><b>Channel</b>
 <dd>

--- a/src/dvr/dvr_timerec.c
+++ b/src/dvr/dvr_timerec.c
@@ -183,7 +183,7 @@ dvr_timerec_create(const char *uuid, htsmsg_t *conf)
     return NULL;
   }
 
-  dte->dte_title = strdup("Time-%x-%R");
+  dte->dte_title = strdup("Time-%F_%R");
   dte->dte_weekdays = 0x7f;
   dte->dte_pri = DVR_PRIO_NORMAL;
   dte->dte_start = -1;
@@ -557,7 +557,7 @@ const idclass_t dvr_timerec_entry_class = {
       .id       = "title",
       .name     = "Title",
       .off      = offsetof(dvr_timerec_entry_t, dte_title),
-      .def.s    = "Time-%x-%R",
+      .def.s    = "Time-%F_%R",
     },
     {
       .type     = PT_STR,


### PR DESCRIPTION
as local date format often conflicts with sorting/playback order
also update documentation with pointers to escape-code documentation