### PR TITLE
No calls to stat() in dvr_inotify_add(). This may significantly slowdown tvh startup.

### DIFF
--- a/src/dvr/dvr_inotify.c
+++ b/src/dvr/dvr_inotify.c
@@ -98,18 +98,13 @@ void dvr_inotify_add ( dvr_entry_t *de )
   if (_inot_fd < 0)
     return;
 
-  if (!de->de_filename || stat(de->de_filename, &st))
+  if (!de->de_filename)
     return;
 
   path = strdup(de->de_filename);
 
   SKEL_ALLOC(dvr_inotify_entry_skel);
   dvr_inotify_entry_skel->path = dirname(path);
-  
-  if (stat(dvr_inotify_entry_skel->path, &st)) {
-    free(path);
-    return;
-  }
   
   e = RB_INSERT_SORTED(&_inot_tree, dvr_inotify_entry_skel, link, _str_cmp);
   if (!e) {


### PR DESCRIPTION
In my case, my recordings are stored on a NAS that automatically falls asleep if it is not accessed for a certain amount of time. Thus, if my NAS sleeps while tvh starts up, the stat() calls in dvr_inotify_add() awake my NAS which can take up to 15 secs and tvh startup is slowed down by (at least) this 15 secs.

OTOH the stat calls IMO can simply be omitted. I cannot see any drawbacks with adding an inotify_watch without doing stat before. inotify thread will detect later (asynchronously) that the file is not present.