### PR TITLE
transcoding: fix encoder time_base again

### DIFF
--- a/src/plumbing/transcoding.c
+++ b/src/plumbing/transcoding.c
@@ -1027,9 +1027,16 @@ transcoder_stream_video(transcoder_t *t, transcoder_stream_t *ts, th_pkt_t *pkt)
     octx->width           = vs->vid_width  ? vs->vid_width  : ictx->width;
     octx->height          = vs->vid_height ? vs->vid_height : ictx->height;
     octx->gop_size        = 25;
-    octx->time_base.den   = ictx->time_base.den;
-    octx->time_base.num   = ictx->time_base.num;
     octx->has_b_frames    = ictx->has_b_frames;
+
+    // Encoder uses "time_base" for bitrate calculation, but "time_base" from decoder
+    // will be deprecated in the future, therefore calculate "time_base" from "framerate" if available.
+    octx->ticks_per_frame = ictx->ticks_per_frame;
+    if (ictx->framerate.num != 0 && ictx->framerate.den != 0) {
+      octx->time_base     = av_inv_q(av_mul_q(ictx->framerate, av_make_q(ictx->ticks_per_frame, 1)));
+    } else {
+      octx->time_base     = ictx->time_base;
+    }
 
     switch (ts->ts_type) {
     case SCT_MPEG2VIDEO:


### PR DESCRIPTION
Apparently my last push request still had an error in it. 

It was missing the `ticks_per_frame`, which is usually 2 when decoding h264 or mpeg2 but by default set to 1 in encoder context.

I also changed it to use `framerate` instead of `time_base` from decoder context to calculate `time_base` for encoder context, as reading `time_base` from decoder context is marked deprecated and will probably be removed in a future version of ffmpeg.