### PR TITLE
capmt: fix endless loop

### DIFF
--- a/src/descrambler/capmt.c
+++ b/src/descrambler/capmt.c
@@ -1372,7 +1372,7 @@ handle_single(capmt_t *capmt)
        }
         if (adapter < MAX_CA) {
           cmd_size = capmt_msg_size(capmt, &buffer, offset);
-          if (cmd_size >= 0)
+          if (cmd_size > 0)
             break;
         }
         sbuf_cut(&buffer, 1);


### PR DESCRIPTION
When tvh receives less then 4 bytes from the socket for some reason,
it stuck in the endless loop in handle_single() calling:
capmt_msg_size()
capmt_analyze_cmd()
The capmt thread eats 100% CPU and cannot be normally terminated
because the capmt_msg_size() was constantly returning 0.

The commit fixes the problem.