### PR TITLE
epggrab: allow updating channel name/number/icon

### DIFF
--- a/src/channels.c
+++ b/src/channels.c
@@ -1,6 +1,6 @@
 /*
  *  tvheadend, channel functions
- *  Copyright (C) 2007 Andreas Öman
+ *  Copyright (C) 2007 Andreas Ã–man
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -587,6 +587,19 @@ channel_get_name ( channel_t *ch )
   return blank;
 }
 
+int
+channel_set_name ( channel_t *ch, const char *name )
+{
+  int save = 0;
+  if (!ch || !name) return 0;
+  if (!ch->ch_name || strcmp(ch->ch_name, name) ) {
+    if (ch->ch_name) free(ch->ch_name);
+    ch->ch_name = strdup(name);
+    save = 1;
+  }
+  return save;
+}
+
 int64_t
 channel_get_number ( channel_t *ch )
 {
@@ -609,6 +622,19 @@ channel_get_number ( channel_t *ch )
     return n;
   }
   return 0;
+}
+
+int
+channel_set_number ( channel_t *ch, uint32_t major, uint32_t minor )
+{
+  int save = 0;
+  int64_t chnum = (uint64_t)major * CHANNEL_SPLIT + (uint64_t)minor;
+  if (!ch || !chnum) return 0;
+  if (!ch->ch_number || ch->ch_number != chnum) {
+    ch->ch_number = chnum;
+    save = 1;
+  }
+  return save;
 }
 
 static int
@@ -736,6 +762,18 @@ channel_get_icon ( channel_t *ch )
   }
 
   return buf;
+}
+
+int channel_set_icon ( channel_t *ch, const char *icon )
+{
+  int save = 0;
+  if (!ch || !icon) return 0;
+  if (!ch->ch_icon || strcmp(ch->ch_icon, icon) ) {
+    if (ch->ch_icon) free(ch->ch_icon);
+    ch->ch_icon = strdup(icon);
+    save = 1;
+  }
+  return save;
 }
 
 /* **************************************************************************

--- a/src/channels.h
+++ b/src/channels.h
@@ -1,6 +1,6 @@
 /*
  *  tvheadend, channel functions
- *  Copyright (C) 2007 Andreas Öman
+ *  Copyright (C) 2007 Andreas Ã–man
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -190,7 +190,7 @@ int channel_tag_access(channel_tag_t *ct, struct access *a, int disabled);
 void channel_save(channel_t *ch);
 
 const char *channel_get_name ( channel_t *ch );
-int channel_set_name ( channel_t *ch, const char *s );
+int channel_set_name ( channel_t *ch, const char *name );
 
 #define CHANNEL_SPLIT 1000000
 
@@ -198,6 +198,7 @@ static inline uint32_t channel_get_major ( int64_t chnum ) { return chnum / CHAN
 static inline uint32_t channel_get_minor ( int64_t chnum ) { return chnum % CHANNEL_SPLIT; }
 
 int64_t channel_get_number ( channel_t *ch );
+int channel_set_number ( channel_t *ch, uint32_t major, uint32_t minor );
 
 const char *channel_get_icon ( channel_t *ch );
 int channel_set_icon ( channel_t *ch, const char *icon );

--- a/src/epggrab.h
+++ b/src/epggrab.h
@@ -83,8 +83,9 @@ typedef struct epggrab_channel
 
   char                      *name;    ///< Channel name
   char                      *icon;    ///< Channel icon
-  int                       number;   ///< Channel number
-  
+  int                       major;    ///< Channel major number
+  int                       minor;    ///< Channel minor number
+
   LIST_HEAD(,epggrab_channel_link) channels; ///< Mapped channels
 } epggrab_channel_t;
 
@@ -107,7 +108,7 @@ htsmsg_t*         epggrab_channel_list      ( int ota );
  */
 int epggrab_channel_set_name     ( epggrab_channel_t *ch, const char *name );
 int epggrab_channel_set_icon     ( epggrab_channel_t *ch, const char *icon );
-int epggrab_channel_set_number   ( epggrab_channel_t *ch, int number );
+int epggrab_channel_set_number   ( epggrab_channel_t *ch, int major, int minor );
 
 /*
  * Updated/link

--- a/src/epggrab/channel.c
+++ b/src/epggrab/channel.c
@@ -59,6 +59,7 @@ epggrab_channel_link_delete
 int
 epggrab_channel_link ( epggrab_channel_t *ec, channel_t *ch )
 {
+  int save = 0;
   epggrab_channel_link_t *ecl;
 
   /* No change */
@@ -80,14 +81,14 @@ epggrab_channel_link ( epggrab_channel_t *ec, channel_t *ch )
   ecl->ecl_epggrab = ec;
   LIST_INSERT_HEAD(&ec->channels, ecl, ecl_epg_link);
   LIST_INSERT_HEAD(&ch->ch_epggrab, ecl, ecl_chn_link);
-#if TODO_CHAN_UPDATE
   if (ec->name && epggrab_channel_rename)
-    channel_rename(ch, ec->name);
-  if (ec->number>0 && epggrab_channel_renumber)
-    channel_set_number(ch, ec->number);
+    save |= channel_set_name(ch, ec->name);
+  if ((ec->major > 0 || ec->minor > 0) && epggrab_channel_renumber)
+    save |= channel_set_number(ch, ec->major, ec->minor);
   if (ec->icon && epggrab_channel_reicon)
-    channel_set_icon(ch, ec->icon);
-#endif
+    save |= channel_set_icon(ch, ec->icon);
+  if (save)
+    channel_save(ch);
 
   /* Save */
   if (ec->mod->ch_save) ec->mod->ch_save(ec->mod, ec);
@@ -111,13 +112,13 @@ int epggrab_channel_set_name ( epggrab_channel_t *ec, const char *name )
   if (!ec->name || strcmp(ec->name, name)) {
     if (ec->name) free(ec->name);
     ec->name = strdup(name);
-#if TODO_CHAN_UPDATE
     if (epggrab_channel_rename) {
       epggrab_channel_link_t *ecl;
-      LIST_FOREACH(ecl, &ec->channels, link)
-        channel_rename(ecl->channel, name);
+      LIST_FOREACH(ecl, &ec->channels, ecl_epg_link) {
+        if (channel_set_name(ecl->ecl_channel, name))
+          channel_save(ecl->ecl_channel);
+      }
     }
-#endif
     save = 1;
   }
   return save;
@@ -131,32 +132,33 @@ int epggrab_channel_set_icon ( epggrab_channel_t *ec, const char *icon )
   if (!ec->icon || strcmp(ec->icon, icon) ) {
     if (ec->icon) free(ec->icon);
     ec->icon = strdup(icon);
-#if TODO_CHAN_UPDATE
     if (epggrab_channel_reicon) {
       epggrab_channel_link_t *ecl;
-      LIST_FOREACH(ecl, &ec->channels, link)
-        channel_set_icon(ecl->channel, icon);
+      LIST_FOREACH(ecl, &ec->channels, ecl_epg_link) {
+        if (channel_set_icon(ecl->ecl_channel, icon))
+          channel_save(ecl->ecl_channel);
+      }
     }
-#endif
     save = 1;
   }
   return save;
 }
 
 /* Set channel number */
-int epggrab_channel_set_number ( epggrab_channel_t *ec, int number )
+int epggrab_channel_set_number ( epggrab_channel_t *ec, int major, int minor )
 {
   int save = 0;
-  if (!ec || (number <= 0)) return 0;
-  if (ec->number != number) {
-    ec->number = number;
-#if TODO_CHAN_UPDATE
+  if (!ec || (major <= 0 && minor <= 0)) return 0;
+  if (ec->major != major || ec->minor != minor) {
+    ec->major = major;
+    ec->minor = minor;
     if (epggrab_channel_renumber) {
       epggrab_channel_link_t *ecl;
-      LIST_FOREACH(ecl, &ec->channels, link)
-        channel_set_number(ecl->channel, number);
+      LIST_FOREACH(ecl, &ec->channels, ecl_epg_link) {
+        if (channel_set_number(ecl->ecl_channel, major, minor))
+          channel_save(ecl->ecl_channel);
+      }
     }
-#endif
     save = 1;
   }
   return save;

--- a/src/epggrab/module.c
+++ b/src/epggrab/module.c
@@ -163,8 +163,10 @@ void epggrab_module_ch_save ( void *_m, epggrab_channel_t *ch )
     htsmsg_add_str(a, NULL, channel_get_uuid(ecl->ecl_channel));
   }
   if (a) htsmsg_add_msg(m, "channels", a);
-  if (ch->number)
-    htsmsg_add_u32(m, "number", ch->number);
+  if (ch->major)
+    htsmsg_add_u32(m, "major", ch->major);
+  if (ch->minor)
+    htsmsg_add_u32(m, "major", ch->minor);
 
   hts_settings_save(m, "epggrab/%s/channels/%s", mod->id, ch->id);
   htsmsg_destroy(m);
@@ -208,8 +210,10 @@ static void _epggrab_module_channel_load
     egc->name = strdup(str);
   if ((str = htsmsg_get_str(m, "icon")))
     egc->icon = strdup(str);
-  if(!htsmsg_get_u32(m, "number", &u32))
-    egc->number = u32;
+  if(!htsmsg_get_u32(m, "major", &u32))
+    egc->major = u32;
+  if(!htsmsg_get_u32(m, "minor", &u32))
+    egc->minor = u32;
   if ((a = htsmsg_get_list(m, "channels"))) {
     HTSMSG_FOREACH(f, a) {
       if ((str = htsmsg_field_get_str(f))) {

--- a/src/epggrab/module/opentv.c
+++ b/src/epggrab/module/opentv.c
@@ -498,7 +498,7 @@ skip_chnum:
       
       if (!ecl)
         epggrab_channel_link(ec, ch);
-      save |= epggrab_channel_set_number(ec, cnum);
+      save |= epggrab_channel_set_number(ec, cnum, 0);
     }
     i += 9;
   }

--- a/src/epggrab/module/pyepg.c
+++ b/src/epggrab/module/pyepg.c
@@ -94,7 +94,7 @@ static int _pyepg_parse_channel
   if ((str = htsmsg_xml_get_cdata_str(tags, "image")))
     save |= epggrab_channel_set_icon(ch, str);
   if ((!htsmsg_xml_get_cdata_u32(tags, "number", &u32)))
-    save |= epggrab_channel_set_number(ch, u32);
+    save |= epggrab_channel_set_number(ch, u32, 0);
   
   /* Update */
   if (save) {


### PR DESCRIPTION
Allow epg grabber to update channel name, number, and/or icon if "Update Channel name", "Update channel number", and/or "Update channel icon" are set in "EPG Grabber" -> "General Config".