### PR TITLE
Use $PKG_CONFIG instead of pkg-config

### DIFF
--- a/configure
+++ b/configure
@@ -328,7 +328,7 @@ else
   if enabled_or_auto libav; then
     has_libav=true
 
-    ffmpeg=$(pkg-config --modversion libavcodec | cut -d '.' -f 3)
+    ffmpeg=$(${PKG_CONFIG} --modversion libavcodec | cut -d '.' -f 3)
     test -z "$ffmpeg" && ffmpeg=0
     printf "$TAB" "checking for ffmpeg libraries ..."
     if test $ffmpeg -lt 100; then

--- a/support/configure.inc
+++ b/support/configure.inc
@@ -204,11 +204,11 @@ check_pkg ()
 
   printf "$TAB" "checking for pkg $pkg $ver ..."
 
-  dver=$(pkg-config --modversion $pkg 2> /dev/null)
+  dver=$(${PKG_CONFIG} --modversion $pkg 2> /dev/null)
   test -z "$dver" && dver="<none>"
 
   # Check for package
-  if pkg-config $pkg $cver; then
+  if ${PKG_CONFIG} $pkg $cver; then
     echo "ok (detected ${dver})"
     enable_pkg $pkg
   else
@@ -416,7 +416,7 @@ print_config ()
   # Packages
   echo "Packages:"
   for pkg in ${PACKAGES[*]}; do
-    printf "$fmt" "${pkg}" "$(pkg-config --modversion $pkg)"
+    printf "$fmt" "${pkg}" "$(${PKG_CONFIG} --modversion $pkg)"
   done
   echo ""
   
@@ -478,8 +478,8 @@ EOF
   # Add package config
   for pkg in ${PACKAGES[*]}; do
     cat >>"${CONFIG_MK}" <<EOF
-LDFLAGS += $(pkg-config --libs $pkg)
-CFLAGS  += $(pkg-config --cflags $pkg)
+LDFLAGS += $(${PKG_CONFIG} --libs $pkg)
+CFLAGS  += $(${PKG_CONFIG} --cflags $pkg)
 EOF
   done
 


### PR DESCRIPTION
This allows to use prefixed versions of pkg-config for cross-compilation.