### PR TITLE
avoid leaving dangling children by killing spawned processes recursively

### DIFF
--- a/src/spawn.c
+++ b/src/spawn.c
@@ -299,7 +299,8 @@ spawn_kill(pid_t pid, int sig)
       if(s->pid == pid)
         break;
     if (s) {
-      r = kill(pid, sig);
+      /* kill the whole process group */
+      r = kill(-pid, sig);
       if (r < 0)
         r = -errno;
     }
@@ -494,7 +495,14 @@ spawn_and_give_stdout(const char *prog, char *argv[], char *envp[],
 
   *rd = fd[0];
   if (pid)
+  {
     *pid = p;
+
+    // make the spawned process a session leader so killing the 
+    // process group recursively kills any child process that 
+    // might have been spawned
+    setpgid(p, p);
+  }
   return 0;
 }
 


### PR DESCRIPTION
This is accomplished by making the spawned process the "group leader" and killing the group instead of just the PID. The group ID is the negation of the PID of the session leader.

This makes it possible to use `pipe://` scripts that spawn child processes, such as rtl_fm or ffmpeg. Without this patch the child processes may remain dangling after the parent has died.