### PR TITLE
transcoding: set AVFrame format, width and height, fixes #2763

### DIFF
--- a/src/plumbing/transcoding.c
+++ b/src/plumbing/transcoding.c
@@ -1211,7 +1211,11 @@ transcoder_stream_video(transcoder_t *t, transcoder_stream_t *ts, th_pkt_t *pkt)
     transcoder_stream_invalidate(ts);
     goto cleanup;
   }
- 
+
+  vs->vid_enc_frame->format  = octx->pix_fmt;
+  vs->vid_enc_frame->width   = octx->width;
+  vs->vid_enc_frame->height  = octx->height;
+
   vs->vid_enc_frame->pkt_pts = vs->vid_dec_frame->pkt_pts;
   vs->vid_enc_frame->pkt_dts = vs->vid_dec_frame->pkt_dts;
 


### PR DESCRIPTION
ffmpeg 2.6 checks, if format, width and height is set in avcodec_encode_video2 and generates a warning, if they aren't set.