### PR TITLE
Fix crash when trying to configure adapters that are already in use.

### DIFF
--- a/src/input/mpegts/linuxdvb/linuxdvb_adapter.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_adapter.c
@@ -399,6 +399,11 @@ linuxdvb_adapter_add ( const char *path )
   /* Relock before exit */
   pthread_mutex_lock(&global_lock);
 
+  /* Adapter couldn't be opened; there's nothing to work with  */
+  if (!la)
+    return;
+ 
+
 #if DVB_VER_ATLEAST(5,5)
   memset(fetypes, 0, sizeof(fetypes));
   LIST_FOREACH(lfe, &la->la_frontends, lfe_link)


### PR DESCRIPTION
If another application has an adapter open, then tvheadend will enter a crash-loop on startup because there's a missing test against 'la' being NULL here.  The in-use adapter will be skipped, allowing other unused adapters to be configured.