### PR TITLE
Revert to earlier FRITZ!-workaround

### DIFF
--- a/src/input/mpegts/satip/satip.c
+++ b/src/input/mpegts/satip/satip.c
@@ -384,7 +384,8 @@ satip_device_hack( satip_device_t *sd )
     sd->sd_pids_max    = 128;
     sd->sd_pids_len    = 2048;
     sd->sd_no_univ_lnb = 1;
-  } else if (strstr(sd->sd_info.modelname, "FRITZ!")) {
+  } else if (strstr(sd->sd_info.manufacturer, "AVM Berlin") &&
+             strstr(sd->sd_info.modelname, "FRITZ!")) {
     sd->sd_fullmux_ok  = 0;
     sd->sd_pids_deladd = 0;
     sd->sd_pids0       = 1;

--- a/src/input/mpegts/satip/satip.c
+++ b/src/input/mpegts/satip/satip.c
@@ -384,6 +384,11 @@ satip_device_hack( satip_device_t *sd )
     sd->sd_pids_max    = 128;
     sd->sd_pids_len    = 2048;
     sd->sd_no_univ_lnb = 1;
+  } else if (strstr(sd->sd_info.modelname, "FRITZ!")) {
+    sd->sd_fullmux_ok  = 0;
+    sd->sd_pids_deladd = 0;
+    sd->sd_pids0       = 1;
+    sd->sd_fritz_quirk = 1;
   }
 }
 

--- a/src/input/mpegts/satip/satip_frontend.c
+++ b/src/input/mpegts/satip/satip_frontend.c
@@ -1280,6 +1280,8 @@ new_tune:
     rtsp_flags |= SATIP_SETUP_PIDS0;
   if (lfe->sf_device->sd_pilot_on)
     rtsp_flags |= SATIP_SETUP_PILOT_ON;
+  if (lfe->sf_device->sd_fritz_quirk)
+    rtsp_flags |= SATIP_SETUP_FRITZ_QUIRK;
   r = -12345678;
   pthread_mutex_lock(&lfe->sf_dvr_lock);
   if (lfe->sf_req == lfe->sf_req_thread)

--- a/src/input/mpegts/satip/satip_frontend.c
+++ b/src/input/mpegts/satip/satip_frontend.c
@@ -580,6 +580,8 @@ satip_frontend_open_pid
     } else {
       change |= satip_frontend_add_pid(lfe, mp->mp_pid, weight);
     }
+    if (lfe->sf_device->sd_fritz_quirk)
+      change |= satip_frontend_add_pid(lfe, 21, 1);
   }
   pthread_mutex_unlock(&lfe->sf_dvr_lock);
   if (change)
@@ -1280,8 +1282,6 @@ new_tune:
     rtsp_flags |= SATIP_SETUP_PIDS0;
   if (lfe->sf_device->sd_pilot_on)
     rtsp_flags |= SATIP_SETUP_PILOT_ON;
-  if (lfe->sf_device->sd_fritz_quirk)
-    rtsp_flags |= SATIP_SETUP_FRITZ_QUIRK;
   r = -12345678;
   pthread_mutex_lock(&lfe->sf_dvr_lock);
   if (lfe->sf_req == lfe->sf_req_thread)

--- a/src/input/mpegts/satip/satip_frontend.c
+++ b/src/input/mpegts/satip/satip_frontend.c
@@ -580,8 +580,6 @@ satip_frontend_open_pid
     } else {
       change |= satip_frontend_add_pid(lfe, mp->mp_pid, weight);
     }
-    if (lfe->sf_device->sd_fritz_quirk)
-      change |= satip_frontend_add_pid(lfe, 21, 1);
   }
   pthread_mutex_unlock(&lfe->sf_dvr_lock);
   if (change)
@@ -1282,6 +1280,8 @@ new_tune:
     rtsp_flags |= SATIP_SETUP_PIDS0;
   if (lfe->sf_device->sd_pilot_on)
     rtsp_flags |= SATIP_SETUP_PILOT_ON;
+  if (lfe->sf_device->sd_fritz_quirk)
+    rtsp_flags |= SATIP_SETUP_FRITZ;
   r = -12345678;
   pthread_mutex_lock(&lfe->sf_dvr_lock);
   if (lfe->sf_req == lfe->sf_req_thread)

--- a/src/input/mpegts/satip/satip_private.h
+++ b/src/input/mpegts/satip/satip_private.h
@@ -84,6 +84,7 @@ struct satip_device
   int                        sd_pids_deladd;
   int                        sd_sig_scale;
   int                        sd_pids0;
+  int                        sd_fritz_quirk;
   int                        sd_pilot_on;
   int                        sd_no_univ_lnb;
   int                        sd_dbus_allow;
@@ -222,6 +223,7 @@ int satip_satconf_get_position
 #define SATIP_SETUP_PLAY     (1<<0)
 #define SATIP_SETUP_PIDS0    (1<<1)
 #define SATIP_SETUP_PILOT_ON (1<<2)
+#define SATIP_SETUP_FRITZ_QUIRK   (1<<3)
 
 int
 satip_rtsp_setup( http_client_t *hc,

--- a/src/input/mpegts/satip/satip_private.h
+++ b/src/input/mpegts/satip/satip_private.h
@@ -223,7 +223,6 @@ int satip_satconf_get_position
 #define SATIP_SETUP_PLAY     (1<<0)
 #define SATIP_SETUP_PIDS0    (1<<1)
 #define SATIP_SETUP_PILOT_ON (1<<2)
-#define SATIP_SETUP_FRITZ_QUIRK   (1<<3)
 
 int
 satip_rtsp_setup( http_client_t *hc,

--- a/src/input/mpegts/satip/satip_private.h
+++ b/src/input/mpegts/satip/satip_private.h
@@ -223,6 +223,7 @@ int satip_satconf_get_position
 #define SATIP_SETUP_PLAY     (1<<0)
 #define SATIP_SETUP_PIDS0    (1<<1)
 #define SATIP_SETUP_PILOT_ON (1<<2)
+#define SATIP_SETUP_FRITZ    (1<<3)
 
 int
 satip_rtsp_setup( http_client_t *hc,

--- a/src/input/mpegts/satip/satip_rtsp.c
+++ b/src/input/mpegts/satip/satip_rtsp.c
@@ -222,6 +222,8 @@ satip_rtsp_setup( http_client_t *hc, int src, int fe,
   }
   if (flags & SATIP_SETUP_PIDS0)
     strcat(buf, "&pids=0");
+  if (flags & SATIP_SETUP_FRITZ_QUIRK)
+    strcat(buf, ",21");
   tvhtrace("satip", "setup params - %s", buf);
   if (hc->hc_rtsp_stream_id >= 0)
     snprintf(stream = _stream, sizeof(_stream), "/stream=%li",

--- a/src/input/mpegts/satip/satip_rtsp.c
+++ b/src/input/mpegts/satip/satip_rtsp.c
@@ -222,8 +222,6 @@ satip_rtsp_setup( http_client_t *hc, int src, int fe,
   }
   if (flags & SATIP_SETUP_PIDS0)
     strcat(buf, "&pids=0");
-  if (flags & SATIP_SETUP_FRITZ_QUIRK)
-    strcat(buf, ",21");
   tvhtrace("satip", "setup params - %s", buf);
   if (hc->hc_rtsp_stream_id >= 0)
     snprintf(stream = _stream, sizeof(_stream), "/stream=%li",

--- a/src/input/mpegts/satip/satip_rtsp.c
+++ b/src/input/mpegts/satip/satip_rtsp.c
@@ -222,6 +222,8 @@ satip_rtsp_setup( http_client_t *hc, int src, int fe,
   }
   if (flags & SATIP_SETUP_PIDS0)
     strcat(buf, "&pids=0");
+  if (flags & SATIP_SETUP_FRITZ)
+    strcat(buf, ",21");
   tvhtrace("satip", "setup params - %s", buf);
   if (hc->hc_rtsp_stream_id >= 0)
     snprintf(stream = _stream, sizeof(_stream), "/stream=%li",


### PR DESCRIPTION
The method suggested by perexg didn't actually work now that I had time to test it properly, it's still not adding pid 21 where it should be. My method, as inelegant as it may be, at least adds the pid there at all times.