### PR TITLE
http: add interpretation of "X-Forwarded-For" header

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -676,7 +676,13 @@ process_request(http_connection_t *hc, htsbuf_queue_t *spill)
   char authbuf[150];
 
   hc->hc_url_orig = tvh_strdupa(hc->hc_url);
+
+  v = http_arg_get(&hc->hc_args, "x-forwarded-for");
+  if (v)
+    tcp_get_sockaddr((struct sockaddr*)hc->hc_peer, v);
+
   tcp_get_ip_str((struct sockaddr*)hc->hc_peer, authbuf, sizeof(authbuf));
+
   hc->hc_peer_ipstr = tvh_strdupa(authbuf);
   hc->hc_representative = hc->hc_peer_ipstr;
   hc->hc_username = NULL;

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -374,6 +374,29 @@ tcp_get_ip_str(const struct sockaddr *sa, char *s, size_t maxlen)
 }
 
 /**
+ * 
+ */
+int
+tcp_get_sockaddr(struct sockaddr *sa, const char *s)
+{
+  if(sa == NULL || s == NULL)
+	return -1;
+
+  struct sockaddr_in *sin = (struct sockaddr_in*)sa;
+  struct sockaddr_in6 *sin6 = (struct sockaddr_in6*)sa;
+
+  if (inet_pton(AF_INET, s, &sin->sin_addr) == 1)
+    sa->sa_family = AF_INET;
+  else if (inet_pton(AF_INET6, s, &sin6->sin6_addr) == 1)
+    sa->sa_family = AF_INET6;
+  else
+    return -1;
+
+  return 0;
+}
+
+
+/**
  *
  */
 static tvhpoll_t *tcp_server_poll;

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -87,6 +87,8 @@ int tcp_read_timeout(int fd, void *buf, size_t len, int timeout);
 
 char *tcp_get_ip_str(const struct sockaddr *sa, char *s, size_t maxlen);
 
+int tcp_get_sockaddr(struct sockaddr *sa, const char *s);
+
 struct access;
 
 void *tcp_connection_launch(int fd, void (*status) (void *opaque, htsmsg_t *m),


### PR DESCRIPTION
This allows to use the builtin ACL when serving TVH behind a SSL reverse
proxy. Before the peer address of the HTTP socket was used.
