### PR TITLE
Tunercfg override

### DIFF
--- a/docs/html/config_tvadapters.html
+++ b/docs/html/config_tvadapters.html
@@ -194,9 +194,8 @@ setting this to 100.</dd>
       allows you to override that. Any value below 1 or above 32 is ignored.
       For now this setting requires a restart of tvheadend.</dd>
 <p>
-  <dt><b>Enable FRITZ!Box-workarounds</b><dt>
-  <dd>Turns off full mux - and addpids/delpids - support, turns on PIDs in setup,
-      and enables one specific workaround for buggy FRITZ!-devices.</dd>
+  <dt><b>PIDs 21 in setup</b><dt>
+  <dd>Enable, if the SAT>IP box requires pids=21 parameter in the SETUP RTSP command.</dd>
 <p>
   <dt><b>Force teardown delay</b><dt>
   <dd>Force the delay between RTSP TEARDOWN and RTSP SETUP command (value
@@ -204,7 +203,7 @@ setting this to 100.</dd>
       quick continuous tuning.</dd>
 <p>
   <dt><b>Tuner bind IP address</b><dt>
-  <dd>Force all network connections to this tuner be made over the specificed 
+  <dd>Force all network connections to this tuner to be made over the specified 
       IP-address, similar to the setting for the SAT-IP - device itself. Setting
       this overrides the device - specific setting.</dd>
 

--- a/docs/html/config_tvadapters.html
+++ b/docs/html/config_tvadapters.html
@@ -186,7 +186,12 @@ setting this to 100.</dd>
 <p>
   <dt><b>Send full PLAY cmd</b></dt>
   <dd>Send the full RTSP PLAY command after full RTSP SETUP command. Some
-      device firmwares requires this to get MPEG-TS stream.</dd>
+      device firmwares require this to get MPEG-TS stream.</dd>
+<p>
+  <dt><b>Override tuner count</b></dt>
+  <dd>Force tvheadend to see a specific number of tuners. Some devices, notably 
+      AVM's FRITZ!Box Cable 6490, report wrong number of tuners and this setting
+      allows you to override that. Any value below 1 or above 32 is ignored.</dd>
 <p>
   <dt><b>Force teardown delay</b><dt>
   <dd>Force the delay between RTSP TEARDOWN and RTSP SETUP command (value

--- a/docs/html/config_tvadapters.html
+++ b/docs/html/config_tvadapters.html
@@ -191,7 +191,8 @@ setting this to 100.</dd>
   <dt><b>Override tuner count</b></dt>
   <dd>Force tvheadend to see a specific number of tuners. Some devices, notably 
       AVM's FRITZ!Box Cable 6490, report wrong number of tuners and this setting
-      allows you to override that. Any value below 1 or above 32 is ignored.</dd>
+      allows you to override that. Any value below 1 or above 32 is ignored.
+      For now this setting requires a restart of tvheadend.</dd>
 <p>
   <dt><b>Force teardown delay</b><dt>
   <dd>Force the delay between RTSP TEARDOWN and RTSP SETUP command (value

--- a/src/input/mpegts/satip/satip.c
+++ b/src/input/mpegts/satip/satip.c
@@ -224,6 +224,13 @@ const idclass_t satip_device_class =
       .off      = offsetof(satip_device_t, sd_bindaddr),
     },
     {
+      .type     = PT_BOOL,
+      .id       = "disablefritz",
+      .name     = "Disable FRITZ!-specific workarounds",
+      .opts     = PO_ADVANCED,
+      .off      = offsetof(satip_device_t, sd_no_fritz_workarounds),
+    },
+    {
       .type     = PT_STR,
       .id       = "addr",
       .name     = "IP Address",
@@ -398,7 +405,15 @@ satip_device_hack( satip_device_t *sd )
     sd->sd_pids_max    = 128;
     sd->sd_pids_len    = 2048;
     sd->sd_no_univ_lnb = 1;
+  } else if (strstr(sd->sd_info.manufacturer, "AVM Berlin") &&
+             strstr(sd->sd_info.modelname, "FRITZ!") &&
+             sd->sd_no_fritz_workarounds != 1) {
+    sd->sd_fullmux_ok  = 0;
+    sd->sd_pids_deladd = 0;
+    sd->sd_pids0       = 1;
+    sd->sd_pids21       = 1;
   }
+
 }
 
 static satip_device_t *
@@ -423,15 +438,6 @@ satip_device_create( satip_device_info_t *info )
   sd->sd_pids_deladd = 1;
   sd->sd_sig_scale   = 240;
   sd->sd_dbus_allow  = 1;
-
-  /* safe defaults for FRITZ!-devices */
-  if (strstr(info->manufacturer, "AVM Berlin") &&
-             strstr(info->modelname, "FRITZ!")) {
-    sd->sd_fullmux_ok  = 0;
-    sd->sd_pids_deladd = 0;
-    sd->sd_pids0       = 1;
-    sd->sd_pids21 = 1;
-  }
 
   if (!tvh_hardware_create0((tvh_hardware_t*)sd, &satip_device_class,
                             uuid.hex, conf)) {

--- a/src/input/mpegts/satip/satip.c
+++ b/src/input/mpegts/satip/satip.c
@@ -225,10 +225,10 @@ const idclass_t satip_device_class =
     },
     {
       .type     = PT_BOOL,
-      .id       = "disablefritz",
-      .name     = "Disable FRITZ!-specific workarounds",
+      .id       = "disableworkarounds",
+      .name     = "Disable device-/firmware-specific workarounds",
       .opts     = PO_ADVANCED,
-      .off      = offsetof(satip_device_t, sd_no_fritz_workarounds),
+      .off      = offsetof(satip_device_t, sd_disable_workarounds),
     },
     {
       .type     = PT_STR,
@@ -385,6 +385,8 @@ satip_device_calc_uuid( tvh_uuid_t *uuid, const char *satip_uuid )
 static void
 satip_device_hack( satip_device_t *sd )
 {
+  if(sd->sd_disable_workarounds)
+      return;
   if (sd->sd_info.deviceid[0] &&
       strcmp(sd->sd_info.server, "Linux/1.0 UPnP/1.1 IDL4K/1.0") == 0) {
     /* AXE Linux distribution - Inverto firmware */
@@ -406,14 +408,12 @@ satip_device_hack( satip_device_t *sd )
     sd->sd_pids_len    = 2048;
     sd->sd_no_univ_lnb = 1;
   } else if (strstr(sd->sd_info.manufacturer, "AVM Berlin") &&
-             strstr(sd->sd_info.modelname, "FRITZ!") &&
-             sd->sd_no_fritz_workarounds != 1) {
+             strstr(sd->sd_info.modelname, "FRITZ!")) {
     sd->sd_fullmux_ok  = 0;
     sd->sd_pids_deladd = 0;
     sd->sd_pids0       = 1;
     sd->sd_pids21       = 1;
   }
-
 }
 
 static satip_device_t *

--- a/src/input/mpegts/satip/satip.c
+++ b/src/input/mpegts/satip/satip.c
@@ -204,10 +204,10 @@ const idclass_t satip_device_class =
     },
     {
       .type     = PT_BOOL,
-      .id       = "fritzquirks",
-      .name     = "Enable FRITZ!Box-workarounds",
+      .id       = "pids21",
+      .name     = "PIDs 21 in setup",
       .opts     = PO_ADVANCED,
-      .off      = offsetof(satip_device_t, sd_fritz_quirk),
+      .off      = offsetof(satip_device_t, sd_pids21),
     },
     {
       .type     = PT_INT,
@@ -415,6 +415,7 @@ satip_device_create( satip_device_info_t *info )
   satip_device_calc_uuid(&uuid, info->uuid);
 
   conf = hts_settings_load("input/satip/adapters/%s", uuid.hex);
+
   /* some sane defaults */
   sd->sd_fullmux_ok  = 1;
   sd->sd_pids_len    = 127;
@@ -429,7 +430,7 @@ satip_device_create( satip_device_info_t *info )
     sd->sd_fullmux_ok  = 0;
     sd->sd_pids_deladd = 0;
     sd->sd_pids0       = 1;
-    sd->sd_fritz_quirk = 1;
+    sd->sd_pids21 = 1;
   }
 
   if (!tvh_hardware_create0((tvh_hardware_t*)sd, &satip_device_class,
@@ -509,7 +510,8 @@ satip_device_create( satip_device_info_t *info )
       m = atoi(argv[i] + 6);
       v2 = 2;
     }
-    if (sd->sd_tunercfg_override > 0 && sd->sd_tunercfg_override < 33) m = sd->sd_tunercfg_override;
+    if (sd->sd_tunercfg_override > 0 && sd->sd_tunercfg_override < 33)
+             m = sd->sd_tunercfg_override;
     if (type == DVB_TYPE_NONE) {
       tvhlog(LOG_ERR, "satip", "%s: bad tuner type [%s]",
              satip_device_nicename(sd, buf2, sizeof(buf2)), argv[i]);
@@ -523,12 +525,6 @@ satip_device_create( satip_device_info_t *info )
           fenum++;
       sd->sd_nosave = 0;
     }
-  }
-
-  if (sd->sd_fritz_quirk == 1) {
-    sd->sd_fullmux_ok  = 0;
-    sd->sd_pids_deladd = 0;
-    sd->sd_pids0       = 1;
   }
 
   if (save)

--- a/src/input/mpegts/satip/satip.c
+++ b/src/input/mpegts/satip/satip.c
@@ -203,6 +203,13 @@ const idclass_t satip_device_class =
       .off      = offsetof(satip_device_t, sd_pilot_on),
     },
     {
+      .type     = PT_INT,
+      .id       = "tunercfgoverride",
+      .name     = "Override tuner count",
+      .opts     = PO_ADVANCED,
+      .off      = offsetof(satip_device_t, sd_tunercfg_override),
+    },
+    {
       .type     = PT_STR,
       .id       = "bindaddr",
       .name     = "Local bind IP address",
@@ -493,6 +500,7 @@ satip_device_create( satip_device_info_t *info )
       m = atoi(argv[i] + 6);
       v2 = 2;
     }
+    if (sd->sd_tunercfg_override > 0 && sd->sd_tunercfg_override < 33) m = sd->sd_tunercfg_override;
     if (type == DVB_TYPE_NONE) {
       tvhlog(LOG_ERR, "satip", "%s: bad tuner type [%s]",
              satip_device_nicename(sd, buf2, sizeof(buf2)), argv[i]);

--- a/src/input/mpegts/satip/satip_frontend.c
+++ b/src/input/mpegts/satip/satip_frontend.c
@@ -1220,8 +1220,8 @@ new_tune:
     rtsp_flags |= SATIP_SETUP_PIDS0;
   if (lfe->sf_device->sd_pilot_on)
     rtsp_flags |= SATIP_SETUP_PILOT_ON;
-  if (lfe->sf_device->sd_fritz_quirk)
-    rtsp_flags |= SATIP_SETUP_FRITZ_QUIRK;
+  if (lfe->sf_device->sd_pids21)
+    rtsp_flags |= SATIP_SETUP_PIDS21;
   r = -12345678;
   pthread_mutex_lock(&lfe->sf_dvr_lock);
   if (lfe->sf_req == lfe->sf_req_thread)

--- a/src/input/mpegts/satip/satip_private.h
+++ b/src/input/mpegts/satip/satip_private.h
@@ -89,6 +89,7 @@ struct satip_device
   int                        sd_pilot_on;
   int                        sd_no_univ_lnb;
   int                        sd_dbus_allow;
+  int                        sd_no_fritz_workarounds;
   pthread_mutex_t            sd_tune_mutex;
 };
 

--- a/src/input/mpegts/satip/satip_private.h
+++ b/src/input/mpegts/satip/satip_private.h
@@ -84,6 +84,7 @@ struct satip_device
   int                        sd_pids_deladd;
   int                        sd_sig_scale;
   int                        sd_pids0;
+  int                        sd_tunercfg_override;
   int                        sd_fritz_quirk;
   int                        sd_pilot_on;
   int                        sd_no_univ_lnb;

--- a/src/input/mpegts/satip/satip_private.h
+++ b/src/input/mpegts/satip/satip_private.h
@@ -89,7 +89,7 @@ struct satip_device
   int                        sd_pilot_on;
   int                        sd_no_univ_lnb;
   int                        sd_dbus_allow;
-  int                        sd_no_fritz_workarounds;
+  int                        sd_disable_workarounds;
   pthread_mutex_t            sd_tune_mutex;
 };
 

--- a/src/input/mpegts/satip/satip_private.h
+++ b/src/input/mpegts/satip/satip_private.h
@@ -85,7 +85,7 @@ struct satip_device
   int                        sd_sig_scale;
   int                        sd_pids0;
   int                        sd_tunercfg_override;
-  int                        sd_fritz_quirk;
+  int                        sd_pids21;
   int                        sd_pilot_on;
   int                        sd_no_univ_lnb;
   int                        sd_dbus_allow;
@@ -225,7 +225,7 @@ int satip_satconf_get_position
 #define SATIP_SETUP_PLAY     (1<<0)
 #define SATIP_SETUP_PIDS0    (1<<1)
 #define SATIP_SETUP_PILOT_ON (1<<2)
-#define SATIP_SETUP_FRITZ_QUIRK   (1<<3)
+#define SATIP_SETUP_PIDS21   (1<<3)
 
 int
 satip_rtsp_setup( http_client_t *hc,

--- a/src/input/mpegts/satip/satip_rtsp.c
+++ b/src/input/mpegts/satip/satip_rtsp.c
@@ -222,9 +222,10 @@ satip_rtsp_setup( http_client_t *hc, int src, int fe,
   }
   if (flags & SATIP_SETUP_PIDS0) {
     strcat(buf, "&pids=0");
-    if (flags & SATIP_SETUP_FRITZ_QUIRK)
+    if (flags & SATIP_SETUP_PIDS21)
       strcat(buf, ",21");
-  }
+  } else if (flags & SATIP_SETUP_PIDS21)
+             strcat(buf, "&pids=21");
   tvhtrace("satip", "setup params - %s", buf);
   if (hc->hc_rtsp_stream_id >= 0)
     snprintf(stream = _stream, sizeof(_stream), "/stream=%li",


### PR DESCRIPTION
Some devices, at least my FRITZ!Box Cable 6490, report wrong count of tuners in the SAT-IP description XML-file. I added a new option called "Override tuner control" (sd_tunercfg_override) that, if 1-32, overrides the number reported in the XML-file. Also added explanation for this in the web-GUI help.

Stay tuned for more FRITZ!-stuffs.