### PR TITLE
Fix unsigned int 64 overflow in timeshift

### DIFF
--- a/src/atomic.h
+++ b/src/atomic.h
@@ -52,6 +52,21 @@ atomic_add_u64(volatile uint64_t *ptr, uint64_t incr)
 }
 
 static inline uint64_t
+atomic_dec_u64(volatile uint64_t *ptr, uint64_t decr)
+{
+#if ENABLE_ATOMIC64
+  return __sync_fetch_and_sub(ptr, decr);
+#else
+  uint64_t ret;
+  pthread_mutex_lock(&atomic_lock);
+  ret = *ptr;
+  *ptr -= decr;
+  pthread_mutex_unlock(&atomic_lock);
+  return ret;
+#endif
+}
+
+static inline uint64_t
 atomic_pre_add_u64(volatile uint64_t *ptr, uint64_t incr)
 {
 #if ENABLE_ATOMIC64

--- a/src/timeshift/timeshift_filemgr.c
+++ b/src/timeshift/timeshift_filemgr.c
@@ -180,9 +180,9 @@ void timeshift_filemgr_remove
     tvhdebug("timeshift", "ts %d RAM segment remove time %li", ts->id, (long)tsf->time);
 #endif
   TAILQ_REMOVE(&ts->files, tsf, link);
-  atomic_add_u64(&timeshift_total_size, -tsf->size);
+  atomic_dec_u64(&timeshift_total_size, tsf->size);
   if (tsf->ram)
-    atomic_add_u64(&timeshift_total_ram_size, -tsf->size);
+    atomic_dec_u64(&timeshift_total_ram_size, tsf->size);
   timeshift_reaper_remove(tsf);
 }
 


### PR DESCRIPTION
As the title says.

This fixes bug https://tvheadend.org/issues/2712

Regression introduced in:

https://github.com/tvheadend/tvheadend/commit/673549141d5d51988e1ee9bdc30ed5a7cc32bf8a

Calling atomic_add_u64(&timeshift_total_size, -tsf->size); while the second parameter is an uint64_t leads to wrapping and at the end our timeshift buffer is claimed full and no timeshift is possible anymore.