### PR TITLE
WebUI static path definitions for icons/images/extjs resources

### DIFF
--- a/src/webui/webui.c
+++ b/src/webui/webui.c
@@ -1419,6 +1419,10 @@ webui_init(int xspf)
   webui_static_content("/docs",          "docs/html");
   webui_static_content("/docresources",  "docs/docresources");
 
+  webui_static_content("/extjs/resources",     "src/webui/static/extjs/resources");
+  webui_static_content("/icons",               "src/webui/static/icons");
+  webui_static_content("/img",                 "src/webui/static/img");
+
   simpleui_start();
   extjs_start();
   comet_init();


### PR DESCRIPTION
Needed to add some web_static_content definitions to get the icons back in the web interface. There may be an easier solution but that's what I could come up with ;)