### PR TITLE
python client: Fix broken int2bin() in htsmsg

### DIFF
--- a/lib/py/tvh/htsmsg.py
+++ b/lib/py/tvh/htsmsg.py
@@ -24,7 +24,7 @@ Support for processing HTSMSG binary format
 
 def int2bin ( i ):
   return chr(i >> 24 & 0xFF) + chr(i >> 16 & 0xFF)\
-       + chr(i >> 16 & 0xFF) + chr(i & 0xFF)
+       + chr(i >> 8 & 0xFF) + chr(i & 0xFF)
 
 def bin2int ( d ):
   return (ord(d[0]) << 24) + (ord(d[1]) << 16)\


### PR DESCRIPTION
The int2bin() method was incorrectly shifting the bits by 16 for the third character instead of 8, which was causing issues for any messages with a length greater than 256. The fixes that :)