### PR TITLE
[en50494] mark as experimental for release

### DIFF
--- a/src/input/mpegts/linuxdvb/linuxdvb_satconf.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_satconf.c
@@ -497,7 +497,7 @@ const idclass_t linuxdvb_satconf_en50494_class =
 {
   .ic_super      = &linuxdvb_satconf_class,
   .ic_class      = "linuxdvb_satconf_en50494",
-  .ic_caption    = "DVB-S EN50494 (UniCable)",
+  .ic_caption    = "DVB-S EN50494 (UniCable, experimental)",
   .ic_properties = (const property_t[]) {
     {
       .type     = PT_U16,
@@ -599,7 +599,7 @@ static struct linuxdvb_satconf_type linuxdvb_satconf_types[] = {
   },
   {
     .type  = "en50494",
-    .name  = "Unicable Switch (Universal LNB)",
+    .name  = "Unicable Switch (Universal LNB, experimental)",
     .idc   = &linuxdvb_satconf_en50494_class,
     .ports = 2,
   },


### PR DESCRIPTION
The UniCable support is not stable enought.
Actual, only same installations are working, but i can't find a
solution.
But it does not brother user, who no use unicable. So we don't have to
remove it from source. I hope we can find one expert, who can help us to
improve the situation.