### PR TITLE
Fix#2 for build in symlinked dirs (fixes #647)

### DIFF
--- a/support/css.py
+++ b/support/css.py
@@ -37,7 +37,7 @@ def url(fn):
 
   f = utf8open(fn, 'r')
   if fn[0] != '/':
-    fn = os.path.join(os.environ['PWD'], fn)
+    fn = os.path.join(os.path.realpath(os.environ['PWD']), fn)
   fn = os.path.normpath(fn)
   if VERBOSE:
     info('css: %s', fn)


### PR DESCRIPTION
Found the location where the path names were built incorrectly when building in a symlinked dir.
Tested with builds in real dir and symlinked dir, produces same output in both now.
The old pull request can be safely ignored/closed.