### PR TITLE
[htsp][autorec,timerec] Handle "retention", "startExtra", "stopExtra"…

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -564,6 +564,12 @@ static inline int dvr_autorec_entry_verify(dvr_autorec_entry_t *dae, access_t *a
   return 0;
 }
 
+int dvr_autorec_get_retention( dvr_autorec_entry_t *dae );
+
+int dvr_autorec_get_extra_time_post( dvr_autorec_entry_t *dae );
+
+int dvr_autorec_get_extra_time_pre( dvr_autorec_entry_t *dae );
+
 /**
  *
  */
@@ -605,6 +611,8 @@ static inline int dvr_timerec_entry_verify(dvr_timerec_entry_t *dte, access_t *a
     return -1;
   return 0;
 }
+
+int dvr_timerec_get_retention( dvr_timerec_entry_t *dte );
 
 /**
  *

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -1245,3 +1245,53 @@ autorec_destroy_by_config(dvr_config_t *kcfg, int delconf)
       dvr_autorec_save(dae);
   }
 }
+
+static inline int extra_valid(time_t extra)
+{
+  return extra != 0 && extra != (time_t)-1;
+}
+
+/**
+ *
+ */
+int
+dvr_autorec_get_extra_time_pre( dvr_autorec_entry_t *dae )
+{
+  time_t extra = dae->dae_start_extra;
+
+  if (!extra_valid(extra)) {
+    if (dae->dae_channel)
+      extra = dae->dae_channel->ch_dvr_extra_time_pre;
+    if (!extra_valid(extra))
+      extra = dae->dae_config->dvr_extra_time_pre;
+  }
+  return extra;
+}
+
+/**
+ *
+ */
+int
+dvr_autorec_get_extra_time_post( dvr_autorec_entry_t *dae )
+{
+  time_t extra = dae->dae_stop_extra;
+
+  if (!extra_valid(extra)) {
+    if (dae->dae_channel)
+      extra = dae->dae_channel->ch_dvr_extra_time_post;
+    if (!extra_valid(extra))
+      extra = dae->dae_config->dvr_extra_time_post;
+  }
+  return extra;
+}
+
+/**
+ *
+ */
+int
+dvr_autorec_get_retention( dvr_autorec_entry_t *dae )
+{
+  if (dae->dae_retention > 0)
+    return dae->dae_retention;
+  return dae->dae_config->dvr_retention_days;
+}

--- a/src/dvr/dvr_timerec.c
+++ b/src/dvr/dvr_timerec.c
@@ -753,3 +753,14 @@ timerec_destroy_by_config(dvr_config_t *kcfg, int delconf)
       dvr_timerec_save(dte);
   }
 }
+
+/**
+ *
+ */
+int
+dvr_timerec_get_retention( dvr_timerec_entry_t *dte )
+{
+  if (dte->dte_retention > 0)
+    return dte->dte_retention;
+  return dte->dte_config->dvr_retention_days;
+}

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -774,7 +774,7 @@ htsp_build_autorecentry(dvr_autorec_entry_t *dae, const char *method)
   htsmsg_add_u32(out, "enabled",     dae->dae_enabled);
   htsmsg_add_u32(out, "maxDuration", dae->dae_maxduration);
   htsmsg_add_u32(out, "minDuration", dae->dae_minduration);
-  htsmsg_add_u32(out, "retention",   dae->dae_retention);
+  htsmsg_add_u32(out, "retention",   dvr_autorec_get_retention(dae));
   htsmsg_add_u32(out, "daysOfWeek",  dae->dae_weekdays);
   if (dae->dae_start >= 0 && dae->dae_start_window >= 0) {
     if (dae->dae_start > dae->dae_start_window)
@@ -790,8 +790,8 @@ htsp_build_autorecentry(dvr_autorec_entry_t *dae, const char *method)
   htsmsg_add_s32(out, "start",       dae->dae_start >= 0 ? dae->dae_start : -1);
   htsmsg_add_s32(out, "startWindow", dae->dae_start_window >= 0 ? dae->dae_start_window : -1);
   htsmsg_add_u32(out, "priority",    dae->dae_pri);
-  htsmsg_add_s64(out, "startExtra",  dae->dae_start_extra);
-  htsmsg_add_s64(out, "stopExtra",   dae->dae_stop_extra);
+  htsmsg_add_s64(out, "startExtra",  dvr_autorec_get_extra_time_pre(dae));
+  htsmsg_add_s64(out, "stopExtra",   dvr_autorec_get_extra_time_post(dae));
   htsmsg_add_u32(out, "dupDetect",   dae->dae_record);
 
   if(dae->dae_title) {
@@ -825,7 +825,7 @@ htsp_build_timerecentry(dvr_timerec_entry_t *dte, const char *method)
   htsmsg_add_str(out, "id",          idnode_uuid_as_str(&dte->dte_id));
   htsmsg_add_u32(out, "enabled",     dte->dte_enabled);
   htsmsg_add_u32(out, "daysOfWeek",  dte->dte_weekdays);
-  htsmsg_add_u32(out, "retention",   dte->dte_retention);
+  htsmsg_add_u32(out, "retention",   dvr_timerec_get_retention(dte));
   htsmsg_add_u32(out, "priority",    dte->dte_pri);
   htsmsg_add_s32(out, "start",       dte->dte_start);
   htsmsg_add_s32(out, "stop",        dte->dte_stop);


### PR DESCRIPTION
… defaults the same way as for normal dvr entries (https://github.com/tvheadend/tvheadend/blob/master/src/htsp_server.c#L687). Do return the current dvr config values instead of 0, which cannot be handled/interpreted by htsp clients (there is no htsp dvr config API).