### PR TITLE
Add trusty (14.04 LTS) build target

### DIFF
--- a/Autobuild/trusty-amd64.sh
+++ b/Autobuild/trusty-amd64.sh
@@ -1,0 +1,3 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --arch=x86_64"
+DEBDIST=trusty
+source Autobuild/debian.sh

--- a/Autobuild/trusty-i386.sh
+++ b/Autobuild/trusty-i386.sh
@@ -1,0 +1,3 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --arch=i686"
+DEBDIST=trusty
+source Autobuild/debian.sh


### PR DESCRIPTION
debian: So that ubuntu package names will appear as '4.0.0-11~gd149c5b~trusty amd64'

It reflects more accurately now the packages were build on `trusty` because that is the current LTS (Long-Term-Service) release. And nobody uses `precise` anymore.

This commit is needed on both the master + stable branches. Tested on my fork:

https://gist.github.com/dreamcat4/f470ed87f650e6752ef8#comment-1462233
