### PR TITLE
config: make server name configureable (avahi, satips)

### DIFF
--- a/src/avahi.h
+++ b/src/avahi.h
@@ -1,7 +1,9 @@
 #ifdef CONFIG_AVAHI
 void avahi_init(void);
 void avahi_done(void);
+void avahi_restart(void);
 #else
 static inline void avahi_init(void) { }
 static inline void avahi_done(void) { }
+static inline void avahi_restart(void) {}
 #endif

--- a/src/config.c
+++ b/src/config.c
@@ -28,6 +28,7 @@
 #include "spawn.h"
 #include "lock.h"
 #include "profile.h"
+#include "avahi.h"
 
 /* *************************************************************************
  * Global data
@@ -1493,6 +1494,7 @@ config_init ( int backup )
   if (config_newcfg) {
     htsmsg_set_u32(config, "version", ARRAY_SIZE(config_migrate_table));
     htsmsg_set_str(config, "fullversion", tvheadend_version);
+    htsmsg_set_str(config, "server_name", "Tvheadend");
     config_save();
   
   /* Perform migrations */
@@ -1560,6 +1562,21 @@ config_set_int ( const char *fld, int val )
     return 1;
   }
   return 0;
+}
+
+const char *config_get_server_name ( void )
+{
+  const char *s = htsmsg_get_str(config, "server_name");
+  if (s == NULL || *s == '\0')
+    return "Tvheadend";
+  return s;
+}
+
+int config_set_server_name ( const char *name )
+{
+  int r = config_set_str("server_name", name);
+  avahi_restart();
+  return r;
 }
 
 const char *config_get_language ( void )

--- a/src/config.h
+++ b/src/config.h
@@ -36,6 +36,10 @@ int         config_set_str ( const char *fld, const char *val );
 int         config_get_int ( const char *fld, int dflt );
 int         config_set_int ( const char *fld, int val );
 
+const char *config_get_server_name ( void );
+int         config_set_server_name ( const char *str )
+  __attribute__((warn_unused_result));
+
 const char *config_get_muxconfpath ( void );
 int         config_set_muxconfpath ( const char *str )
   __attribute__((warn_unused_result));

--- a/src/satip/server.c
+++ b/src/satip/server.c
@@ -61,7 +61,7 @@ satip_server_http_xml(http_connection_t *hc)
 <specVersion><major>1</major><minor>1</minor></specVersion>\n\
 <device>\n\
 <deviceType>urn:ses-com:device:SatIPServer:1</deviceType>\n\
-<friendlyName>TVHeadend%s</friendlyName>\n\
+<friendlyName>%s%s</friendlyName>\n\
 <manufacturer>TVHeadend Team</manufacturer>\n\
 <manufacturerURL>http://tvheadend.org</manufacturerURL>\n\
 <modelDescription>TVHeadend %s</modelDescription>\n\
@@ -172,6 +172,7 @@ satip_server_http_xml(http_connection_t *hc)
     snprintf(buf2, sizeof(buf2), " %s", satip_server_uuid + 26);
 
   snprintf(buf, sizeof(buf), MSG,
+           config_get_server_name(),
            buf2, tvheadend_version,
            satip_server_uuid,
            http_server_ip, http_server_port,

--- a/src/webui/extjs.c
+++ b/src/webui/extjs.c
@@ -477,6 +477,8 @@ extjs_config(http_connection_t *hc, const char *remain, void *opaque)
 
     /* Misc settings */
     pthread_mutex_lock(&global_lock);
+    if ((str = http_arg_get(&hc->hc_req_args, "server_name")))
+      save |= config_set_server_name(str);
     if ((str = http_arg_get(&hc->hc_req_args, "muxconfpath")))
       save |= config_set_muxconfpath(str);
     if ((str = http_arg_get(&hc->hc_req_args, "language")))

--- a/src/webui/static/app/config.js
+++ b/src/webui/static/app/config.js
@@ -41,7 +41,7 @@ tvheadend.miscconf = function(panel, index) {
         root: 'config'
     },
     [
-        'muxconfpath', 'language',
+        'server_name', 'muxconfpath', 'language',
         'tvhtime_update_enabled', 'tvhtime_ntp_enabled',
         'tvhtime_tolerance',
         'prefer_picon', 'chiconpath', 'piconpath',
@@ -57,6 +57,22 @@ tvheadend.miscconf = function(panel, index) {
     /*
     * DVB path
     */
+
+    var serverName = new Ext.form.TextField({
+        fieldLabel: 'Tvheadend server name',
+        name: 'server_name',
+        allowBlank: true,
+        width: 400
+    });
+
+    var serverWrap = new Ext.form.FieldSet({
+        title: 'Server',
+        width: 700,
+        autoHeight: true,
+        collapsible: true,
+        animCollapse: true,
+        items : [ serverName ]
+    });
 
     var dvbscanPath = new Ext.form.TextField({
         fieldLabel: 'DVB scan files path',
@@ -322,7 +338,7 @@ tvheadend.miscconf = function(panel, index) {
         }
     });
 
-    var _items = [languageWrap, dvbscanWrap, tvhtimePanel, piconPanel];
+    var _items = [serverWrap, languageWrap, dvbscanWrap, tvhtimePanel, piconPanel];
 
     if (satipPanel)
       _items.push(satipPanel);


### PR DESCRIPTION
This should avoid confusion when multiple tvh instances are running on the network.
Whatever is configured as server name will show up in avahi and sat>ip announcements.

To support this I added ability to restart avahi service announcements.