### PR TITLE
Build system: some minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ src/webui/static/tvh.css.gz
 data/dvb-scan
 
 libav_static
+libhdhomerun_static
 
 .cproject
 .project

--- a/Makefile
+++ b/Makefile
@@ -461,6 +461,7 @@ distclean: clean
 	rm -rf ${ROOTDIR}/libav_static
 	rm -rf ${ROOTDIR}/libhdhomerun_static
 	rm -rf ${ROOTDIR}/build.*
+	rm -rf ${ROOTDIR}/data/dvb-scan
 	rm -f ${ROOTDIR}/.config.mk
 
 # Create version
@@ -515,7 +516,7 @@ endif
 ${BUILDDIR}/libffmpeg_stamp: ${ROOTDIR}/libav_static/build/ffmpeg/lib/libavcodec.a
 	@touch $@
 
-${ROOTDIR}/libav_static/build/ffmpeg/lib/libavcodec.a:
+${ROOTDIR}/libav_static/build/ffmpeg/lib/libavcodec.a: Makefile.ffmpeg
 	CONFIG_LIBFFMPEG_STATIC_X264=$(CONFIG_LIBFFMPEG_STATIC_X264) \
 	  $(MAKE) -f Makefile.ffmpeg build
 
@@ -529,7 +530,7 @@ endif
 ${BUILDDIR}/libhdhomerun_stamp: ${ROOTDIR}/libhdhomerun_static/libhdhomerun/libhdhomerun.a
 	@touch $@
 
-${ROOTDIR}/libhdhomerun_static/libhdhomerun/libhdhomerun.a:
+${ROOTDIR}/libhdhomerun_static/libhdhomerun/libhdhomerun.a: Makefile.hdhomerun
 	$(MAKE) -f Makefile.hdhomerun build
 
 # linuxdvb git tree

--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -23,12 +23,13 @@ unexport LDFLAGS
 
 define DOWNLOAD
 	@mkdir -p $(LIBAVDIR)/build
-	if test -z "$${TVHEADEND_FILE_CACHE}"; then \
-          wget --no-verbose -O $(2) $(1); \
-        else \
-          file=$$(basename $(2)); \
-          cp "$$TVHEADEND_FILE_CACHE/$$(file)" $(2); \
-        fi
+	@if test -z "$${TVHEADEND_FILE_CACHE}"; then \
+	  printf "WGET            $(1)\n"; \
+	  wget --no-verbose -O $(2) $(1); \
+	else \
+	  file=$$(basename $(2)); \
+	  cp "$$TVHEADEND_FILE_CACHE/$$(file)" $(2); \
+	fi
 	@{ \
 	  sum=$$(sha1sum $(2) | cut -d ' ' -f 1); \
 	  printf "SHA1SUM test '$${sum}' == '$(3)': "; \
@@ -38,7 +39,10 @@ define DOWNLOAD
 endef
 
 define UNTAR
-	tar x -C $(LIBAVDIR) -$(2)f $(LIBAVDIR)/$(1)
+	@{ \
+	  printf "UNTAR           $(1)\n"; \
+	  tar x -C $(LIBAVDIR) -$(2)f $(LIBAVDIR)/$(1); \
+	}
 endef
 
 LIBAVDIR = $(ROOTDIR)/libav_static
@@ -68,10 +72,10 @@ LIBOGG_TB       = $(LIBOGG).tar.gz
 LIBOGG_URL      = http://downloads.xiph.org/releases/ogg/$(LIBOGG_TB)
 LIBOGG_SHA1     = df7f3977bbeda67306bc2a427257dd7375319d7d
 
-LIBVORBIS       = libvorbis-1.3.4
+LIBVORBIS       = libvorbis-1.3.5
 LIBVORBIS_TB    = $(LIBVORBIS).tar.gz
 LIBVORBIS_URL   = http://downloads.xiph.org/releases/vorbis/$(LIBVORBIS_TB)
-LIBVORBIS_SHA1  = 1602716c187593ffe4302124535240cec2079df3
+LIBVORBIS_SHA1  = 10c7fee173178d72855aa7593dfe49d9b3d6c804
 
 LIBX264         = x264-snapshot-20141218-2245
 LIBX264_TB      = $(LIBX264).tar.bz2

--- a/Makefile.hdhomerun
+++ b/Makefile.hdhomerun
@@ -23,22 +23,26 @@ unexport LDFLAGS
 
 define DOWNLOAD
 	@mkdir -p $(LIBHDHRDIR)/build
-	if test -z "$${TVHEADEND_FILE_CACHE}"; then \
-          wget --no-verbose -O $(2) $(1); \
-        else \
-          file=$$(basename $(2)); \
-          cp "$$TVHEADEND_FILE_CACHE/$$(file)" $(2); \
-        fi
-        @{ \
+	@if test -z "$${TVHEADEND_FILE_CACHE}"; then \
+	  printf "WGET            $(1)\n"; \
+	  wget --no-verbose -O $(2) $(1); \
+	else \
+	  file=$$(basename $(2)); \
+	  cp "$$TVHEADEND_FILE_CACHE/$$(file)" $(2); \
+	fi
+	@{ \
 	  sum=$$(sha1sum $(2) | cut -d ' ' -f 1); \
-          printf "SHA1SUM test '$${sum}' == '$(3)': "; \
-          test "y$${sum}" = "y$(3)"; \
-        }
+	  printf "SHA1SUM test '$${sum}' == '$(3)': "; \
+	  test "y$${sum}" = "y$(3)"; \
+	}
 	@echo "OK"
 endef
 
 define UNTAR
-	tar x -C $(LIBHDHRDIR) -$(2)f $(LIBHDHRDIR)/$(1)
+	@{ \
+	  printf "UNTAR           $(1)\n"; \
+	  tar x -C $(LIBHDHRDIR) -$(2)f $(LIBHDHRDIR)/$(1); \
+	}
 endef
 
 LIBHDHRDIR = $(ROOTDIR)/libhdhomerun_static


### PR DESCRIPTION
Added static hdhomerun build dir to .gitignore.
Delete data/dvb-scan on `make distclean`.
Add dependency for Makefile to static hdhomerun and ffmpeg, so they get rebuilt when the Makefile changes.
Removed some clutter from the build output of static hdhomerun and ffmpeg.
Updated static libvorbis.