### PR TITLE
htsp: updateDvrEntry: add support for updating channel.

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -447,7 +447,7 @@ dvr_entry_create_htsp( const char *dvr_config_uuid,
                        const char *comment );
 
 dvr_entry_t *
-dvr_entry_update( dvr_entry_t *de,
+dvr_entry_update( dvr_entry_t *de, channel_t *ch,
                   const char *title, const char *subtitle,
                   const char *desc, const char *lang,
                   time_t start, time_t stop,

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -941,9 +941,10 @@ dvr_timer_expire(void *aux)
 }
 
 static dvr_entry_t *_dvr_entry_update
-  ( dvr_entry_t *de, epg_broadcast_t *e, const char *title, const char *subtitle,
-    const char *desc, const char *lang, time_t start, time_t stop,
-    time_t start_extra, time_t stop_extra, dvr_prio_t pri, int retention )
+  ( dvr_entry_t *de, epg_broadcast_t *e, channel_t *ch, const char *title,
+    const char *subtitle, const char *desc, const char *lang, time_t start,
+    time_t stop, time_t start_extra, time_t stop_extra, dvr_prio_t pri,
+    int retention )
 {
   char buf[40];
   int save = 0, updated = 0;
@@ -964,6 +965,12 @@ static dvr_entry_t *_dvr_entry_update
       save = 1;
     }
     goto dosave;
+  }
+
+  /* Channel */
+  if (ch && (ch != de->de_channel)) {
+    de->de_channel = ch;
+    save = 1;
   }
 
   /* Start/Stop */
@@ -1086,14 +1093,14 @@ dosave:
  */
 dvr_entry_t * 
 dvr_entry_update
-  ( dvr_entry_t *de,
+  ( dvr_entry_t *de, channel_t *ch,
     const char *title, const char *subtitle,
     const char *desc, const char *lang,
     time_t start, time_t stop,
     time_t start_extra, time_t stop_extra,
     dvr_prio_t pri, int retention )
 {
-  return _dvr_entry_update(de, NULL, title, subtitle, desc, lang,
+  return _dvr_entry_update(de, NULL, ch, title, subtitle, desc, lang,
                            start, stop, start_extra, stop_extra,
                            pri, retention);
 }
@@ -1142,7 +1149,7 @@ dvr_event_replaced(epg_broadcast_t *e, epg_broadcast_t *new_e)
                    channel_get_name(e->channel),
                    e->start, e->stop);
           dvr_entry_assign_broadcast(de, e);
-          _dvr_entry_update(de, e, NULL, NULL, NULL, NULL, 0, 0, 0, 0, DVR_PRIO_NOTSET, 0);
+          _dvr_entry_update(de, e, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 0, DVR_PRIO_NOTSET, 0);
           return;
         }
       }
@@ -1156,7 +1163,7 @@ void dvr_event_updated ( epg_broadcast_t *e )
   dvr_entry_t *de;
   de = dvr_entry_find_by_event(e);
   if (de)
-    _dvr_entry_update(de, e, NULL, NULL, NULL, NULL, 0, 0, 0, 0, DVR_PRIO_NOTSET, 0);
+    _dvr_entry_update(de, e, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 0, DVR_PRIO_NOTSET, 0);
   else {
     LIST_FOREACH(de, &dvrentries, de_global_link) {
       if (de->de_sched_state != DVR_SCHEDULED) continue;
@@ -1171,7 +1178,7 @@ void dvr_event_updated ( epg_broadcast_t *e )
                  channel_get_name(e->channel),
                  e->start, e->stop);
         dvr_entry_assign_broadcast(de, e);
-        _dvr_entry_update(de, e, NULL, NULL, NULL, NULL, 0, 0, 0, 0, DVR_PRIO_NOTSET, 0);
+        _dvr_entry_update(de, e, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 0, DVR_PRIO_NOTSET, 0);
         break;
       }
     }

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -71,7 +71,7 @@
 
 static void *htsp_server, *htsp_server_2;
 
-#define HTSP_PROTO_VERSION 21
+#define HTSP_PROTO_VERSION 22
 
 #define HTSP_ASYNC_OFF  0x00
 #define HTSP_ASYNC_ON   0x01
@@ -1590,11 +1590,12 @@ static htsmsg_t *
 htsp_method_updateDvrEntry(htsp_connection_t *htsp, htsmsg_t *in)
 {
   htsmsg_t *out;
-  uint32_t dvrEntryId;
+  uint32_t dvrEntryId, u32;
   dvr_entry_t *de;
   time_t start, stop, start_extra, stop_extra, priority, retention;
   const char *title, *subtitle, *desc, *lang;
-    
+  channel_t *channel = NULL;
+
   if(htsmsg_get_u32(in, "id", &dvrEntryId))
     return htsp_error("Missing argument 'id'");
   
@@ -1604,9 +1605,14 @@ htsp_method_updateDvrEntry(htsp_connection_t *htsp, htsmsg_t *in)
   if(dvr_entry_verify(de, htsp->htsp_granted_access, 1))
     return htsp_error("User does not have access");
 
+  if(!htsmsg_get_u32(in, "channelId", &u32))
+    channel = channel_find_by_id(u32);
+  if (!channel)
+    channel = de->de_channel;
+
   /* Check access */
-  if (!htsp_user_access_channel(htsp, de->de_channel))
-    return htsp_error("User does not have access");
+  if (!htsp_user_access_channel(htsp, channel))
+    return htsp_error("User does not have access to channel");
 
   start       = htsmsg_get_s64_or_default(in, "start",      0);
   stop        = htsmsg_get_s64_or_default(in, "stop",       0);
@@ -1619,7 +1625,7 @@ htsp_method_updateDvrEntry(htsp_connection_t *htsp, htsmsg_t *in)
   desc        = htsmsg_get_str(in, "description");
   lang        = htsmsg_get_str(in, "language") ?: htsp->htsp_language;
 
-  de = dvr_entry_update(de, title, subtitle, desc, lang, start, stop,
+  de = dvr_entry_update(de, channel, title, subtitle, desc, lang, start, stop,
                         start_extra, stop_extra, priority, retention);
 
   //create response


### PR DESCRIPTION
No idea why this was not implemented in the first place. Maybe it just has been forgotten? This PR adds support for updating the channel using htsp method "updateDvrEntry" and bumps HTSP version to 22.