### PR TITLE
Add per network tags

### DIFF
--- a/src/api/api_service.c
+++ b/src/api/api_service.c
@@ -42,6 +42,7 @@ api_mapper_start
   get_u32(encrypted);
   get_u32(merge_same_name);
   get_u32(provider_tags);
+  get_u32(network_tags);
   
   pthread_mutex_lock(&global_lock);
   service_mapper_start(&conf, uuids);

--- a/src/service_mapper.c
+++ b/src/service_mapper.c
@@ -255,6 +255,13 @@ service_mapper_process ( service_t *s, bouquet_t *bq )
       if ((prov = s->s_provider_name(s)))
         channel_tag_map(channel_tag_find_by_name(prov, 1), chn, chn);
 
+    /* Network */
+    if (service_mapper_conf.network_tags) {
+      source_info_t si;
+      s->s_setsourceinfo(s, &si);
+      channel_tag_map(channel_tag_find_by_name(si.si_network, 1), chn, chn);
+    }
+
     /* save */
     idnode_notify_changed(&chn->ch_id);
     channel_save(chn);

--- a/src/service_mapper.h
+++ b/src/service_mapper.h
@@ -27,6 +27,7 @@ typedef struct service_mapper_conf
   int encrypted;          ///< Include encrypted services
   int merge_same_name;    ///< Merge entries with the same name
   int provider_tags;      ///< Create tags based on provider name
+  int network_tags;       ///< Create tags based on network name (useful for multi adapter equipments)
 } service_mapper_conf_t;
 
 typedef struct service_mapper_status

--- a/src/webui/static/app/servicemapper.js
+++ b/src/webui/static/app/servicemapper.js
@@ -105,9 +105,14 @@ tvheadend.service_mapper = function(t, e, store, select)
         fieldLabel: _('Create provider tags'),
         checked: false
     });
+    var nettagCheck = new Ext.form.Checkbox({                                                                                                                                      
+        name: 'network_tags',                                                                                                                                                      
+        fieldLabel: _('Create network tags'),
+        checked: false
+    });
 
     // TODO: provider list
-    items = [availCheck, ftaCheck, mergeCheck, provtagCheck];
+    items = [availCheck, ftaCheck, mergeCheck, provtagCheck, nettagCheck];
 
     /* Form */
     var undoBtn = new Ext.Button({


### PR DESCRIPTION
This is useful in multi-adapter equipments. Adding the network (source) tag to each channel lets to group in clients like kodi simply choosing the proper (source) tag in group list (eg. DTT, HorBird, Astra, etc.). This is also useful in rotor setups, grouping channels by satellite avoids the continuous move of the dish that happens in an unique enormous list of mixed-sources channels 