### PR TITLE
extra space

### DIFF
--- a/src/input/mpegts/linuxdvb/linuxdvb_frontend.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_frontend.c
@@ -89,7 +89,7 @@ const idclass_t linuxdvb_frontend_class =
     {
       .type     = PT_INT,
       .id       = "pids_max",
-      .name     = N_("Maximum PIDs "),
+      .name     = N_("Maximum PIDs"),
       .off      = offsetof(linuxdvb_frontend_t, lfe_pids_max),
       .opts     = PO_ADVANCED,
       .def.i    = 32


### PR DESCRIPTION
There was an extra space in the phrase "Maximum PIDs" that prevented it to be merged with another similar. The space looks unuseful.