### PR TITLE
linuxdvb: handle possible bad pilot config

### DIFF
--- a/src/input/mpegts/linuxdvb/linuxdvb_frontend.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_frontend.c
@@ -1278,6 +1278,7 @@ linuxdvb_frontend_tune0
     { .t = DVB_PILOT_AUTO,              .l = PILOT_AUTO },
     { .t = DVB_PILOT_ON,                .l = PILOT_ON   },
     { .t = DVB_PILOT_OFF,               .l = PILOT_OFF  },
+    { .t = DVB_PILOT_NONE,              .l = PILOT_AUTO },
     { .l = TABLE_EOD }
   };
   static linuxdvb_tbl_t rolloff_tbl[] = {


### PR DESCRIPTION
This is no doubt a result of some previous configuration migration issues.

However this change should be fairly benign and will stop FE's reporting
unecessary tuning errors.

Not sure though if the best error is to fix the configuration?