### PR TITLE
Fix GMT offset during DST on vanilla glibc systems

### DIFF
--- a/configure
+++ b/configure
@@ -185,6 +185,17 @@ int test(void)
 }
 '
 
+check_cc_snippet gmtoff '
+#include <time.h>
+#define TEST test
+int test(void)
+{
+  struct tm x;
+  x.tm_gmtoff = 0;
+  return 0;
+}
+' -DHAS_GMTOFF
+
 check_cc_snippet recvmmsg '
 #define _GNU_SOURCE
 #include <stdlib.h>

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -65,7 +65,7 @@
 
 static void *htsp_server, *htsp_server_2;
 
-#define HTSP_PROTO_VERSION 22
+#define HTSP_PROTO_VERSION 23
 
 #define HTSP_ASYNC_OFF  0x00
 #define HTSP_ASYNC_ON   0x01
@@ -1088,13 +1088,33 @@ htsp_method_getSysTime(htsp_connection_t *htsp, htsmsg_t *in)
   htsmsg_t *out;
   struct timeval tv;
   struct timezone tz;
+  int tz_offset;
+  struct tm serverLocalTime;
 
   if(gettimeofday(&tv, &tz) == -1)
     return htsp_error("Unable to get system time"); 
 
+  if (!localtime_r(&tv.tv_sec, &serverLocalTime))
+    return htsp_error("Unable to get system local time");
+#if defined(HAS_GMTOFF)
+  tz_offset = - serverLocalTime.tm_gmtoff / (60);
+#else
+  // NB: This will be a day out when GMT offsets >= 13hrs or <11 hrs apply
+  struct tm serverGmTime;
+  if (!gmtime_r(&tv.tv_sec, &serverGmTime))
+    return htsp_error("Unable to get system gmt");
+  tz_offset = (serverGmTime.tm_hour - serverLocalTime.tm_hour) * 60;
+  tz_offset += serverGmTime.tm_min - serverLocalTime.tm_min;
+  if (tz_offset > 11 * 60)
+    tz_offset -= 24 * 60;
+  if (tz_offset <= -13 * 60)
+    tz_offset += 24 * 60;
+#endif
+
   out = htsmsg_create_map();
   htsmsg_add_s32(out, "time", tv.tv_sec);
-  htsmsg_add_s32(out, "timezone", tz.tz_minuteswest / 60);
+  htsmsg_add_s32(out, "timezone", tz_offset/60);
+  htsmsg_add_s32(out, "gmtoffset", -tz_offset);
   return out;
 }
 


### PR DESCRIPTION
Requested by @ksooo while investigating a pvr.hts issue (https://github.com/kodi-pvr/pvr.hts/pull/85)

Tested on my gentoo server (not a vanilla glibc system) but I can confirm that it is using the new code path successfully and provides the correct time offset when tested against https://github.com/kodi-pvr/pvr.hts/pull/85 in the Europe/London timezone during DST.

The idea for this change came from http://stackoverflow.com/questions/635780/why-does-glibc-timezone-global-not-agree-with-system-time-on-dst

Known 'vanilla glibc' systems include rasbian (aka debian) and openElec.
Known 'not vanilla' glibc systems include gentoo and ubuntu.