### PR TITLE
DVR: autorec directory name, fixes #3037

### DIFF
--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -172,9 +172,10 @@ dvr_rec_unsubscribe(dvr_entry_t *de)
 
 /**
  * Replace various chars with a dash
+ * - ondemand specifies if user demanded substitutions are performed
  */
 static char *
-cleanup_filename(dvr_config_t *cfg, char *s)
+cleanup_filename(dvr_config_t *cfg, char *s, int ondemand )
 {
   int len = strlen(s);
   char *s1, *p;
@@ -206,16 +207,19 @@ cleanup_filename(dvr_config_t *cfg, char *s)
       *s = '-';
 
     else if (cfg->dvr_whitespace_in_title &&
-             (*s == ' ' || *s == '\t'))
+             (*s == ' ' || *s == '\t') &&
+             ondemand )
       *s = '-';	
 
     else if (cfg->dvr_clean_title &&
              ((*s < 32) || (*s > 122) ||
-             (strchr("/:\\<>|*?\"", *s) != NULL)))
+             (strchr("/:\\<>|*?\"", *s) != NULL)) &&
+             ondemand )
       *s = '_';
 
     else if (cfg->dvr_windows_compatible_filenames &&
-             (strchr("/:\\<>|*?\"", *s) != NULL))
+             (strchr("/:\\<>|*?\"", *s) != NULL) && 
+             ondemand )
       *s = '_';
   }
 
@@ -607,7 +611,7 @@ pvr_generate_filename(dvr_entry_t *de, const streaming_start_t *ss)
       break;
     *(dirsep - 1) = '\0';
     if (*x) {
-      s = cleanup_filename(cfg, x);
+      s = cleanup_filename(cfg, x, de->de_directory == NULL);
       tvh_strlcatf(filename, sizeof(filename), j, "%s/", s);
       free(s);
     }
@@ -646,7 +650,7 @@ pvr_generate_filename(dvr_entry_t *de, const streaming_start_t *ss)
       number[0] = '\0';
     }
     htsstr_substitute(filename + j, ptmp, sizeof(ptmp), '$', dvr_subs_tally, number);
-    s = cleanup_filename(cfg, ptmp);
+    s = cleanup_filename(cfg, ptmp, 1);
     if (s == NULL)
       return -1;
 

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -583,7 +583,9 @@ pvr_generate_filename(dvr_entry_t *de, const streaming_start_t *ss)
       strcpy(filename, dirsep + 1);
     else
       strcpy(filename, path + l);
-    htsstr_substitute(de->de_directory, ptmp, sizeof(ptmp), '$', dvr_subs_entry, de);
+    //htsstr_substitute(de->de_directory, ptmp, sizeof(ptmp), '$', dvr_subs_entry, de);
+    strncpy(ptmp, de->de_directory, sizeof(ptmp));
+
     s = ptmp;
     while (*s == '/')
       s++;


### PR DESCRIPTION
I added a new parameter 'ondemand' to the cleanup_filename() function. If ondemand == 0 the function doesnt apply dvr_whitespace_in_title, dvr_clean_title and dvr_windows_compatible_filenames substitutions.
This allows me to disable this features for explicitly specified directory name in autorec entry.

'de->de_directory == NULL' determines whether the processed directory name was specified in autorec entry.

Fixes https://tvheadend.org/issues/3037.