### PR TITLE
Add systemd socket activation support

### DIFF
--- a/configure
+++ b/configure
@@ -49,6 +49,7 @@ OPTIONS=(
   "android:no"
   "tsdebug:no"
   "gtimer_check:no"
+  "libsystemd_daemon:no"
 )
 
 #
@@ -545,6 +546,17 @@ fi
 #
 if enabled_or_auto tsdebug; then
   enable mpegts_dvb
+fi
+
+#
+# systemd
+#
+if enabled_or_auto libsystemd_daemon; then
+  if check_pkg libsystemd-daemon; then
+    enable libsystemd_daemon
+  elif enabled libsystemd_daemon; then
+    die "libsystemd-daemon development support not found (use --disable-systemd_daemon)"
+  fi
 fi
 
 


### PR DESCRIPTION
Hello.

This patch enables the systemd socket activation. I've tested the code on my Fedora 22 and it seems to work OK. The functionality needs to be enabled explicitly with --enable-libsystemd_daemon configure option.
The new code checks when creating a TCP server whether systemd didn't pass the application a socket listening on the requested address/port and eventually reuses the given file descriptor.

Let me know what you think.