### PR TITLE
Makefile: Remove -ldl to fix static build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ CFLAGS  += -fms-extensions -funsigned-char -fno-strict-aliasing
 CFLAGS  += -D_FILE_OFFSET_BITS=64
 CFLAGS  += -I${BUILDDIR} -I${ROOTDIR}/src -I${ROOTDIR}
 ifeq ($(CONFIG_ANDROID),yes)
-LDFLAGS += -ldl -lm
+LDFLAGS += -lm
 else
-LDFLAGS += -ldl -lpthread -lm
+LDFLAGS += -lpthread -lm
 endif
 ifeq ($(CONFIG_LIBICONV),yes)
 LDFLAGS += -liconv


### PR DESCRIPTION
-ldl was added in 2010: "Link with libdl (for dladdr())"
https://github.com/tvheadend/tvheadend/commit/0fca6020008c0964155a18e23093e136333ad9ef

The only trace of dladdr() can be found currently in src/trap.c in line
192, encapsulated in #if ENABLE_EXECINFO. The buildsystem does not
contain any trace of ENABLE_EXECINFO so I suppose -ldl is not needed
anymore. Unconditionally adding "-ldl" breaks static builds in buildroot
however:
http://autobuild.buildroot.net/results/f1c/f1c40ac9dda5ceeb5665d021333058eb29828d62/build-end.log

This patch, written by Thomas Petazzoni, fixes the problem.
He gave me written consent to send this patch upstream in his name:
http://article.gmane.org/gmane.comp.lib.uclibc.buildroot/125500