### PR TITLE
xmltv: handle timezone attached to time with no space padding

### DIFF
--- a/src/epggrab/module/xmltv.c
+++ b/src/epggrab/module/xmltv.c
@@ -17,6 +17,7 @@
  */
 
 #include <assert.h>
+#include <ctype.h>
 #include <sys/stat.h>
 #include <errno.h>
 #include <string.h>
@@ -72,13 +73,15 @@ static time_t _xmltv_str2time(const char *in)
   str[sizeof(str)-1] = '\0';
 
   /* split tz */
-  while (str[sp] && str[sp] != ' ')
+  while (str[sp] && str[sp] != ' ' && str[sp] != '+' && str[sp] != '-')
+    sp++;
+  if (str[sp] == ' ')
     sp++;
 
   /* parse tz */
   // TODO: handle string TZ?
   if (str[sp]) {
-    sscanf(str+sp+1, "%d", &tz);
+    sscanf(str+sp, "%d", &tz);
     tz = (tz % 100) + (tz / 100) * 3600; // Convert from HHMM to seconds
     str[sp] = 0;
   }


### PR DESCRIPTION
These changes needed for xmltv downloaded from a VBox Gateway device.

I added a check for alphabetic characters but not actually the parsing of timezone strings.

xmltv example attached
https://www.dropbox.com/s/i7sr7omjfn15rbx/vboxXmltv.xml?dl=0