### PR TITLE
include in/out fields in subscription_create_msg()

### DIFF
--- a/src/atomic.h
+++ b/src/atomic.h
@@ -40,6 +40,12 @@ atomic_exchange(volatile int *ptr, int new)
   return  __sync_lock_test_and_set(ptr, new);
 }
 
+static inline int
+atomic_exchange_u64(volatile uint64_t *ptr, uint64_t new)
+{
+  return  __sync_lock_test_and_set(ptr, new);
+}
+
 static inline uint64_t
 atomic_add_u64(volatile uint64_t *ptr, uint64_t incr)
 {

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -915,7 +915,7 @@ dvr_thread(void *aux)
         }
       }
       if (pb)
-        atomic_add(&ts->ths_bytes_out, pktbuf_len(pb));
+        subscription_add_bytes_out(ts, pktbuf_len(pb));
     }
 
     streaming_queue_remove(sq, sm);

--- a/src/epggrab/module/eit.c
+++ b/src/epggrab/module/eit.c
@@ -597,8 +597,8 @@ _eit_callback
   /* Statistics */
   ths = mpegts_mux_find_subscription_by_name(mm, "epggrab");
   if (ths) {
-    ths->ths_bytes_in += len;
-    ths->ths_bytes_out += len;
+    subscription_add_bytes_in(ths, len);
+    subscription_add_bytes_out(ths, len);
   }
 
   /* Validate */

--- a/src/epggrab/module/opentv.c
+++ b/src/epggrab/module/opentv.c
@@ -563,8 +563,8 @@ opentv_table_callback
   /* Statistics */
   ths = mpegts_mux_find_subscription_by_name(mt->mt_mux, "epggrab");
   if (ths) {
-    ths->ths_bytes_in += len;
-    ths->ths_bytes_out += len;
+    subscription_add_bytes_in(ths, len);
+    subscription_add_bytes_out(ths, len);
   }
 
 
@@ -642,8 +642,8 @@ opentv_bat_callback
   /* Statistics */
   ths = mpegts_mux_find_subscription_by_name(mt->mt_mux, "epggrab");
   if (ths) {
-    ths->ths_bytes_in += len;
-    ths->ths_bytes_out += len;
+    subscription_add_bytes_in(ths, len);
+    subscription_add_bytes_out(ths, len);
   }
 
   r = dvb_bat_callback(mt, buf, len, tableid);

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -3415,7 +3415,7 @@ htsp_stream_deliver(htsp_subscription_t *hs, th_pkt_t *pkt)
   payloadlen = pktbuf_len(pkt->pkt_payload);
   htsmsg_add_binptr(m, "payload", pktbuf_ptr(pkt->pkt_payload), payloadlen);
   htsp_send_subscription(htsp, m, pkt->pkt_payload, hs, payloadlen);
-  atomic_add(&hs->hs_s->ths_bytes_out, payloadlen);
+  subscription_add_bytes_out(hs->hs_s, payloadlen);
 
   if(hs->hs_last_report != dispatch_clock) {
 

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -65,7 +65,7 @@
 
 static void *htsp_server, *htsp_server_2;
 
-#define HTSP_PROTO_VERSION 22
+#define HTSP_PROTO_VERSION 23
 
 #define HTSP_ASYNC_OFF  0x00
 #define HTSP_ASYNC_ON   0x01

--- a/src/satip/rtp.c
+++ b/src/satip/rtp.c
@@ -189,7 +189,7 @@ satip_rtp_thread(void *aux)
     switch (sm->sm_type) {
     case SMT_MPEGTS:
       pb = sm->sm_data;
-      atomic_add(&subs->ths_bytes_out, pktbuf_len(pb));
+      subscription_add_bytes_out(subs, pktbuf_len(pb));
       pthread_mutex_lock(&rtp->lock);
       r = satip_rtp_loop(rtp, pktbuf_ptr(pb), pktbuf_len(pb));
       pthread_mutex_unlock(&rtp->lock);

--- a/src/subscriptions.c
+++ b/src/subscriptions.c
@@ -957,6 +957,7 @@ subscription_done(void)
 void subscription_add_bytes_in(th_subscription_t *s, size_t in)
 {
   atomic_add(&s->ths_bytes_in, in);
+  atomic_add_u64(&s->ths_total_bytes_in, in);
 }
 
 /**
@@ -965,6 +966,7 @@ void subscription_add_bytes_in(th_subscription_t *s, size_t in)
 void subscription_add_bytes_out(th_subscription_t *s, size_t out)
 {
   atomic_add(&s->ths_bytes_out, out);
+  atomic_add_u64(&s->ths_total_bytes_out, out);
 }
 
 /**

--- a/src/subscriptions.c
+++ b/src/subscriptions.c
@@ -457,11 +457,11 @@ subscription_input_direct(void *opauqe, streaming_message_t *sm)
     th_pkt_t *pkt = sm->sm_data;
     s->ths_total_err += pkt->pkt_err;
     if (pkt->pkt_payload)
-      s->ths_bytes_in += pkt->pkt_payload->pb_size;
+      subscription_add_bytes_in(s, pkt->pkt_payload->pb_size);
   } else if(sm->sm_type == SMT_MPEGTS) {
     pktbuf_t *pb = sm->sm_data;
     s->ths_total_err += pb->pb_err;
-    s->ths_bytes_in += pb->pb_size;
+    subscription_add_bytes_in(s, pb->pb_size);
   }
 
   /* Pass to output */
@@ -950,6 +950,22 @@ subscription_done(void)
 /* **************************************************************************
  * Subscription control
  * *************************************************************************/
+
+/**
+ * Update incoming byte count
+ */
+void subscription_add_bytes_in(th_subscription_t *s, size_t in)
+{
+  atomic_add(&s->ths_bytes_in, in);
+}
+
+/**
+ * Update outgoing byte count
+ */
+void subscription_add_bytes_out(th_subscription_t *s, size_t out)
+{
+  atomic_add(&s->ths_bytes_out, out);
+}
 
 /**
  * Change weight

--- a/src/subscriptions.c
+++ b/src/subscriptions.c
@@ -913,14 +913,14 @@ subscription_status_callback ( void *p )
   LIST_FOREACH(s, &subscriptions, ths_global_link) {
     /* Store the difference between total bytes from the last round */
     uint64_t in_prev = s->ths_total_bytes_in_prev;
-    uint64_t in_curr = s->ths_total_bytes_in;
+    uint64_t in_curr = atomic_add_u64(&s->ths_total_bytes_in, 0);
     uint64_t out_prev = s->ths_total_bytes_out_prev;
-    uint64_t out_curr = s->ths_total_bytes_out;
+    uint64_t out_curr = atomic_add_u64(&s->ths_total_bytes_out, 0);
 
-    atomic_exchange(&s->ths_bytes_in_avg, (in_curr - in_prev));
-    atomic_exchange_u64(&s->ths_total_bytes_in_prev, s->ths_total_bytes_in);
-    atomic_exchange(&s->ths_bytes_out_avg, (out_curr - out_prev));
-    atomic_exchange_u64(&s->ths_total_bytes_out_prev, s->ths_total_bytes_out);
+    s->ths_bytes_in_avg = (int)(in_curr - in_prev);
+    s->ths_total_bytes_in_prev = s->ths_total_bytes_in;
+    s->ths_bytes_out_avg = (int)(out_curr - out_prev);
+    s->ths_total_bytes_out_prev = s->ths_total_bytes_out;
 
     htsmsg_t *m = subscription_create_msg(s);
     htsmsg_add_u32(m, "updateEntry", 1);

--- a/src/subscriptions.c
+++ b/src/subscriptions.c
@@ -891,6 +891,8 @@ subscription_create_msg(th_subscription_t *s)
 
   htsmsg_add_u32(m, "in", s->ths_bytes_in_prev);
   htsmsg_add_u32(m, "out", s->ths_bytes_out_prev);
+  htsmsg_add_s64(m, "total_in", s->ths_total_bytes_in);
+  htsmsg_add_s64(m, "total_out", s->ths_total_bytes_out);
 
   return m;
 }

--- a/src/subscriptions.h
+++ b/src/subscriptions.h
@@ -90,6 +90,8 @@ typedef struct th_subscription {
   uint64_t ths_total_bytes_out; /* total bytes since the subscription started */
   int ths_bytes_in;   // Reset every second to get aprox. bandwidth (in)
   int ths_bytes_out; // Reset every second to get approx bandwidth (out)
+  int ths_bytes_in_prev; /* Bytes received during the last second */
+  int ths_bytes_out_prev; /* Bytes sent during the last second */
 
   streaming_target_t ths_input;
 

--- a/src/subscriptions.h
+++ b/src/subscriptions.h
@@ -88,10 +88,10 @@ typedef struct th_subscription {
   int ths_total_err; /* total errors during entire subscription */
   uint64_t ths_total_bytes_in; /* total bytes since the subscription started */
   uint64_t ths_total_bytes_out; /* total bytes since the subscription started */
-  int ths_bytes_in;   // Reset every second to get aprox. bandwidth (in)
-  int ths_bytes_out; // Reset every second to get approx bandwidth (out)
-  int ths_bytes_in_prev; /* Bytes received during the last second */
-  int ths_bytes_out_prev; /* Bytes sent during the last second */
+  uint64_t ths_total_bytes_in_prev; /* total bytes since the subscription started, minus 1 second */
+  uint64_t ths_total_bytes_out_prev; /* total bytes since the subscription started, minus 1 second */
+  int ths_bytes_in_avg; /* Average bytes in per second */
+  int ths_bytes_out_avg; /* Average bytes out per second */
 
   streaming_target_t ths_input;
 

--- a/src/subscriptions.h
+++ b/src/subscriptions.h
@@ -201,6 +201,9 @@ void subscription_unlink_service(th_subscription_t *s, int reason);
 
 void subscription_dummy_join(const char *id, int first);
 
+void subscription_add_bytes_in(th_subscription_t *s, size_t in);
+
+void subscription_add_bytes_out(th_subscription_t *s, size_t out);
 
 static inline int subscriptions_active(void)
   { return LIST_FIRST(&subscriptions) != NULL; }

--- a/src/subscriptions.h
+++ b/src/subscriptions.h
@@ -86,6 +86,8 @@ typedef struct th_subscription {
   char *ths_title; /* display title */
   time_t ths_start;  /* time when subscription started */
   int ths_total_err; /* total errors during entire subscription */
+  uint64_t ths_total_bytes_in; /* total bytes since the subscription started */
+  uint64_t ths_total_bytes_out; /* total bytes since the subscription started */
   int ths_bytes_in;   // Reset every second to get aprox. bandwidth (in)
   int ths_bytes_out; // Reset every second to get approx bandwidth (out)
 

--- a/src/webui/webui.c
+++ b/src/webui/webui.c
@@ -349,7 +349,7 @@ http_stream_run(http_connection_t *hc, profile_chain_t *prch,
           pb = ((th_pkt_t*)sm->sm_data)->pkt_payload;
         else
           pb = sm->sm_data;
-        atomic_add(&s->ths_bytes_out, pktbuf_len(pb));
+        subscription_add_bytes_out(s, pktbuf_len(pb));
         muxer_write_pkt(mux, sm->sm_type, sm->sm_data);
         sm->sm_data = NULL;
       }
@@ -1500,8 +1500,8 @@ page_dvrfile(http_connection_t *hc, const char *remain, void *opaque)
       }
       content_len -= r;
       if (sub) {
-        sub->ths_bytes_in += r;
-        sub->ths_bytes_out += r;
+        subscription_add_bytes_in(sub, r);
+        subscription_add_bytes_out(sub, r);
       }
     }
   }


### PR DESCRIPTION
Without this potential clients will have to use the poll mechanism to get continuous updates on the bitrate of subscriptions.

@perexg I'd like to get this into the 4.0 branch as well, should I PR it or will you cherry-pick it?