### PR TITLE
webui: redir to parent instead of root

### DIFF
--- a/src/webui/webui.c
+++ b/src/webui/webui.c
@@ -1717,7 +1717,7 @@ http_redir(http_connection_t *hc, const char *remain, void *opaque)
       if (lang) {
         snprintf(buf, sizeof(buf), "src/webui/static/intl/tvh.%s.js.gz", lang);
         if (!http_file_test(buf)) {
-          snprintf(buf, sizeof(buf), "/static/intl/tvh.%s.js.gz", lang);
+          snprintf(buf, sizeof(buf), "../static/intl/tvh.%s.js.gz", lang);
           http_redirect(hc, buf, NULL, 0);
           return 0;
         }
@@ -1736,7 +1736,7 @@ http_redir(http_connection_t *hc, const char *remain, void *opaque)
       snprintf(buf, sizeof(buf), "docs/html/%s/%s%s%s", lang, components[1],
                                  nc > 2 ? "/" : "", nc > 2 ? components[1] : "");
       if (http_file_test(buf)) lang = "en";
-      snprintf(buf, sizeof(buf), "/docs/%s/%s%s%s", lang, components[1],
+      snprintf(buf, sizeof(buf), "../docs/%s/%s%s%s", lang, components[1],
                                  nc > 2 ? "/" : "", nc > 2 ? components[1] : "");
       http_redirect(hc, buf, NULL, 0);
       return 0;


### PR DESCRIPTION
Fixes the webui when running in an Apache ProxyPass/ProxyPassReverse scenario, where e.g. Apache is used as SSL host and serves the TVHeadend webserver from port 9981 to a subdir of the SSL host (https://host/tvheadend <-> http://host:9981). Without the patch, the webui won't load due to the missing locale causing a JS error.