### PR TITLE
libffmpeg_static: integrate libx265 (prelimirary work)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,10 +72,17 @@ LDFLAGS += ${LDFLAGS_FFDIR}/libavutil.a
 LDFLAGS += ${LDFLAGS_FFDIR}/libvorbisenc.a
 LDFLAGS += ${LDFLAGS_FFDIR}/libvorbis.a
 LDFLAGS += ${LDFLAGS_FFDIR}/libogg.a
-ifeq ($(CONFIG_LIBFFMPEG_STATIC_X264),yes)
+ifeq ($(CONFIG_LIBX264_STATIC),yes)
 LDFLAGS += ${LDFLAGS_FFDIR}/libx264.a
 else
 LDFLAGS += -lx264
+endif
+ifeq ($(CONFIG_LIBX265),yes)
+ifeq ($(CONFIG_LIBX265_STATIC),yes)
+LDFLAGS += ${LDFLAGS_FFDIR}/libx265.a -lstdc++
+else
+LDFLAGS += -lx265
+endif
 endif
 LDFLAGS += ${LDFLAGS_FFDIR}/libvpx.a
 endif
@@ -642,7 +649,9 @@ ${BUILDDIR}/libffmpeg_stamp: ${ROOTDIR}/libav_static/build/ffmpeg/lib/libavcodec
 	@touch $@
 
 ${ROOTDIR}/libav_static/build/ffmpeg/lib/libavcodec.a: Makefile.ffmpeg
-	CONFIG_LIBFFMPEG_STATIC_X264=$(CONFIG_LIBFFMPEG_STATIC_X264) \
+	CONFIG_LIBX264_STATIC=$(CONFIG_LIBX264_STATIC) \
+	CONFIG_LIBX265=$(CONFIG_LIBX265) \
+	CONFIG_LIBX265_STATIC=$(CONFIG_LIBX265_STATIC) \
 	  $(MAKE) -f Makefile.ffmpeg build
 
 # Static HDHOMERUN library

--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -187,7 +187,7 @@ $(LIBAVDIR)/$(LIBVORBIS)/.tvh_build: \
 # libx264
 #
 
-ifneq (yes,$(CONFIG_LIBFFMPEG_STATIC_X264))
+ifneq (yes,$(CONFIG_LIBX264_STATIC))
 
 $(LIBAVDIR)/$(LIBX264)/.tvh_download:
 	@echo "***** LIBX264 STATIC BUILD IS DISABLED, USING INSTALLED PACKAGE *****"
@@ -229,6 +229,16 @@ endif
 # libx265
 #
 
+ifeq (yes,$(CONFIG_LIBX265))
+
+EXTLIBS  += libx265
+ENCODERS += libx265
+
+endif
+
+
+ifeq (yes,$(CONFIG_LIBX265_STATIC))
+
 $(LIBAVDIR)/$(LIBX265)/.tvh_download:
 	$(call DOWNLOAD,$(LIBX265_URL),$(LIBAVDIR)/$(LIBX265_TB),$(LIBX265_SHA1))
 	$(call UNTAR,$(LIBX265_TB),z)
@@ -237,19 +247,25 @@ $(LIBAVDIR)/$(LIBX265)/.tvh_download:
 $(LIBAVDIR)/$(LIBX265)/.tvh_build: \
 		$(LIBAVDIR)/$(LIBX265)/.tvh_download \
 		$(LIBAVDIR)/$(YASM)/.tvh_build
-	cd $(LIBAVDIR)/$(LIBX265) && $(CONFIGURE) \
-		--prefix=/ffmpeg \
-		--enable-static \
-		--disable-shared \
-		--disable-avs \
-		--disable-swscale \
-		--disable-lavf \
-		--disable-ffms \
-		--disable-gpac \
-		--disable-lsmash
+	cd $(LIBAVDIR)/$(LIBX265)/build/linux && cmake \
+		-G "Unix Makefiles" \
+		-DCMAKE_INSTALL_PREFIX="/ffmpeg" \
+		-DENABLE_SHARED:bool=off \
+		../../source
 	DESTDIR=$(LIBAVDIR)/build \
-		$(MAKE) -C $(LIBAVDIR)/$(LIBX265) install
+		$(MAKE) -C $(LIBAVDIR)/$(LIBX265)/build/linux install
 	@touch $@
+
+else
+
+$(LIBAVDIR)/$(LIBX265)/.tvh_download:
+	@mkdir -p $(LIBAVDIR)/$(LIBX265)
+	@touch $@
+
+$(LIBAVDIR)/$(LIBX265)/.tvh_build: $(LIBAVDIR)/$(LIBX265)/.tvh_download
+	@touch $@
+
+endif
 
 #
 # libvpx (VP8)
@@ -286,6 +302,7 @@ $(LIBAVDIR)/$(FFMPEG)/.tvh_build: \
 		$(LIBAVDIR)/$(YASM)/.tvh_build \
 		$(LIBAVDIR)/$(LIBVORBIS)/.tvh_build \
 		$(LIBAVDIR)/$(LIBX264)/.tvh_build \
+		$(LIBAVDIR)/$(LIBX265)/.tvh_build \
 		$(LIBAVDIR)/$(LIBVPX)/.tvh_build \
 		$(LIBAVDIR)/$(FFMPEG)/.tvh_download
 	cd $(LIBAVDIR)/$(FFMPEG) && $(CONFIGURE) \
@@ -296,6 +313,7 @@ $(LIBAVDIR)/$(FFMPEG)/.tvh_build: \
 		--enable-gpl \
 		--extra-cflags="$(ECFLAGS)" \
 		--extra-libs="$(ELIBS)" \
+		--pkg-config-flags="--static" \
 		$(foreach extlib,$(EXTLIBS),--enable-$(extlib)) \
 		$(foreach component,$(COMPONENTS),--enable-$(component)) \
 		$(foreach protocol,$(PROTOCOLS),--enable-protocol=$(protocol)) \

--- a/configure
+++ b/configure
@@ -35,7 +35,7 @@ OPTIONS=(
   "zlib:auto"
   "libav:auto"
   "libffmpeg_static:no"
-  "libffmpeg_static_x264:yes"
+  "libx264_static:yes"
   "inotify:auto"
   "epoll:auto"
   "uriparser:auto"
@@ -50,6 +50,8 @@ OPTIONS=(
   "tsdebug:no"
   "gtimer_check:no"
   "libsystemd_daemon:no"
+  "libx265:no"
+  "libx265_static:yes"
 )
 
 #
@@ -376,6 +378,24 @@ if enabled libffmpeg_static; then
 
   enable libav
   has_libav=true
+
+  # libx264
+  if disabled libx264_static; then
+    check_cc_lib x264 || die "libx264 not found"
+  fi
+
+  # libx265
+  if enabled libx265; then
+    if enabled libx265_static; then
+      check_bin cmake || die "cmake not found (needed for building libx265)"
+      check_cc_lib stdc++ stdcpp ||\
+        die "libstdc++ not found (needed for building libx265)"
+    else
+      check_cc_lib x265 || die "libx265 not found"
+    fi
+  else
+    disable libx265_static
+  fi
 
 else
 


### PR DESCRIPTION
- Adds options '--enable-libx265' and '--disable-libx265_static'
- Integrates libx265 into ffmpeg building process