### PR TITLE
libav: transcode in HEVC - prologue

### DIFF
--- a/src/libav.c
+++ b/src/libav.c
@@ -81,6 +81,9 @@ streaming_component_type2codec_id(streaming_component_type_t type)
   case SCT_VP9:
     codec_id = AV_CODEC_ID_VP9;
     break;
+  case SCT_HEVC:
+    codec_id = AV_CODEC_ID_HEVC;
+    break;
   case SCT_AC3:
     codec_id = AV_CODEC_ID_AC3;
     break;
@@ -135,6 +138,9 @@ codec_id2streaming_component_type(enum AVCodecID id)
     break;
   case AV_CODEC_ID_VP9:
     type = SCT_VP9;
+    break;
+  case AV_CODEC_ID_HEVC:
+    type = SCT_HEVC;
     break;
   case AV_CODEC_ID_AC3:
     type = SCT_AC3;

--- a/src/muxer/muxer_libav.c
+++ b/src/muxer/muxer_libav.c
@@ -193,6 +193,7 @@ lav_muxer_support_stream(muxer_container_type_t mc,
   case MC_MPEGTS:
     ret |= (type == SCT_MPEG2VIDEO);
     ret |= (type == SCT_H264);
+    ret |= (type == SCT_HEVC);
 
     ret |= (type == SCT_MPEG2AUDIO);
     ret |= (type == SCT_AC3);
@@ -527,6 +528,9 @@ lav_muxer_destroy(muxer_t *m)
 
   if(lm->lm_h264_filter)
     av_bitstream_filter_close(lm->lm_h264_filter);
+
+  if(lm->lm_hevc_filter)
+    av_bitstream_filter_close(lm->lm_hevc_filter);
 
   if (lm->lm_oc) {
     for(i=0; i<lm->lm_oc->nb_streams; i++)

--- a/src/plumbing/transcoding.c
+++ b/src/plumbing/transcoding.c
@@ -1917,7 +1917,7 @@ transcoder_get_capabilities(int experimental)
       continue;
 
     sct = codec_id2streaming_component_type(p->id);
-    if (sct == SCT_NONE)
+    if (sct == SCT_NONE || sct == SCT_UNKNOWN)
       continue;
 
     m = htsmsg_create_map();


### PR DESCRIPTION
- setup HEVC ids for transcode
- allow HEVC stream in MPEGTS (afaik it is possible)
- close hevc bitstream filter on muxer destroy
- balk on SCT_NONE and SCT_UNKNOWN in codec enumeration