### PR TITLE
Added configure options and builddeps to support HEVC in the RPM Build

### DIFF
--- a/rpm/tvheadend.spec.in
+++ b/rpm/tvheadend.spec.in
@@ -21,6 +21,7 @@ BuildRequires:  avahi-devel
 BuildRequires:  avahi-libs
 BuildRequires:  openssl-devel
 BuildRequires:  wget python git
+BuildRequires:  cmake
 
 Requires:       systemd-units
 
@@ -40,7 +41,7 @@ echo %{version}-%{release} > %{_builddir}/%{buildsubdir}/rpm/version
 %ifarch %arm
       %configure --disable-lockowner --enable-bundle --disable-libffmpeg_static
 %else
-      %configure --disable-lockowner --enable-bundle --enable-libffmpeg_static
+      %configure --disable-lockowner --enable-bundle --enable-libffmpeg_static --enable-libx265
 %endif
 %{__make} %{?_smp_mflags}
 


### PR DESCRIPTION
I've added cmake as a Builder, required by libx265, and the configure option to enable libx265. 