### PR TITLE
libav_muxer: copy over header for HEVC as well

### DIFF
--- a/src/muxer/muxer_libav.c
+++ b/src/muxer/muxer_libav.c
@@ -29,6 +29,7 @@
 #include "libav.h"
 #include "muxer_libav.h"
 #include "parsers/parser_avc.h"
+#include "parsers/parser_hevc.h"
 
 typedef struct lav_muxer {
   muxer_t;
@@ -108,11 +109,16 @@ lav_muxer_add_stream(lav_muxer_t *lm,
   }
 
   if(ssc->ssc_gh) {
-    if (ssc->ssc_type == SCT_H264) {
+    if (ssc->ssc_type == SCT_H264 || ssc->ssc_type == SCT_HEVC) {
       sbuf_t hdr;
       sbuf_init(&hdr);
-      isom_write_avcc(&hdr, pktbuf_ptr(ssc->ssc_gh),
-                      pktbuf_len(ssc->ssc_gh));
+      if (ssc->ssc_type == SCT_H264) {
+          isom_write_avcc(&hdr, pktbuf_ptr(ssc->ssc_gh),
+                          pktbuf_len(ssc->ssc_gh));
+      } else {
+          isom_write_hvcc(&hdr, pktbuf_ptr(ssc->ssc_gh),
+                          pktbuf_len(ssc->ssc_gh));
+      }
       c->extradata_size = hdr.sb_ptr;
       c->extradata = av_malloc(hdr.sb_ptr);
       memcpy(c->extradata, hdr.sb_data, hdr.sb_ptr);


### PR DESCRIPTION
This allow streaming hevc, but breaks recording using the matroska libav muxer (h264 recording with the same muxer is also broken).
Maybe we should remove the container 'Matroska (mkv)/av-lib'?