### PR TITLE
Cleanup, using configurable patterns, the title of the shows on OpenTV EPG

### DIFF
--- a/data/conf/epggrab/opentv/prov/skyit
+++ b/data/conf/epggrab/opentv/prov/skyit
@@ -36,7 +36,13 @@
     "[0-9]+'?a? Stagione -? ?'(([^']*(' [^A-Z0-9-])?('[^ '])?)+)'",
     "[0-9]+'?a? Stagione -? ?Puntata ?[0-9]+[A-Za-z]? \"\" *([^\"]+) *\"\""
   ],
-  "__reference": [
+  "cleanup_title": [
+    "^ *(.*) *- *1\\^TV *$"
+  ],
+  "__title_references": [
+    "The Big Bang Theory - 1^TV "
+  ],
+  "__summary_references": [
     "4' Stagione Ep.9B - 'L'Hub' Gli agenti ...: sara' Ward ...",
     "3a Stagione - Puntata 1 ...",
     "4' Stagione - 'Title' ...",

--- a/data/conf/epggrab/opentv/prov/skyit
+++ b/data/conf/epggrab/opentv/prov/skyit
@@ -37,7 +37,8 @@
     "[0-9]+'?a? Stagione -? ?Puntata ?[0-9]+[A-Za-z]? \"\" *([^\"]+) *\"\""
   ],
   "cleanup_title": [
-    "^ *(.*) *- *1\\^TV *$"
+    "^ *(.*) *- *1\\^TV *$",
+    "^ *(.*) *$"
   ],
   "__title_references": [
     "The Big Bang Theory - 1^TV "


### PR DESCRIPTION
now just remove annoying "first showing" marks ("...1^TV") on Sky-IT that create a lot of problems to the episodes duplication routine

removed also previous code used to remove trailing spaces on the title: now it is managed by the patterns