### PR TITLE
Simplify an English translation of Spanish language

### DIFF
--- a/src/lang_codes.c
+++ b/src/lang_codes.c
@@ -408,7 +408,7 @@ const lang_code_t lang_codes[] = {
   { "sog", NULL, NULL , "Sogdian" },
   { "som", "so", NULL , "Somali" },
   { "son", NULL, NULL , "Songhai languages" },
-  { "spa", "es", NULL , "Spanish; Castilian" },
+  { "spa", "es", NULL , "Spanish" },
   { "srd", "sc", NULL , "Sardinian" },
   { "srn", NULL, NULL , "Sranan Tongo" },
   { "srp", "sr", NULL , "Serbian" },


### PR DESCRIPTION
I think "Spanish" is a more acurrate translation for "Spanish; Castilian" language in the menu