### PR TITLE
Implement max schedules limit for autorrecordings.

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -306,6 +306,8 @@ typedef struct dvr_autorec_entry {
   uint32_t dae_retention;
   uint32_t dae_removal;
   uint32_t dae_max_count;
+  uint32_t dae_max_sched_count;
+
 
   time_t dae_start_extra;
   time_t dae_stop_extra;

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -1113,6 +1113,13 @@ const idclass_t dvr_autorec_entry_class = {
       .opts     = PO_HIDDEN,
     },
     {
+      .type     = PT_U32,
+      .id       = "max_sched_count",
+      .name     = N_("Maximum schedules limit (0=unlimited)"),
+      .off      = offsetof(dvr_autorec_entry_t, dae_max_sched_count),
+      .opts     = PO_HIDDEN,
+    },
+    {
       .type     = PT_STR,
       .id       = "config_name",
       .name     = N_("DVR Configuration"),
@@ -1264,7 +1271,7 @@ dvr_autorec_changed(dvr_autorec_entry_t *dae, int purge)
         enabled = 1;
         if (disabled) {
           for (p = disabled; *p && *p != e; p++);
-          enabled = *p != NULL;
+          enabled = *p == NULL;
         }
         dvr_entry_create_by_autorec(enabled, e, dae);
       }

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -1264,7 +1264,7 @@ dvr_autorec_changed(dvr_autorec_entry_t *dae, int purge)
         enabled = 1;
         if (disabled) {
           for (p = disabled; *p && *p != e; p++);
-          enabled = *p != NULL;
+          enabled = *p == NULL;
         }
         dvr_entry_create_by_autorec(enabled, e, dae);
       }

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -1113,13 +1113,6 @@ const idclass_t dvr_autorec_entry_class = {
       .opts     = PO_HIDDEN,
     },
     {
-      .type     = PT_U32,
-      .id       = "max_sched_count",
-      .name     = N_("Maximum schedules limit (0=unlimited)"),
-      .off      = offsetof(dvr_autorec_entry_t, dae_max_sched_count),
-      .opts     = PO_HIDDEN,
-    },
-    {
       .type     = PT_STR,
       .id       = "config_name",
       .name     = N_("DVR Configuration"),
@@ -1271,7 +1264,7 @@ dvr_autorec_changed(dvr_autorec_entry_t *dae, int purge)
         enabled = 1;
         if (disabled) {
           for (p = disabled; *p && *p != e; p++);
-          enabled = *p == NULL;
+          enabled = *p != NULL;
         }
         dvr_entry_create_by_autorec(enabled, e, dae);
       }

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -1113,6 +1113,13 @@ const idclass_t dvr_autorec_entry_class = {
       .opts     = PO_HIDDEN,
     },
     {
+      .type     = PT_U32,
+      .id       = "max_sched_count",
+      .name     = N_("Maximum schedules limit (0=unlimited)"),
+      .off      = offsetof(dvr_autorec_entry_t, dae_max_sched_count),
+      .opts     = PO_HIDDEN,
+    },    
+    {
       .type     = PT_STR,
       .id       = "config_name",
       .name     = N_("DVR Configuration"),

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -298,8 +298,14 @@ dvr_entry_nostate(dvr_entry_t *de, int error_code)
 static void
 dvr_entry_missed_time(dvr_entry_t *de, int error_code)
 {
+  dvr_autorec_entry_t *dae = de->de_autorec; 
+
   dvr_entry_set_state(de, DVR_MISSED_TIME, DVR_RS_PENDING, error_code);
   dvr_entry_retention_timer(de);
+
+  // Trigger autorec update in case of max schedules limit
+  if ( dae && dae->dae_max_sched_count > 0)
+    dvr_autorec_changed( dae, 0 );
 }
 
 /*
@@ -974,19 +980,38 @@ dvr_entry_create_by_autorec(int enabled, epg_broadcast_t *e, dvr_autorec_entry_t
 {
   char buf[512];
   char ubuf[UUID_HEX_SIZE];
+  dvr_entry_t* de;
 
   /* Identical duplicate detection
      NOTE: Semantic duplicate detection is deferred to the start time of recording and then done using _dvr_duplicate_event by dvr_timer_start_recording. */
-  dvr_entry_t* de;
+
   LIST_FOREACH(de, &dvrentries, de_global_link) {
     if (de->de_bcast == e || (de->de_bcast && de->de_bcast->episode == e->episode))
       return;
   }
 
+ /* Handle max schedules limit for autorrecord */
+
+  uint32_t count = 0;
+
+  if (dae->dae_max_sched_count > 0){
+    count = 0;
+    LIST_FOREACH(de, &dae->dae_spawns, de_autorec_link){
+      if ( (de->de_sched_state == DVR_SCHEDULED) ||
+           (de->de_sched_state == DVR_RECORDING) ) count++;
+    }
+
+    if ( count >= dae->dae_max_sched_count ) {
+      tvhlog(LOG_INFO, "dvr", "Autorecord \"%s\": Not scheduling \"%s\" because of autorrecord max schedules limit reached", 
+          dae->dae_name, lang_str_get(e->episode->title, NULL));
+      return;
+    }
+
+  }
+
   snprintf(buf, sizeof(buf), "Auto recording%s%s",
            dae->dae_comment ? ": " : "",
            dae->dae_comment ?: "");
-
   dvr_entry_create_by_event(enabled, idnode_uuid_as_str(&dae->dae_config->dvr_id, ubuf),
                             e, dae->dae_start_extra, dae->dae_stop_extra,
                             dae->dae_owner, dae->dae_creator, dae, dae->dae_pri,
@@ -1410,6 +1435,7 @@ void
 dvr_stop_recording(dvr_entry_t *de, int stopcode, int saveconf, int clone)
 {
   dvr_rs_state_t rec_state = de->de_rec_state;
+  dvr_autorec_entry_t *dae = de->de_autorec;
 
   if (!clone)
     dvr_rec_unsubscribe(de);
@@ -1431,6 +1457,10 @@ dvr_stop_recording(dvr_entry_t *de, int stopcode, int saveconf, int clone)
     dvr_entry_save(de);
 
   dvr_entry_retention_timer(de);
+
+  // Trigger autorecord update in case of schedules limit
+  if (dae && dae->dae_max_sched_count > 0) 
+    dvr_autorec_changed(de->de_autorec, 0);
 }
 
 
@@ -2877,6 +2907,8 @@ dvr_entry_cancel(dvr_entry_t *de)
 void
 dvr_entry_cancel_delete(dvr_entry_t *de)
 {
+  dvr_autorec_entry_t *dae = de->de_autorec;
+
   switch(de->de_sched_state) {
   case DVR_SCHEDULED:
     dvr_entry_destroy(de, 1);
@@ -2898,6 +2930,11 @@ dvr_entry_cancel_delete(dvr_entry_t *de)
   default:
     abort();
   }
+
+  // Trigger autorec update in case of max sched count limit
+  if ( dae && dae->dae_max_sched_count > 0 )
+    dvr_autorec_changed(dae, 0); 
+
 }
 
 /**

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -513,6 +513,7 @@ tvheadend.autorec_editor = function(panel, index) {
             retention:    { width: 80 },
             removal:      { width: 80 },
             maxcount:     { width: 80 },
+            max_sched_count: { width: 80 },
             config_name:  { width: 120 },
             owner:        { width: 100 },
             creator:      { width: 200 },
@@ -523,7 +524,7 @@ tvheadend.autorec_editor = function(panel, index) {
             params: {
                list: 'enabled,name,directory,title,fulltext,channel,tag,content_type,minduration,' +
                      'maxduration,weekdays,start,start_window,pri,dedup,retention,removal,' +
-                     'maxcount,config_name,comment'
+                     'maxcount,max_sched_count,config_name,comment'
             },
             create: { }
         },


### PR DESCRIPTION
Hello. I have implemented a max number of schedules for autorrecords. As it's name states, It limits the number of schedules an autorrecord can create in one sigle search. For example:

Suppose in EPG of one channel.
- C.S.I MIAMI from 22:30 to 23:30
- C.S.I NEW YORK from 23:30 to 0:30
- C.S.I LAS VEGAS from 0:30 to 1:30.

An autorrecord for recording "C.S.I. " but limited only to one scheduled record, plus 240 mins of margin at the end. This gives me the posibility of record my favorite series only for watching later and jump the comercials, but in one big file without interruptions. When the recording finishes a new search is triggered to schedule the remainings if there are any.

Another example: 

Record all the videoclips from "Beyonce, Taylor Swift and Red Hot Chilli Pepers" from a music channel, but keep the upcoming grid "clean", as this music channel puts in EPG every single videclip for the next 5 days and there were 20 schedules only in the first 3 days (real case ;) ).

Besides this new feature, I've found a bug in dvr_autorec_changed function. When a autorec change was triggered and there were disabled schedules for this autorec, all of them inverted their states. I'ts now fixed.

Of course, I'm a newbie in C++ and git, so this code can have lots of bugs.

Sorry for my english ;)

