### PR TITLE
new service with opentv EPG data for sky-it

### DIFF
--- a/data/conf/epggrab/opentv/prov/skyit
+++ b/data/conf/epggrab/opentv/prov/skyit
@@ -4,7 +4,7 @@
   "genre": "skyit",
   "nid": 64511,
   "tsid": 5800,
-  "sid": 3635,
+  "sid": 3641,
   "bouquetid": 0,
   "channel" : [
     17


### PR DESCRIPTION
service with sid=3635 doesn't exist anymore