### PR TITLE
[htsp] fix htsp not informed when dvr changes

### DIFF
--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1549,6 +1549,8 @@ dvr_entry_class_save(idnode_t *self)
   dvr_entry_save(de);
   if (dvr_entry_is_valid(de))
     dvr_entry_set_timer(de);
+
+  htsp_dvr_entry_update(de);
 }
 
 static void


### PR DESCRIPTION
When editing a dvr entry through the webui, the htsp clients are not updated until a restart.

@perexg 
Can you check if this is right, although it's working? 
Also, do you know if updates are passed to the htsp clients when parameters are changing automatically (by epg), like start and stop time?