### PR TITLE
WebUI: Add Ctrl+A/select-all to DVR grids - fixes #3232

### DIFF
--- a/src/webui/static/app/idnode.js
+++ b/src/webui/static/app/idnode.js
@@ -1609,6 +1609,14 @@ tvheadend.idnode_grid = function(panel, conf)
             viewConfig: {
                 forceFit: true
             },
+            keys: {
+                key: 'a',
+                ctrl: true,
+                stopEvent: true,
+                handler: function() {
+                    grid.getSelectionModel().selectAll();
+                }
+            },
             tbar: buttons,
             bbar: page
         };


### PR DESCRIPTION
As it says - this adds a keyboard shortcut to the DVR grids (upcoming, finished, failed) so you can select all events at the same time. 

Useful it e.g. you're clearing out a load of old recordings, or if you have many that have failed (perhaps because they were disabled?).