### PR TITLE
include filters in static ffmpeg build, fixes #3261

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ LDFLAGS_FFDIR = ${ROOTDIR}/libav_static/build/ffmpeg/lib
 LDFLAGS += ${LDFLAGS_FFDIR}/libavresample.a
 LDFLAGS += ${LDFLAGS_FFDIR}/libswresample.a
 LDFLAGS += ${LDFLAGS_FFDIR}/libavfilter.a
+LDFLAGS += ${LDFLAGS_FFDIR}/libswscale.a
 LDFLAGS += ${LDFLAGS_FFDIR}/libavutil.a
 LDFLAGS += ${LDFLAGS_FFDIR}/libavformat.a
 LDFLAGS += ${LDFLAGS_FFDIR}/libavcodec.a

--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -62,12 +62,13 @@ FFMPEG_URL      = http://ffmpeg.org/releases/$(FFMPEG_TB)
 FFMPEG_SHA1     = 95046cd9251b69c61b11ebcd1e163ac14d0fc2c6
 
 EXTLIBS         = libx264 libvorbis libvpx
-COMPONENTS      = avutil avformat avcodec swresample avfilter avresample
+COMPONENTS      = avutil avformat avcodec swresample swscale avfilter avresample
 PROTOCOLS       = file
 DECODERS        = mpeg2video mp2 ac3 eac3 h264 h264_vdpau hevc aac aac_latm vorbis libvorbis
 ENCODERS        = mpeg2video mp2 libx264 libvpx_vp8 libvpx_vp9 aac libaacplus vorbis libvorbis
 MUXERS          = mpegts mpeg2dvd matroska webm
 BSFS            = h264_mp4toannexb hevc_mp4toannexb
+FILTERS         = yadif scale
 
 LIBOGG          = libogg-1.3.2
 LIBOGG_TB       = $(LIBOGG).tar.gz
@@ -370,7 +371,8 @@ $(LIBAVDIR)/$(FFMPEG)/.tvh_build: \
 		$(foreach decoder,$(DECODERS),--enable-decoder=$(decoder)) \
 		$(foreach encoder,$(ENCODERS),--enable-encoder=$(encoder)) \
 		$(foreach muxer,$(MUXERS),--enable-muxer=$(muxer)) \
-		$(foreach bsf,$(BSFS),--enable-bsf=$(bsf))
+		$(foreach bsf,$(BSFS),--enable-bsf=$(bsf)) \
+		$(foreach filter,$(FILTERS),--enable-filter=$(filter))
 	DESTDIR=$(LIBAVDIR)/build \
 		$(MAKE) -C $(LIBAVDIR)/$(FFMPEG) install
 	@touch $@


### PR DESCRIPTION
enable the filters used by the transcoder in the static ffmpeg build as well