### PR TITLE
Fix compilation issues in Fedora 23

### DIFF
--- a/rpm/tvheadend.spec.in
+++ b/rpm/tvheadend.spec.in
@@ -2,6 +2,10 @@
 %global commit @COMMIT@
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 
+#Allow static builds on Fedora >= 23
+#see https://fedoraproject.org/wiki/Changes/Harden_All_Packages
+%undefine _hardened_build
+
 Name:           tvheadend
 Summary:        TV streaming server and Digital Video Recorder
 Version:        @VERSION@

--- a/rpm/tvheadend.spec.in
+++ b/rpm/tvheadend.spec.in
@@ -86,6 +86,9 @@ exit 0
 %{_unitdir}/*
 
 %changelog
+* Wed Nov 4 2015 Daniele Viganò <daniele@vigano.me> 4.1-859-ac12606
+- disable compilation hardening
+
 * Wed May 27 2015 Jaroslav Kysela <perex@perex.cz> 4.0.3-1
 - rpmlint fixes
 


### PR DESCRIPTION
To compile Tvheadend on Fedora 23 with `--enable-libffmpeg_static` the compilation hardening should be disabled. Maybe it's not the best approach, but at least for now it works.

Hardening is now enabled by default in Fedora 23 (see https://fedoraproject.org/wiki/Changes/Harden_All_Packages)

Fixes https://tvheadend.org/issues/3252