### PR TITLE
fix potential crash in constcw descrabler destructor

### DIFF
--- a/src/descrambler/constcw.c
+++ b/src/descrambler/constcw.c
@@ -169,7 +169,7 @@ constcw_free(caclient_t *cac)
   while((ct = LIST_FIRST(&ccw->ccw_services)) != NULL) {
     service_t *t = ct->td_service;
     pthread_mutex_lock(&t->s_stream_mutex);
-    constcw_service_destroy((th_descrambler_t *)&ct);
+    constcw_service_destroy((th_descrambler_t *)ct);
     pthread_mutex_unlock(&t->s_stream_mutex);
   }
 }


### PR DESCRIPTION
gcc's lto noted that free() is passed a pointer to a pointer
to memory.