### PR TITLE
Provide network interface list for IPTV, factor out service auto-enable function

### DIFF
--- a/configure
+++ b/configure
@@ -251,6 +251,16 @@ if enabled_or_auto dvben50221; then
   fi
 fi
 
+check_cc_snippet ifnames '
+#include <net/if.h>
+int test(void)
+{
+  struct if_nameindex *ifnames = if_nameindex();
+  if_freenameindex(ifnames);
+  return 0;
+}
+'
+
 #
 # Python
 #

--- a/src/filebundle.c
+++ b/src/filebundle.c
@@ -43,7 +43,7 @@ struct filebundle_dir
     } d;
     struct {
       const filebundle_entry_t *root;
-      filebundle_entry_t       *cur;
+      const filebundle_entry_t *cur;
     } b;
   };
 };
@@ -142,7 +142,7 @@ fb_dir *fb_opendir ( const char *path )
     char *tmp1, *tmp2, *tmp3 = NULL;
     tmp1 = strdup(path);
     tmp2 = strtok_r(tmp1, "/", &tmp3);
-    filebundle_entry_t *fb = filebundle_root;
+    const filebundle_entry_t *fb = filebundle_root;
     while (fb && tmp2) {
       if (fb->type == FB_DIR && !strcmp(fb->name, tmp2)) {
         tmp2 = strtok_r(NULL, "/", &tmp3);

--- a/src/filebundle.h
+++ b/src/filebundle.h
@@ -44,11 +44,11 @@ typedef struct filebundle_entry
 {
   enum filebundle_type     type;
   const char              *name;
-  struct filebundle_entry *next;
+  const struct filebundle_entry *next;
   union {
     struct {
       size_t count;
-      struct filebundle_entry *child;
+      const struct filebundle_entry *child;
     } d;
     struct {
       const uint8_t *data;
@@ -78,7 +78,7 @@ typedef struct filebundle_dir  fb_dir;
 typedef struct filebundle_file fb_file;
 
 /* Root of bundle */
-extern filebundle_entry_t *filebundle_root;
+extern const filebundle_entry_t * const filebundle_root;
 
 /* Miscellaneous */
 int fb_stat ( const char *path, struct filebundle_stat *st );

--- a/src/http.c
+++ b/src/http.c
@@ -567,15 +567,13 @@ http_access_verify(http_connection_t *hc, int mask)
  */
 int
 http_access_verify_channel(http_connection_t *hc, int mask,
-                           struct channel *ch, int ticket)
+                           struct channel *ch)
 {
   int res = -1;
 
   assert(ch);
 
-  if (ticket)
-    http_access_verify_ticket(hc);
-
+  http_access_verify_ticket(hc);
   if (hc->hc_access) {
     res = access_verify2(hc->hc_access, mask);
 

--- a/src/http.h
+++ b/src/http.h
@@ -237,7 +237,7 @@ void http_server_done(void);
 
 int http_access_verify(http_connection_t *hc, int mask);
 int http_access_verify_channel(http_connection_t *hc, int mask,
-                               struct channel *ch, int ticket);
+                               struct channel *ch);
 
 void http_deescape(char *s);
 

--- a/src/input/mpegts/iptv/iptv_mux.c
+++ b/src/input/mpegts/iptv/iptv_mux.c
@@ -152,6 +152,7 @@ const idclass_t iptv_mux_class =
       .id       = "iptv_interface",
       .name     = N_("Interface"),
       .off      = offsetof(iptv_mux_t, mm_iptv_interface),
+      .list     = network_interfaces_enum,
     },
     {
       .type     = PT_BOOL,

--- a/src/input/mpegts/mpegts_input.c
+++ b/src/input/mpegts/mpegts_input.c
@@ -96,6 +96,9 @@ mpegts_input_class_network_enum ( void *obj, const char *lang )
 {
   htsmsg_t *p, *m;
 
+  if (!obj)
+    return NULL;
+
   p = htsmsg_create_map();
   htsmsg_add_str (p, "uuid",    idnode_uuid_as_sstr((idnode_t*)obj));
   htsmsg_add_bool(p, "enum",    1);

--- a/src/prop.c
+++ b/src/prop.c
@@ -484,8 +484,11 @@ prop_serialize_value
     htsmsg_add_bool(m, "multiline", 1);
 
   /* Enum list */
-  if (pl->list)
-    htsmsg_add_msg(m, "enum", pl->list(obj, lang));
+  if (pl->list) {
+    htsmsg_t *list = pl->list(obj, lang);
+    if (list)
+      htsmsg_add_msg(m, "enum", list);
+  }
 
   /* Visual group */
   if (pl->group)

--- a/src/tvheadend.h
+++ b/src/tvheadend.h
@@ -783,6 +783,8 @@ static inline uint32_t deltaU32(uint32_t a, uint32_t b) { return (a > b) ? (a - 
 #define SKEL_USED(name) do { name = NULL; } while (0)
 #define SKEL_FREE(name) do { free(name); name = NULL; } while (0)
 
+htsmsg_t *network_interfaces_enum(void *obj, const char *lang);
+
 /* glibc wrapper */
 #if ! ENABLE_QSORT_R
 void

--- a/src/utils.c
+++ b/src/utils.c
@@ -26,6 +26,7 @@
 #include <dirent.h>
 #include <unistd.h>
 #include <ctype.h>
+#include <net/if.h>
 
 #include <openssl/sha.h>
 
@@ -773,4 +774,27 @@ gcdU32(uint32_t a, uint32_t b)
     }
     return b;
   }
+}
+
+htsmsg_t *network_interfaces_enum(void *obj, const char *lang)
+{
+#if ENABLE_IFNAMES
+  htsmsg_t *list = htsmsg_create_list();
+  struct if_nameindex *ifnames = if_nameindex();
+
+  if (ifnames) {
+    struct if_nameindex *ifname;
+    for (ifname = ifnames; ifname->if_name; ifname++) {
+      htsmsg_t *entry = htsmsg_create_map();
+      htsmsg_add_str(entry, "key", ifname->if_name);
+      htsmsg_add_str(entry, "val", ifname->if_name);
+      htsmsg_add_msg(list, NULL, entry);
+    }
+    if_freenameindex(ifnames);
+  }
+
+  return list;
+#else
+  return NULL;
+#endif
 }

--- a/src/webui/webui.c
+++ b/src/webui/webui.c
@@ -543,7 +543,7 @@ http_channel_playlist(http_connection_t *hc, int pltype, channel_t *channel)
   char *profile, *hostpath;
   const char *name;
 
-  if (http_access_verify_channel(hc, ACCESS_STREAMING, channel, 1))
+  if (http_access_verify_channel(hc, ACCESS_STREAMING, channel))
     return HTTP_STATUS_UNAUTHORIZED;
 
   profile = profile_validate_name(http_arg_get(&hc->hc_req_args, "profile"));
@@ -626,7 +626,7 @@ http_tag_playlist(http_connection_t *hc, int pltype, channel_tag_t *tag)
     htsbuf_qprintf(hq, "#NAME %s\n", tag->ct_name);
   for (idx = 0; idx < count; idx++) {
     ch = chlist[idx];
-    if (http_access_verify_channel(hc, ACCESS_STREAMING, ch, 0))
+    if (http_access_verify_channel(hc, ACCESS_STREAMING, ch))
       continue;
     snprintf(buf, sizeof(buf), "/stream/channelid/%d", channel_get_id(ch));
     name = channel_get_name(ch);
@@ -788,7 +788,7 @@ http_channel_list_playlist(http_connection_t *hc, int pltype)
   for (idx = 0; idx < count; idx++) {
     ch = chlist[idx];
 
-    if (http_access_verify_channel(hc, ACCESS_STREAMING, ch, 0))
+    if (http_access_verify_channel(hc, ACCESS_STREAMING, ch))
       continue;
 
     name = channel_get_name(ch);
@@ -842,7 +842,7 @@ http_dvr_list_playlist(http_connection_t *hc, int pltype)
       continue;
 
     if (de->de_channel &&
-        http_access_verify_channel(hc, ACCESS_RECORDER, de->de_channel, 0))
+        http_access_verify_channel(hc, ACCESS_RECORDER, de->de_channel))
       continue;
 
     durration  = dvr_entry_get_stop_time(de) - dvr_entry_get_start_time(de);
@@ -1194,7 +1194,7 @@ http_stream_channel(http_connection_t *hc, channel_t *ch, int weight)
   void *tcp_id;
   int res = HTTP_STATUS_SERVICE;
 
-  if (http_access_verify_channel(hc, ACCESS_STREAMING, ch, 1))
+  if (http_access_verify_channel(hc, ACCESS_STREAMING, ch))
     return HTTP_STATUS_UNAUTHORIZED;
 
   if(!(pro = profile_find_by_list(hc->hc_access->aa_profiles,

--- a/src/webui/xmltv.c
+++ b/src/webui/xmltv.c
@@ -122,7 +122,7 @@ http_xmltv_channel(http_connection_t *hc, channel_t *channel)
 {
   char *hostpath;
 
-  if (http_access_verify_channel(hc, ACCESS_STREAMING, channel, 1))
+  if (http_access_verify_channel(hc, ACCESS_STREAMING, channel))
     return HTTP_STATUS_UNAUTHORIZED;
 
   hostpath = http_get_hostpath(hc);
@@ -154,13 +154,13 @@ http_xmltv_tag(http_connection_t *hc, channel_tag_t *tag)
   http_xmltv_begin(&hc->hc_reply);
   LIST_FOREACH(ilm, &tag->ct_ctms, ilm_in1_link) {
     ch = (channel_t *)ilm->ilm_in2;
-    if (http_access_verify_channel(hc, ACCESS_STREAMING, ch, 0))
+    if (http_access_verify_channel(hc, ACCESS_STREAMING, ch))
       continue;
     http_xmltv_channel_add(&hc->hc_reply, hostpath, ch);
   }
   LIST_FOREACH(ilm, &tag->ct_ctms, ilm_in1_link) {
     ch = (channel_t *)ilm->ilm_in2;
-    if (http_access_verify_channel(hc, ACCESS_STREAMING, ch, 0))
+    if (http_access_verify_channel(hc, ACCESS_STREAMING, ch))
       continue;
     http_xmltv_programme_add(&hc->hc_reply, hostpath, ch);
   }
@@ -187,12 +187,12 @@ http_xmltv_channel_list(http_connection_t *hc)
 
   http_xmltv_begin(&hc->hc_reply);
   CHANNEL_FOREACH(ch) {
-    if (http_access_verify_channel(hc, ACCESS_STREAMING, ch, 0))
+    if (http_access_verify_channel(hc, ACCESS_STREAMING, ch))
       continue;
     http_xmltv_channel_add(&hc->hc_reply, hostpath, ch);
   }
   CHANNEL_FOREACH(ch) {
-    if (http_access_verify_channel(hc, ACCESS_STREAMING, ch, 0))
+    if (http_access_verify_channel(hc, ACCESS_STREAMING, ch))
       continue;
     http_xmltv_programme_add(&hc->hc_reply, hostpath, ch);
   }

--- a/support/mkbundle
+++ b/support/mkbundle
@@ -102,7 +102,7 @@ def output_file ( path, name, idx, next = -1 ):
   outf.write('\n')
   outf.write('};\n')
   
-  outf.write('static filebundle_entry_t filebundle_entry_%06d = {\n' % idx)
+  outf.write('static const filebundle_entry_t filebundle_entry_%06d = {\n' % idx)
   outf.write('  .type    = FB_FILE,\n')
   outf.write('  .name    = "%s",\n'  % name)
   outf.write('  .next    = %s,\n' % n)
@@ -120,7 +120,7 @@ def output_dir ( path, name, idx, child, count, next = -1 ):
   if next >= 0: n = '&filebundle_entry_%06d' % next
   outf.write('/* DIR: %s %s %d %d %d %d */\n' \
              % (path, name, idx, child, count, next))
-  outf.write('static filebundle_entry_t filebundle_entry_%06d = {\n' % idx)
+  outf.write('static const filebundle_entry_t filebundle_entry_%06d = {\n' % idx)
   outf.write('  .type    = FB_DIR,\n')
   outf.write('  .name    = "%s",\n'  % name)
   outf.write('  .next    = %s,\n' % n)
@@ -172,4 +172,4 @@ outf.write('\n')
 idx = add_entry(ents)
 
 # Output top link
-outf.write('filebundle_entry_t *filebundle_root = &filebundle_entry_%06d;\n' % idx)
+outf.write('const filebundle_entry_t * const filebundle_root = &filebundle_entry_%06d;\n' % idx)


### PR DESCRIPTION
I've got another patch for the auto-enable function that also adds it to dvb_pat_callback(), as the service is also created there, which would obsolete it in psi_parse_pmt().
I've got some data services that end up being auto-disabled, because the service_has_audio_or_video() check in psi_parse_pmt() fails for them, but the services are in PAT and the auto-disable message is a bit misleading in this case.