### PR TITLE
describe the transliteration of channel icons with two examples

### DIFF
--- a/docs/html/en/config_misc.html
+++ b/docs/html/en/config_misc.html
@@ -62,7 +62,7 @@
 <tbody>
 <tr>
 <td><strong>%C</strong></td>
-<td>The transliterated channel name in ASCII (safe characters, no spaces etc.)</td>
+<td>The transliterated channel name in ASCII (safe characters, no spaces etc.). <code>Das Erste HD</code> will be <code>Das_Erste_HD</code>, <code>ZDF_neo HD</code> will be <code>ZDF_neo_HD</code> for example.</td>
 </tr>
 <tr>
 <td><strong>%c</strong></td>


### PR DESCRIPTION
This would make the transliteration easier to understand. 
My first thought was that the unsave chars are discarded and not replaced.