### PR TITLE
ignore comments in m3u8-playlist

### DIFF
--- a/src/misc/m3u.c
+++ b/src/misc/m3u.c
@@ -135,7 +135,10 @@ htsmsg_t *parse_m3u
     return m;
   }
   while (*data) {
-    if (strncmp(data, "#EXTINF:", 8) == 0) {
+    if (strncmp(data, "##", 2) == 0) {
+      data = until_eol(data + 2);
+      continue;
+    } else if (strncmp(data, "#EXTINF:", 8) == 0) {
       if (item == NULL)
         item = htsmsg_create_map();
       data += 8;


### PR DESCRIPTION
comments in m3u8-files are currently interpreted as a url for a video segment. This patch skips such comments