### PR TITLE
[DVR] retention corrections after last PR

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -133,7 +133,7 @@ typedef enum {
   DVR_RET_1MONTH    = (30+1),
   DVR_RET_2MONTH    = (60+2),
   DVR_RET_3MONTH    = (90+2),
-  DVR_RET_6MONTH    = (180+2),
+  DVR_RET_6MONTH    = (180+3),
   DVR_RET_1YEAR     = (365+1),
   DVR_RET_2YEARS    = (2*365+1),
   DVR_RET_3YEARS    = (3*365+1),

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -1105,7 +1105,7 @@ const idclass_t dvr_autorec_entry_class = {
       .def.i    = DVR_RET_DVRCONFIG,
       .off      = offsetof(dvr_autorec_entry_t, dae_removal),
       .list     = dvr_entry_class_removal_list,
-      .opts     = PO_HIDDEN | PO_EXPERT,
+      .opts     = PO_HIDDEN | PO_ADVANCED,
     },
     {
       .type     = PT_U32,
@@ -1394,6 +1394,9 @@ uint32_t
 dvr_autorec_get_retention_days( dvr_autorec_entry_t *dae )
 {
   if (dae->dae_retention > 0) {
+    if (dae->dae_retention > DVR_RET_FOREVER)
+      return DVR_RET_FOREVER;
+
     uint32_t removal = dvr_autorec_get_removal_days(dae);
     /* As we need the db entry when deleting the file on disk */
     if (removal != DVR_RET_FOREVER && removal > dae->dae_retention)
@@ -1410,7 +1413,11 @@ dvr_autorec_get_retention_days( dvr_autorec_entry_t *dae )
 uint32_t
 dvr_autorec_get_removal_days( dvr_autorec_entry_t *dae )
 {
-  if (dae->dae_removal > 0)
+  if (dae->dae_removal > 0) {
+    if (dae->dae_removal > DVR_RET_FOREVER)
+      return DVR_RET_FOREVER;
+
     return dae->dae_removal;
+  }
   return dvr_retention_cleanup(dae->dae_config->dvr_removal_days);
 }

--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -186,8 +186,8 @@ dvr_config_create(const char *name, const char *uuid, htsmsg_t *conf)
   cfg->dvr_warm_time = 30;
   cfg->dvr_update_window = 24 * 3600;
   cfg->dvr_pathname = strdup("$t$n.$x");
-  cfg->dvr_cleanup_threshold_free = 200;
-  cfg->dvr_cleanup_threshold_used = 2000;
+  cfg->dvr_cleanup_threshold_free = 1000; // keep 1000 MiB of free space on disk by default
+  cfg->dvr_cleanup_threshold_used = 0;    // disabled
 
   /* Muxer config */
   cfg->dvr_muxcnf.m_cache  = MC_CACHE_DONTKEEP;
@@ -519,11 +519,13 @@ dvr_config_save(dvr_config_t *cfg)
   dvr_config_storage_check(cfg);
   if (cfg->dvr_cleanup_threshold_free < 50)
     cfg->dvr_cleanup_threshold_free = 50; // as checking is only periodically, lower is not save
-  if (cfg->dvr_cleanup_threshold_used < cfg->dvr_cleanup_threshold_used)
-    cfg->dvr_cleanup_threshold_used = cfg->dvr_cleanup_threshold_free + 50;
   if (cfg->dvr_removal_days != DVR_RET_FOREVER &&
       cfg->dvr_removal_days > cfg->dvr_retention_days)
     cfg->dvr_retention_days = DVR_RET_ONREMOVE;
+  if (cfg->dvr_removal_days > DVR_RET_FOREVER)
+    cfg->dvr_removal_days = DVR_RET_FOREVER;
+  if (cfg->dvr_retention_days > DVR_RET_FOREVER)
+    cfg->dvr_retention_days = DVR_RET_FOREVER;
   idnode_save(&cfg->dvr_id, m);
   hts_settings_save(m, "dvr/config/%s", idnode_uuid_as_sstr(&cfg->dvr_id));
   htsmsg_destroy(m);
@@ -717,6 +719,8 @@ dvr_config_class_removal_list ( void *o, const char *lang )
     { N_("3 months"),           DVR_RET_3MONTH },
     { N_("6 months"),           DVR_RET_6MONTH },
     { N_("1 year"),             DVR_RET_1YEAR },
+    { N_("2 years"),            DVR_RET_2YEARS },
+    { N_("3 years"),            DVR_RET_3YEARS },
     { N_("Maintained space"),   DVR_RET_SPACE },
     { N_("Forever"),            DVR_RET_FOREVER },
   };
@@ -869,6 +873,7 @@ const idclass_t dvr_config_class = {
       .off      = offsetof(dvr_config_t, dvr_retention_days),
       .def.u32  = DVR_RET_ONREMOVE,
       .list     = dvr_config_class_retention_list,
+      .opts     = PO_EXPERT,
       .group    = 1,
     },
     {
@@ -985,17 +990,19 @@ const idclass_t dvr_config_class = {
     {
       .type     = PT_U32,
       .id       = "storage-mfree",
-      .name     = N_("Maintain free storage space (MiB)"),
+      .name     = N_("Maintain free storage space in MiB"),
       .off      = offsetof(dvr_config_t, dvr_cleanup_threshold_free),
-      .def.i    = 200,
+      .def.i    = 1000,
+      .opts     = PO_ADVANCED,
       .group    = 2,
     },
     {
       .type     = PT_U32,
       .id       = "storage-mused",
-      .name     = N_("Maintain used storage space (MiB)"),
+      .name     = N_("Maintain used storage space in MiB (0=disabled)"),
       .off      = offsetof(dvr_config_t, dvr_cleanup_threshold_used),
-      .def.i    = 2000,
+      .def.i    = 0,
+      .opts     = PO_EXPERT,
       .group    = 2,
     },
     {

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -291,6 +291,9 @@ uint32_t
 dvr_entry_get_retention_days( dvr_entry_t *de )
 {
   if (de->de_retention > 0) {
+    if (de->de_retention > DVR_RET_FOREVER)
+      return DVR_RET_FOREVER;
+
     /* As we need the db entry when deleting the file on disk */
     if (dvr_entry_get_removal_days(de) != DVR_RET_FOREVER &&
         dvr_entry_get_removal_days(de) > de->de_retention)
@@ -304,8 +307,12 @@ dvr_entry_get_retention_days( dvr_entry_t *de )
 uint32_t
 dvr_entry_get_removal_days ( dvr_entry_t *de )
 {
-  if (de->de_removal > 0)
+  if (de->de_removal > 0) {
+    if (de->de_removal > DVR_RET_FOREVER)
+      return DVR_RET_FOREVER;
+
     return de->de_removal;
+  }
   return dvr_retention_cleanup(de->de_config->dvr_removal_days);
 }
 
@@ -2197,6 +2204,8 @@ dvr_entry_class_retention_list ( void *o, const char *lang )
     { N_("3 months"),           DVR_RET_3MONTH },
     { N_("6 months"),           DVR_RET_6MONTH },
     { N_("1 year"),             DVR_RET_1YEAR },
+    { N_("2 years"),            DVR_RET_2YEARS },
+    { N_("3 years"),            DVR_RET_3YEARS },
     { N_("On file removal"),    DVR_RET_ONREMOVE },
     { N_("Forever"),            DVR_RET_FOREVER },
   };
@@ -2219,6 +2228,8 @@ dvr_entry_class_removal_list ( void *o, const char *lang )
     { N_("3 months"),           DVR_RET_3MONTH },
     { N_("6 months"),           DVR_RET_6MONTH },
     { N_("1 year"),             DVR_RET_1YEAR },
+    { N_("2 years"),            DVR_RET_2YEARS },
+    { N_("3 years"),            DVR_RET_3YEARS },
     { N_("Maintained space"),   DVR_RET_SPACE },
     { N_("Forever"),            DVR_RET_FOREVER },
   };
@@ -2789,7 +2800,7 @@ const idclass_t dvr_entry_class = {
       .off      = offsetof(dvr_entry_t, de_retention),
       .def.i    = DVR_RET_DVRCONFIG,
       .list     = dvr_entry_class_retention_list,
-      .opts     = PO_HIDDEN | PO_ADVANCED
+      .opts     = PO_HIDDEN | PO_EXPERT
     },
     {
       .type     = PT_U32,

--- a/src/dvr/dvr_timerec.c
+++ b/src/dvr/dvr_timerec.c
@@ -622,7 +622,7 @@ const idclass_t dvr_timerec_entry_class = {
       .def.i    = DVR_RET_DVRCONFIG,
       .off      = offsetof(dvr_timerec_entry_t, dte_removal),
       .list     = dvr_entry_class_removal_list,
-      .opts     = PO_EXPERT
+      .opts     = PO_ADVANCED
     },
     {
       .type     = PT_STR,
@@ -765,6 +765,9 @@ uint32_t
 dvr_timerec_get_retention_days( dvr_timerec_entry_t *dte )
 {
   if (dte->dte_retention > 0) {
+    if (dte->dte_retention > DVR_RET_FOREVER)
+      return DVR_RET_FOREVER;
+
     /* As we need the db entry when deleting the file on disk */
     if (dvr_timerec_get_removal_days(dte) != DVR_RET_FOREVER &&
         dvr_timerec_get_removal_days(dte) > dte->dte_retention)
@@ -781,7 +784,11 @@ dvr_timerec_get_retention_days( dvr_timerec_entry_t *dte )
 uint32_t
 dvr_timerec_get_removal_days( dvr_timerec_entry_t *dte )
 {
-  if (dte->dte_removal > 0)
+  if (dte->dte_removal > 0) {
+    if (dte->dte_removal > DVR_RET_FOREVER)
+      return DVR_RET_FOREVER;
+
     return dte->dte_removal;
+  }
   return dvr_retention_cleanup(dte->dte_config->dvr_removal_days);
 }


### PR DESCRIPTION
- fixed possible overflow as we are now using INT_MAX instead of UINT_MAX
- moved "log retention" to expert level as it is set to "on file removal" by default
and the user is probably more interested how long the file stays on disk instead of the log.
- used space was 2GB by default, so when 2GB of the total disk space was used (almost nothing), dvr's where deleted, added a possibility to disable this "used size" setting
- fixed wrong logging: dvr_vfsmgr.c line 203
- fixed one dvr config was skipped: dvr_vfsmgr.c line 218, incrementing was already done on line 181
- cosmetics

@perexg Can you explain the "used storage size" feature a bit, because I don't exactly get what you try to achieve with this?