### PR TITLE
Only delete once count is greater than max_count.

### DIFF
--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -120,7 +120,7 @@ dvr_autorec_completed(dvr_entry_t *de, int error_code)
     }
     if (total == 0)
       total = count;
-    if (count < max_count)
+    if (count =< max_count)
       break;
     if (de_prev) {
       tvhinfo("dvr", "autorec %s removing recordings %s (allowed count %u total %u)",


### PR DESCRIPTION
[dvr] When autorec has max count set only remove recordings after count exceeds max count. If max count is set to 5,  currently only 4 recordings are kept not 5 as expected.