### PR TITLE
Add "Video codec preset:" menu in WebUI to change preset according to system performance

### DIFF
--- a/src/hts_strtab.h
+++ b/src/hts_strtab.h
@@ -34,6 +34,11 @@ struct strtab_u32 {
   uint32_t val;
 };
 
+struct strtab_str {
+  const char *str;
+  const char *val;
+};
+
 static int str2val0(const char *str, const struct strtab tab[], int l)
      __attribute((unused));
 
@@ -116,5 +121,21 @@ strtab2htsmsg0_u32(const struct strtab_u32 tab[], uint32_t n, int i18n, const ch
 }
 
 #define strtab2htsmsg_u32(tab,i18n,lang) strtab2htsmsg0_u32(tab, sizeof(tab) / sizeof(tab[0]), i18n, lang)
+
+static inline htsmsg_t *
+strtab2htsmsg0_str(const struct strtab_str tab[], uint32_t n, int i18n, const char *lang)
+{
+  uint32_t i;
+  htsmsg_t *e, *l = htsmsg_create_list();
+  for (i = 0; i < n; i++) {
+    e = htsmsg_create_map();
+    htsmsg_add_str(e, "key", tab[i].val);
+    htsmsg_add_str(e, "val", i18n ? tvh_gettext_lang(lang, tab[i].str) : tab[i].str);
+    htsmsg_add_msg(l, NULL, e);
+  }
+  return l;
+}
+
+#define strtab2htsmsg_str(tab,i18n,lang) strtab2htsmsg0_str(tab, sizeof(tab) / sizeof(tab[0]), i18n, lang)
 
 #endif /* STRTAB_H_ */

--- a/src/plumbing/transcoding.c
+++ b/src/plumbing/transcoding.c
@@ -1331,12 +1331,9 @@ transcoder_stream_video(transcoder_t *t, transcoder_stream_t *ts, th_pkt_t *pkt)
       octx->flags         |= CODEC_FLAG_GLOBAL_HEADER;
 
       // Default = "medium". We gain more encoding speed compared to the loss of quality when lowering it _slightly_.
-      if (!strcmp(ocodec->name, "nvenc"))
-         av_dict_set(&opts, "preset",  "hq", 0);
-      else if (!strcmp(ocodec->name, "h264_qsv"))
-         av_dict_set(&opts, "preset",  "medium", 0);
-      else
-         av_dict_set(&opts, "preset",  "faster", 0);
+      // select preset according to system performance and codec type
+      av_dict_set(&opts, "preset",  t->t_props.tp_vcodec_preset, 0);
+      tvhinfo("transcode", "%04X: Using preset %s", shortid(t), t->t_props.tp_vcodec_preset);
 
       // All modern devices should support "high" profile
       av_dict_set(&opts, "profile", "high", 0);
@@ -1365,7 +1362,10 @@ transcoder_stream_video(transcoder_t *t, transcoder_stream_t *ts, th_pkt_t *pkt)
       octx->flags         |= CODEC_FLAG_GLOBAL_HEADER;
 
       // on all hardware ultrafast (or maybe superfast) should be safe
-      av_dict_set(&opts, "preset", "ultrafast",  0);
+      // select preset according to system performance
+      av_dict_set(&opts, "preset",  t->t_props.tp_vcodec_preset, 0);
+      tvhinfo("transcode", "%04X: Using preset %s", shortid(t), t->t_props.tp_vcodec_preset);
+
       // disables encoder features which tend to be bottlenecks for the decoder/player
       av_dict_set(&opts, "tune",   "fastdecode", 0);
 
@@ -2065,6 +2065,7 @@ transcoder_set_properties(streaming_target_t *st,
   transcoder_props_t *tp = &t->t_props;
 
   strncpy(tp->tp_vcodec, props->tp_vcodec, sizeof(tp->tp_vcodec)-1);
+  strncpy(tp->tp_vcodec_preset, props->tp_vcodec_preset, sizeof(tp->tp_vcodec_preset)-1);
   strncpy(tp->tp_acodec, props->tp_acodec, sizeof(tp->tp_acodec)-1);
   strncpy(tp->tp_scodec, props->tp_scodec, sizeof(tp->tp_scodec)-1);
   tp->tp_channels   = props->tp_channels;

--- a/src/plumbing/transcoding.h
+++ b/src/plumbing/transcoding.h
@@ -22,6 +22,7 @@
 
 typedef struct transcoder_prop {
   char     tp_vcodec[32];
+  char     tp_vcodec_preset[32];
   char     tp_acodec[32];
   char     tp_scodec[32];
 


### PR DESCRIPTION
I added "Video codec preset:" menu in WebUI to change preset according to system performance.

The previous code selects "faster" preset for H264 encoding.

I think there are lots of systems which cannot run with a fixed "faster" preset in real-time.
But my system (on VMware Player in Windows10, CPU:i3-5005u) can not transcode 1080i h264 stream to even 480p h264 stream with "faster" preset in real-time.

So I added preset selection feature.
I integrated the preset selection for all h264,h265 codecs (qsv, nvenc) also.

The default selection is chosen to "faster" for those users who use h264 as a encoder.
The users using qsv or nvenc have to select "medium" or "hq" in the WebUI to have correct operation or same performance to the previous version.

![preset_selection](https://cloud.githubusercontent.com/assets/16429155/12005370/c47b2b86-abe4-11e5-8418-764f751695fd.png)
