### PR TITLE
bump htspmon reported HTSP version

### DIFF
--- a/lib/py/tvh/htsp.py
+++ b/lib/py/tvh/htsp.py
@@ -29,7 +29,7 @@ import log
 # HTSP Client
 # ###########################################################################
 
-HTSP_PROTO_VERSION = 6
+HTSP_PROTO_VERSION = 25
 
 # Create passwd digest
 def htsp_digest ( user, passwd, chal ):


### PR DESCRIPTION
Servers may omit messages if they know the client is too old to support them. Since this tool is for monitoring what the server sends it makes sense to report the highest possible version number.