### PR TITLE
[descrambler] don't attempt to open IP addresses as files when the highest OSCam mode is used

### DIFF
--- a/src/descrambler/capmt.c
+++ b/src/descrambler/capmt.c
@@ -484,7 +484,9 @@ capmt_connect(capmt_t *capmt, int i)
   if (!capmt->capmt_running)
     return -1;
 
-  if (capmt->capmt_oscam == CAPMT_OSCAM_TCP || capmt->capmt_oscam == CAPMT_OSCAM_NET_PROTO) {
+  if (capmt->capmt_oscam == CAPMT_OSCAM_TCP ||
+      capmt->capmt_oscam == CAPMT_OSCAM_NET_PROTO ||
+      capmt->capmt_oscam == CAPMT_OSCAM_UNIX_SOCKET_NP) {
 
     char errbuf[256];
 


### PR DESCRIPTION
Without this patch the "pc-nodmx" mode can't be used, tvheadend will fail spectacularly with something like `Could not open 127.0.0.1 (No such file or directory). Do you have OSCam running`.

@manio what is this mode supposed to do? Judging by the log both this and "mode 5" seem to work the same (both report "protocol version 2").