### PR TITLE
Channel-EPG mapping should ignore case

### DIFF
--- a/src/channels.c
+++ b/src/channels.c
@@ -484,14 +484,12 @@ const idclass_t channel_class = {
 channel_t *
 channel_find_by_name ( const char *name )
 {
-printf("1an");
   channel_t *ch;
   if (name == NULL)
     return NULL;
   CHANNEL_FOREACH(ch)
     if (ch->ch_enabled && !strcasecmp(channel_get_name(ch), name))
       break;
-printf("1an");
   return ch;
 }
 

--- a/src/channels.c
+++ b/src/channels.c
@@ -484,12 +484,14 @@ const idclass_t channel_class = {
 channel_t *
 channel_find_by_name ( const char *name )
 {
+printf("1an");
   channel_t *ch;
   if (name == NULL)
     return NULL;
   CHANNEL_FOREACH(ch)
-    if (ch->ch_enabled && !strcmp(channel_get_name(ch), name))
+    if (ch->ch_enabled && !strcasecmp(channel_get_name(ch), name))
       break;
+printf("1an");
   return ch;
 }
 

--- a/src/epggrab/channel.c
+++ b/src/epggrab/channel.c
@@ -82,13 +82,13 @@ int epggrab_channel_match_name ( epggrab_channel_t *ec, channel_t *ch )
   if (name == NULL)
     return 0;
 
-  if (ec->name && !strcmp(ec->name, name))
+  if (ec->name && !strcasecmp(ec->name, name))
     return 1;
 
   if (ec->names)
     HTSMSG_FOREACH(f, ec->names)
       if ((s = htsmsg_field_get_str(f)) != NULL)
-        if (!strcmp(s, name))
+        if (!strcasecmp(s, name))
           return 1;
 
   return 0;


### PR DESCRIPTION
When channel is mapped with a grabber, it should ignore case for maximum automatic possible matches.