### PR TITLE
WebUI: Update copyright year and contributors

### DIFF
--- a/src/webui/extjs.c
+++ b/src/webui/extjs.c
@@ -195,7 +195,7 @@ page_about(http_connection_t *hc, const char *remain, void *opaque)
 
   htsbuf_qprintf(hq, "<center>\n\
 <div class=\"about-title\">HTS Tvheadend %s</div>\n\
-<p>&copy; 2006 - 2015 Andreas \303\226man, et al.</p>\n\
+<p>&copy; 2006 - 2016 Andreas \303\226man, Jaroslav Kysela, Adam Sutton, et al.</p>\n\
 <p><img src=\"docresources/tvheadendlogo.png\"></p>\n\
 <p><a href=\"https://tvheadend.org\">https://tvheadend.org</a></p>\n",
     tvheadend_version);


### PR DESCRIPTION
As it says - update the copyright statement in the web interface now that the year has changed. 

Also, extend the major contributors to the top three by commits - @andoma, @perexg and @adamsutton. Seems only fair to give you guys all the credit, given the input you've all had!

@andoma - a little confused about your preferred surname, though...  