### PR TITLE
Fix 'integer constant is too large' in x86 build

### DIFF
--- a/src/parsers/parser_hevc.c
+++ b/src/parsers/parser_hevc.c
@@ -828,7 +828,7 @@ static void hvcc_init(HEVCDecoderConfigurationRecord *hvcc)
      * the ProfileTierLevel parsing code will unset them when needed.
      */
     hvcc->general_profile_compatibility_flags = 0xffffffff;
-    hvcc->general_constraint_indicator_flags  = 0xffffffffffff;
+    hvcc->general_constraint_indicator_flags  = 0xffffffffffffLL;
 
     /*
      * Initialize this field with an invalid value which can be used to detect


### PR DESCRIPTION
I got the error "integer constant is too large" when compiling in a x86 Debian VM.
Applying the fix, as described on ticket 1657 by Adam, solves the issue.