### PR TITLE
Fixed bug-3507 - incorrect dereference of argv when performing variab…

### DIFF
--- a/src/spawn.c
+++ b/src/spawn.c
@@ -414,7 +414,7 @@ spawn_parse_args(char ***argv, int argc, const char *cmd, const char **replace)
           strcpy(a, f);
           strcat(a, r[1]);
           strcat(a, p + l);
-          *argv[i++] = a;
+          (*argv)[i++] = a;
           break;
         }
       }


### PR DESCRIPTION
Fixed bug-3507 - incorrect dereference of argv when performing variable interpolation for pipe:// URLs in IPTV.  This affects all versions and should be backported throughout.