### PR TITLE
Fix crash when selecting once per day in duplicate handling. fixes #3552

### DIFF
--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1166,6 +1166,9 @@ static dvr_entry_t *_dvr_duplicate_event(dvr_entry_t *de)
       if (lang_str_empty(de->de_desc))
         return NULL;
       break;
+    case DVR_AUTOREC_RECORD_ONCE_PER_DAY:
+    case DVR_AUTOREC_LRECORD_ONCE_PER_DAY:
+      break;
     case DVR_AUTOREC_RECORD_ONCE_PER_WEEK:
     case DVR_AUTOREC_LRECORD_ONCE_PER_WEEK:
       break;


### PR DESCRIPTION
Attempt at fixing crash (issue #3552) when using once per day in duplicate handling.

After applying fix autorec does not crash server and only 1 recording is scheduled to record for the day with the rest marked as duplicates of it.