### PR TITLE
Fix compilation error when using Android NDK

### DIFF
--- a/src/wrappers.c
+++ b/src/wrappers.c
@@ -206,6 +206,10 @@ tvhtread_renice(int value)
   pid_t tid;
   tid = syscall(SYS_gettid);
   ret = setpriority(PRIO_PROCESS, tid, value);
+#elif ENABLE_ANDROID
+  pid_t tid;
+  tid = gettid();
+  ret = setpriority(PRIO_PROCESS, tid, value);
 #else
 #warning "Implement renice for your platform!"
 #endif


### PR DESCRIPTION
src/wrappers.c: In function 'tvhtread_renice':
src/wrappers.c:210:2: error: #warning "Implement renice for your
platform!" [-Werror=cpp]
#warning "Implement renice for your platform!"
^
cc1: all warnings being treated as errors