### PR TITLE
Add service type override.

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -150,13 +150,11 @@ static htsmsg_t *
 service_type_auto_list ( void *o, const char *lang )
 {
   static const struct strtab tab[] = {
-    { N_("Override disabled"),  ST_UNSET },
-    { N_("None (0)"),           ST_NONE },
-    { N_("MPEG2 SD TV (0x01)"), 0x01 },
-    { N_("Radio       (0x02)"), 0x02 },
-    { N_("MPEG2 HD TV (0x11)"), 0x11 },
-    { N_("H.264 SD TV (0x16)"), 0x16 },
-    { N_("H.264 HD TV (0x19)"), 0x19 }
+    { N_("Override disabled"), ST_UNSET },
+    { N_("None"),              ST_NONE  },
+    { N_("Radio"),             ST_RADIO },
+    { N_("SD TV"),             ST_SDTV  },
+    { N_("HD TV)"),            ST_HDTV  }
   };
   return strtab2htsmsg(tab, 1, lang);
 }

--- a/src/service.c
+++ b/src/service.c
@@ -150,9 +150,12 @@ static htsmsg_t *
 service_type_auto_list ( void *o, const char *lang )
 {
   static const struct strtab tab[] = {
-    { N_("Override disabled"),  -1 },
-    { N_("Radio (0x02)"), 0x02 },
-    { N_("MPEG2 HD TV (0x11)"),  0x11 },
+    { N_("Override disabled"),  ST_UNSET },
+    { N_("None (0)"),           ST_NONE },
+    { N_("MPEG2 SD TV (0x01)"), 0x01 },
+    { N_("Radio       (0x02)"), 0x02 },
+    { N_("MPEG2 HD TV (0x11)"), 0x11 },
+    { N_("H.264 SD TV (0x16)"), 0x16 },
     { N_("H.264 HD TV (0x19)"), 0x19 }
   };
   return strtab2htsmsg(tab, 1, lang);
@@ -960,7 +963,7 @@ service_create0
   pthread_mutex_init(&t->s_stream_mutex, NULL);
   pthread_cond_init(&t->s_tss_cond, NULL);
   t->s_type = service_type;
-  t->s_type_user = -1;
+  t->s_type_user = ST_UNSET;
   t->s_source_type = source_type;
   t->s_refcount = 1;
   t->s_enabled = 1;
@@ -1158,10 +1161,10 @@ int
 service_is_sdtv(service_t *t)
 {
   char s_type;
-  if(t->s_type_user > -1)
-    s_type = t->s_type_user;
-  else
+  if(t->s_type_user == ST_UNSET)
     s_type = t->s_servicetype;
+  else
+    s_type = t->s_type_user;
   if (s_type == ST_SDTV)
     return 1;
   else if (s_type == ST_NONE) {
@@ -1177,10 +1180,10 @@ int
 service_is_hdtv(service_t *t)
 {
   char s_type;
-  if(t->s_type_user > -1)
-    s_type = t->s_type_user;
-  else
+  if(t->s_type_user == ST_UNSET)
     s_type = t->s_servicetype;
+  else
+    s_type = t->s_type_user;
   if (s_type == ST_HDTV)
     return 1;
   else if (s_type == ST_NONE) {
@@ -1200,10 +1203,10 @@ service_is_radio(service_t *t)
 {
   int ret = 0;
   char s_type;
-  if(t->s_type_user > -1)
-    s_type = t->s_type_user;
-  else
+  if(t->s_type_user == ST_UNSET)
     s_type = t->s_servicetype;
+  else
+    s_type = t->s_type_user;
   if (s_type == ST_RADIO)
     return 1;
   else if (s_type == ST_NONE) {

--- a/src/service.c
+++ b/src/service.c
@@ -211,6 +211,15 @@ const idclass_t service_class = {
       .get      = service_class_caid_get,
       .opts     = PO_NOSAVE | PO_RDONLY | PO_HIDDEN | PO_EXPERT,
     },
+    {
+      .type     = PT_INT,
+      .id       = "s_type_user",
+      .name     = N_("Type override"),
+      .desc     = N_("Service type override. This value will override the "
+                     "service type provided by the stream."),
+      .off      = offsetof(service_t, s_type_user),
+      .opts     = PO_ADVANCED
+    },
     {}
   }
 };
@@ -938,6 +947,7 @@ service_create0
   pthread_mutex_init(&t->s_stream_mutex, NULL);
   pthread_cond_init(&t->s_tss_cond, NULL);
   t->s_type = service_type;
+  t->s_type_user = -1;
   t->s_source_type = source_type;
   t->s_refcount = 1;
   t->s_enabled = 1;
@@ -1134,9 +1144,14 @@ service_has_audio_or_video(service_t *t)
 int
 service_is_sdtv(service_t *t)
 {
-  if (t->s_servicetype == ST_SDTV)
+  char s_type;
+  if(t->s_type_user > -1)
+    s_type = t->s_type_user;
+  else
+    s_type = t->s_servicetype;
+  if (s_type == ST_SDTV)
     return 1;
-  else if (t->s_servicetype == ST_NONE) {
+  else if (s_type == ST_NONE) {
     elementary_stream_t *st;
     TAILQ_FOREACH(st, &t->s_components, es_link)
       if (SCT_ISVIDEO(st->es_type) && st->es_height < 720)
@@ -1148,9 +1163,14 @@ service_is_sdtv(service_t *t)
 int
 service_is_hdtv(service_t *t)
 {
-  if (t->s_servicetype == ST_HDTV)
+  char s_type;
+  if(t->s_type_user > -1)
+    s_type = t->s_type_user;
+  else
+    s_type = t->s_servicetype;
+  if (s_type == ST_HDTV)
     return 1;
-  else if (t->s_servicetype == ST_NONE) {
+  else if (s_type == ST_NONE) {
     elementary_stream_t *st;
     TAILQ_FOREACH(st, &t->s_components, es_link)
       if (SCT_ISVIDEO(st->es_type) && st->es_height >= 720)
@@ -1166,9 +1186,14 @@ int
 service_is_radio(service_t *t)
 {
   int ret = 0;
-  if (t->s_servicetype == ST_RADIO)
+  char s_type;
+  if(t->s_type_user > -1)
+    s_type = t->s_type_user;
+  else
+    s_type = t->s_servicetype;
+  if (s_type == ST_RADIO)
     return 1;
-  else if (t->s_servicetype == ST_NONE) {
+  else if (s_type == ST_NONE) {
     elementary_stream_t *st;
     TAILQ_FOREACH(st, &t->s_components, es_link) {
       if (SCT_ISVIDEO(st->es_type))

--- a/src/service.c
+++ b/src/service.c
@@ -146,6 +146,18 @@ service_class_auto_list ( void *o, const char *lang )
   return strtab2htsmsg(tab, 1, lang);
 }
 
+static htsmsg_t *
+service_type_auto_list ( void *o, const char *lang )
+{
+  static const struct strtab tab[] = {
+    { N_("Override disabled"),  -1 },
+    { N_("Radio (0x02)"), 0x02 },
+    { N_("MPEG2 HD TV (0x11)"),  0x11 },
+    { N_("H.264 HD TV (0x19)"), 0x19 }
+  };
+  return strtab2htsmsg(tab, 1, lang);
+}
+
 const idclass_t service_class = {
   .ic_class      = "service",
   .ic_caption    = N_("Service"),
@@ -217,6 +229,7 @@ const idclass_t service_class = {
       .name     = N_("Type override"),
       .desc     = N_("Service type override. This value will override the "
                      "service type provided by the stream."),
+      .list     = service_type_auto_list,
       .off      = offsetof(service_t, s_type_user),
       .opts     = PO_ADVANCED
     },

--- a/src/service.h
+++ b/src/service.h
@@ -303,6 +303,7 @@ typedef struct service {
   int s_enabled;
   int s_auto;
   int s_prio;
+  int s_type_user;
 
   LIST_ENTRY(service) s_active_link;
 

--- a/src/service.h
+++ b/src/service.h
@@ -274,7 +274,8 @@ typedef struct service {
    * Service type
    */
   enum {
-    ST_NONE,
+    ST_UNSET = -1,
+    ST_NONE = 0,
     ST_OTHER,
     ST_SDTV,
     ST_HDTV,


### PR DESCRIPTION
Some providers don't set the service type correctly. This causes a problem when, for instance,
the client doesn't know if it's Radio or TV and chooses the wrong one.

This override will let the user set the service type.