### PR TITLE
 RTSP: Use GET_PARAMETER in keep alive loop to prevent time out

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -50,16 +50,17 @@ static pthread_mutex_t http_paths_mutex = PTHREAD_MUTEX_INITIALIZER;
 static http_path_list_t http_paths;
 
 static struct strtab HTTP_cmdtab[] = {
-  { "NONE",       HTTP_CMD_NONE },
-  { "GET",        HTTP_CMD_GET },
-  { "HEAD",       HTTP_CMD_HEAD },
-  { "POST",       HTTP_CMD_POST },
-  { "DESCRIBE",   RTSP_CMD_DESCRIBE },
-  { "OPTIONS",    RTSP_CMD_OPTIONS },
-  { "SETUP",      RTSP_CMD_SETUP },
-  { "PLAY",       RTSP_CMD_PLAY },
-  { "TEARDOWN",   RTSP_CMD_TEARDOWN },
-  { "PAUSE",      RTSP_CMD_PAUSE },
+  { "NONE",          HTTP_CMD_NONE },
+  { "GET",           HTTP_CMD_GET },
+  { "HEAD",          HTTP_CMD_HEAD },
+  { "POST",          HTTP_CMD_POST },
+  { "DESCRIBE",      RTSP_CMD_DESCRIBE },
+  { "OPTIONS",       RTSP_CMD_OPTIONS },
+  { "SETUP",         RTSP_CMD_SETUP },
+  { "PLAY",          RTSP_CMD_PLAY },
+  { "TEARDOWN",      RTSP_CMD_TEARDOWN },
+  { "PAUSE",         RTSP_CMD_PAUSE },
+  { "GET_PARAMETER", RTSP_CMD_GET_PARAMETER },
 };
 
 

--- a/src/http.h
+++ b/src/http.h
@@ -391,8 +391,14 @@ void http_client_unpause( http_client_t *hc );
  * RTSP helpers
  */
 
-int rtsp_send( http_client_t *hc, http_cmd_t cmd, const char *path,
-               const char *query, http_arg_list_t *hdr );
+int rtsp_send_ext( http_client_t *hc, http_cmd_t cmd, const char *path,
+               const char *query, http_arg_list_t *hdr, const char *body, size_t size );
+
+static inline int
+rtsp_send( http_client_t *hc, http_cmd_t cmd, const char *path,
+               const char *query, http_arg_list_t *hdr ) {
+  return rtsp_send_ext( hc, cmd, path, query, hdr, NULL, 0 );
+}
                       
 void rtsp_clear_session( http_client_t *hc );
 
@@ -421,7 +427,10 @@ rtsp_teardown( http_client_t *hc, const char *path, const char *query ) {
 }
 
 static inline int rtsp_get_parameter( http_client_t *hc, const char *parameter ) {
-  return rtsp_send(hc, RTSP_CMD_GET_PARAMETER, NULL, parameter, NULL);
+  http_arg_list_t hdr;
+  http_arg_init(&hdr);
+  http_arg_set(&hdr, "Content-Type", "text/parameters");
+  return rtsp_send_ext(hc, RTSP_CMD_GET_PARAMETER, NULL, NULL, &hdr, parameter, strlen(parameter));
 }
 
 int rtsp_describe_decode( http_client_t *hc );

--- a/src/http.h
+++ b/src/http.h
@@ -426,12 +426,7 @@ rtsp_teardown( http_client_t *hc, const char *path, const char *query ) {
   return rtsp_send(hc, RTSP_CMD_TEARDOWN, path, query, NULL);
 }
 
-static inline int rtsp_get_parameter( http_client_t *hc, const char *parameter ) {
-  http_arg_list_t hdr;
-  http_arg_init(&hdr);
-  http_arg_set(&hdr, "Content-Type", "text/parameters");
-  return rtsp_send_ext(hc, RTSP_CMD_GET_PARAMETER, NULL, NULL, &hdr, parameter, strlen(parameter));
-}
+int rtsp_get_parameter( http_client_t *hc, const char *parameter );
 
 int rtsp_describe_decode( http_client_t *hc );
 static inline int

--- a/src/http.h
+++ b/src/http.h
@@ -110,6 +110,7 @@ typedef enum http_cmd {
   RTSP_CMD_TEARDOWN,
   RTSP_CMD_PLAY,
   RTSP_CMD_PAUSE,
+  RTSP_CMD_GET_PARAMETER,
 } http_cmd_t;
 
 #define HTTP_CMD_OPTIONS RTSP_CMD_OPTIONS
@@ -409,8 +410,17 @@ rtsp_play( http_client_t *hc, const char *path, const char *query ) {
 }
 
 static inline int
+rtsp_pause( http_client_t *hc, const char *path, const char *query ) {
+  return rtsp_send(hc, RTSP_CMD_PAUSE, path, query, NULL);
+}
+
+static inline int
 rtsp_teardown( http_client_t *hc, const char *path, const char *query ) {
   return rtsp_send(hc, RTSP_CMD_TEARDOWN, path, query, NULL);
+}
+
+static inline int rtsp_get_parameter( http_client_t *hc, const char *parameter ) {
+  return rtsp_send(hc, RTSP_CMD_GET_PARAMETER, NULL, parameter, NULL);
 }
 
 int rtsp_describe_decode( http_client_t *hc );

--- a/src/http.h
+++ b/src/http.h
@@ -345,6 +345,7 @@ struct http_client {
   int          hc_rtp_timeout;
   char        *hc_rtsp_user;
   char        *hc_rtsp_pass;
+  char         hc_rtsp_keep_alive_cmd;
 
   struct http_client_ssl *hc_ssl; /* ssl internals */
 

--- a/src/input/mpegts/iptv/iptv_rtsp.c
+++ b/src/input/mpegts/iptv/iptv_rtsp.c
@@ -52,8 +52,12 @@ iptv_rtsp_alive_cb ( void *aux )
 {
   iptv_mux_t *im = aux;
   rtsp_priv_t *rp = im->im_data;
-
-  rtsp_get_parameter(rp->hc, "");
+  if(rp->hc->hc_rtsp_keep_alive_cmd == RTSP_CMD_GET_PARAMETER)
+    rtsp_get_parameter(rp->hc, "");
+  else if(rp->hc->hc_rtsp_keep_alive_cmd == RTSP_CMD_OPTIONS)
+    rtsp_send(rp->hc, RTSP_CMD_OPTIONS, rp->path, rp->query, NULL);
+  else
+    return;
   mtimer_arm_rel(&rp->alive_timer, iptv_rtsp_alive_cb, im,
                  sec2mono(MAX(1, (rp->hc->hc_rtp_timeout / 2) - 1)));
 }
@@ -75,6 +79,13 @@ iptv_rtsp_header ( http_client_t *hc )
       mtimer_arm_rel(&hc->hc_close_timer, iptv_rtsp_close_cb, hc, 0);
       pthread_mutex_unlock(&global_lock);
     }
+    return 0;
+  }
+
+  if (hc->hc_cmd == RTSP_CMD_GET_PARAMETER && hc->hc_code != HTTP_STATUS_OK) {
+    tvherror("iptv", "GET_PARAMETER command returned invalid error code %d for '%s', "
+        "fall back to OPTIONS in keep alive loop.", hc->hc_code, im->mm_iptv_url_raw);
+    hc->hc_rtsp_keep_alive_cmd = RTSP_CMD_OPTIONS;
     return 0;
   }
 
@@ -160,10 +171,11 @@ iptv_rtsp_start
     return SM_CODE_TUNING_FAILED;
   }
 
-  hc->hc_hdr_received    = iptv_rtsp_header;
-  hc->hc_data_received   = iptv_rtsp_data;
-  hc->hc_handle_location = 1;        /* allow redirects */
-  http_client_register(hc);          /* register to the HTTP thread */
+  hc->hc_hdr_received        = iptv_rtsp_header;
+  hc->hc_data_received       = iptv_rtsp_data;
+  hc->hc_handle_location     = 1;                      /* allow redirects */
+  hc->hc_rtsp_keep_alive_cmd = RTSP_CMD_GET_PARAMETER; /* start keep alive loop with GET_PARAMETER */
+  http_client_register(hc);                            /* register to the HTTP thread */
   r = rtsp_setup(hc, u->path, u->query, NULL,
                  ntohs(IP_PORT(rtp->ip)),
                  ntohs(IP_PORT(rtcp->ip)));

--- a/src/input/mpegts/iptv/iptv_rtsp.c
+++ b/src/input/mpegts/iptv/iptv_rtsp.c
@@ -83,7 +83,7 @@ iptv_rtsp_header ( http_client_t *hc )
   }
 
   if (hc->hc_cmd == RTSP_CMD_GET_PARAMETER && hc->hc_code != HTTP_STATUS_OK) {
-    tvherror("iptv", "GET_PARAMETER command returned invalid error code %d for '%s', "
+    tvhtrace("iptv", "GET_PARAMETER command returned invalid error code %d for '%s', "
         "fall back to OPTIONS in keep alive loop.", hc->hc_code, im->mm_iptv_url_raw);
     hc->hc_rtsp_keep_alive_cmd = RTSP_CMD_OPTIONS;
     return 0;

--- a/src/input/mpegts/iptv/iptv_rtsp.c
+++ b/src/input/mpegts/iptv/iptv_rtsp.c
@@ -53,7 +53,7 @@ iptv_rtsp_alive_cb ( void *aux )
   iptv_mux_t *im = aux;
   rtsp_priv_t *rp = im->im_data;
   if(rp->hc->hc_rtsp_keep_alive_cmd == RTSP_CMD_GET_PARAMETER)
-    rtsp_get_parameter(rp->hc, "");
+    rtsp_get_parameter(rp->hc, "position");
   else if(rp->hc->hc_rtsp_keep_alive_cmd == RTSP_CMD_OPTIONS)
     rtsp_send(rp->hc, RTSP_CMD_OPTIONS, rp->path, rp->query, NULL);
   else

--- a/src/input/mpegts/iptv/iptv_rtsp.c
+++ b/src/input/mpegts/iptv/iptv_rtsp.c
@@ -53,7 +53,7 @@ iptv_rtsp_alive_cb ( void *aux )
   iptv_mux_t *im = aux;
   rtsp_priv_t *rp = im->im_data;
 
-  rtsp_send(rp->hc, RTSP_CMD_OPTIONS, rp->path, rp->query, NULL);
+  rtsp_get_parameter(rp->hc, "");
   mtimer_arm_rel(&rp->alive_timer, iptv_rtsp_alive_cb, im,
                  sec2mono(MAX(1, (rp->hc->hc_rtp_timeout / 2) - 1)));
 }

--- a/src/rtsp.c
+++ b/src/rtsp.c
@@ -266,3 +266,11 @@ rtsp_describe_decode( http_client_t *hc )
   printf("data:\n%s\n",    hc->hc_data);
   return HTTP_CON_OK;
 }
+
+int
+rtsp_get_parameter( http_client_t *hc, const char *parameter ) {
+  http_arg_list_t hdr;
+  http_arg_init(&hdr);
+  http_arg_set(&hdr, "Content-Type", "text/parameters");
+  return rtsp_send_ext(hc, RTSP_CMD_GET_PARAMETER, NULL, NULL, &hdr, parameter, strlen(parameter));
+}

--- a/src/rtsp.c
+++ b/src/rtsp.c
@@ -28,9 +28,10 @@
  * Utils
  */
 int
-rtsp_send( http_client_t *hc, http_cmd_t cmd,
+rtsp_send_ext( http_client_t *hc, http_cmd_t cmd,
            const char *path, const char *query,
-           http_arg_list_t *hdr )
+           http_arg_list_t *hdr,
+           const char *body, size_t size )
 {
   http_arg_list_t h;
   size_t blen = 7 + strlen(hc->hc_host) +
@@ -38,6 +39,7 @@ rtsp_send( http_client_t *hc, http_cmd_t cmd,
                 (path ? strlen(path) : 1) + 1;
   char *buf = alloca(blen);
   char buf2[7];
+  char buf_body[size + 3];
 
   if (hc->hc_rtsp_session) {
     if (hdr == NULL) {
@@ -46,13 +48,28 @@ rtsp_send( http_client_t *hc, http_cmd_t cmd,
     }
     http_arg_set(hdr, "Session", hc->hc_rtsp_session);
   }
+
+  if (size > 0) {
+    if (hdr == NULL) {
+      hdr = &h;
+      http_arg_init(&h);
+    }
+    strncpy(buf_body, body, sizeof(buf_body));
+    strncat(buf_body, "\r\n", 2);
+    snprintf(buf2, sizeof(buf2), "%lu", size + 2);
+    http_arg_set(hdr, "Content-Length", buf2);
+  }
+
   http_client_basic_auth(hc, hdr, hc->hc_rtsp_user, hc->hc_rtsp_pass);
   if (hc->hc_port != 554)
     snprintf(buf2, sizeof(buf2), ":%d", hc->hc_port);
   else
     buf2[0] = '\0';
   snprintf(buf, blen, "rtsp://%s%s%s", hc->hc_host, buf2, path ? path : "/");
-  return http_client_send(hc, cmd, buf, query, hdr, NULL, 0);
+  if(size > 0)
+    return http_client_send(hc, cmd, buf, query, hdr, buf_body, size + 2);
+  else
+    return http_client_send(hc, cmd, buf, query, hdr, NULL, 0);
 }
 
 void


### PR DESCRIPTION
Use GET_PARAMETER in keep alive loop to prevent time out. Currently OPTIONS is used but the connection will still time out. With an empty GET_PARAMETER request the timer does reset.