### PR TITLE
Add remote timeshift support for RTSP sources

### DIFF
--- a/src/http.h
+++ b/src/http.h
@@ -346,6 +346,8 @@ struct http_client {
   char        *hc_rtsp_user;
   char        *hc_rtsp_pass;
   char         hc_rtsp_keep_alive_cmd;
+  int          hc_rtsp_range_start;
+  int          hc_rtsp_scale;
 
   struct http_client_ssl *hc_ssl; /* ssl internals */
 

--- a/src/rtsp.c
+++ b/src/rtsp.c
@@ -38,7 +38,7 @@ rtsp_send_ext( http_client_t *hc, http_cmd_t cmd,
                 (hc->hc_port != 554 ? 7 : 0) +
                 (path ? strlen(path) : 1) + 1;
   char *buf = alloca(blen);
-  char buf2[7];
+  char buf2[64];
   char buf_body[size + 3];
 
   if (hc->hc_rtsp_session) {
@@ -60,6 +60,24 @@ rtsp_send_ext( http_client_t *hc, http_cmd_t cmd,
     http_arg_set(hdr, "Content-Length", buf2);
   }
 
+  // Add RTSP range_start for Range header (timestamp)
+  if(hc->hc_rtsp_range_start > 0) {
+    if (hdr == NULL) {
+      hdr = &h;
+        http_arg_init(&h);
+     }
+     snprintf(buf2, sizeof(buf2), "npt=%d-", hc->hc_rtsp_range_start);
+     http_arg_set(hdr, "Range", buf2);
+  }
+  // Add RTSP scale header
+  if(hc->hc_rtsp_scale != 0) {
+    if (hdr == NULL) {
+      hdr = &h;
+        http_arg_init(&h);
+     }
+     snprintf(buf2, sizeof(buf2), "%d.00", hc->hc_rtsp_scale);
+     http_arg_set(hdr, "Scale", buf2);
+  }
   http_client_basic_auth(hc, hdr, hc->hc_rtsp_user, hc->hc_rtsp_pass);
   if (hc->hc_port != 554)
     snprintf(buf2, sizeof(buf2), ":%d", hc->hc_port);

--- a/src/service.c
+++ b/src/service.c
@@ -188,6 +188,14 @@ const idclass_t service_class = {
       .opts     = PO_ADVANCED,
     },
     {
+      .type     = PT_BOOL,
+      .id       = "remote_timeshift",
+      .name     = N_("Remote timeshift"),
+      .desc     = N_("Pass timeshift commands to a remote RTSP server"),
+      .off      = offsetof(service_t, s_remote_timeshift),
+      .opts     = PO_ADVANCED,
+    },
+    {
       .type     = PT_STR,
       .islist   = 1,
       .id       = "channel",

--- a/src/service.h
+++ b/src/service.h
@@ -299,6 +299,7 @@ typedef struct service {
    * subscription scheduling.
    */
   int s_enabled;
+  int s_remote_timeshift;
   int s_auto;
   int s_prio;
   int s_type_user;


### PR DESCRIPTION
IPTV providers provide RTSP servers for timeshifting and cloud recoding. This pull request creates an option to pass timeshift commands to the remote RTSP server.

Already added:
Headers set the position in the stream buffer (UNIX timestamp (start-end)) and playback speed (-16 - 16).
Option for service to pass through commands.
Pause and get_parameter (to get the current position) command from pull #806.

Still missing is the integration into the TvHeadend timeshift system. I'm not sure at which point a intersection can be created to send the command to the timeshift or rtsp client. Also the local timeshift buffer should be disabled for this service.
