### PR TITLE
config: Exclude timeshift buffer from configuration backup

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1413,6 +1413,7 @@ dobackup(const char *oldver)
   const char *argv[] = {
     "/usr/bin/tar", "cjf", outfile,
     "--exclude", "backup", "--exclude", "epggrab/*.sock",
+    "--exclude", "timeshift/buffer",
     ".", NULL
   };
   const char *root = hts_settings_get_root();


### PR DESCRIPTION
This fixes the issue where if TVHeadend was streaming live TV with
timeshift turned on and suffered an unclean shutdown followed
immediately by an upgrade, it would try to put the entire timeshift
buffer into the configuration backup.