### PR TITLE
libav: try to tidy up the mess that is Makefile.ffmpeg

### DIFF
--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -22,84 +22,101 @@ include $(DIR)/.config.mk
 unexport CFLAGS
 unexport LDFLAGS
 
-# ###########################################################################
+
+# ##############################################################################
 # Upstream Packages
-# ###########################################################################
+# ##############################################################################
 
-FFMPEG          = ffmpeg-2.8.5
-FFMPEG_TB       = $(FFMPEG).tar.bz2
-FFMPEG_URL      = http://ffmpeg.org/releases/$(FFMPEG_TB)
-FFMPEG_SHA1     = 74f82c0bdaada050ada9010ecb574fb02d434c00
-FFMPEG_DIFFS    =
+EXTLIBS        =
+COMPONENTS     = avutil avcodec avformat swscale avresample swresample avfilter
+PROTOCOLS      = file
+DECODERS       = mpeg2video mp2 aac vorbis ac3 eac3 aac_latm h264 hevc
+ENCODERS       = mpeg2video mp2 aac vorbis
+MUXERS         = mpegts mpeg2dvd matroska webm mp4
+BSFS           = h264_mp4toannexb hevc_mp4toannexb
+FILTERS        = yadif scale null aresample anull
 
-EXTLIBS         = libx264 libvorbis libvpx
-COMPONENTS      = avutil avformat avcodec swresample swscale avfilter avresample
-PROTOCOLS       = file
-DECODERS        = mpeg2video mp2 ac3 eac3 h264 h264_vdpau hevc aac aac_latm vorbis libvorbis
-ENCODERS        = mpeg2video mp2 libx264 libvpx_vp8 libvpx_vp9 aac libaacplus vorbis libvorbis
-MUXERS          = mpegts mpeg2dvd matroska webm mp4
-BSFS            = h264_mp4toannexb hevc_mp4toannexb
-FILTERS         = yadif scale
+YASM           = yasm-1.3.0
+YASM_TB        = $(YASM).tar.gz
+YASM_URL       = http://www.tortall.net/projects/yasm/releases/$(YASM_TB)
+YASM_SHA1      = b7574e9f0826bedef975d64d3825f75fbaeef55e
 
-LIBOGG          = libogg-1.3.2
-LIBOGG_TB       = $(LIBOGG).tar.gz
-LIBOGG_URL      = http://downloads.xiph.org/releases/ogg/$(LIBOGG_TB)
-LIBOGG_SHA1     = df7f3977bbeda67306bc2a427257dd7375319d7d
+LIBX264        = x264-snapshot-20160217-2245
+LIBX264_TB     = $(LIBX264).tar.bz2
+LIBX264_URL    = http://ftp.via.ecp.fr/pub/videolan/x264/snapshots/$(LIBX264_TB)
+LIBX264_SHA1   = e3b9d6f3372c9052fac3bffe7175518bb269a359
+LIBX264_DIFFS  = libx264.configure.diff
 
-LIBVORBIS       = libvorbis-1.3.5
-LIBVORBIS_TB    = $(LIBVORBIS).tar.gz
-LIBVORBIS_URL   = http://downloads.xiph.org/releases/vorbis/$(LIBVORBIS_TB)
-LIBVORBIS_SHA1  = 10c7fee173178d72855aa7593dfe49d9b3d6c804
+LIBX265        = x265_1.9
+LIBX265_TB     = $(LIBX265).tar.gz
+LIBX265_URL    = http://ftp.videolan.org/pub/videolan/x265/$(LIBX265_TB)
+LIBX265_SHA1   = 8c9aa3b87b0f0a418bbb9782e9354d112d75e003
 
-LIBX264         = x264-snapshot-20160217-2245
-LIBX264_TB      = $(LIBX264).tar.bz2
-LIBX264_URL     = http://ftp.via.ecp.fr/pub/videolan/x264/snapshots/$(LIBX264_TB)
-LIBX264_SHA1    = e3b9d6f3372c9052fac3bffe7175518bb269a359
+LIBVPX         = libvpx-1.5.0
+LIBVPX_TB      = $(LIBVPX).tar.bz2
+LIBVPX_URL     = http://storage.googleapis.com/downloads.webmproject.org/releases/webm/$(LIBVPX_TB)
+LIBVPX_SHA1    = 0baf76627eb08450eaf307347d1721f56a880c64
 
-LIBX265         = x265_1.9
-LIBX265_TB      = $(LIBX265).tar.gz
-LIBX265_URL     = http://ftp.videolan.org/pub/videolan/x265/$(LIBX265_TB)
-LIBX265_SHA1    = 8c9aa3b87b0f0a418bbb9782e9354d112d75e003
+LIBOGG         = libogg-1.3.2
+LIBOGG_TB      = $(LIBOGG).tar.gz
+LIBOGG_URL     = http://downloads.xiph.org/releases/ogg/$(LIBOGG_TB)
+LIBOGG_SHA1    = df7f3977bbeda67306bc2a427257dd7375319d7d
 
-LIBVPX          = libvpx-1.5.0
-LIBVPX_TB       = $(LIBVPX).tar.bz2
-LIBVPX_URL      = http://storage.googleapis.com/downloads.webmproject.org/releases/webm/$(LIBVPX_TB)
-LIBVPX_SHA1     = 0baf76627eb08450eaf307347d1721f56a880c64
+LIBTHEORA      = libtheora-1.1.1
+LIBTHEORA_TB   = $(LIBTHEORA).tar.gz
+LIBTHEORA_URL  = http://downloads.xiph.org/releases/theora/$(LIBTHEORA_TB)
+LIBTHEORA_SHA1 = 0b91be522746a29351a5ee592fd8160940059303
 
-YASM            = yasm-1.3.0
-YASM_TB         = $(YASM).tar.gz
-YASM_URL        = http://www.tortall.net/projects/yasm/releases/$(YASM_TB)
-YASM_SHA1       = b7574e9f0826bedef975d64d3825f75fbaeef55e
+LIBVORBIS      = libvorbis-1.3.5
+LIBVORBIS_TB   = $(LIBVORBIS).tar.gz
+LIBVORBIS_URL  = http://downloads.xiph.org/releases/vorbis/$(LIBVORBIS_TB)
+LIBVORBIS_SHA1 = 10c7fee173178d72855aa7593dfe49d9b3d6c804
 
-LIBMFX_HASH     = 8220f463a97b098d9e37bbfa2110b117700d1205
-LIBMFX          = mfx_dispatch-$(LIBMFX_HASH)
-LIBMFX_TB       = $(LIBMFX_HASH).tar.gz
-LIBMFX_URL      = https://github.com/lu-zero/mfx_dispatch/archive/$(LIBMFX_TB)
-LIBMFX_SHA1     = e7905a4e18f8d3933f23ed5cf5a96a40a31c76a8
+LIBFDKAAC      = fdk-aac-0.1.4
+LIBFDKAAC_TB   = $(LIBFDKAAC).tar.gz
+LIBFDKAAC_URL  = http://sourceforge.net/projects/opencore-amr/files/fdk-aac/$(LIBFDKAAC_TB)
+LIBFDKAAC_SHA1 = 9215d19bdd911954fd5bc879c707ab571716ba0d
 
-# ###########################################################################
+LIBMFX_HASH    = 9f4a84d73fb73d430f07a80cea3688c424439f6a
+LIBMFX         = mfx_dispatch-$(LIBMFX_HASH)
+LIBMFX_TB      = $(LIBMFX_HASH).tar.gz
+LIBMFX_URL     = https://github.com/lu-zero/mfx_dispatch/archive/$(LIBMFX_TB)
+LIBMFX_SHA1    = 84dbdf4a6b409067e863eb9564bb2efdec6d39ce
+LIBMFX_DIFFS   = libmfx.linux.path.diff
+
+FFMPEG         = ffmpeg-3.0
+FFMPEG_TB      = $(FFMPEG).tar.bz2
+FFMPEG_URL     = http://ffmpeg.org/releases/$(FFMPEG_TB)
+FFMPEG_SHA1    = daa827a8d1b7d5be418087165a55bdad5197f9d5
+
+
+# ##############################################################################
 # Library Config
-# ###########################################################################
+# ##############################################################################
 
 LIB_NAME  := ffmpeg
 LIB_ROOT  := $(BUILDDIR)/$(LIB_NAME)
-LIB_FILES :=\
-	$(LIB_ROOT)/$(FFMPEG)/.tvh_download \
-	$(LIB_ROOT)/$(FFMPEG)/.tvh_build \
-	$(LIB_ROOT)/$(LIBOGG)/.tvh_download \
-	$(LIB_ROOT)/$(LIBOGG)/.tvh_build \
-	$(LIB_ROOT)/$(LIBVORBIS)/.tvh_download \
-	$(LIB_ROOT)/$(LIBVORBIS)/.tvh_build \
+LIB_FILES := \
+	$(LIB_ROOT)/$(YASM)/.tvh_download \
+	$(LIB_ROOT)/$(YASM)/.tvh_build \
 	$(LIB_ROOT)/$(LIBX264)/.tvh_download \
 	$(LIB_ROOT)/$(LIBX264)/.tvh_build \
 	$(LIB_ROOT)/$(LIBX265)/.tvh_download \
 	$(LIB_ROOT)/$(LIBX265)/.tvh_build \
 	$(LIB_ROOT)/$(LIBVPX)/.tvh_download \
 	$(LIB_ROOT)/$(LIBVPX)/.tvh_build \
-	$(LIB_ROOT)/$(YASM)/.tvh_download \
-	$(LIB_ROOT)/$(YASM)/.tvh_build \
+	$(LIB_ROOT)/$(LIBOGG)/.tvh_download \
+	$(LIB_ROOT)/$(LIBOGG)/.tvh_build \
+	$(LIB_ROOT)/$(LIBTHEORA)/.tvh_download \
+	$(LIB_ROOT)/$(LIBTHEORA)/.tvh_build \
+	$(LIB_ROOT)/$(LIBVORBIS)/.tvh_download \
+	$(LIB_ROOT)/$(LIBVORBIS)/.tvh_build \
+	$(LIB_ROOT)/$(LIBFDKAAC)/.tvh_download \
+	$(LIB_ROOT)/$(LIBFDKAAC)/.tvh_build \
 	$(LIB_ROOT)/$(LIBMFX)/.tvh_download \
 	$(LIB_ROOT)/$(LIBMFX)/.tvh_build \
+	$(LIB_ROOT)/$(FFMPEG)/.tvh_download \
+	$(LIB_ROOT)/$(FFMPEG)/.tvh_build \
 	$(LIB_ROOT)/build/ffmpeg/lib/*.a \
 	$(LIB_ROOT)/build/ffmpeg/include/*
 
@@ -108,20 +125,24 @@ include $(DIR)/Makefile.static
 .PHONY: build $(PHONY)
 build: $(LIB_ROOT)/$(FFMPEG)/.tvh_build
 
-# ###########################################################################
+
+# ##############################################################################
 # Build Rules
-# ###########################################################################
+# ##############################################################################
 
 export PATH := $(LIB_ROOT)/build/ffmpeg/bin:$(PATH)
 
-ECFLAGS      = -I$(LIB_ROOT)/build/ffmpeg/include
-ELIBS        = -L$(LIB_ROOT)/build/ffmpeg/lib -ldl
+EBUILDIR  := $(LIB_ROOT)/build
+EPREFIX   := $(EBUILDIR)/ffmpeg
+ECFLAGS   := -I$(EPREFIX)/include
+ELIBS     := -L$(EPREFIX)/lib -ldl
 
-EXTRAENV     =
-CONFIGURE    = TVHEADEND_LIBAV_BUILD=$(LIB_ROOT)/build/ffmpeg \
-  PKG_CONFIG=$(ROOTDIR)/support/pkg-config.ffmpeg ./configure
+CONFIGURE := FFMPEG_PREFIX=$(EPREFIX) \
+             PKG_CONFIG=$(ROOTDIR)/support/pkg-config.ffmpeg \
+             ./configure --prefix=/ffmpeg --enable-static --disable-shared
 
-#
+
+# ##############################################################################
 # YASM
 #
 
@@ -131,147 +152,26 @@ $(LIB_ROOT)/$(YASM)/.tvh_download:
 	@touch $@
 
 $(LIB_ROOT)/$(YASM)/.tvh_build: \
-		$(LIB_ROOT)/$(YASM)/.tvh_download
-	cd $(LIB_ROOT)/$(YASM) && $(CONFIGURE) \
-                --prefix=/ffmpeg
-	DESTDIR=$(LIB_ROOT)/build \
+	$(LIB_ROOT)/$(YASM)/.tvh_download
+	cd $(LIB_ROOT)/$(YASM) && $(CONFIGURE)
+	DESTDIR=$(EBUILDIR) \
 		$(MAKE) -C $(LIB_ROOT)/$(YASM) install
 	@touch $@
 
+
+# ##############################################################################
+# LIBX264
 #
-# VDPAU library
-#
 
-ifeq (yes,$(CONFIG_VDPAU))
+ifeq (yes,$(CONFIG_LIBX264))
 
-EXTRAARG += --enable-vdpau
-
-DECODERS += h264_vdpau
+EXTLIBS  += libx264
+ENCODERS += libx264
 
 endif
 
-#
-# NVENC
-#
 
-ifeq (yes,$(CONFIG_NVENC))
-
-EXTRAARG += --enable-nvenc --enable-nonfree
-
-ENCODERS += nvenc_h264 nvenc_hevc
-
-endif
-
-#
-# MFX Dispatcher (libmfx)
-#
-
-ifeq (yes,$(CONFIG_LIBMFX))
-
-EXTLIBS  += libmfx
-
-DECODERS += mpeg2_qsv h264_qsv hevc_qsv
-ENCODERS += mpeg2_qsv h264_qsv hevc_qsv
-
-ELIBS += -lva
-ifeq ($(CONFIG_VA_DRM),yes)
-ELIBS += -lva-drm
-endif
-ifeq ($(CONFIG_VA_X11),yes)
-ELIBS += -lva-x11
-endif
-
-endif
-
-ifeq (yes,$(CONFIG_LIBMFX_STATIC))
-
-$(LIB_ROOT)/$(LIBMFX)/.tvh_download:
-	$(call DOWNLOAD,$(LIBMFX_URL),$(LIB_ROOT)/$(LIBMFX_TB),$(LIBMFX_SHA1))
-	$(call UNTAR,$(LIBMFX_TB),z)
-	@touch $@
-
-$(LIB_ROOT)/$(LIBMFX)/.tvh_build: \
-		$(LIB_ROOT)/$(LIBMFX)/.tvh_download
-	cd $(LIB_ROOT)/$(LIBMFX) && autoreconf -i
-	cd $(LIB_ROOT)/$(LIBMFX) && ./configure \
-		--prefix=/ffmpeg \
-		--enable-static \
-		--disable-shared
-	DESTDIR=$(LIB_ROOT)/build \
-		$(MAKE) -C $(LIB_ROOT)/$(LIBMFX) install
-	@touch $@
-
-else
-
-LIBMFX_CFLAGS = $(shell $(PKG_CONFIG) --cflags libmfx)
-LIBMFX_LIBS   = $(shell $(PKG_CONFIG) --libs libmfx)
-
-EXTRAENV += TVHEADEND_LIBMFX_CFLAGS="$(LIBMFX_CFLAGS)" TVHEADEND_LIBMFX_LIBS="$(LIBMFX_LIBS)"
-
-$(LIB_ROOT)/$(LIBMFX)/.tvh_download:
-	@mkdir -p $(LIB_ROOT)/$(LIBMFX)
-	@touch $@
-
-$(LIB_ROOT)/$(LIBMFX)/.tvh_build: \
-		$(LIB_ROOT)/$(LIBMFX)/.tvh_download
-	@touch $@
-
-endif
-
-#
-# libogg & libvorbis
-#
-
-$(LIB_ROOT)/$(LIBOGG)/.tvh_download:
-	$(call DOWNLOAD,$(LIBOGG_URL),$(LIB_ROOT)/$(LIBOGG_TB),$(LIBOGG_SHA1))
-	$(call UNTAR,$(LIBOGG_TB),z)
-	@touch $@
-
-$(LIB_ROOT)/$(LIBOGG)/.tvh_build: \
-		$(LIB_ROOT)/$(YASM)/.tvh_build \
-		$(LIB_ROOT)/$(LIBOGG)/.tvh_download
-	cd $(LIB_ROOT)/$(LIBOGG) && $(CONFIGURE) \
-		--prefix=/ffmpeg \
-		--enable-static \
-		--disable-shared
-	DESTDIR=$(LIB_ROOT)/build \
-		$(MAKE) -C $(LIB_ROOT)/$(LIBOGG) install
-	@touch $@
-
-$(LIB_ROOT)/$(LIBVORBIS)/.tvh_download: \
-		$(LIB_ROOT)/$(LIBOGG)/.tvh_download
-	$(call DOWNLOAD,$(LIBVORBIS_URL),$(LIB_ROOT)/$(LIBVORBIS_TB),$(LIBVORBIS_SHA1))
-	$(call UNTAR,$(LIBVORBIS_TB),z)
-	@touch $@
-
-$(LIB_ROOT)/$(LIBVORBIS)/.tvh_build: \
-		$(LIB_ROOT)/$(LIBVORBIS)/.tvh_download \
-		$(LIB_ROOT)/$(YASM)/.tvh_build \
-		$(LIB_ROOT)/$(LIBOGG)/.tvh_build
-	cd $(LIB_ROOT)/$(LIBVORBIS) && $(CONFIGURE) \
-		--prefix=/ffmpeg \
-		--enable-static \
-		--disable-shared \
-		--with-ogg=$(LIB_ROOT)/build/ffmpeg
-	DESTDIR=$(LIB_ROOT)/build \
-		$(MAKE) -C $(LIB_ROOT)/$(LIBVORBIS) install
-	@touch $@
-
-#
-# libx264
-#
-
-ifneq (yes,$(CONFIG_LIBX264_STATIC))
-
-$(LIB_ROOT)/$(LIBX264)/.tvh_download:
-	@echo "***** LIBX264 STATIC BUILD IS DISABLED, USING INSTALLED PACKAGE *****"
-	@mkdir -p $(LIB_ROOT)/$(LIBX264)
-	@touch $@
-
-$(LIB_ROOT)/$(LIBX264)/.tvh_build: $(LIB_ROOT)/$(LIBX264)/.tvh_download
-	@touch $@
-
-else
+ifeq (yes,$(CONFIG_LIBX264_STATIC))
 
 ifneq (,$(DEB_BUILD_GNU_TYPE))
 LIBX264_HOST := --host=$(DEB_BUILD_GNU_TYPE)
@@ -279,33 +179,39 @@ endif
 
 $(LIB_ROOT)/$(LIBX264)/.tvh_download:
 	$(call DOWNLOAD,$(LIBX264_URL),$(LIB_ROOT)/$(LIBX264_TB),$(LIBX264_SHA1))
-	#rm -rf $(LIB_ROOT)/x264-snapshot-*
 	$(call UNTAR,$(LIBX264_TB),j)
-	#{ ln -sf $$(basename $(LIB_ROOT)/x264-snapshot-*) $(LIB_ROOT)/$(LIBX264); }
+	$(call PATCH,$(LIBX264),$(LIBX264_DIFFS))
 	@touch $@
 
 $(LIB_ROOT)/$(LIBX264)/.tvh_build: \
-		$(LIB_ROOT)/$(LIBX264)/.tvh_download \
-		$(LIB_ROOT)/$(YASM)/.tvh_build
+	$(LIB_ROOT)/$(YASM)/.tvh_build \
+	$(LIB_ROOT)/$(FFMPEG)/.tvh_tmp \
+	$(LIB_ROOT)/$(LIBX264)/.tvh_download
 	cd $(LIB_ROOT)/$(LIBX264) && $(CONFIGURE) \
-		--prefix=/ffmpeg \
-		--enable-static \
-		--disable-shared \
 		--disable-avs \
-		--disable-swscale \
-		--disable-lavf \
 		--disable-ffms \
 		--disable-gpac \
 		--disable-lsmash \
 		$(LIBX264_HOST)
-	DESTDIR=$(LIB_ROOT)/build \
+	DESTDIR=$(EBUILDIR) \
 		$(MAKE) -C $(LIB_ROOT)/$(LIBX264) install
+	@touch $@
+
+else
+
+$(LIB_ROOT)/$(LIBX264)/.tvh_download:
+	@mkdir -p $(LIB_ROOT)/$(LIBX264)
+	@touch $@
+
+$(LIB_ROOT)/$(LIBX264)/.tvh_build: \
+	$(LIB_ROOT)/$(LIBX264)/.tvh_download
 	@touch $@
 
 endif
 
-#
-# libx265
+
+# ##############################################################################
+# LIBX265
 #
 
 ifeq (yes,$(CONFIG_LIBX265))
@@ -324,14 +230,13 @@ $(LIB_ROOT)/$(LIBX265)/.tvh_download:
 	@touch $@
 
 $(LIB_ROOT)/$(LIBX265)/.tvh_build: \
-		$(LIB_ROOT)/$(LIBX265)/.tvh_download \
-		$(LIB_ROOT)/$(YASM)/.tvh_build
-	cd $(LIB_ROOT)/$(LIBX265)/build/linux && cmake \
-		-G "Unix Makefiles" \
+	$(LIB_ROOT)/$(YASM)/.tvh_build \
+	$(LIB_ROOT)/$(LIBX265)/.tvh_download
+	cd $(LIB_ROOT)/$(LIBX265)/build/linux && cmake -G "Unix Makefiles" \
 		-DCMAKE_INSTALL_PREFIX="/ffmpeg" \
-		-DENABLE_SHARED:bool=off \
+		-DENABLE_SHARED:BOOL=OFF \
 		../../source
-	DESTDIR=$(LIB_ROOT)/build \
+	DESTDIR=$(EBUILDIR) \
 		$(MAKE) -C $(LIB_ROOT)/$(LIBX265)/build/linux install
 	@touch $@
 
@@ -341,69 +246,324 @@ $(LIB_ROOT)/$(LIBX265)/.tvh_download:
 	@mkdir -p $(LIB_ROOT)/$(LIBX265)
 	@touch $@
 
-$(LIB_ROOT)/$(LIBX265)/.tvh_build: $(LIB_ROOT)/$(LIBX265)/.tvh_download
+$(LIB_ROOT)/$(LIBX265)/.tvh_build: \
+	$(LIB_ROOT)/$(LIBX265)/.tvh_download
 	@touch $@
 
 endif
 
-#
-# libvpx (VP8)
+
+# ##############################################################################
+# LIBVPX
 #
 
+ifeq (yes,$(CONFIG_LIBVPX))
+
+EXTLIBS  += libvpx
+ENCODERS += libvpx_vp8 libvpx_vp9
+
+endif
+
+
+ifeq (yes,$(CONFIG_LIBVPX_STATIC))
+
 $(LIB_ROOT)/$(LIBVPX)/.tvh_download:
-	@mkdir -p $(LIB_ROOT)
 	$(call DOWNLOAD,$(LIBVPX_URL),$(LIB_ROOT)/$(LIBVPX_TB),$(LIBVPX_SHA1))
 	$(call UNTAR,$(LIBVPX_TB),j)
 	@touch $@
 
 $(LIB_ROOT)/$(LIBVPX)/.tvh_build: \
-		$(LIB_ROOT)/$(LIBVPX)/.tvh_download \
-		$(LIB_ROOT)/$(YASM)/.tvh_build
+	$(LIB_ROOT)/$(YASM)/.tvh_build \
+	$(LIB_ROOT)/$(LIBVPX)/.tvh_download
 	cd $(LIB_ROOT)/$(LIBVPX) && $(CONFIGURE) \
-		--prefix=/ffmpeg \
-		--enable-static \
-		--disable-shared
-	DIST_DIR=$(LIB_ROOT)/build/ffmpeg \
+		--disable-examples \
+		--disable-docs \
+		--disable-unit-tests
+	DIST_DIR=$(EPREFIX) \
 		$(MAKE) -C $(LIB_ROOT)/$(LIBVPX) install
 	@touch $@
 
+else
+
+$(LIB_ROOT)/$(LIBVPX)/.tvh_download:
+	@mkdir -p $(LIB_ROOT)/$(LIBVPX)
+	@touch $@
+
+$(LIB_ROOT)/$(LIBVPX)/.tvh_build: \
+	$(LIB_ROOT)/$(LIBVPX)/.tvh_download
+	@touch $@
+
+endif
+
+
+# ##############################################################################
+# LIBOGG
 #
+
+ifeq (yes,$(CONFIG_LIBOGG_STATIC))
+
+$(LIB_ROOT)/$(LIBOGG)/.tvh_download:
+	$(call DOWNLOAD,$(LIBOGG_URL),$(LIB_ROOT)/$(LIBOGG_TB),$(LIBOGG_SHA1))
+	$(call UNTAR,$(LIBOGG_TB),z)
+	@touch $@
+
+$(LIB_ROOT)/$(LIBOGG)/.tvh_build: \
+	$(LIB_ROOT)/$(YASM)/.tvh_build \
+	$(LIB_ROOT)/$(LIBOGG)/.tvh_download
+	cd $(LIB_ROOT)/$(LIBOGG) && $(CONFIGURE)
+	DESTDIR=$(EBUILDIR) \
+		$(MAKE) -C $(LIB_ROOT)/$(LIBOGG) install
+	@touch $@
+
+endif
+
+
+# ##############################################################################
+# LIBTHEORA
+#
+
+ifeq (yes,$(CONFIG_LIBTHEORA))
+
+EXTLIBS  += libtheora
+ENCODERS += libtheora
+
+endif
+
+
+ifeq (yes,$(CONFIG_LIBTHEORA_STATIC))
+
+$(LIB_ROOT)/$(LIBTHEORA)/.tvh_download:
+	$(call DOWNLOAD,$(LIBTHEORA_URL),$(LIB_ROOT)/$(LIBTHEORA_TB),$(LIBTHEORA_SHA1))
+	$(call UNTAR,$(LIBTHEORA_TB),z)
+	@touch $@
+
+$(LIB_ROOT)/$(LIBTHEORA)/.tvh_build: \
+	$(LIB_ROOT)/$(YASM)/.tvh_build \
+	$(LIB_ROOT)/$(LIBOGG)/.tvh_build \
+	$(LIB_ROOT)/$(LIBTHEORA)/.tvh_download
+	cd $(LIB_ROOT)/$(LIBTHEORA) && $(CONFIGURE) \
+		--with-ogg=$(EPREFIX) \
+		--disable-examples
+	DESTDIR=$(EBUILDIR) \
+		$(MAKE) -C $(LIB_ROOT)/$(LIBTHEORA) install
+	@touch $@
+
+else
+
+$(LIB_ROOT)/$(LIBTHEORA)/.tvh_download:
+	@mkdir -p $(LIB_ROOT)/$(LIBTHEORA)
+	@touch $@
+
+$(LIB_ROOT)/$(LIBTHEORA)/.tvh_build: \
+	$(LIB_ROOT)/$(LIBTHEORA)/.tvh_download
+	@touch $@
+
+endif
+
+
+# ##############################################################################
+# LIBVORBIS
+#
+
+ifeq (yes,$(CONFIG_LIBVORBIS))
+
+EXTLIBS  += libvorbis
+DECODERS += libvorbis
+ENCODERS += libvorbis
+
+endif
+
+
+ifeq (yes,$(CONFIG_LIBVORBIS_STATIC))
+
+$(LIB_ROOT)/$(LIBVORBIS)/.tvh_download:
+	$(call DOWNLOAD,$(LIBVORBIS_URL),$(LIB_ROOT)/$(LIBVORBIS_TB),$(LIBVORBIS_SHA1))
+	$(call UNTAR,$(LIBVORBIS_TB),z)
+	@touch $@
+
+$(LIB_ROOT)/$(LIBVORBIS)/.tvh_build: \
+	$(LIB_ROOT)/$(YASM)/.tvh_build \
+	$(LIB_ROOT)/$(LIBOGG)/.tvh_build \
+	$(LIB_ROOT)/$(LIBVORBIS)/.tvh_download
+	cd $(LIB_ROOT)/$(LIBVORBIS) && $(CONFIGURE) \
+		--with-ogg=$(EPREFIX)
+	DESTDIR=$(EBUILDIR) \
+		$(MAKE) -C $(LIB_ROOT)/$(LIBVORBIS) install
+	@touch $@
+
+else
+
+$(LIB_ROOT)/$(LIBVORBIS)/.tvh_download:
+	@mkdir -p $(LIB_ROOT)/$(LIBVORBIS)
+	@touch $@
+
+$(LIB_ROOT)/$(LIBVORBIS)/.tvh_build: \
+	$(LIB_ROOT)/$(LIBVORBIS)/.tvh_download
+	@touch $@
+
+endif
+
+
+# ##############################################################################
+# LIBFDKAAC
+#
+
+ifeq (yes,$(CONFIG_LIBFDKAAC))
+
+EXTLIBS  += libfdk-aac
+ENCODERS += libfdk_aac
+
+endif
+
+
+ifeq (yes,$(CONFIG_LIBFDKAAC_STATIC))
+
+$(LIB_ROOT)/$(LIBFDKAAC)/.tvh_download:
+	$(call DOWNLOAD,$(LIBFDKAAC_URL),$(LIB_ROOT)/$(LIBFDKAAC_TB),$(LIBFDKAAC_SHA1))
+	$(call UNTAR,$(LIBFDKAAC_TB),z)
+	@touch $@
+
+$(LIB_ROOT)/$(LIBFDKAAC)/.tvh_build: \
+	$(LIB_ROOT)/$(LIBFDKAAC)/.tvh_download
+	cd $(LIB_ROOT)/$(LIBFDKAAC) && $(CONFIGURE)
+	DESTDIR=$(EBUILDIR) \
+		$(MAKE) -C $(LIB_ROOT)/$(LIBFDKAAC) install
+	@touch $@
+
+else
+
+$(LIB_ROOT)/$(LIBFDKAAC)/.tvh_download:
+	@mkdir -p $(LIB_ROOT)/$(LIBFDKAAC)
+	@touch $@
+
+$(LIB_ROOT)/$(LIBFDKAAC)/.tvh_build: \
+	$(LIB_ROOT)/$(LIBFDKAAC)/.tvh_download
+	@touch $@
+
+endif
+
+
+# ##############################################################################
+# NVENC
+#
+
+ifeq (yes,$(CONFIG_NVENC))
+
+EXTLIBS  += nvenc
+ENCODERS += nvenc_h264 nvenc_hevc
+
+endif
+
+
+# ##############################################################################
+# LIBMFX
+#
+
+ifeq (yes,$(CONFIG_QSV))
+
+EXTLIBS  += libmfx
+DECODERS += mpeg2_qsv h264_qsv hevc_qsv
+ENCODERS += mpeg2_qsv h264_qsv hevc_qsv
+
+endif
+
+
+ifeq (yes,$(CONFIG_LIBMFX_STATIC))
+
+$(LIB_ROOT)/$(LIBMFX)/.tvh_download:
+	$(call DOWNLOAD,$(LIBMFX_URL),$(LIB_ROOT)/$(LIBMFX_TB),$(LIBMFX_SHA1))
+	$(call UNTAR,$(LIBMFX_TB),z)
+	$(call PATCH,$(LIBMFX),$(LIBMFX_DIFFS))
+	@touch $@
+
+$(LIB_ROOT)/$(LIBMFX)/.tvh_build: \
+	$(LIB_ROOT)/$(LIBMFX)/.tvh_download
+	cd $(LIB_ROOT)/$(LIBMFX) && autoreconf -i && $(CONFIGURE) \
+		--with-libva_x11 \
+		--with-libva_drm
+	DESTDIR=$(EBUILDIR) \
+		$(MAKE) -C $(LIB_ROOT)/$(LIBMFX) install
+	@touch $@
+
+else
+
+$(LIB_ROOT)/$(LIBMFX)/.tvh_download:
+	@mkdir -p $(LIB_ROOT)/$(LIBMFX)
+	@touch $@
+
+$(LIB_ROOT)/$(LIBMFX)/.tvh_build: \
+	$(LIB_ROOT)/$(LIBMFX)/.tvh_download
+	@touch $@
+
+endif
+
+
+# ##############################################################################
+# Misc.
+#
+
+ifneq (,$(filter yes,$(CONFIG_LIBVORBIS) $(CONFIG_LIBTHEORA)))
+
+MUXERS += ogg
+
+endif
+
+
+ifneq (,$(filter yes,$(CONFIG_NVENC) $(CONFIG_LIBFDKAAC)))
+
+EXTLIBS += nonfree
+
+endif
+
+
+# ##############################################################################
 # FFMPEG
 #
 
 $(LIB_ROOT)/$(FFMPEG)/.tvh_download:
-	@mkdir -p $(LIB_ROOT)/build
+	@mkdir -p $(EBUILDIR)
 	$(call DOWNLOAD,$(FFMPEG_URL),$(LIB_ROOT)/$(FFMPEG_TB),$(FFMPEG_SHA1))
 	$(call UNTAR,$(FFMPEG_TB),j)
-	$(call PATCH,$(FFMPEG),$(FFMPEG_DIFFS))
 	@touch $@
 
-$(LIB_ROOT)/$(FFMPEG)/.tvh_build: \
-		$(LIB_ROOT)/$(YASM)/.tvh_build \
-		$(LIB_ROOT)/$(LIBVORBIS)/.tvh_build \
-		$(LIB_ROOT)/$(LIBX264)/.tvh_build \
-		$(LIB_ROOT)/$(LIBX265)/.tvh_build \
-		$(LIB_ROOT)/$(LIBVPX)/.tvh_build \
-		$(LIB_ROOT)/$(LIBMFX)/.tvh_build \
-		$(LIB_ROOT)/$(FFMPEG)/.tvh_download
-	cd $(LIB_ROOT)/$(FFMPEG) && $(EXTRAENV) $(CONFIGURE) \
-                --prefix=/ffmpeg \
+$(LIB_ROOT)/$(FFMPEG)/.tvh_tmp: \
+	$(LIB_ROOT)/$(YASM)/.tvh_build \
+	$(LIB_ROOT)/$(FFMPEG)/.tvh_download
+	cd $(LIB_ROOT)/$(FFMPEG) && $(CONFIGURE) \
 		--disable-all \
-		--enable-static \
-		--disable-shared \
 		--enable-gpl \
 		--extra-cflags="$(ECFLAGS)" \
 		--extra-libs="$(ELIBS)" \
-                --pkg-config="$(ROOTDIR)/support/pkg-config.ffmpeg" \
-		$(EXTRAARG) \
-		$(foreach extlib,$(EXTLIBS),--enable-$(extlib)) \
+		--pkg-config="$(ROOTDIR)/support/pkg-config.ffmpeg" \
+		$(foreach component,$(COMPONENTS),--enable-$(component))
+	DESTDIR=$(EBUILDIR) \
+		$(MAKE) -C $(LIB_ROOT)/$(FFMPEG) install clean distclean
+	@touch $@
+
+$(LIB_ROOT)/$(FFMPEG)/.tvh_build: \
+	$(LIB_ROOT)/$(YASM)/.tvh_build \
+	$(LIB_ROOT)/$(LIBX264)/.tvh_build \
+	$(LIB_ROOT)/$(LIBX265)/.tvh_build \
+	$(LIB_ROOT)/$(LIBVPX)/.tvh_build \
+	$(LIB_ROOT)/$(LIBTHEORA)/.tvh_build \
+	$(LIB_ROOT)/$(LIBVORBIS)/.tvh_build \
+	$(LIB_ROOT)/$(LIBFDKAAC)/.tvh_build \
+	$(LIB_ROOT)/$(LIBMFX)/.tvh_build \
+	$(LIB_ROOT)/$(FFMPEG)/.tvh_download
+	cd $(LIB_ROOT)/$(FFMPEG) && $(CONFIGURE) \
+		--disable-all \
+		--enable-gpl \
+		--extra-cflags="$(ECFLAGS)" \
+		--extra-libs="$(ELIBS)" \
+		--pkg-config="$(ROOTDIR)/support/pkg-config.ffmpeg" \
 		$(foreach component,$(COMPONENTS),--enable-$(component)) \
+		$(foreach extlib,$(EXTLIBS),--enable-$(extlib)) \
 		$(foreach protocol,$(PROTOCOLS),--enable-protocol=$(protocol)) \
 		$(foreach decoder,$(DECODERS),--enable-decoder=$(decoder)) \
 		$(foreach encoder,$(ENCODERS),--enable-encoder=$(encoder)) \
 		$(foreach muxer,$(MUXERS),--enable-muxer=$(muxer)) \
 		$(foreach bsf,$(BSFS),--enable-bsf=$(bsf)) \
 		$(foreach filter,$(FILTERS),--enable-filter=$(filter))
-	DESTDIR=$(LIB_ROOT)/build \
+	DESTDIR=$(EBUILDIR) \
 		$(MAKE) -C $(LIB_ROOT)/$(FFMPEG) install
 	@touch $@

--- a/configure
+++ b/configure
@@ -34,13 +34,21 @@ OPTIONS=(
   "avahi:auto"
   "zlib:auto"
   "libav:auto"
-  "libffmpeg_static:yes"
+  "ffmpeg_static:yes"
+  "libx264:yes"
   "libx264_static:yes"
-  "libx265:no"
+  "libx265:yes"
   "libx265_static:yes"
-  "vdpau:auto"
+  "libvpx:yes"
+  "libvpx_static:yes"
+  "libtheora:yes"
+  "libtheora_static:yes"
+  "libvorbis:yes"
+  "libvorbis_static:yes"
+  "libfdkaac:yes"
+  "libfdkaac_static:yes"
   "nvenc:auto"
-  "libmfx:no"
+  "qsv:no"
   "libmfx_static:yes"
   "inotify:auto"
   "epoll:auto"
@@ -141,7 +149,7 @@ else
   COMPILER=gcc
 fi
 
-check_cc_snippet getloadavg '#include <stdlib.h> 
+check_cc_snippet getloadavg '#include <stdlib.h>
 void test() { getloadavg(NULL,0); }'
 
 check_cc_snippet atomic64 '#include <stdint.h>
@@ -395,38 +403,76 @@ if enabled_or_auto avahi; then
 fi
 
 #
-# libav
+# ffmpeg
 #
-if enabled libffmpeg_static; then
+if enabled ffmpeg_static; then
 
   enable libav
   has_libav=true
 
   # libx264
-  if disabled libx264_static; then
-    check_cc_lib x264 || die "libx264 not found"
+  if enabled libx264; then
+    if disabled libx264_static; then
+      check_pkg x264 ">=0.142" || die "x264 package not found"
+    fi
+  else
+    disable libx264_static
   fi
 
   # libx265
   if enabled libx265; then
-    if enabled libx265_static; then
-      check_bin cmake || die "cmake not found (needed for building libx265)"
-      check_cc_lib stdc++ stdcpp ||\
-        die "libstdc++ not found (needed for building libx265)"
+    if disabled libx265_static; then
+      check_pkg x265 ">=1.5" || die "x265 package not found"
     else
-      check_cc_lib x265 || die "libx265 not found"
+      check_bin cmake || die "cmake not found"
+      check_cc_lib stdc++ stdcpp || die "libstdc++ not found"
     fi
   else
     disable libx265_static
   fi
 
-  # vdpau
-  if enabled_or_auto vdpau; then
-    if check_pkg vdpau; then
-      enable vdpau
-    elif enabled vdpau; then
-      die "vdpau (Video API library) not found"
+  # libvpx
+  if enabled libvpx; then
+    if disabled libvpx_static; then
+      check_pkg vpx ">=1.3.0" || die "vpx package not found"
     fi
+  else
+    disable libvpx_static
+  fi
+
+  # libtheora
+  if enabled libtheora; then
+    if disabled libtheora_static; then
+      check_pkg theoraenc ">=1.1.1" || die "theoraenc package not found"
+      check_pkg theoradec ">=1.1.1" || die "theoradec package not found"
+      check_pkg theora    ">=1.1.1" || die "theora package not found"
+    else
+      enable libogg_static
+    fi
+  else
+    disable libtheora_static
+  fi
+
+  # libvorbis
+  if enabled libvorbis; then
+    if disabled libvorbis_static; then
+      check_pkg vorbisfile ">=1.3.4" || die "vorbisfile package not found"
+      check_pkg vorbisenc  ">=1.3.4" || die "vorbisenc package not found"
+      check_pkg vorbis     ">=1.3.4" || die "vorbis package not found"
+    else
+      enable libogg_static
+    fi
+  else
+    disable libvorbis_static
+  fi
+
+  # libfdk-aac
+  if enabled libfdkaac; then
+    if disabled libfdkaac_static; then
+      check_pkg fdk-aac ">=0.1.3" || die "fdk-aac package not found"
+    fi
+  else
+    disable libfdkaac_static
   fi
 
   # nvenc
@@ -438,28 +484,27 @@ if enabled libffmpeg_static; then
     fi
   fi
 
-  # libmfx
-  if enabled libmfx; then
-    check_cc_lib va || die "libva not found"
-    check_cc_lib va-drm va_drm || disable va_drm
-    check_cc_lib va-x11 va_x11 || disable va_x11
-    if disabled va_drm && disabled va_x11; then
-      die "neither libva-drm nor libva-x11 was found"
-    fi
-    if enabled libmfx_static; then
-      check_bin autoreconf ||\
-        die "autoreconf not found (needed for building libmfx)"
-      check_bin libtool ||\
-        die "libtool not found (needed for building libmfx)"
-      check_bin libtoolize ||\
-        die "libtoolize not found (needed for building libmfx)"
-      check_cc_lib stdc++ stdcpp ||\
-        die "libstdc++ not found (needed for building libmfx)"
+  # qsv
+  if enabled qsv; then
+    if disabled libmfx_static; then
+      check_pkg libmfx ">=1.16" || die "libmfx package not found"
     else
-      check_cc_lib mfx || die "libmfx not found"
+      check_bin autoreconf       || die "autoreconf not found"
+      check_bin libtool          || die "libtool not found"
+      check_bin libtoolize       || die "libtoolize not found"
+      check_cc_lib stdc++ stdcpp || die "libstdc++ not found"
     fi
+    enable vaapi
   else
     disable libmfx_static
+  fi
+
+  # vaapi
+  if enabled vaapi; then
+    check_pkg libva ">=0.38.0"     || \
+      die "vaapi (Video Acceleration (VA) API for Linux) not found"
+    check_pkg libva-x11 ">=0.38.0" || die "libva-x11 not found"
+    check_pkg libva-drm ">=0.38.0" || die "libva-drm not found"
   fi
 
 else
@@ -467,81 +512,24 @@ else
   if enabled_or_auto libav; then
     has_libav=true
 
-    ffmpeg=$(${PKG_CONFIG} --modversion libavcodec | cut -d '.' -f 3)
-    test -z "$ffmpeg" && ffmpeg=0
-    printf "$TAB" "checking for ffmpeg libraries ..."
-    if test $ffmpeg -lt 100; then
-      ffmpeg=
-      echo "fail"
-    else
-      ffmpeg=yes
-      echo "ok"
-    fi
-
-    if test "$ffmpeg" == "yes"; then
-
-      #
-      # check for version n1.2+
-      #
-      if $has_libav && ! check_pkg libavcodec ">=55.18.102"; then
-        has_libav=false
-      fi
-
-      if $has_libav && ! check_pkg libavutil ">=52.38.100"; then
-        has_libav=false
-      fi
-
-      if $has_libav && ! check_pkg libavformat ">=55.12.100"; then
-        has_libav=false
-      fi
-
-      if $has_libav && ! check_pkg libavfilter ">=4.0.0"; then
-        has_libav=false
-      fi
-
-      if $has_libav && ! check_pkg libavresample ">=1.1.0"; then
-        has_libav=false
-      fi
-
-    else
-
-      #
-      # check for version v10+
-      #
-
-      if $has_libav && ! check_pkg libavcodec ">=55.34.1"; then
-        has_libav=false
-      fi
-
-      if $has_libav && ! check_pkg libavutil ">=53.3.0"; then
-        has_libav=false
-      fi
-
-      if $has_libav && ! check_pkg libavformat ">=55.12.0"; then
-        has_libav=false
-      fi
-
-      if $has_libav && ! check_pkg libavfilter ">=4.0.0"; then
-        has_libav=false
-      fi
-
-      if $has_libav && ! check_pkg libavresample ">=1.1.0"; then
-        has_libav=false
-      fi
-
-    fi
+    check_pkg libavfilter   ">=6.31.100"  || has_libav=false
+    check_pkg libswresample ">=2.0.101"   || has_libav=false
+    check_pkg libavresample ">=3.0.0"     || has_libav=false
+    check_pkg libswscale    ">=4.0.100"   || has_libav=false
+    check_pkg libavformat   ">=57.25.100" || has_libav=false
+    check_pkg libavcodec    ">=57.24.102" || has_libav=false
+    check_pkg libavutil     ">=55.17.103" || has_libav=false
 
     if $has_libav; then
       enable libav
     else
-      echo "WARNING: none or old libav or libffmpeg libraries were detected"
-      echo "         * use --disable-libav or --enable-libffmpeg_static"
-      echo "         ** supported ffmpeg libs n1.2+"
-      echo "         ** supported libav  libs v10+"
+      echo "WARNING: none or old ffmpeg libraries were detected"
+      echo "         * use --disable-libav or --enable-ffmpeg_static"
       if enabled libav; then
-        die "libav development support not found"
+        die "ffmpeg development support not found"
       fi
     fi
+
   fi
 
 fi

--- a/debian/rules
+++ b/debian/rules
@@ -13,6 +13,9 @@ override_dh_auto_build:
 override_dh_strip:
 	dh_strip --dbg-package=tvheadend-dbg
 
+override_dh_shlibdeps:
+	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
+
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/tvheadend
 

--- a/rpm/rpmfusion.spec.in
+++ b/rpm/rpmfusion.spec.in
@@ -39,7 +39,7 @@ SAT>IP and various other clients using these protocols.
 
 %build
 echo %{version}-%{release} > %{_builddir}/%{buildsubdir}/rpm/version
-%configure --disable-lockowner --enable-bundle --disable-libffmpeg_static
+%configure --disable-lockowner --enable-bundle --disable-ffmpeg_static
 %{__make} %{?_smp_mflags}
 
 %install
@@ -104,4 +104,4 @@ exit 0
 * Mon Oct 13 2014 Jaroslav Kysela <perex@perex.cz> 3.9-1803-g392dec0
 - Add basic RPM build support
 
-~   
+~

--- a/rpm/tvheadend.spec.in
+++ b/rpm/tvheadend.spec.in
@@ -39,9 +39,9 @@ SAT>IP and various other clients using these protocols.
 %build
 echo %{version}-%{release} > %{_builddir}/%{buildsubdir}/rpm/version
 %ifarch %arm
-      %configure --disable-lockowner --enable-bundle --disable-libffmpeg_static
+      %configure --disable-lockowner --enable-bundle --disable-ffmpeg_static
 %else
-      %configure --disable-lockowner --enable-bundle --enable-libffmpeg_static --enable-libx265
+      %configure --disable-lockowner --enable-bundle --enable-ffmpeg_static --enable-libx265
 %endif
 %{__make} %{?_smp_mflags}
 
@@ -107,4 +107,4 @@ exit 0
 * Mon Oct 13 2014 Jaroslav Kysela <perex@perex.cz> 3.9-1803-g392dec0
 - Add basic RPM build support
 
-~   
+~

--- a/support/patches/libmfx.linux.path.diff
+++ b/support/patches/libmfx.linux.path.diff
@@ -1,0 +1,12 @@
+diff -urN ../mfx_dispatch.orig/src/mfx_library_iterator_linux.cpp ./src/mfx_library_iterator_linux.cpp
+--- ../mfx_dispatch.orig/src/mfx_library_iterator_linux.cpp	2016-02-06 12:48:45.070749257 +0100
++++ ./src/mfx_library_iterator_linux.cpp	2016-02-06 12:50:40.830752490 +0100
+@@ -333,7 +333,7 @@
+     m_implType = implType;
+ 
+     snprintf(m_path, sizeof(m_path)/sizeof(m_path[0]),
+-             "%s/%s/%04x/%04x", mfx_storage_opt, mfx_folder, m_vendorID, m_deviceID);
++             "%s/%s", mfx_storage_opt, mfx_folder);
+ 
+     m_libs_num = mfx_list_libraries(m_path, (MFX_LIB_HARDWARE == implType), &m_libs);
+ 

--- a/support/patches/libx264.configure.diff
+++ b/support/patches/libx264.configure.diff
@@ -1,0 +1,100 @@
+diff -urN ../x264-snapshot-20160217-2245.orig/configure ./configure
+--- ../x264-snapshot-20160217-2245.orig/configure	2016-02-17 22:45:04.000000000 +0100
++++ ./configure	2016-03-16 10:25:41.000913817 +0100
+@@ -364,6 +364,7 @@
+ CHECK_CFLAGS=""
+ HAVE_GETOPT_LONG=1
+ cross_prefix=""
++PKG_CONFIG="$PKG_CONFIG"
+ 
+ EXE=""
+ AS_EXT=".S"
+@@ -508,6 +509,10 @@
+ STRIP="${STRIP-${cross_prefix}strip}"
+ INSTALL="${INSTALL-install}"
+ 
++if [ "x$PKG_CONFIG" = x ]; then
++    PKG_CONFIG=${cross_prefix}pkg-config
++fi
++
+ if [ "x$host" = x ]; then
+     host=`${SRCPATH}/config.guess`
+ fi
+@@ -902,9 +907,9 @@
+ 
+ if [ "$cli_libx264" = "system" -a "$shared" != "yes" ] ; then
+     [ "$static" = "yes" ] && die "Option --system-libx264 can not be used together with --enable-static"
+-    if ${cross_prefix}pkg-config --exists x264 2>/dev/null; then
+-        X264_LIBS="$(${cross_prefix}pkg-config --libs x264)"
+-        X264_INCLUDE_DIR="${X264_INCLUDE_DIR-$(${cross_prefix}pkg-config --variable=includedir x264)}"
++    if ${PKG_CONFIG} --exists x264 2>/dev/null; then
++        X264_LIBS="$(${PKG_CONFIG} --libs x264)"
++        X264_INCLUDE_DIR="${X264_INCLUDE_DIR-$(${PKG_CONFIG} --variable=includedir x264)}"
+         configure_system_override "$X264_INCLUDE_DIR" || die "Detection of system libx264 configuration failed"
+     else
+         die "Can not find system libx264"
+@@ -978,9 +983,9 @@
+ 
+ if [ "$swscale" = "auto" ] ; then
+     swscale="no"
+-    if ${cross_prefix}pkg-config --exists libswscale 2>/dev/null; then
+-        SWSCALE_LIBS="$SWSCALE_LIBS $(${cross_prefix}pkg-config --libs libswscale libavutil)"
+-        SWSCALE_CFLAGS="$SWSCALE_CFLAGS $(${cross_prefix}pkg-config --cflags libswscale libavutil)"
++    if ${PKG_CONFIG} --exists libswscale 2>/dev/null; then
++        SWSCALE_LIBS="$SWSCALE_LIBS $(${PKG_CONFIG} --libs libswscale libavutil)"
++        SWSCALE_CFLAGS="$SWSCALE_CFLAGS $(${PKG_CONFIG} --cflags libswscale libavutil)"
+     fi
+     [ -z "$SWSCALE_LIBS" ] && SWSCALE_LIBS="-lswscale -lavutil"
+ 
+@@ -995,9 +1000,9 @@
+ 
+ if [ "$lavf" = "auto" ] ; then
+     lavf="no"
+-    if ${cross_prefix}pkg-config --exists libavformat libavcodec libswscale 2>/dev/null; then
+-        LAVF_LIBS="$LAVF_LIBS $(${cross_prefix}pkg-config --libs libavformat libavcodec libavutil libswscale)"
+-        LAVF_CFLAGS="$LAVF_CFLAGS $(${cross_prefix}pkg-config --cflags libavformat libavcodec libavutil libswscale)"
++    if ${PKG_CONFIG} --exists libavformat libavcodec libswscale 2>/dev/null; then
++        LAVF_LIBS="$LAVF_LIBS $(${PKG_CONFIG} --libs libavformat libavcodec libavutil libswscale)"
++        LAVF_CFLAGS="$LAVF_CFLAGS $(${PKG_CONFIG} --cflags libavformat libavcodec libavutil libswscale)"
+     fi
+     if [ -z "$LAVF_LIBS" -a -z "$LAVF_CFLAGS" ]; then
+         LAVF_LIBS="-lavformat"
+@@ -1019,9 +1024,9 @@
+     ffms_major="2"; ffms_minor="16"; ffms_micro="2"; ffms_bump="0"
+     ffms="no"
+ 
+-    if ${cross_prefix}pkg-config --exists ffms2 2>/dev/null; then
+-        FFMS2_LIBS="$FFMS2_LIBS $(${cross_prefix}pkg-config --libs ffms2)"
+-        FFMS2_CFLAGS="$FFMS2_CFLAGS $(${cross_prefix}pkg-config --cflags ffms2)"
++    if ${PKG_CONFIG} --exists ffms2 2>/dev/null; then
++        FFMS2_LIBS="$FFMS2_LIBS $(${PKG_CONFIG} --libs ffms2)"
++        FFMS2_CFLAGS="$FFMS2_CFLAGS $(${PKG_CONFIG} --cflags ffms2)"
+     fi
+     [ -z "$FFMS2_LIBS" ] && FFMS2_LIBS="-lffms2"
+ 
+@@ -1061,9 +1066,9 @@
+ 
+ if [ "$lsmash" = "auto" ] ; then
+     lsmash="no"
+-    if ${cross_prefix}pkg-config --exists liblsmash 2>/dev/null; then
+-        LSMASH_LIBS="$LSMASH_LIBS $(${cross_prefix}pkg-config --libs liblsmash)"
+-        LSMASH_CFLAGS="$LSMASH_CFLAGS $(${cross_prefix}pkg-config --cflags liblsmash)"
++    if ${PKG_CONFIG} --exists liblsmash 2>/dev/null; then
++        LSMASH_LIBS="$LSMASH_LIBS $(${PKG_CONFIG} --libs liblsmash)"
++        LSMASH_CFLAGS="$LSMASH_CFLAGS $(${PKG_CONFIG} --cflags liblsmash)"
+     fi
+     [ -z "$LSMASH_LIBS" ] && LSMASH_LIBS="-llsmash"
+ 
+@@ -1324,6 +1329,7 @@
+ RANLIB=$RANLIB
+ STRIP=$STRIP
+ INSTALL=$INSTALL
++PKG_CONFIG=$PKG_CONFIG
+ AS=$AS
+ ASFLAGS=$ASFLAGS
+ RC=$RC
+@@ -1445,4 +1451,3 @@
+ 
+ echo
+ echo "You can run 'make' or 'make fprofiled' now."
+-

--- a/support/pkg-config.ffmpeg
+++ b/support/pkg-config.ffmpeg
@@ -1,69 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-if test -z "$TVHEADEND_LIBAV_BUILD"; then
-  exit 1
-fi
-if test "$1" = "--version"; then
-  echo "0.28"
-  exit 0
-fi
-
-cmd=
-brk=
-while test "$brk" = ""; do
-  case "$1" in
-    --exists|--cflags|--libs)
-      cmd=${1:2}
-      shift
-      ;;
-    --print-errors)
-      shift
-      ;;
-    *)
-      brk=t
-      ;;
-  esac
-done
-
-pkg="$1"
-if test -z "$pkg"; then
+if test -z "$FFMPEG_PREFIX"; then
   exit 1
 fi
 
-case "$pkg" in
-x264)
-  cflags_="-I$TVHEADEND_LIBAV_BUILD/include"
-  libs_="-L$TVHEADEND_LIBAV_BUILD/lib -lx264"
-  ;;
-x265)
-  cflags_="-I$TVHEADEND_LIBAV_BUILD/include"
-  libs_="-L$TVHEADEND_LIBAV_BUILD/lib -lx265 -lstdc++"
-  ;;
-libmfx)
-  if test -z "$TVHEADEND_LIBMFX_CFLAGS" -a -z "$TVHEADEND_LIBMFX_LIBS"; then
-    cflags_="-I$TVHEADEND_LIBAV_BUILD/include"
-    libs_="-L$TVHEADEND_LIBAV_BUILD/lib -lmfx -lstdc++"
-  else
-    cflags_="$TVHEADEND_LIBMFX_CFLAGS"
-    libs_="$TVHEADEND_LIBMFX_LIBS"
-  fi
-  ;;
-esac
+CONFIG="`which pkg-config` --static"
+CONFIG_PREFIX="PKG_CONFIG_LIBDIR=$FFMPEG_PREFIX/lib/pkgconfig"
+CONFIG_SUFFIX="--silence-errors --define-variable=prefix=$FFMPEG_PREFIX"
+CONFIG_ARGS=$(printf "%q " "$@")
 
-case "$cmd" in
-exists)
-  if test -z "$cflags_"; then exit 1; fi
-  exit 0
-  ;;
-cflags)
-  if test -z "$cflags_"; then exit 1; fi
-  echo $cflags_
-  exit 0
-  ;;
-libs)
-  if test -z "$libs_"; then exit 1; fi
-  echo $libs_
-  exit 0
-  ;;
-esac
-exit 1
+eval "$CONFIG_PREFIX $CONFIG $CONFIG_SUFFIX $CONFIG_ARGS || $CONFIG $CONFIG_ARGS"


### PR DESCRIPTION
- fix broken libx265 build
- rename libffmpeg_static to ffmpeg_static
- rename libmfx option to qsv (which is what one really wants)
- update to ffmpeg 3.0
- drop support for non-ffmpeg libav libs (kinda needed for libswresample, but might force users
  to upgrade)
- drop vdpau config option (unused)
- add multiple options (libvpx, libvorbis, ...) to customize builds to one's needs
- add libfdk-aac support
- add libtheora support
- try to cleanup the libav section in Makefile
- libx264 now supports swscale and avfilter
- patch libmfx to support the correct path to libmfx(s|h)w64.so on ubuntu (other distro users
  might not be pleased with that one)