### PR TITLE
webui: Fix display of signal strength if scale differs from SNR scale

### DIFF
--- a/src/webui/static/app/status.js
+++ b/src/webui/static/app/status.js
@@ -433,7 +433,7 @@ tvheadend.status_streams = function(panel, index)
             colored: true,
             ceiling: 65535,
             tvh_renderer: function(v, p, record) {
-                var scale = record.get('snr_scale');
+                var scale = record.get('signal_scale');
                 if (scale == 1)
                   return v;
                 if (scale == 2) {


### PR DESCRIPTION
Typo or C/P probably, resulting in wrong display of the signal strength column. If the SNR property reports FE_SCALE_DECIBEL but the strength property reports FE_SCALE_RELATIVE, strength is shown as dBm instead of a percentage bar.