### PR TITLE
transcoding: disable swscale and avfilter support in libx264

### DIFF
--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -175,6 +175,8 @@ $(LIB_ROOT)/$(LIBX264)/.tvh_build: \
 		$(LIB_ROOT)/$(YASM)/.tvh_build \
 		$(LIB_ROOT)/$(LIBX264)/.tvh_download
 	cd $(LIB_ROOT)/$(LIBX264) && $(CONFIGURE) \
+		--disable-swscale \
+		--disable-lavf \
 		--disable-avs \
 		--disable-ffms \
 		--disable-gpac \

--- a/src/plumbing/transcoding.c
+++ b/src/plumbing/transcoding.c
@@ -2110,8 +2110,10 @@ transcoder_get_capabilities(int experimental)
     if (!WORKING_ENCODER(p->id))
       continue;
 
-    if ((p->capabilities & CODEC_CAP_EXPERIMENTAL) && !experimental)
+    if (((p->capabilities & CODEC_CAP_EXPERIMENTAL) && !experimental) ||
+        (p->capabilities & AV_CODEC_CAP_VARIABLE_FRAME_SIZE)) {
       continue;
+    }
 
     sct = codec_id2streaming_component_type(p->id);
     if (sct == SCT_NONE || sct == SCT_UNKNOWN)


### PR DESCRIPTION
- it seems the way I implemented it broke parallel building :( (might be worth investigating why later)