### PR TITLE
Fix epggrab to close accepted socket after grabbing

### DIFF
--- a/src/epggrab/module.c
+++ b/src/epggrab/module.c
@@ -463,6 +463,7 @@ static void *_epggrab_socket_thread ( void *p )
     if (s <= 0) continue;
     tvhlog(LOG_DEBUG, mod->id, "got connection %d", s);
     _epggrab_socket_handler(mod, s);
+    close(s);
   }
   tvhlog(LOG_DEBUG, mod->id, "terminated");
   return NULL;


### PR DESCRIPTION
This patch fixes #3678
https://tvheadend.org/issues/3678