### PR TITLE
Do not crash on retention overflow.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1416,6 +1416,5 @@ htsmsg_t *tvheadend_capabilities_list(int check)
  */
 void time_t_out_of_range_notify(int64_t val)
 {
-  tvherror("main", "time value of of range (%"PRId64") of time_t", val);
-  abort();
+  tvherror("main", "time value out of range (%"PRId64") of time_t", val);
 }


### PR DESCRIPTION
When a user enters for example '10000' in the dvr retention/removal field (on a 32-bit machine), tvheadend will crash due to an overflow when the recording finishes. 
With the abort() removed, an overflow would be handled as forever.

Also there was a small typo.

@perexg 