### PR TITLE
ffmpeg: revert minimum required version numbers

### DIFF
--- a/configure
+++ b/configure
@@ -512,13 +512,13 @@ else
   if enabled_or_auto libav; then
     has_libav=true
 
-    check_pkg libavfilter   ">=6.31.100"  || has_libav=false
-    check_pkg libswresample ">=2.0.101"   || has_libav=false
-    check_pkg libavresample ">=3.0.0"     || has_libav=false
-    check_pkg libswscale    ">=4.0.100"   || has_libav=false
-    check_pkg libavformat   ">=57.25.100" || has_libav=false
-    check_pkg libavcodec    ">=57.24.102" || has_libav=false
-    check_pkg libavutil     ">=55.17.103" || has_libav=false
+    check_pkg libavfilter   ">=3.79.101"  || has_libav=false
+    check_pkg libswresample ">=0.17.102"   || has_libav=false
+    check_pkg libavresample ">=1.1.0"     || has_libav=false
+    check_pkg libswscale    ">=2.3.100"   || has_libav=false
+    check_pkg libavformat   ">=55.12.100" || has_libav=false
+    check_pkg libavcodec    ">=55.18.102" || has_libav=false
+    check_pkg libavutil     ">=52.38.100" || has_libav=false
 
     if $has_libav; then
       enable libav


### PR DESCRIPTION
This commit reverts the minimum version numbers required by configure to
the values before
https://github.com/tvheadend/tvheadend/commit/1359effe28a0381b8c9cbd362d6e144fb87b00fc#diff-e2d5a00791bce9a01f99bc6fd613a39dL486
in order to allow compilation with older versions of ffmpeg again.

Please note that the previous version numbers of all ffmpeg libs, with
the exception of libavfilter, are those of ffmpeg 2.0.7:
https://ffmpeg.org/olddownload.html

Therefore I synced the minimum version number required for libavfilter to
3.79.101 and not to 4.0.0 as previous in tvheadend's configure script.

Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>