### PR TITLE
Clients should be able to split radio and tv properly

### DIFF
--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -830,10 +830,12 @@ htsp_build_channel(channel_t *ch, const char *method, htsp_connection_t *htsp)
     t = (service_t *)ilm->ilm_in1;
     htsmsg_t *svcmsg = htsmsg_create_map();
     htsmsg_add_str(svcmsg, "name", service_nicename(t));
+
+    /* Service type string, i.e. UHD, HD, Radio,... */
     htsmsg_add_str(svcmsg, "type", service_servicetype_txt(t));
 
-    /* The client may wants to separate radio and tv, none = 0x00, radio = 0x01, tv = 0x02 */
-    htsmsg_add_u32(svcmsg, "serviceType", service_is_tv(t) ? 0x02 : (service_is_radio(t) ? 0x01 : 0x00));
+    /* Service content, other = 0x00, tv = 0x01, radio = 0x02 */
+    htsmsg_add_u32(svcmsg, "content", service_is_tv(t) ? 0x01 : (service_is_radio(t) ? 0x02 : 0x00));
 
     if (service_is_encrypted(t)) {
       htsmsg_add_u32(svcmsg, "caid", 65535);


### PR DESCRIPTION
With Kodi 17 there are some problems with the separation between radio and tv.
(recordings where not separated before v17)

1) User or bouquet update deletes a channel. Result, Kodi has no way to determine it is dealing with a radio or tv recording anymore. This can be solved when adding hasvideo/hasaudio flags for each dvr filename (don't know if this is the best solution).
2) When working on 1), I realized that recordings with an empty channel filed where not send to the client, this was working with tvh3.4 (no channel check).
Simply removing the channel acces check fixes this and brings the functionality in line with the webui (which has no channel check for dvr) .
Generally: The user is prevented to add a dvr on channels without acces, so why checking afterwards?
Also the current code ignores the "dvr all" setting (when channel limit set), it could even lead to problems like an owner that can't watch it's own recording.  
3) Separating radio and tv channels is currently done by parsing the "type", this returns a non api specified string which can be changed over time. Here I introduced the "content field". Also there are some channels where the type frequently changes from radio to other or tv and back. I suppose this be caused by undefined service type codes, which leads to 4).
4) There are some service codes we don not handle, page 97 in the doc below.
https://www.dvb.org/resources/public/standards/a38_dvb-si_specification.pdf
One of them is HEVC (0x1F), but I'm not sure what to assign to it, HD, UHD? Most times it will be UHD, but there can be exceptions?
Also there are some time shifted services (0x17 and 0x1A), I suppose these are the +1 channels?

@perexg Please review 