### PR TITLE
webui: change property->get_opts() signature to accept a property ptr argument

### DIFF
--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -197,7 +197,7 @@ autorec_cmp(dvr_autorec_entry_t *dae, epg_broadcast_t *e)
     if (!ls) return 0;
   }
 
-  // Note: ignore channel test if we allow quality unlocking 
+  // Note: ignore channel test if we allow quality unlocking
   if ((cfg = dae->dae_config) == NULL)
     return 0;
   if(dae->dae_channel != NULL) {
@@ -969,7 +969,7 @@ dvr_autorec_entry_class_btype_list ( void *o, const char *lang )
 }
 
 static uint32_t
-dvr_autorec_entry_class_owner_opts(void *o)
+dvr_autorec_entry_class_owner_opts(void *o, const property_t *p)
 {
   dvr_autorec_entry_t *dae = (dvr_autorec_entry_t *)o;
   if (dae && dae->dae_id.in_access &&

--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -609,7 +609,7 @@ dvr_config_class_enabled_set(void *o, const void *v)
 }
 
 static uint32_t
-dvr_config_class_enabled_opts(void *o)
+dvr_config_class_enabled_opts(void *o, const property_t *p)
 {
   dvr_config_t *cfg = (dvr_config_t *)o;
   if (cfg && dvr_config_is_default(cfg) && dvr_config_is_valid(cfg))
@@ -764,7 +764,7 @@ dvr_config_class_retention_list ( void *o, const char *lang )
 static htsmsg_t *
 dvr_config_class_extra_list(void *o, const char *lang)
 {
-  return dvr_entry_class_duration_list(o, 
+  return dvr_entry_class_duration_list(o,
            tvh_gettext_lang(lang, N_("Not set (none or channel configuration)")),
            4*60, 1, lang);
 }

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -476,7 +476,7 @@ dvr_entry_status(dvr_entry_t *de)
   switch(de->de_sched_state) {
   case DVR_SCHEDULED:
     return N_("Scheduled for recording");
-    
+
   case DVR_RECORDING:
 
     switch(de->de_rec_state) {
@@ -688,7 +688,7 @@ dvr_entry_fuzzy_match(dvr_entry_t *de, epg_broadcast_t *e, uint16_t eid, int64_t
   /* Outside of window */
   if ((int64_t)llabs(e->start - de->de_start) > time_window)
     return 0;
-  
+
   /* Title match (or contains?) */
   if (strcmp(title1, title2))
     return 0;
@@ -1208,7 +1208,7 @@ static dvr_entry_t *_dvr_duplicate_event(dvr_entry_t *de)
       // if titles are not defined or do not match, don't dedup
       if (lang_str_compare(de->de_title, de2->de_title))
         continue;
-      
+
       if (match(de, de2, &aux)) {
         free(aux);
         return de2;
@@ -1233,7 +1233,7 @@ static dvr_entry_t *_dvr_duplicate_event(dvr_entry_t *de)
       if (record != DVR_AUTOREC_LRECORD_DIFFERENT_TITLE &&
           lang_str_compare(de->de_title, de2->de_title))
         continue;
-      
+
       if (match(de, de2, &aux)) {
         free(aux);
         return de2;
@@ -1343,7 +1343,7 @@ dvr_entry_destroy(dvr_entry_t *de, int delconf)
     hts_settings_remove("dvr/log/%s", idnode_uuid_as_str(&de->de_id, ubuf));
 
   htsp_dvr_entry_delete(de);
-  
+
 #if ENABLE_INOTIFY
   dvr_inotify_del(de);
 #endif
@@ -1565,7 +1565,7 @@ static dvr_entry_t *_dvr_entry_update
     dvr_entry_set_timer(de);
   }
 
-  /* Title */ 
+  /* Title */
   if (e && e->episode && e->episode->title) {
     save |= lang_str_set2(&de->de_title, e->episode->title) ? DVR_UPDATED_TITLE : 0;
   } else if (title) {
@@ -1646,7 +1646,7 @@ dosave:
 /**
  *
  */
-dvr_entry_t * 
+dvr_entry_t *
 dvr_entry_update
   ( dvr_entry_t *de, int enabled,
     const char *dvr_config_uuid, channel_t *ch,
@@ -1665,7 +1665,7 @@ dvr_entry_update
 /**
  * Used to notify the DVR that an event has been replaced in the EPG
  */
-void 
+void
 dvr_event_replaced(epg_broadcast_t *e, epg_broadcast_t *new_e)
 {
   dvr_entry_t *de, *de_next;
@@ -1987,7 +1987,7 @@ dvr_entry_find_by_id(int id)
   LIST_FOREACH(de, &dvrentries, de_global_link)
     if(idnode_get_short_uuid(&de->de_id) == id)
       break;
-  return de;  
+  return de;
 }
 
 
@@ -2120,7 +2120,7 @@ dvr_entry_class_start_set(void *o, const void *v)
 }
 
 static uint32_t
-dvr_entry_class_start_opts(void *o)
+dvr_entry_class_start_opts(void *o, const property_t *p)
 {
   dvr_entry_t *de = (dvr_entry_t *)o;
   if (de && !dvr_entry_is_editable(de))
@@ -2129,7 +2129,7 @@ dvr_entry_class_start_opts(void *o)
 }
 
 static uint32_t
-dvr_entry_class_config_name_opts(void *o)
+dvr_entry_class_config_name_opts(void *o, const property_t *p)
 {
   dvr_entry_t *de = (dvr_entry_t *)o;
   if (de && !dvr_entry_is_editable(de))
@@ -2138,7 +2138,7 @@ dvr_entry_class_config_name_opts(void *o)
 }
 
 static uint32_t
-dvr_entry_class_owner_opts(void *o)
+dvr_entry_class_owner_opts(void *o, const property_t *p)
 {
   dvr_entry_t *de = (dvr_entry_t *)o;
   if (de && de->de_id.in_access &&
@@ -2148,7 +2148,7 @@ dvr_entry_class_owner_opts(void *o)
 }
 
 static uint32_t
-dvr_entry_class_start_extra_opts(void *o)
+dvr_entry_class_start_extra_opts(void *o, const property_t *p)
 {
   dvr_entry_t *de = (dvr_entry_t *)o;
   if (de && !dvr_entry_is_editable(de))
@@ -2799,7 +2799,7 @@ dvr_entry_class_extra_list(void *o, const char *lang)
   const char *msg = N_("Not set (use channel or DVR configuration)");
   return dvr_entry_class_duration_list(o, tvh_gettext_lang(lang, msg), 4*60, 1, lang);
 }
-                                        
+
 static htsmsg_t *
 dvr_entry_class_content_type_list(void *o, const char *lang)
 {
@@ -2811,7 +2811,7 @@ dvr_entry_class_content_type_list(void *o, const char *lang)
 
 static char *
 dvr_entry_prop_status_doc(const struct property *p, const char *lang)
-{    
+{
     extern const char *tvh_doc_dvr_status_property[];
     return prop_md_doc(tvh_doc_dvr_status_property, lang);
 }

--- a/src/dvr/dvr_timerec.c
+++ b/src/dvr/dvr_timerec.c
@@ -505,7 +505,7 @@ dvr_timerec_entry_class_weekdays_rend(void *o, const char *lang)
 }
 
 static uint32_t
-dvr_timerec_entry_class_owner_opts(void *o)
+dvr_timerec_entry_class_owner_opts(void *o, const property_t *p)
 {
   dvr_timerec_entry_t *dte = (dvr_timerec_entry_t *)o;
   if (dte && dte->dte_id.in_access &&

--- a/src/profile.c
+++ b/src/profile.c
@@ -183,7 +183,7 @@ profile_class_delete(idnode_t *self)
 }
 
 static uint32_t
-profile_class_enabled_opts(void *o)
+profile_class_enabled_opts(void *o, const property_t *p)
 {
   profile_t *pro = o;
   uint32_t r = 0;
@@ -231,7 +231,7 @@ profile_class_default_set(void *o, const void *v)
 }
 
 static uint32_t
-profile_class_name_opts(void *o)
+profile_class_name_opts(void *o, const property_t *p)
 {
   profile_t *pro = o;
   uint32_t r = 0;

--- a/src/prop.c
+++ b/src/prop.c
@@ -99,7 +99,7 @@ prop_write_values
     if (!f) continue;
 
     /* Ignore */
-    u32 = p->get_opts ? p->get_opts(obj) : p->opts;
+    u32 = p->get_opts ? p->get_opts(obj, p) : p->opts;
     if(u32 & optmask) continue;
 
     /* Sanity check */
@@ -223,7 +223,7 @@ prop_write_values
         break;
       }
     }
-  
+
     /* Setter */
     if (p->set && new)
       save = p->set(obj, new);
@@ -259,7 +259,7 @@ prop_read_value
   char buf[24];
 
   /* Ignore */
-  u32 = p->get_opts ? p->get_opts(obj) : p->opts;
+  u32 = p->get_opts ? p->get_opts(obj, p) : p->opts;
   if (u32 & optmask) return;
   if (p->type == PT_NONE) return;
 
@@ -276,7 +276,7 @@ prop_read_value
     assert(p->get); /* requirement */
     if (val)
       htsmsg_add_msg(m, name, (htsmsg_t*)val);
-  
+
   /* Single */
   } else {
     switch(p->type) {
@@ -362,7 +362,7 @@ prop_read_values
     const property_t *p;
     htsmsg_field_t *f;
     int b, total = 0, count = 0;
-    
+
     HTSMSG_FOREACH(f, list) {
       total++;
       if (!htsmsg_field_get_bool(f, &b)) {
@@ -476,7 +476,7 @@ prop_serialize_value
   }
 
   /* Options */
-  opts = pl->get_opts ? pl->get_opts(obj) : pl->opts;
+  opts = pl->get_opts ? pl->get_opts(obj, pl) : pl->opts;
   if (opts & PO_RDONLY)
     htsmsg_add_bool(m, "rdonly", 1);
   if (opts & PO_NOSAVE)

--- a/src/prop.h
+++ b/src/prop.h
@@ -114,7 +114,7 @@ typedef struct property {
   } def;
 
   /* Extended options */
-  uint32_t    (*get_opts) (void *ptr);
+  uint32_t    (*get_opts) (void *ptr, const struct property *prop);
 
   /* Documentation callback */
   char       *(*doc) ( const struct property *prop, const char *lang );


### PR DESCRIPTION
this would allow us to extend property options.
ex.:
```
uint32_t
my_get_opts(void *obj, const property_t *prop)
{
    uint32_t opts = prop->opts;

    if (obj && !(((mystruct *)obj)->enabled)) {
        opts |= PO_RDONLY;
    }
    return opts;
}
```
@perexg: please do not merge if you feel/know there is a better way to achieve the same result.