### PR TITLE
input: tvhdhomerun: Handle the device changing IP addresses

### DIFF
--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c
@@ -21,6 +21,7 @@
 #include "tvheadend.h"
 #include "tvhpoll.h"
 #include "streaming.h"
+#include "tcp.h"
 #include "tvhdhomerun_private.h"
 
 static int
@@ -722,8 +723,10 @@ tvhdhomerun_frontend_create(tvhdhomerun_device_t *hd, struct hdhomerun_discover_
        strstr(hfe->mi_name, " Tuner ") &&
        strstr(hfe->mi_name, " #"))) {
     char lname[256];
+    char ip[64];
+    tcp_get_str_from_ip((struct sockaddr *)&hd->hd_info.ip_address, ip, sizeof(ip));
     snprintf(lname, sizeof(lname), "HDHomeRun %s Tuner #%i (%s)",
-             dvb_type2str(type), hfe->hf_tunerNumber, hd->hd_info.ip_address);
+             dvb_type2str(type), hfe->hf_tunerNumber, ip);
     free(hfe->mi_name);
     hfe->mi_name = strdup(lname);
   }

--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun_private.h
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun_private.h
@@ -35,7 +35,7 @@ static struct hdhomerun_debug_t* hdhomerun_debug_obj = 0;
 
 struct tvhdhomerun_device_info
 {
-  char *ip_address;         /* IP address */
+  struct sockaddr_storage ip_address;         /* IP address */
   char *friendlyname;
   char *deviceModel;
   char *uuid;


### PR DESCRIPTION
Previously the device detection loop would always ignore HDHomeRuns
with the same UID as devices that had already been detected.  This
would not detect if an HDHomeRun changed IPs for any reason (e.g.
APIPA, misconfigured DHCP server) while TVHeadend was running,
requiring a restart to resume functionality.  Instead, if
a newly detected device has the same UID as an previously-detected
one but a different IP address, destroy the old device and recreate
it with the new IP address.