### PR TITLE
settings: minor code cleanup

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -228,7 +228,7 @@ hts_settings_load_one(const char *filename)
   /* Open */
   if (!(fp = fb_open(filename, 1, 0))) return NULL;
   size = fb_size(fp);
-  
+
   /* Load data */
   mem    = malloc(size+1);
   n      = fb_read(fp, mem, size);
@@ -396,6 +396,7 @@ int
 hts_settings_open_file(int for_write, const char *pathfmt, ...)
 {
   char path[PATH_MAX];
+  int flags;
   va_list ap;
 
   /* Build path */
@@ -408,7 +409,7 @@ hts_settings_open_file(int for_write, const char *pathfmt, ...)
     if (hts_settings_makedirs(path)) return -1;
 
   /* Open file */
-  int flags = for_write ? O_CREAT | O_TRUNC | O_WRONLY : O_RDONLY;
+  flags = for_write ? O_CREAT | O_TRUNC | O_WRONLY : O_RDONLY;
 
   return tvh_open(path, flags, S_IRUSR | S_IWUSR);
 }


### PR DESCRIPTION
Fixes a whitespace issue and puts a variable declaration at the start
of its scope rather then mid-scope which can improve portability.