### PR TITLE
Fix compilation error with Android NDK

### DIFF
--- a/src/api/api_idnode.c
+++ b/src/api/api_idnode.c
@@ -22,6 +22,11 @@
 #include "idnode.h"
 #include "htsmsg.h"
 #include "api.h"
+#if ENABLE_ANDROID
+#ifndef pthread_yield
+#define pthread_yield() sched_yield()
+#endif
+#endif
 
 htsmsg_t *
 api_idnode_flist_conf( htsmsg_t *args, const char *name )

--- a/src/api/api_idnode.c
+++ b/src/api/api_idnode.c
@@ -22,11 +22,6 @@
 #include "idnode.h"
 #include "htsmsg.h"
 #include "api.h"
-#if ENABLE_ANDROID
-#ifndef pthread_yield
-#define pthread_yield() sched_yield()
-#endif
-#endif
 
 htsmsg_t *
 api_idnode_flist_conf( htsmsg_t *args, const char *name )

--- a/src/compat.h
+++ b/src/compat.h
@@ -31,6 +31,9 @@
 #ifndef index
 #define index(...) strchr(__VA_ARGS__)
 #endif
+#ifndef pthread_yield
+#define pthread_yield() sched_yield()
+#endif
 #define S_IEXEC S_IXUSR
 #define epoll_create1(EPOLL_CLOEXEC) epoll_create(n)
 #define inotify_init1(IN_CLOEXEC) inotify_init()


### PR DESCRIPTION
pthread_yield is not implemented on Android NDK.
Using sched_yield instead