### PR TITLE
Fix C/Ku Label and Change switch frequency

### DIFF
--- a/src/input/mpegts/linuxdvb/linuxdvb_lnb.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_lnb.c
@@ -328,7 +328,7 @@ struct linuxdvb_lnb_conf linuxdvb_lnb_all[] = {
   },
   {
      { {
-       .ld_type    = "C 5150/Ku 11750 (22khz switch)",
+       .ld_type    = "C 5150/Ku 10750 (22kHz Switch)",
        .ld_tune    = linuxdvb_lnb_standard_tune,
        },
        .lnb_freq   = linuxdvb_lnb_standard_freq,
@@ -337,7 +337,10 @@ struct linuxdvb_lnb_conf linuxdvb_lnb_all[] = {
      },
      .lnb_low    =  5150000,
      .lnb_high   = 10750000,
-     .lnb_switch = 11700000,
+     /* Arbitrary midpoint chosen for switch activation,
+      * because some 10750 Ku feeds operate below 11.7GHz.
+      **/
+     .lnb_switch = 7950000,
   },
   {
     { {


### PR DESCRIPTION
* The C/Ku label was 5150/11700, in spite of the fact that the local
  oscillator frequencies were 5150/10750. This label is now changed to
  reflect the correct frequencies. Just to be clear: the frequencies
  themselves are unchanged, still at 5150/10750. Only the description
  changed.
* To accomodate feeds operating outside of the standardized band
  (11.7GHz - 12.2Ghz), (eg: 11175 V 4200 @ 71.8W,) the switch is now set
  to operate at an arbitrary midpoint of 7.95, rather than the lower
  edge of the standard Ku freq.

Signed-off-by: Nicholas Sielicki <sielicki@bitwise>