### PR TITLE
tvhdhomerun: fix full mux pid filter

### DIFF
--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c
@@ -331,7 +331,10 @@ static void tvhdhomerun_device_open_pid(tvhdhomerun_frontend_t *hfe, int pid) {
   tvhdebug("tvhdhomerun", "current pfilter: %s", pfilter);
 
   /* make sure the pid maps to a max of 0x1FFF, API will reject the call otherwise */
-  pid = (pid & 0x1FFF);
+  if(pid > 0x1FFF) {
+    tvhlog(LOG_ERR, "tvhdhomerun", "pid %d is too large, masking to API maximum of 0x1FFF", pid);
+    pid = (pid & 0x1FFF);
+  }
 
   memset(buf, 0x00, sizeof(buf));
   snprintf(buf, sizeof(buf), "0x%04x", pid);


### PR DESCRIPTION
I came across a warning message during some debugging that caught my attention. The original code performed a check for raw (full) PID subscriptions that did not work, and moreover the resulting call to the hdhomerun API failed because it simply refuses to subscribe to PIDs above 0x1FFF.

My proposed fix: detect the full mux subscription correctly, set the PID filter to 0x0 - 0x1FFF in that case. I also added a mask to prevent specific subscriptions above 0x1FFF, those will not work anyway.