### PR TITLE
webui: add program image (when available) to epg detailed window

### DIFF
--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -95,6 +95,12 @@ tvheadend.epgDetails = function(event) {
     if (event.start && event.stop && event.stop - event.start > 0)
         duration = (event.stop - event.start) / 1000;
 
+    if (event.image != null && event.image.length > 0) {
+        content += '<div>';
+        content += '<img class="x-epg-image" src="' + event.image + '">';
+        content += '</div>';
+    }
+
     if (event.channelIcon != null && event.channelIcon.length > 0) {
         content += '<img class="x-epg-chicon" src="' + event.channelIcon + '">';
         chicon = 1;
@@ -405,6 +411,7 @@ tvheadend.epg = function() {
             { name: 'summary' },
             { name: 'description' },
             { name: 'episodeOnscreen' },
+            { name: 'image' },
             {
                 name: 'start',
                 type: 'date',

--- a/src/webui/static/app/ext.css
+++ b/src/webui/static/app/ext.css
@@ -698,6 +698,13 @@
     max-height: 99px;
 }
 
+.x-epg-image{
+    display: block;
+    margin: 5px;
+    max-height: 300px;
+    width: auto;
+}
+
 .x-epg-time {
     margin: 5px 5px 5px 10px;
 }


### PR DESCRIPTION
Show the program image in the EPG detailed window if available (depending on XMLTV grabber used)
![epg_with_preview](https://cloud.githubusercontent.com/assets/20028221/16178769/f40e6d2a-3651-11e6-8675-f233efc531ac.png)
