### PR TITLE
(not for merging) webui: editor form customization

### DIFF
--- a/src/webui/static/app/idnode.js
+++ b/src/webui/static/app/idnode.js
@@ -884,6 +884,7 @@ tvheadend.idnode_editor_form = function(uilevel, d, meta, panel, conf)
     var df = [];
     var groups = null;
     var width = 0;
+    var hiddenFields = [];
 
     /* Fields */
     for (var i = 0; i < d.length; i++) {
@@ -919,7 +920,9 @@ tvheadend.idnode_editor_form = function(uilevel, d, meta, panel, conf)
                 ]
             });
         }
-        if (p.group && meta && meta.groups) {
+        if (p.hidden) {
+            hiddenFields.push(f);
+        } else if (p.group && meta && meta.groups) {
             f.tvh_uilevel = p.expert ? 'expert' : (p.advanced ? 'advanced' : 'basic');
             if (!groups)
                 groups = {};
@@ -1046,7 +1049,20 @@ tvheadend.idnode_editor_form = function(uilevel, d, meta, panel, conf)
         if (rf.length)
             panel.add(newFieldSet({ title: _("Read-only Info"), items: rf, collapsed: 'true'}));
     }
+
+    if (hiddenFields.length) {
+        var f = newFieldSet({ items: hiddenFields });
+        f.setVisible(false);
+        panel.add(f);
+    }
+
+    // form customization (if any) before layout()
+    if (conf.forms && (meta['class'] in conf.forms)) {
+        conf.forms[meta['class']](panel.getForm());
+    }
+
     panel.doLayout();
+
     if (width)
         panel.fixedWidth = width + 50;
     if (conf.uuids) {
@@ -1085,7 +1101,8 @@ tvheadend.idnode_editor = function(_uilevel, item, conf)
         var c = {
             showpwd: conf.showpwd,
             uuids: conf.uuids,
-            labelWidth: conf.labelWidth || 200
+            labelWidth: conf.labelWidth || 200,
+            forms: conf.forms
         };
 
         tvheadend.idnode_editor_form(uilevel, item.props || item.params, item.meta, panel, c);
@@ -1362,10 +1379,14 @@ tvheadend.idnode_create = function(conf, onlyDefault, cloneValues)
                         pclass = r.get(conf.select.valueField);
                         win.setTitle(String.format(_('Add {0}'), s.lastSelectionText));
                         panel.remove(s);
-                        tvheadend.idnode_editor_form(uilevel, d, r.json, panel, { create: true, showpwd: true });
+                        tvheadend.idnode_editor_form(uilevel, d, r.json, panel, { create: true, showpwd: true, forms: conf.forms });
                         abuttons.save.setVisible(true);
                         abuttons.apply.setVisible(true);
                         win.setOriginSize(true);
+                        if (conf.select.formField) {
+                            values = values || {};
+                            values[conf.select.formField] = r.data[conf.select.valueField];
+                        }
                         if (values)
                             panel.getForm().setValues(values);
                     }
@@ -2289,6 +2310,9 @@ tvheadend.idnode_form_grid = function(panel, conf)
                 text: _('Add'),
                 disabled: false,
                 handler: function() {
+                    if (!conf.add.forms && conf.forms) {
+                        conf.add['forms'] = conf['forms'];
+                    }
                     tvheadend.idnode_create(conf.add, true);
                 }
             });
@@ -2474,7 +2498,8 @@ tvheadend.idnode_form_grid = function(panel, conf)
                         noButtons: true,
                         width: 730,
                         noautoWidth: true,
-                        showpwd: conf.showpwd
+                        showpwd: conf.showpwd,
+                        forms: conf.forms
                     });
                     abuttons.save.setDisabled(false);
                     abuttons.undo.setDisabled(false);


### PR DESCRIPTION
@perexg I thought that if you saw some code my needs might get clearer.

So, in codec profiles ([wip](https://github.com/lekma/tvheadend/commits/transcoding)) I rely heavily on form customization to setup field max/range/list (you can see examples [here](https://github.com/lekma/tvheadend/commit/00998bae5d7f4426f13464e309537ba2192e585d#diff-813dba2d1046e951234d273fb7719265R31) or [here](https://github.com/lekma/tvheadend/commit/00998bae5d7f4426f13464e309537ba2192e585d#diff-813dba2d1046e951234d273fb7719265R69)).

Now some of those fields exist for some codecs but not for others so I need them to be hidden by default and shown if and only if we know the codec exists and is enabled (see [here](https://github.com/lekma/tvheadend/commit/00998bae5d7f4426f13464e309537ba2192e585d#diff-8a1eb215f6eb4ed749b2390b309afae9R37)), unfortunately at profile creation time (in the gui) we don't know yet. But, I still want some customization to happen see [genericCBRvsVBR](https://github.com/lekma/tvheadend/commit/00998bae5d7f4426f13464e309537ba2192e585d#diff-813dba2d1046e951234d273fb7719265R6) for example, so I need all the fields to be in the form even though some of them won't be shown.

That's  the short explanation for it (the long one involves explaining why I didn't make a different customization function for creation even though I allow for it [here](https://github.com/lekma/tvheadend/commit/b0766efd7637f35a294ab990ca861ab2b4777e69#diff-13e2411ad4cc0d171a6a1a7ab12116a8R2313) (lazyness?)).

Anyway, I hope those links will make my irc ramblings more obvious.