### PR TITLE
Fix FSF address

### DIFF
--- a/src/avahi.c
+++ b/src/avahi.c
@@ -31,7 +31,7 @@
 
   You should have received a copy of the GNU Lesser General Public
   License along with avahi; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
   USA.
 ***/
 

--- a/src/descrambler/ffdecsa/FFdecsa.c
+++ b/src/descrambler/ffdecsa/FFdecsa.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 

--- a/src/descrambler/ffdecsa/FFdecsa.h
+++ b/src/descrambler/ffdecsa/FFdecsa.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 

--- a/src/descrambler/ffdecsa/fftable.h
+++ b/src/descrambler/ffdecsa/fftable.h
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #ifndef FFTABLE_H

--- a/src/descrambler/ffdecsa/parallel_032_int.h
+++ b/src/descrambler/ffdecsa/parallel_032_int.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #include "parallel_std_def.h"

--- a/src/descrambler/ffdecsa/parallel_064_mmx.h
+++ b/src/descrambler/ffdecsa/parallel_064_mmx.h
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #include <mmintrin.h>

--- a/src/descrambler/ffdecsa/parallel_128_sse2.h
+++ b/src/descrambler/ffdecsa/parallel_128_sse2.h
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 #include <emmintrin.h>

--- a/src/descrambler/ffdecsa/parallel_generic.h
+++ b/src/descrambler/ffdecsa/parallel_generic.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 

--- a/src/descrambler/ffdecsa/parallel_std_def.h
+++ b/src/descrambler/ffdecsa/parallel_std_def.h
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 #define FFXOR(a,b) ((a)^(b))

--- a/src/descrambler/ffdecsa/stream.c
+++ b/src/descrambler/ffdecsa/stream.c
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 

--- a/src/extra/capmt_ca.c
+++ b/src/extra/capmt_ca.c
@@ -17,8 +17,8 @@
  *
  * You should have received a copy of the GNU Library General Public
  * License along with this library; if not, write to the
- * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- * Boston, MA 02111-1307, USA.
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
  */
 
 //#define DEBUG

--- a/src/redblack.h
+++ b/src/redblack.h
@@ -14,8 +14,8 @@
 * for more details.
 *
 * You should have received a copy of the GNU General Public License along with
-* software; if not, write to the Free Software Foundation, Inc., 59 Temple
-* Place, Suite 330, Boston, MA  02111-1307 USA
+* software; if not, write to the Free Software Foundation, Inc., 51 Franklin
+* Street, Fifth Floor, Boston, MA 02110-1301 USA
 *
 * Written by Mark Edel
 * Macroified + additional support functions by Andreas Öman


### PR DESCRIPTION
The license headers have old addresses for the FSF. This trivial patch fixes such addresses.