### PR TITLE
Fix timeshift hangs.

### DIFF
--- a/src/input/mpegts/tsdemux.c
+++ b/src/input/mpegts/tsdemux.c
@@ -80,6 +80,13 @@ ts_recv_packet0
         if (!error)
           errors++;
         error |= 2;
+
+        // Skip packet and return so it does not corupt time offset
+        // for timeshift        
+        st->es_cc = (cc + 1) & 0xf;
+        ts_skip(t,tsb,len);
+        return;
+
       }
       st->es_cc = (cc + 1) & 0xf;
     }
@@ -244,7 +251,13 @@ ts_recv_packet1
     }
 
   } else {
-    ts_recv_packet0(t, st, tsb, len);
+    // If we had an errot, skip packet and return so it does not corrupt
+    // time offset for timeshift        
+    if(error){
+      ts_skip(t,tsb,len);
+    } else {
+      ts_recv_packet0(t, st, tsb, len);
+    }
   }
   pthread_mutex_unlock(&t->s_stream_mutex);
   return 1;


### PR DESCRIPTION
This patch simply skips a packet if it finds a MPEG transport or continuity error.

This is with respect to: https://tvheadend.org/issues/3899

I guessing this is the correct way to have my changes reviewed