### PR TITLE
SAT>IP: manufacturer optional on SAT>IP discovery

### DIFF
--- a/src/input/mpegts/satip/satip.c
+++ b/src/input/mpegts/satip/satip.c
@@ -844,7 +844,7 @@ satip_discovery_http_closed(http_client_t *hc, int errn)
   if ((friendlyname = htsmsg_xml_get_cdata_str(device, "friendlyName")) == NULL)
     goto finish;
   if ((manufacturer = htsmsg_xml_get_cdata_str(device, "manufacturer")) == NULL)
-    goto finish;
+    manufacturer = "";
   if ((manufacturerURL = htsmsg_xml_get_cdata_str(device, "manufacturerURL")) == NULL)
     manufacturerURL = "";
   if ((modeldesc    = htsmsg_xml_get_cdata_str(device, "modelDescription")) == NULL)


### PR DESCRIPTION
As the XML element „manufacturer“ seems to be optional, treat it as optional.

This is the discovery.xml from my SelfSat Dish. It was not found by the discovery after the last Firmware update, which seems to include an empty <manufacturer/> tag.

```xml
<root xmlns="urn:schemas-upnp-org:device-1-0" configId="0">
    <specVersion>
        <major>1</major>
        <minor>1</minor>
    </specVersion>
    <device>
        <deviceType>urn:ses-com:device:SatIPServer:1</deviceType>
        <friendlyName>SELFSAT-IP</friendlyName>
        <manufacturer/>
        <manufacturerURL/>
        <modelDescription>This is GMIM-8000 SAT>IP server</modelDescription>
        <modelName>GMIM-8000</modelName>
        <modelNumber>1.0</modelNumber>
        <modelURL/>
        <serialNumber>manufacturer's serial number</serialNumber>
        <UDN>uuid:213ef372-1dd2-11b2-afd5-8093d24cb32d</UDN>
        <UPC>123456789012</UPC>
        <iconList>
            <icon>
                <mimetype>image/jpeg</mimetype>
                <width>48</width>
                <height>48</height>
                <depth>24</depth>
                <url>small.jpg</url>
            </icon>
            <icon>
                <mimetype>image/jpeg</mimetype>
                <width>120</width>
                <height>120</height>
                <depth>24</depth>
                <url>large.jpg</url>
            </icon>
            <icon>
                <mimetype>image/png</mimetype>
                <width>48</width>
                <height>48</height>
                <depth>32</depth>
                <url>small.png</url>
            </icon>
            <icon>
                <mimetype>image/png</mimetype>
                <width>120</width>
                <height>120</height>
                <depth>32</depth>
                <url>large.png</url>
            </icon>
        </iconList>
        <presentationURL>index.html</presentationURL>
        <satip:X_SATIPCAP xmlns:satip="urn:ses-com:satip">DVBS2-8</satip:X_SATIPCAP>
    </device>
</root>
```