### PR TITLE
Improve handling of a manual deleted dvr [WIP]

### DIFF
--- a/src/api/api_dvr.c
+++ b/src/api/api_dvr.c
@@ -245,8 +245,8 @@ api_dvr_entry_create_by_event
                                        e, 0, 0,
                                        perm->aa_username,
                                        perm->aa_representative,
-                                       NULL, DVR_PRIO_NORMAL, DVR_RET_DVRCONFIG,
-                                       DVR_RET_DVRCONFIG, comment);
+                                       NULL, DVR_PRIO_NORMAL, DVR_RET_REM_DVRCONFIG,
+                                       DVR_RET_REM_DVRCONFIG, comment);
         if (de)
           idnode_changed(&de->de_id);
       }

--- a/src/api/api_dvr.c
+++ b/src/api/api_dvr.c
@@ -69,7 +69,7 @@ static int is_dvr_entry_finished(dvr_entry_t *entry)
 {
   dvr_entry_sched_state_t state = entry->de_sched_state;
   return state == DVR_COMPLETED && !entry->de_last_error &&
-         dvr_get_filesize(entry, 0) != -1 &&
+         (dvr_get_filesize(entry, 0) != -1 || entry->de_file_removed) &&
          entry->de_data_errors < DVR_MAX_DATA_ERRORS;
 }
 

--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -54,6 +54,7 @@ typedef struct dvr_config {
   int dvr_clone;
   uint32_t dvr_rerecord_errors;
   uint32_t dvr_retention_days;
+  uint32_t dvr_retention_minimal;
   uint32_t dvr_removal_days;
   uint32_t dvr_autorec_max_count;
   uint32_t dvr_autorec_max_sched_count;
@@ -128,24 +129,25 @@ typedef enum {
 } dvr_rs_state_t;
 
 typedef enum {
-  DVR_RET_DVRCONFIG = 0,
-  DVR_RET_1DAY      = 1,
-  DVR_RET_3DAY      = 3,
-  DVR_RET_5DAY      = 5,
-  DVR_RET_1WEEK     = 7,
-  DVR_RET_2WEEK     = 14,
-  DVR_RET_3WEEK     = 21,
-  DVR_RET_1MONTH    = (30+1),
-  DVR_RET_2MONTH    = (60+2),
-  DVR_RET_3MONTH    = (90+2),
-  DVR_RET_6MONTH    = (180+3),
-  DVR_RET_1YEAR     = (365+1),
-  DVR_RET_2YEARS    = (2*365+1),
-  DVR_RET_3YEARS    = (3*365+1),
-  DVR_RET_ONREMOVE  = INT32_MAX-1, // for retention only
-  DVR_RET_SPACE     = INT32_MAX-1, // for removal only
-  DVR_RET_FOREVER   = INT32_MAX
-} dvr_retention_t;
+  DVR_RET_MIN_DISABLED  = 0, /* For dvr config minimal retention only */
+  DVR_RET_REM_DVRCONFIG = 0,
+  DVR_RET_REM_1DAY      = 1,
+  DVR_RET_REM_3DAY      = 3,
+  DVR_RET_REM_5DAY      = 5,
+  DVR_RET_REM_1WEEK     = 7,
+  DVR_RET_REM_2WEEK     = 14,
+  DVR_RET_REM_3WEEK     = 21,
+  DVR_RET_REM_1MONTH    = (30+1),
+  DVR_RET_REM_2MONTH    = (60+2),
+  DVR_RET_REM_3MONTH    = (90+2),
+  DVR_RET_REM_6MONTH    = (180+3),
+  DVR_RET_REM_1YEAR     = (365+1),
+  DVR_RET_REM_2YEARS    = (2*365+1),
+  DVR_RET_REM_3YEARS    = (3*365+1),
+  DVR_RET_ONREMOVE      = INT32_MAX-1, /* For retention only */
+  DVR_REM_SPACE         = INT32_MAX-1, /* For removal only */
+  DVR_RET_REM_FOREVER   = INT32_MAX
+} dvr_retention_removal_t;
 
 typedef struct dvr_entry {
 
@@ -204,6 +206,7 @@ typedef struct dvr_entry {
   int de_pri;
   int de_dont_reschedule;
   int de_dont_rerecord;
+  uint32_t de_file_removed;
   uint32_t de_retention;
   uint32_t de_removal;
 
@@ -449,7 +452,7 @@ void dvr_config_destroy_by_profile(profile_t *pro, int delconf);
 
 static inline uint32_t dvr_retention_cleanup(uint32_t val)
 {
-  return val > DVR_RET_FOREVER ? DVR_RET_FOREVER : val;
+  return val > DVR_RET_REM_FOREVER ? DVR_RET_REM_FOREVER : val;
 }
 
 /*
@@ -584,7 +587,9 @@ void dvr_entry_dec_ref(dvr_entry_t *de);
 
 int dvr_entry_delete(dvr_entry_t *de);
 
-void dvr_entry_cancel_delete(dvr_entry_t *de, int rerecord);
+void dvr_entry_cancel_delete(dvr_entry_t *de, int rerecord, int forcedestroy);
+
+void dvr_entry_trydestroy(dvr_entry_t *de);
 
 int dvr_entry_file_moved(const char *src, const char *dst);
 

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -125,7 +125,7 @@ dvr_autorec_completed(dvr_autorec_entry_t *dae, int error_code)
     if (de_prev) {
       tvhinfo(LS_DVR, "autorec %s removing recordings %s (allowed count %u total %u)",
               dae->dae_name, idnode_uuid_as_str(&de_prev->de_id, ubuf), max_count, total);
-      dvr_entry_cancel_delete(de_prev, 0);
+      dvr_entry_cancel_delete(de_prev, 0, 0);
     }
   }
 }
@@ -1189,7 +1189,7 @@ const idclass_t dvr_autorec_entry_class = {
       .id       = "retention",
       .name     = N_("DVR log retention"),
       .desc     = N_("Number of days to retain infomation about recording."),
-      .def.i    = DVR_RET_DVRCONFIG,
+      .def.i    = DVR_RET_REM_DVRCONFIG,
       .off      = offsetof(dvr_autorec_entry_t, dae_retention),
       .list     = dvr_entry_class_retention_list,
       .opts     = PO_HIDDEN | PO_EXPERT | PO_DOC_NLIST,
@@ -1199,7 +1199,7 @@ const idclass_t dvr_autorec_entry_class = {
       .id       = "removal",
       .name     = N_("DVR file retention period"),
       .desc     = N_("Number of days to keep the recorded file."),
-      .def.i    = DVR_RET_DVRCONFIG,
+      .def.i    = DVR_RET_REM_DVRCONFIG,
       .off      = offsetof(dvr_autorec_entry_t, dae_removal),
       .list     = dvr_entry_class_removal_list,
       .opts     = PO_HIDDEN | PO_ADVANCED | PO_DOC_NLIST,
@@ -1506,12 +1506,12 @@ uint32_t
 dvr_autorec_get_retention_days( dvr_autorec_entry_t *dae )
 {
   if (dae->dae_retention > 0) {
-    if (dae->dae_retention > DVR_RET_FOREVER)
-      return DVR_RET_FOREVER;
+    if (dae->dae_retention > DVR_RET_REM_FOREVER)
+      return DVR_RET_REM_FOREVER;
 
     uint32_t removal = dvr_autorec_get_removal_days(dae);
     /* As we need the db entry when deleting the file on disk */
-    if (removal != DVR_RET_FOREVER && removal > dae->dae_retention)
+    if (removal != DVR_RET_REM_FOREVER && removal > dae->dae_retention)
       return DVR_RET_ONREMOVE;
 
     return dae->dae_retention;
@@ -1526,8 +1526,8 @@ uint32_t
 dvr_autorec_get_removal_days( dvr_autorec_entry_t *dae )
 {
   if (dae->dae_removal > 0) {
-    if (dae->dae_removal > DVR_RET_FOREVER)
-      return DVR_RET_FOREVER;
+    if (dae->dae_removal > DVR_RET_REM_FOREVER)
+      return DVR_RET_REM_FOREVER;
 
     return dae->dae_removal;
   }

--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -178,7 +178,8 @@ dvr_config_create(const char *name, const char *uuid, htsmsg_t *conf)
   cfg->dvr_enabled = 1;
   cfg->dvr_config_name = strdup(name);
   cfg->dvr_retention_days = DVR_RET_ONREMOVE;
-  cfg->dvr_removal_days = DVR_RET_FOREVER;
+  cfg->dvr_retention_minimal = DVR_RET_MIN_DISABLED;
+  cfg->dvr_removal_days = DVR_RET_REM_FOREVER;
   cfg->dvr_clone = 1;
   cfg->dvr_tag_files = 1;
   cfg->dvr_skip_commercials = 1;
@@ -531,13 +532,13 @@ dvr_config_changed(dvr_config_t *cfg)
   dvr_config_storage_check(cfg);
   if (cfg->dvr_cleanup_threshold_free < 50)
     cfg->dvr_cleanup_threshold_free = 50; // as checking is only periodically, lower is not save
-  if (cfg->dvr_removal_days != DVR_RET_FOREVER &&
+  if (cfg->dvr_removal_days != DVR_RET_REM_FOREVER &&
       cfg->dvr_removal_days > cfg->dvr_retention_days)
     cfg->dvr_retention_days = DVR_RET_ONREMOVE;
-  if (cfg->dvr_removal_days > DVR_RET_FOREVER)
-    cfg->dvr_removal_days = DVR_RET_FOREVER;
-  if (cfg->dvr_retention_days > DVR_RET_FOREVER)
-    cfg->dvr_retention_days = DVR_RET_FOREVER;
+  if (cfg->dvr_removal_days > DVR_RET_REM_FOREVER)
+    cfg->dvr_removal_days = DVR_RET_REM_FOREVER;
+  if (cfg->dvr_retention_days > DVR_RET_REM_FOREVER)
+    cfg->dvr_retention_days = DVR_RET_REM_FOREVER;
 }
 
 
@@ -719,21 +720,21 @@ static htsmsg_t *
 dvr_config_class_removal_list ( void *o, const char *lang )
 {
   static const struct strtab_u32 tab[] = {
-    { N_("1 day"),              DVR_RET_1DAY },
-    { N_("3 days"),             DVR_RET_3DAY },
-    { N_("5 days"),             DVR_RET_5DAY },
-    { N_("1 week"),             DVR_RET_1WEEK },
-    { N_("2 weeks"),            DVR_RET_2WEEK },
-    { N_("3 weeks"),            DVR_RET_3WEEK },
-    { N_("1 month"),            DVR_RET_1MONTH },
-    { N_("2 months"),           DVR_RET_2MONTH },
-    { N_("3 months"),           DVR_RET_3MONTH },
-    { N_("6 months"),           DVR_RET_6MONTH },
-    { N_("1 year"),             DVR_RET_1YEAR },
-    { N_("2 years"),            DVR_RET_2YEARS },
-    { N_("3 years"),            DVR_RET_3YEARS },
-    { N_("Maintained space"),   DVR_RET_SPACE },
-    { N_("Forever"),            DVR_RET_FOREVER },
+    { N_("1 day"),              DVR_RET_REM_1DAY },
+    { N_("3 days"),             DVR_RET_REM_3DAY },
+    { N_("5 days"),             DVR_RET_REM_5DAY },
+    { N_("1 week"),             DVR_RET_REM_1WEEK },
+    { N_("2 weeks"),            DVR_RET_REM_2WEEK },
+    { N_("3 weeks"),            DVR_RET_REM_3WEEK },
+    { N_("1 month"),            DVR_RET_REM_1MONTH },
+    { N_("2 months"),           DVR_RET_REM_2MONTH },
+    { N_("3 months"),           DVR_RET_REM_3MONTH },
+    { N_("6 months"),           DVR_RET_REM_6MONTH },
+    { N_("1 year"),             DVR_RET_REM_1YEAR },
+    { N_("2 years"),            DVR_RET_REM_2YEARS },
+    { N_("3 years"),            DVR_RET_REM_3YEARS },
+    { N_("Maintained space"),   DVR_REM_SPACE },
+    { N_("Forever"),            DVR_RET_REM_FOREVER },
   };
   return strtab2htsmsg_u32(tab, 1, lang);
 }
@@ -742,21 +743,44 @@ static htsmsg_t *
 dvr_config_class_retention_list ( void *o, const char *lang )
 {
   static const struct strtab_u32 tab[] = {
-    { N_("1 day"),              DVR_RET_1DAY },
-    { N_("3 days"),             DVR_RET_3DAY },
-    { N_("5 days"),             DVR_RET_5DAY },
-    { N_("1 week"),             DVR_RET_1WEEK },
-    { N_("2 weeks"),            DVR_RET_2WEEK },
-    { N_("3 weeks"),            DVR_RET_3WEEK },
-    { N_("1 month"),            DVR_RET_1MONTH },
-    { N_("2 months"),           DVR_RET_2MONTH },
-    { N_("3 months"),           DVR_RET_3MONTH },
-    { N_("6 months"),           DVR_RET_6MONTH },
-    { N_("1 year"),             DVR_RET_1YEAR },
-    { N_("2 years"),            DVR_RET_2YEARS },
-    { N_("3 years"),            DVR_RET_3YEARS },
+    { N_("1 day"),              DVR_RET_REM_1DAY },
+    { N_("3 days"),             DVR_RET_REM_3DAY },
+    { N_("5 days"),             DVR_RET_REM_5DAY },
+    { N_("1 week"),             DVR_RET_REM_1WEEK },
+    { N_("2 weeks"),            DVR_RET_REM_2WEEK },
+    { N_("3 weeks"),            DVR_RET_REM_3WEEK },
+    { N_("1 month"),            DVR_RET_REM_1MONTH },
+    { N_("2 months"),           DVR_RET_REM_2MONTH },
+    { N_("3 months"),           DVR_RET_REM_3MONTH },
+    { N_("6 months"),           DVR_RET_REM_6MONTH },
+    { N_("1 year"),             DVR_RET_REM_1YEAR },
+    { N_("2 years"),            DVR_RET_REM_2YEARS },
+    { N_("3 years"),            DVR_RET_REM_3YEARS },
     { N_("On file removal"),    DVR_RET_ONREMOVE },
-    { N_("Forever"),            DVR_RET_FOREVER },
+    { N_("Forever"),            DVR_RET_REM_FOREVER },
+  };
+  return strtab2htsmsg_u32(tab, 1, lang);
+}
+
+static htsmsg_t *
+dvr_config_class_retention_list_minimal ( void *o, const char *lang )
+{
+  static const struct strtab_u32 tab[] = {
+    { N_("Disabled"),           DVR_RET_MIN_DISABLED },
+    { N_("1 day"),              DVR_RET_REM_1DAY },
+    { N_("3 days"),             DVR_RET_REM_3DAY },
+    { N_("5 days"),             DVR_RET_REM_5DAY },
+    { N_("1 week"),             DVR_RET_REM_1WEEK },
+    { N_("2 weeks"),            DVR_RET_REM_2WEEK },
+    { N_("3 weeks"),            DVR_RET_REM_3WEEK },
+    { N_("1 month"),            DVR_RET_REM_1MONTH },
+    { N_("2 months"),           DVR_RET_REM_2MONTH },
+    { N_("3 months"),           DVR_RET_REM_3MONTH },
+    { N_("6 months"),           DVR_RET_REM_6MONTH },
+    { N_("1 year"),             DVR_RET_REM_1YEAR },
+    { N_("2 years"),            DVR_RET_REM_2YEARS },
+    { N_("3 years"),            DVR_RET_REM_3YEARS },
+    { N_("Forever"),            DVR_RET_REM_FOREVER },
   };
   return strtab2htsmsg_u32(tab, 1, lang);
 }
@@ -900,10 +924,21 @@ const idclass_t dvr_config_class = {
       .type     = PT_U32,
       .id       = "retention-days",
       .name     = N_("DVR log retention period"),
-      .desc     = N_("Number of days to retain infomation about recordings."),
+      .desc     = N_("Number of days to retain information about recordings. Once this period is exceeded, duplicate detection will not be possible for this recording."),
       .off      = offsetof(dvr_config_t, dvr_retention_days),
       .def.u32  = DVR_RET_ONREMOVE,
       .list     = dvr_config_class_retention_list,
+      .opts     = PO_EXPERT | PO_DOC_NLIST,
+      .group    = 1,
+    },
+    {
+      .type     = PT_U32,
+      .id       = "retention-minimal",
+      .name     = N_("Minimal log retention period"),
+      .desc     = N_("Minimal number of days to retain information from recordings that where deleted manually. Once this period is exceeded, duplicate detection will not be possible for this recording."),
+      .off      = offsetof(dvr_config_t, dvr_retention_minimal),
+      .def.u32  = DVR_RET_MIN_DISABLED,
+      .list     = dvr_config_class_retention_list_minimal,
       .opts     = PO_EXPERT | PO_DOC_NLIST,
       .group    = 1,
     },
@@ -913,7 +948,7 @@ const idclass_t dvr_config_class = {
       .name     = N_("DVR file retention period"),
       .desc     = N_("Number of days to keep the recorded files."),
       .off      = offsetof(dvr_config_t, dvr_removal_days),
-      .def.u32  = DVR_RET_FOREVER,
+      .def.u32  = DVR_RET_REM_FOREVER,
       .list     = dvr_config_class_removal_list,
       .opts     = PO_DOC_NLIST,
       .group    = 1,

--- a/src/dvr/dvr_timerec.c
+++ b/src/dvr/dvr_timerec.c
@@ -625,7 +625,7 @@ const idclass_t dvr_timerec_entry_class = {
       .id       = "retention",
       .name     = N_("DVR log retention"),
       .desc     = N_("Number of days to retain entry information."),
-      .def.i    = DVR_RET_DVRCONFIG,
+      .def.i    = DVR_RET_REM_DVRCONFIG,
       .off      = offsetof(dvr_timerec_entry_t, dte_retention),
       .list     = dvr_entry_class_retention_list,
       .opts     = PO_EXPERT | PO_DOC_NLIST,
@@ -635,7 +635,7 @@ const idclass_t dvr_timerec_entry_class = {
       .id       = "removal",
       .name     = N_("DVR file retention period"),
       .desc     = N_("Number of days to keep the recorded file."),
-      .def.i    = DVR_RET_DVRCONFIG,
+      .def.i    = DVR_RET_REM_DVRCONFIG,
       .off      = offsetof(dvr_timerec_entry_t, dte_removal),
       .list     = dvr_entry_class_removal_list,
       .opts     = PO_ADVANCED | PO_DOC_NLIST,
@@ -788,11 +788,11 @@ uint32_t
 dvr_timerec_get_retention_days( dvr_timerec_entry_t *dte )
 {
   if (dte->dte_retention > 0) {
-    if (dte->dte_retention > DVR_RET_FOREVER)
-      return DVR_RET_FOREVER;
+    if (dte->dte_retention > DVR_RET_REM_FOREVER)
+      return DVR_RET_REM_FOREVER;
 
     /* As we need the db entry when deleting the file on disk */
-    if (dvr_timerec_get_removal_days(dte) != DVR_RET_FOREVER &&
+    if (dvr_timerec_get_removal_days(dte) != DVR_RET_REM_FOREVER &&
         dvr_timerec_get_removal_days(dte) > dte->dte_retention)
       return DVR_RET_ONREMOVE;
 
@@ -808,8 +808,8 @@ uint32_t
 dvr_timerec_get_removal_days( dvr_timerec_entry_t *dte )
 {
   if (dte->dte_removal > 0) {
-    if (dte->dte_removal > DVR_RET_FOREVER)
-      return DVR_RET_FOREVER;
+    if (dte->dte_removal > DVR_RET_REM_FOREVER)
+      return DVR_RET_REM_FOREVER;
 
     return dte->dte_removal;
   }

--- a/src/dvr/dvr_vfsmgr.c
+++ b/src/dvr/dvr_vfsmgr.c
@@ -231,7 +231,7 @@ dvr_disk_space_cleanup(dvr_config_t *cfg)
       if (dvr_entry_get_stop_time(de) > stoptime)
         continue;
 
-      if (dvr_entry_get_removal_days(de) != DVR_RET_SPACE) // only remove the allowed ones
+      if (dvr_entry_get_removal_days(de) != DVR_REM_SPACE) // only remove the allowed ones
         continue;
 
       if (dvr_get_filename(de) == NULL || dvr_get_filesize(de, DVR_FILESIZE_TOTAL) <= 0)

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -629,9 +629,9 @@ htsp_serierec_convert(htsp_connection_t *htsp, htsmsg_t *in, channel_t *ch, int 
   if (!(retval = htsmsg_get_u32(in, "enabled", &u32)) || add)
     htsmsg_add_u32(conf, "enabled", !retval ? (u32 > 0 ? 1 : 0) : 1); // default on
   if (!(retval = htsmsg_get_u32(in, "retention", &u32)) || add)
-    htsmsg_add_u32(conf, "retention", !retval ? u32 : DVR_RET_DVRCONFIG);
+    htsmsg_add_u32(conf, "retention", !retval ? u32 : DVR_RET_REM_DVRCONFIG);
   if (!(retval = htsmsg_get_u32(in, "removal", &u32)) || add)
-    htsmsg_add_u32(conf, "removal", !retval ? u32 : DVR_RET_DVRCONFIG);
+    htsmsg_add_u32(conf, "removal", !retval ? u32 : DVR_RET_REM_DVRCONFIG);
   if(!(retval = htsmsg_get_u32(in, "priority", &u32)) || add)
     htsmsg_add_u32(conf, "pri", !retval ? u32 : DVR_PRIO_NORMAL);
   if ((str = htsmsg_get_str(in, "name")) || add)
@@ -1803,9 +1803,9 @@ htsp_method_addDvrEntry(htsp_connection_t *htsp, htsmsg_t *in)
   if(htsmsg_get_u32(in, "priority", &priority))
     priority = DVR_PRIO_NORMAL;
   if(htsmsg_get_u32(in, "retention", &retention))
-    retention = DVR_RET_DVRCONFIG;
+    retention = DVR_RET_REM_DVRCONFIG;
   if(htsmsg_get_u32(in, "removal", &removal))
-    removal = DVR_RET_DVRCONFIG;
+    removal = DVR_RET_REM_DVRCONFIG;
   comment = htsmsg_get_str(in, "comment");
   if (!(lang  = htsmsg_get_str(in, "language")))
     lang = htsp->htsp_language;
@@ -1934,8 +1934,8 @@ htsp_method_updateDvrEntry(htsp_connection_t *htsp, htsmsg_t *in)
   stop        = htsmsg_get_s64_or_default(in, "stop",       0);
   start_extra = htsmsg_get_s64_or_default(in, "startExtra", 0);
   stop_extra  = htsmsg_get_s64_or_default(in, "stopExtra",  0);
-  retention   = htsmsg_get_u32_or_default(in, "retention",  DVR_RET_DVRCONFIG);
-  removal     = htsmsg_get_u32_or_default(in, "removal",    DVR_RET_DVRCONFIG);
+  retention   = htsmsg_get_u32_or_default(in, "retention",  DVR_RET_REM_DVRCONFIG);
+  removal     = htsmsg_get_u32_or_default(in, "removal",    DVR_RET_REM_DVRCONFIG);
   priority    = htsmsg_get_u32_or_default(in, "priority",   DVR_PRIO_NORMAL);
   title       = htsmsg_get_str(in, "title");
   subtitle    = htsmsg_get_str(in, "subtitle");
@@ -1998,7 +1998,7 @@ htsp_method_deleteDvrEntry(htsp_connection_t *htsp, htsmsg_t *in)
   if (de == NULL)
     return out;
 
-  dvr_entry_cancel_delete(de, 0);
+  dvr_entry_cancel_delete(de, 0, 0);
 
   return htsp_success();
 }

--- a/src/webui/simpleui.c
+++ b/src/webui/simpleui.c
@@ -337,8 +337,8 @@ page_einfo(http_connection_t *hc, const char *remain, void *opaque)
   if((http_arg_get(&hc->hc_req_args, "rec")) != NULL) {
     de = dvr_entry_create_by_event(1, NULL, e, 0, 0, hc->hc_username ?: NULL,
                                    hc->hc_representative ?: NULL, NULL,
-                                   DVR_PRIO_NORMAL, DVR_RET_DVRCONFIG,
-				   DVR_RET_DVRCONFIG, "simpleui");
+                                   DVR_PRIO_NORMAL, DVR_RET_REM_DVRCONFIG,
+                                   DVR_RET_REM_DVRCONFIG, "simpleui");
   } else if(de != NULL && (http_arg_get(&hc->hc_req_args, "cancel")) != NULL) {
     de = dvr_entry_cancel(de, 0);
   }


### PR DESCRIPTION
The following user case is not handled correctly with the current code:
1) Autorec rule with duplicate prevention is set up.
2) Let's say that there are 5 upcoming identical episodes.
3) The first one will be recorded and the others not (detected as rerun of)
4) Now, the user watches that first recording and deletes it afterwards.
5) The video file and logfile are deleted.
6) Now the rerun detection fails because of the missing logfile and the show will be recorded again.

My idea was to keep the logfile when the user deletes a recording (htsp or webui).
For the webui, the dvr file will be moved to the failed recordings with the comment that the user deleted the file.

However I'm not familiar with the new stuff as parent, child, don't reschedule and don't rerecord. Maybe one of those are meant to prevent this issue? @perexg Can you please explain these methods a bit?

@perexg 