### PR TITLE
Correct the documented default config path

### DIFF
--- a/man/tvheadend.1
+++ b/man/tvheadend.1
@@ -29,7 +29,7 @@ Show built-in help information (may be more up to date).
 Service Configuration Options
 .TP
 \fB\-c\fR, \fB\-\-config\fR
-Specify an alternative config path; the default is \fI${HOME}/.hts\fR
+Specify an alternative config path; the default is \fI${HOME}/.hts/tvheadend\fR
 .TP
 \fB\-B\fR, \fB\-\-nobackup\fR
 Don't backup configuration tree at upgrade.


### PR DESCRIPTION
The documentation of the default for the config path option is wrong.

This can cause problems when migrating the location of the config path, e.g. when moving from a self-built tvheadend run with the default location to the fedora package, which is run with "-c /var/lib/tvheadend/config", as I need to know what the default path actually is to rename it. Moving/renaming $HOME/.hts does not pick up my settings whereas moving $HOME/.hts/tvheadend does.