### PR TITLE
Implemented "moved recordings" in order to improve the user experience, fixup #889

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -54,7 +54,6 @@ typedef struct dvr_config {
   int dvr_clone;
   uint32_t dvr_rerecord_errors;
   uint32_t dvr_retention_days;
-  uint32_t dvr_retention_minimal;
   uint32_t dvr_removal_days;
   uint32_t dvr_autorec_max_count;
   uint32_t dvr_autorec_max_sched_count;
@@ -588,9 +587,9 @@ void dvr_entry_dec_ref(dvr_entry_t *de);
 
 int dvr_entry_delete(dvr_entry_t *de);
 
-void dvr_entry_cancel_delete(dvr_entry_t *de, int rerecord, int forcedestroy);
+void dvr_entry_cancel_delete(dvr_entry_t *de, int rerecord);
 
-void dvr_entry_trydestroy(dvr_entry_t *de);
+void dvr_entry_cancel_remove(dvr_entry_t *de, int rerecord);
 
 int dvr_entry_file_moved(const char *src, const char *dst);
 

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -125,7 +125,7 @@ dvr_autorec_completed(dvr_autorec_entry_t *dae, int error_code)
     if (de_prev) {
       tvhinfo(LS_DVR, "autorec %s removing recordings %s (allowed count %u total %u)",
               dae->dae_name, idnode_uuid_as_str(&de_prev->de_id, ubuf), max_count, total);
-      dvr_entry_cancel_delete(de_prev, 0, 0);
+      dvr_entry_cancel_remove(de_prev, 0);
     }
   }
 }

--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -178,7 +178,6 @@ dvr_config_create(const char *name, const char *uuid, htsmsg_t *conf)
   cfg->dvr_enabled = 1;
   cfg->dvr_config_name = strdup(name);
   cfg->dvr_retention_days = DVR_RET_ONREMOVE;
-  cfg->dvr_retention_minimal = DVR_RET_MIN_DISABLED;
   cfg->dvr_removal_days = DVR_RET_REM_FOREVER;
   cfg->dvr_clone = 1;
   cfg->dvr_tag_files = 1;
@@ -763,29 +762,6 @@ dvr_config_class_retention_list ( void *o, const char *lang )
 }
 
 static htsmsg_t *
-dvr_config_class_retention_list_minimal ( void *o, const char *lang )
-{
-  static const struct strtab_u32 tab[] = {
-    { N_("Disabled"),           DVR_RET_MIN_DISABLED },
-    { N_("1 day"),              DVR_RET_REM_1DAY },
-    { N_("3 days"),             DVR_RET_REM_3DAY },
-    { N_("5 days"),             DVR_RET_REM_5DAY },
-    { N_("1 week"),             DVR_RET_REM_1WEEK },
-    { N_("2 weeks"),            DVR_RET_REM_2WEEK },
-    { N_("3 weeks"),            DVR_RET_REM_3WEEK },
-    { N_("1 month"),            DVR_RET_REM_1MONTH },
-    { N_("2 months"),           DVR_RET_REM_2MONTH },
-    { N_("3 months"),           DVR_RET_REM_3MONTH },
-    { N_("6 months"),           DVR_RET_REM_6MONTH },
-    { N_("1 year"),             DVR_RET_REM_1YEAR },
-    { N_("2 years"),            DVR_RET_REM_2YEARS },
-    { N_("3 years"),            DVR_RET_REM_3YEARS },
-    { N_("Forever"),            DVR_RET_REM_FOREVER },
-  };
-  return strtab2htsmsg_u32(tab, 1, lang);
-}
-
-static htsmsg_t *
 dvr_config_class_extra_list(void *o, const char *lang)
 {
   return dvr_entry_class_duration_list(o, 
@@ -924,21 +900,10 @@ const idclass_t dvr_config_class = {
       .type     = PT_U32,
       .id       = "retention-days",
       .name     = N_("DVR log retention period"),
-      .desc     = N_("Number of days to retain information about recordings. Once this period is exceeded, duplicate detection will not be possible for this recording."),
+      .desc     = N_("Number of days to retain information about recordings. Once this period is exceeded, duplicate detection will not be possible anymore."),
       .off      = offsetof(dvr_config_t, dvr_retention_days),
       .def.u32  = DVR_RET_ONREMOVE,
       .list     = dvr_config_class_retention_list,
-      .opts     = PO_EXPERT | PO_DOC_NLIST,
-      .group    = 1,
-    },
-    {
-      .type     = PT_U32,
-      .id       = "retention-minimal",
-      .name     = N_("Minimal log retention period"),
-      .desc     = N_("Minimal number of days to retain information from recordings that where deleted manually. Once this period is exceeded, duplicate detection will not be possible for this recording."),
-      .off      = offsetof(dvr_config_t, dvr_retention_minimal),
-      .def.u32  = DVR_RET_MIN_DISABLED,
-      .list     = dvr_config_class_retention_list_minimal,
       .opts     = PO_EXPERT | PO_DOC_NLIST,
       .group    = 1,
     },

--- a/src/dvr/dvr_vfsmgr.c
+++ b/src/dvr/dvr_vfsmgr.c
@@ -262,13 +262,7 @@ dvr_disk_space_cleanup(dvr_config_t *cfg)
               lang_str_get(oldest->de_title, NULL), tbuf, TOMIB(fileSize));
 
       dvr_disk_space_config_lastdelete = mclk();
-      if (dvr_entry_get_retention_days(oldest) == DVR_RET_ONREMOVE) {
-        dvr_entry_delete(oldest);     // delete actual file
-        dvr_entry_destroy(oldest, 1); // also delete database entry
-      } else {
-        if (dvr_entry_delete(oldest)) // delete actual file
-          idnode_changed(&oldest->de_id);
-      }
+      dvr_entry_cancel_remove(oldest, 0); /* Remove stored files and mark as "removed" */
     } else {
       tvhwarn(LS_DVR, "%s \"until space needed\" recordings found for config \"%s\", you are running out of disk space very soon!",
               loops > 0 ? "Not enough" : "No", configName);

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -1998,7 +1998,7 @@ htsp_method_deleteDvrEntry(htsp_connection_t *htsp, htsmsg_t *in)
   if (de == NULL)
     return out;
 
-  dvr_entry_cancel_delete(de, 0, 0);
+  dvr_entry_cancel_remove(de, 0);
 
   return htsp_success();
 }


### PR DESCRIPTION
@perexg, @ksooo 
This PR is a fixup for #889 (which was actually not ready for merging yet)

Behavior with this PR:
1) assume retention is set to something different than "on file removal" (this is still an expert setting)
2) recording finished -> recording is showing in the" finished recordings" list now
3) now the remove (instead of delete) button is showed, this will remove the stored files and place the recording in the "removed recordings" list.
4) when going to the "removed recordings" page (only in expert mode!), the user can delete the database entry. Otherwise the "removed recording" will be deleted automatically after the retention time has expired.

There are no changes in functioning or GUI when using basic or advanced mode.
![schermafdruk van 2016-10-04 22 52 50](https://cloud.githubusercontent.com/assets/2036512/19092789/a1b0ff12-8a88-11e6-89c8-4dfb4374be40.png)






