### PR TITLE
Uilevel polish

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -1394,6 +1394,7 @@ const idclass_t access_entry_class = {
       .id       = "enabled",
       .name     = N_("Enabled"),
       .desc     = N_("Enable/Disable the entry."),
+      .def.i    = 1,
       .off      = offsetof(access_entry_t, ae_enabled),
     },
     {
@@ -1460,7 +1461,7 @@ const idclass_t access_entry_class = {
       .doc      = prop_doc_themes,
       .list     = theme_get_ui_list,
       .off      = offsetof(access_entry_t, ae_theme),
-      .opts     = PO_DOC_NLIST,
+      .opts     = PO_DOC_NLIST | PO_ADVANCED,
     },
     {
       .type     = PT_BOOL,
@@ -1536,8 +1537,9 @@ const idclass_t access_entry_class = {
       .id       = "failed_dvr",
       .name     = N_("Failed DVR"),
       .desc     = N_("Allow/disallow access to all failed DVR entries."),
+      .def.i    = 1,
       .off      = offsetof(access_entry_t, ae_failed_dvr),
-      .opts     = PO_ADVANCED | PO_HIDDEN,
+      .opts     = PO_EXPERT | PO_HIDDEN,
     },
     {
       .type     = PT_BOOL,
@@ -1547,7 +1549,7 @@ const idclass_t access_entry_class = {
                      "the HTSP client like signal strength, input source "
                      "etc."),
       .off      = offsetof(access_entry_t, ae_htsp_anonymize),
-      .opts     = PO_ADVANCED | PO_HIDDEN,
+      .opts     = PO_EXPERT | PO_HIDDEN,
     },
     {
       .type     = PT_STR,
@@ -1603,6 +1605,7 @@ const idclass_t access_entry_class = {
       .name     = N_("Minimal channel number"),
       .desc     = N_("Lowest channel number the user can access."),
       .off      = offsetof(access_entry_t, ae_chmin),
+      .opts     = PO_ADVANCED,
     },
     {
       .type     = PT_S64,
@@ -1611,6 +1614,7 @@ const idclass_t access_entry_class = {
       .name     = N_("Maximal channel number"),
       .desc     = N_("Highest channel number the user can access."),
       .off      = offsetof(access_entry_t, ae_chmax),
+      .opts     = PO_ADVANCED,
     },
     {
       .type     = PT_BOOL,
@@ -1825,6 +1829,7 @@ const idclass_t passwd_entry_class = {
       .id       = "enabled",
       .name     = N_("Enabled"),
       .desc     = N_("Enable/disable the entry."),
+      .def.i    = 1,
       .off      = offsetof(passwd_entry_t, pw_enabled),
     },
     {

--- a/src/bouquet.c
+++ b/src/bouquet.c
@@ -94,6 +94,9 @@ bouquet_create(const char *uuid, htsmsg_t *conf,
   bq->bq_active_services = idnode_set_create(1);
   bq->bq_ext_url_period = 60;
   bq->bq_mapencrypted = 1;
+  bq->bq_mapradio = 1;
+  bq->bq_maptoch = 1;
+  bq->bq_chtag = 1;
 
   if (idnode_insert(&bq->bq_id, uuid, &bouquet_class, 0)) {
     if (uuid)
@@ -978,6 +981,7 @@ const idclass_t bouquet_class = {
       .id       = "enabled",
       .name     = N_("Enabled"),
       .desc     = N_("Enable/disable the bouquet."),
+      .def.i    = 1,
       .off      = offsetof(bouquet_t, bq_enabled),
       .notify   = bouquet_class_enabled_notify,
     },

--- a/src/channels.c
+++ b/src/channels.c
@@ -376,6 +376,7 @@ const idclass_t channel_class = {
       .id       = "enabled",
       .name     = N_("Enabled"),
       .desc     = N_("Enable/disable the channel."),
+      .def.i    = 1,
       .off      = offsetof(channel_t, ch_enabled),
     },
     {
@@ -439,6 +440,7 @@ const idclass_t channel_class = {
                      "turn this option off, only the OTA EPG grabber "
                      "will be used for this channel unless you've "
                      "specifically set a different EPG Source."),
+      .def.i    = 1,
       .off      = offsetof(channel_t, ch_epgauto),
       .opts     = PO_ADVANCED,
     },
@@ -489,7 +491,7 @@ const idclass_t channel_class = {
       .doc      = prop_doc_runningstate,
       .off      = offsetof(channel_t, ch_epg_running),
       .list     = channel_class_epg_running_list,
-      .opts     = PO_ADVANCED | PO_DOC_NLIST,
+      .opts     = PO_EXPERT | PO_DOC_NLIST,
     },
     {
       .type     = PT_STR,
@@ -501,7 +503,6 @@ const idclass_t channel_class = {
       .set      = channel_class_services_set,
       .list     = channel_class_services_enum,
       .rend     = channel_class_services_rend,
-      .opts     = PO_ADVANCED
     },
     {
       .type     = PT_STR,
@@ -1419,6 +1420,7 @@ const idclass_t channel_tag_class = {
       .id       = "enabled",
       .name     = N_("Enabled"),
       .desc     = N_("Enable/disable the tag."),
+      .def.i    = 1,
       .off      = offsetof(channel_tag_t, ct_enabled),
     },
     {
@@ -1452,7 +1454,7 @@ const idclass_t channel_tag_class = {
                      "no tags at all) set in "
                      "access configuration to use the tag."),
       .off      = offsetof(channel_tag_t, ct_private),
-      .opts     = PO_ADVANCED
+      .opts     = PO_EXPERT
     },
     {
       .type     = PT_STR,
@@ -1479,7 +1481,7 @@ const idclass_t channel_tag_class = {
       .desc     = N_("If set, presentation of the tag icon will not "
                      "superimpose the tag name on top of the icon."),
       .off      = offsetof(channel_tag_t, ct_titled_icon),
-      .opts     = PO_ADVANCED
+      .opts     = PO_EXPERT
     },
     {
       .type     = PT_STR,

--- a/src/config.c
+++ b/src/config.c
@@ -2079,7 +2079,7 @@ const idclass_t config_class = {
                    "It is intended to replace unencrypted HTTP basic access authentication. "
                    "This option should be enabled for standard usage."),
       .off    = offsetof(config_t, digest),
-      .opts   = PO_ADVANCED,
+      .opts   = PO_EXPERT,
       .group  = 1
     },
     {
@@ -2090,7 +2090,7 @@ const idclass_t config_class = {
       .desc   = N_("The number of days cookies set by Tvheadend should "
                    "expire."),
       .off    = offsetof(config_t, cookie_expires),
-      .opts   = PO_ADVANCED,
+      .opts   = PO_EXPERT,
       .group  = 1
     },
     {
@@ -2131,6 +2131,7 @@ const idclass_t config_class = {
                    "for the advanced level. By default, this tab is visible only "
                    "in the expert level."),
       .off    = offsetof(config_t, caclient_ui),
+      .opts   = PO_ADVANCED,
       .group  = 1
     },
     {

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -289,6 +289,7 @@ dvr_autorec_create(const char *uuid, htsmsg_t *conf)
   dae->dae_pri = DVR_PRIO_NORMAL;
   dae->dae_start = -1;
   dae->dae_start_window = -1;
+  dae->dae_enabled = 1;
   dae->dae_config = dvr_config_find_by_name_default(NULL);
   LIST_INSERT_HEAD(&dae->dae_config->dvr_autorec_entries, dae, dae_config_link);
 
@@ -1000,6 +1001,7 @@ const idclass_t dvr_autorec_entry_class = {
       .id       = "enabled",
       .name     = N_("Enabled"),
       .desc     = N_("Enable/disable auto-rec rule."),
+      .def.i    = 1,
       .off      = offsetof(dvr_autorec_entry_t, dae_enabled),
     },
     {
@@ -1009,7 +1011,7 @@ const idclass_t dvr_autorec_entry_class = {
       .desc     = N_("The name of the the rule."),
       .off      = offsetof(dvr_autorec_entry_t, dae_name),
     },
-	{
+	  {
       .type     = PT_STR,
       .id       = "directory",
       .name     = N_("Directory"),
@@ -1019,6 +1021,7 @@ const idclass_t dvr_autorec_entry_class = {
                      "recordings done by this entry into the "
                      "subdirectory named here. See Help for more info."),
       .off      = offsetof(dvr_autorec_entry_t, dae_directory),
+      .opts     = PO_EXPERT,
     },
     {
       .type     = PT_STR,
@@ -1089,6 +1092,7 @@ const idclass_t dvr_autorec_entry_class = {
       .desc     = N_("An event which starts between this \"start after\" "
                      "and \"start before\" will be matched (including "
                      "boundary values)."),
+      .def.s    = N_("Any"),
       .set      = dvr_autorec_entry_class_start_set,
       .get      = dvr_autorec_entry_class_start_get,
       .list     = dvr_autorec_entry_class_time_list_,
@@ -1101,6 +1105,7 @@ const idclass_t dvr_autorec_entry_class = {
       .desc     = N_("An event which starts between this \"start after\" "
                      "and \"start before\" will be matched (including "
                      "boundary values)."),
+      .def.s    = N_("Any"),
       .set      = dvr_autorec_entry_class_start_window_set,
       .get      = dvr_autorec_entry_class_start_window_get,
       .list     = dvr_autorec_entry_class_time_list_,
@@ -1148,7 +1153,7 @@ const idclass_t dvr_autorec_entry_class = {
                      "shorter than this duration."),
       .list     = dvr_autorec_entry_class_minduration_list,
       .off      = offsetof(dvr_autorec_entry_t, dae_minduration),
-      .opts     = PO_ADVANCED | PO_DOC_NLIST,
+      .opts     = PO_EXPERT | PO_DOC_NLIST,
     },
     {
       .type     = PT_INT,
@@ -1159,7 +1164,7 @@ const idclass_t dvr_autorec_entry_class = {
                      "longer than this duration."),
       .list     = dvr_autorec_entry_class_maxduration_list,
       .off      = offsetof(dvr_autorec_entry_t, dae_maxduration),
-      .opts     = PO_ADVANCED | PO_DOC_NLIST,
+      .opts     = PO_EXPERT | PO_DOC_NLIST,
     },
     {
       .type     = PT_U32,

--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -207,7 +207,7 @@ dvr_config_create(const char *name, const char *uuid, htsmsg_t *conf)
   tvhinfo(LS_DVR, "Creating new configuration '%s'", cfg->dvr_config_name);
 
   if (cfg->dvr_profile == NULL) {
-    cfg->dvr_profile = profile_find_by_name("dvr", NULL);
+    cfg->dvr_profile = profile_find_by_name("pass", NULL);
     assert(cfg->dvr_profile);
     LIST_INSERT_HEAD(&cfg->dvr_profile->pro_dvr_configs, cfg, profile_link);
   }
@@ -538,6 +538,8 @@ dvr_config_changed(dvr_config_t *cfg)
     cfg->dvr_removal_days = DVR_RET_REM_FOREVER;
   if (cfg->dvr_retention_days > DVR_RET_REM_FOREVER)
     cfg->dvr_retention_days = DVR_RET_REM_FOREVER;
+  if (cfg->dvr_profile && !strcmp(profile_get_name(cfg->dvr_profile), "htsp")) // htsp is for streaming only
+    cfg->dvr_profile = profile_find_by_name("pass", NULL);
 }
 
 
@@ -640,7 +642,7 @@ dvr_config_class_profile_set(void *o, const void *v)
   profile_t *pro;
 
   pro = v ? profile_find_by_uuid(v) : NULL;
-  pro = pro ?: profile_find_by_name(v, "dvr");
+  pro = pro ?: profile_find_by_name(v, "pass");
   if (pro == NULL) {
     if (cfg->dvr_profile) {
       LIST_REMOVE(cfg, profile_link);
@@ -880,6 +882,7 @@ const idclass_t dvr_config_class = {
       .get      = dvr_config_class_profile_get,
       .rend     = dvr_config_class_profile_rend,
       .list     = profile_class_get_list,
+      .opts     = PO_ADVANCED,
       .group    = 1,
     },
     {
@@ -893,7 +896,7 @@ const idclass_t dvr_config_class = {
       .off      = offsetof(dvr_config_t, dvr_muxcnf.m_cache),
       .def.i    = MC_CACHE_DONTKEEP,
       .list     = dvr_config_class_cache_list,
-      .opts     = PO_ADVANCED | PO_DOC_NLIST,
+      .opts     = PO_EXPERT | PO_DOC_NLIST,
       .group    = 1,
     },
     {
@@ -948,7 +951,7 @@ const idclass_t dvr_config_class = {
                      "those with tuners that take some time to tune "
                      "and/or send garbage data at the beginning. "),
       .off      = offsetof(dvr_config_t, dvr_warm_time),
-      .opts     = PO_ADVANCED,
+      .opts     = PO_EXPERT,
       .group    = 1,
       .def.u32  = 30
     },
@@ -966,7 +969,7 @@ const idclass_t dvr_config_class = {
                      "in the channel or DVR entry will be used."),
       .off      = offsetof(dvr_config_t, dvr_extra_time_pre),
       .list     = dvr_config_class_extra_list,
-      .opts     = PO_ADVANCED | PO_DOC_NLIST,
+      .opts     = PO_DOC_NLIST,
       .group    = 1,
     },
     {
@@ -977,7 +980,7 @@ const idclass_t dvr_config_class = {
                      "stop time."),
       .off      = offsetof(dvr_config_t, dvr_extra_time_post),
       .list     = dvr_config_class_extra_list,
-      .opts     = PO_ADVANCED | PO_DOC_NLIST,
+      .opts     = PO_DOC_NLIST,
       .group    = 1,
     },
     {
@@ -1102,7 +1105,7 @@ const idclass_t dvr_config_class = {
       .off      = offsetof(dvr_config_t, dvr_charset),
       .set      = dvr_config_class_charset_set,
       .list     = dvr_config_class_charset_list,
-      .opts     = PO_ADVANCED,
+      .opts     = PO_EXPERT,
       .def.s    = "UTF-8",
       .group    = 2,
     },
@@ -1197,7 +1200,7 @@ const idclass_t dvr_config_class = {
                      "the event title. This applies to both the title "
                      "stored in the file and to the filename itself."),
       .off      = offsetof(dvr_config_t, dvr_channel_in_title),
-      .opts     = PO_EXPERT,
+      .opts     = PO_ADVANCED,
       .group    = 5,
     },
     {
@@ -1208,7 +1211,7 @@ const idclass_t dvr_config_class = {
                      "the event title. This applies to both the title "
                      "stored in the file and to the filename itself."),
       .off      = offsetof(dvr_config_t, dvr_date_in_title),
-      .opts     = PO_EXPERT,
+      .opts     = PO_ADVANCED,
       .group    = 5,
     },
     {
@@ -1219,7 +1222,7 @@ const idclass_t dvr_config_class = {
                      "the event title. This applies to both the title "
                      "stored in the file and to the filename itself."),
       .off      = offsetof(dvr_config_t, dvr_time_in_title),
-      .opts     = PO_EXPERT,
+      .opts     = PO_ADVANCED,
       .group    = 5,
     },
     {
@@ -1279,7 +1282,7 @@ const idclass_t dvr_config_class = {
                      "(e.g. for an SMB/CIFS share) will be stripped out "
                      "or converted."),
       .off      = offsetof(dvr_config_t, dvr_windows_compatible_filenames),
-      .opts     = PO_EXPERT,
+      .opts     = PO_ADVANCED,
       .group    = 6,
     },
     {}
@@ -1296,7 +1299,7 @@ dvr_config_destroy_by_profile(profile_t *pro, int delconf)
 
   while((cfg = LIST_FIRST(&pro->pro_dvr_configs)) != NULL) {
     LIST_REMOVE(cfg, profile_link);
-    cfg->dvr_profile = profile_find_by_name(NULL, "dvr");
+    cfg->dvr_profile = profile_find_by_name(NULL, "pass");
   }
 }
 

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -2935,7 +2935,6 @@ const idclass_t dvr_entry_class = {
       .name     = N_("Enabled"),
       .desc     = N_("Enable/disable the entry."),
       .off      = offsetof(dvr_entry_t, de_enabled),
-      .opts     = PO_ADVANCED
     },
     {
       .type     = PT_TIME,
@@ -3089,7 +3088,7 @@ const idclass_t dvr_entry_class = {
       .def.i    = DVR_PRIO_NORMAL,
       .set      = dvr_entry_class_pri_set,
       .list     = dvr_entry_class_pri_list,
-      .opts     = PO_SORTKEY | PO_DOC_NLIST,
+      .opts     = PO_SORTKEY | PO_DOC_NLIST | PO_ADVANCED,
     },
     {
       .type     = PT_U32,

--- a/src/dvr/dvr_timerec.c
+++ b/src/dvr/dvr_timerec.c
@@ -188,6 +188,7 @@ dvr_timerec_create(const char *uuid, htsmsg_t *conf)
   dte->dte_pri = DVR_PRIO_NORMAL;
   dte->dte_start = -1;
   dte->dte_stop = -1;
+  dte->dte_enabled = 1;
   dte->dte_config = dvr_config_find_by_name_default(NULL);
   LIST_INSERT_HEAD(&dte->dte_config->dvr_timerec_entries, dte, dte_config_link);
 
@@ -536,6 +537,7 @@ const idclass_t dvr_timerec_entry_class = {
       .id       = "enabled",
       .name     = N_("Enabled"),
       .desc     = N_("Enable/disable the entry."),
+      .def.i    = 1,
       .off      = offsetof(dvr_timerec_entry_t, dte_enabled),
     },
     {
@@ -553,6 +555,7 @@ const idclass_t dvr_timerec_entry_class = {
       .doc      = prop_doc_dvr_timerec_title_format,
       .off      = offsetof(dvr_timerec_entry_t, dte_title),
       .def.s    = "Time-%F_%R",
+      .opts     = PO_ADVANCED
     },
     {
       .type     = PT_STR,

--- a/src/epggrab.c
+++ b/src/epggrab.c
@@ -280,6 +280,7 @@ const idclass_t epggrab_class = {
                    "Note: this may cause unwanted changes to "
                    "already defined channel names."),
       .off    = offsetof(epggrab_conf_t, channel_rename),
+      .opts   = PO_ADVANCED,
       .group  = 1,
     },
     {
@@ -291,6 +292,7 @@ const idclass_t epggrab_class = {
                    "Note: this may cause unwanted changes to "
                    "already defined channel numbers."),
       .off    = offsetof(epggrab_conf_t, channel_renumber),
+      .opts   = PO_ADVANCED,
       .group  = 1,
     },
     {
@@ -302,6 +304,7 @@ const idclass_t epggrab_class = {
                    "Note: this may cause unwanted changes to "
                    "already defined channel icons."),
       .off    = offsetof(epggrab_conf_t, channel_reicon),
+      .opts   = PO_ADVANCED,
       .group  = 1,
     },
     {
@@ -361,7 +364,7 @@ const idclass_t epggrab_class = {
                    "time at most. If the EPG data is complete before "
                    "this limit, the mux is released sooner."),
       .off    = offsetof(epggrab_conf_t, ota_timeout),
-      .opts   = PO_ADVANCED,
+      .opts   = PO_EXPERT,
       .group  = 3,
     },
     {}

--- a/src/epggrab/module.c
+++ b/src/epggrab/module.c
@@ -158,7 +158,7 @@ const idclass_t epggrab_mod_class = {
                    "grabber is enabled. Priority is given to the grabber "
                    "with the highest value set here."),
       .off    = offsetof(epggrab_module_t, priority),
-      .opts   = PO_ADVANCED,
+      .opts   = PO_EXPERT,
       .group  = 1
     },
     {}

--- a/src/input/mpegts/mpegts_mux.c
+++ b/src/input/mpegts/mpegts_mux.c
@@ -612,7 +612,7 @@ const idclass_t mpegts_mux_class =
       .off      = offsetof(mpegts_mux_t, mm_scan_state),
       .set      = mpegts_mux_class_scan_state_set,
       .list     = mpegts_mux_class_scan_state_enum,
-      .opts     = PO_NOSAVE | PO_SORTKEY | PO_DOC_NLIST,
+      .opts     = PO_ADVANCED | PO_NOSAVE | PO_SORTKEY | PO_DOC_NLIST,
     },
     {
       .type     = PT_INT,
@@ -656,7 +656,7 @@ const idclass_t mpegts_mux_class =
        .id       = "tsid_zero",
        .name     = N_("Accept zero value for TSID"),
        .off      = offsetof(mpegts_mux_t, mm_tsid_accept_zero_value),
-       .opts     = PO_ADVANCED
+       .opts     = PO_EXPERT
     },
     {
       .type     = PT_INT,

--- a/src/input/mpegts/mpegts_mux_dvb.c
+++ b/src/input/mpegts/mpegts_mux_dvb.c
@@ -473,10 +473,12 @@ const idclass_t dvb_mux_dvbs_class =
     {
       MUX_PROP_STR("rolloff", N_("Rolloff"), dvbs, rolloff, "AUTO"),
       .desc     = N_("The rolloff used on the mux."),
+      .opts     = PO_ADVANCED,
     },
     {
       MUX_PROP_STR("pilot", N_("Pilot"), dvbs, pilot, "AUTO"),
       .desc     = N_("Enable/disable pilot tone."),
+      .opts     = PO_ADVANCED,
     },
     {
       .type     = PT_INT,
@@ -485,12 +487,13 @@ const idclass_t dvb_mux_dvbs_class =
       .desc     = N_("The stream ID used for the mux."),
       .off      = offsetof(dvb_mux_t, lm_tuning.dmc_fe_stream_id),
       .def.i	= DVB_NO_STREAM_ID_FILTER,
-      .opts     = PO_ADVANCED
+      .opts     = PO_EXPERT
     },
     {
       MUX_PROP_STR("pls_mode", N_("PLS mode"), dvbs, pls_mode, "ROOT"),
       .desc     = N_("The Physical Layer Scrambling (PLS) mode "
                      "used on the mux."),
+      .opts     = PO_ADVANCED,
     },
     {
       .type     = PT_U32,
@@ -500,7 +503,7 @@ const idclass_t dvb_mux_dvbs_class =
                      "used on the mux."),
       .off      = offsetof(dvb_mux_t, lm_tuning.dmc_fe_pls_code),
       .def.u32	= 1,
-      .opts     = PO_ADVANCED
+      .opts     = PO_EXPERT
     },
     {
       .type     = PT_STR,

--- a/src/input/mpegts/mpegts_mux_dvb.c
+++ b/src/input/mpegts/mpegts_mux_dvb.c
@@ -493,7 +493,7 @@ const idclass_t dvb_mux_dvbs_class =
       MUX_PROP_STR("pls_mode", N_("PLS mode"), dvbs, pls_mode, "ROOT"),
       .desc     = N_("The Physical Layer Scrambling (PLS) mode "
                      "used on the mux."),
-      .opts     = PO_ADVANCED,
+      .opts     = PO_EXPERT,
     },
     {
       .type     = PT_U32,

--- a/src/profile.c
+++ b/src/profile.c
@@ -306,7 +306,8 @@ const idclass_t profile_class =
       .desc     = N_("Enable/disable the profile."),
       .off      = offsetof(profile_t, pro_enabled),
       .get_opts = profile_class_enabled_opts,
-      .group    = 1
+      .group    = 1,
+      .def.i    = 1
     },
     {
       .type     = PT_BOOL,
@@ -1097,7 +1098,7 @@ const idclass_t profile_mpegts_pass_class =
                      "include information about the currently-streamed "
                      "service."),
       .off      = offsetof(profile_mpegts_t, pro_rewrite_pmt),
-      .opts     = PO_ADVANCED,
+      .opts     = PO_EXPERT,
       .def.i    = 1,
       .group    = 2
     },
@@ -1109,7 +1110,7 @@ const idclass_t profile_mpegts_pass_class =
                      "to only include information about the currently-"
                      "streamed service."),
       .off      = offsetof(profile_mpegts_t, pro_rewrite_pat),
-      .opts     = PO_ADVANCED,
+      .opts     = PO_EXPERT,
       .def.i    = 1,
       .group    = 2
     },
@@ -1121,7 +1122,7 @@ const idclass_t profile_mpegts_pass_class =
                      "to only include information about the currently-"
                      "streamed service."),
       .off      = offsetof(profile_mpegts_t, pro_rewrite_sdt),
-      .opts     = PO_ADVANCED,
+      .opts     = PO_EXPERT,
       .def.i    = 1,
       .group    = 2
     },
@@ -1133,7 +1134,7 @@ const idclass_t profile_mpegts_pass_class =
                      "to only include information about the currently-"
                      "streamed service."),
       .off      = offsetof(profile_mpegts_t, pro_rewrite_eit),
-      .opts     = PO_ADVANCED,
+      .opts     = PO_EXPERT,
       .def.i    = 1,
       .group    = 2
     },
@@ -2257,6 +2258,7 @@ profile_init(void)
     htsmsg_add_str (conf, "name", name);
     htsmsg_add_str (conf, "comment", _("Audio-only stream"));
     htsmsg_add_s32 (conf, "priority", PROFILE_SPRIO_NORMAL);
+    htsmsg_add_bool(conf, "shield", 1);
     (void)profile_create(NULL, conf, 1);
     htsmsg_destroy(conf);
   }

--- a/src/timeshift.c
+++ b/src/timeshift.c
@@ -267,7 +267,7 @@ const idclass_t timeshift_conf_class = {
       .name   = N_("RAM only"),
       .desc   = N_("Only use system RAM for timeshift buffers."),
       .off    = offsetof(timeshift_conf_t, ram_only),
-      .opts   = PO_EXPERT,
+      .opts   = PO_ADVANCED,
     },
     {
       .type   = PT_BOOL,

--- a/src/timeshift.c
+++ b/src/timeshift.c
@@ -197,6 +197,7 @@ const idclass_t timeshift_conf_class = {
                    "because there is no buffer on the first request "
                    "rewinding is not possible at that point."),
       .off    = offsetof(timeshift_conf_t, ondemand),
+      .opts   = PO_EXPERT,
     },
     {
       .type   = PT_STR,
@@ -206,6 +207,7 @@ const idclass_t timeshift_conf_class = {
                    "If nothing is specified this will default to "
                    "CONF_DIR/timeshift/buffer."),
       .off    = offsetof(timeshift_conf_t, path),
+      .opts   = PO_ADVANCED,
     },
     {
       .type   = PT_U32,
@@ -224,6 +226,7 @@ const idclass_t timeshift_conf_class = {
                    "enabling this option may cause your system to slow "
                    "down or crash completely!"),
       .off    = offsetof(timeshift_conf_t, unlimited_period),
+      .opts   = PO_EXPERT,
     },
     {
       .type   = PT_S64,
@@ -234,6 +237,7 @@ const idclass_t timeshift_conf_class = {
                    "recommended you specify a value here."),
       .set    = timeshift_conf_class_max_size_set,
       .get    = timeshift_conf_class_max_size_get,
+      .opts   = PO_ADVANCED,
     },
     {
       .type   = PT_S64,
@@ -245,6 +249,7 @@ const idclass_t timeshift_conf_class = {
                    "storage."),
       .set    = timeshift_conf_class_ram_size_set,
       .get    = timeshift_conf_class_ram_size_get,
+      .opts   = PO_ADVANCED,
     },
     {
       .type   = PT_BOOL,
@@ -254,6 +259,7 @@ const idclass_t timeshift_conf_class = {
                    "potentially grow unbounded until your storage media "
                    "runs out of space."),
       .off    = offsetof(timeshift_conf_t, unlimited_size),
+      .opts   = PO_EXPERT,
     },
     {
       .type   = PT_BOOL,
@@ -261,6 +267,7 @@ const idclass_t timeshift_conf_class = {
       .name   = N_("RAM only"),
       .desc   = N_("Only use system RAM for timeshift buffers."),
       .off    = offsetof(timeshift_conf_t, ram_only),
+      .opts   = PO_EXPERT,
     },
     {
       .type   = PT_BOOL,
@@ -269,6 +276,7 @@ const idclass_t timeshift_conf_class = {
       .desc   = N_("If possible, maintain the timeshift data in the server memory only. "
                    "This may reduce the amount of allowed rewind time."),
       .off    = offsetof(timeshift_conf_t, ram_fit),
+      .opts   = PO_EXPERT,
     },
     {}
   }

--- a/src/webui/static/app/acleditor.js
+++ b/src/webui/static/app/acleditor.js
@@ -120,6 +120,7 @@ tvheadend.ipblockeditor = function(panel, index)
             comment: { width: 250 }
         },
         tabIndex: index,
+        uilevel: 'expert',
         edit: {
             params: {
                 list: list

--- a/src/webui/static/app/config.js
+++ b/src/webui/static/app/config.js
@@ -108,7 +108,7 @@ tvheadend.imgcacheconf = function(panel, index) {
         title: _('Image Cache'),
         iconCls: 'imgcacheconf',
         tabIndex: index,
-        uilevel: 'advanced',
+        uilevel: 'expert',
         comet: 'imagecache',
         width: 550,
         labelWidth: 200,

--- a/src/webui/static/app/config.js
+++ b/src/webui/static/app/config.js
@@ -108,6 +108,7 @@ tvheadend.imgcacheconf = function(panel, index) {
         title: _('Image Cache'),
         iconCls: 'imgcacheconf',
         tabIndex: index,
+        uilevel: 'advanced',
         comet: 'imagecache',
         width: 550,
         labelWidth: 200,

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -201,11 +201,10 @@ tvheadend.filesizeRenderer = function(st) {
 tvheadend.dvr_upcoming = function(panel, index) {
 
     var actions = tvheadend.dvrRowActions();
-    var list = 'disp_title,start,start_extra,stop,stop_extra,' +
-               'channel,config_name,comment';
+    var list = 'disp_title,channel,start,start_extra,stop,stop_extra,config_name,comment';
     var elist = 'enabled,' +
                 (tvheadend.accessUpdate.admin ?
-                  list + ',retention,removal,owner,creator' : list);
+                list + ',owner,creator' : list) + ',pri,retention,removal';
 
     var stopButton = {
         name: 'stop',
@@ -302,9 +301,9 @@ tvheadend.dvr_upcoming = function(panel, index) {
             }
         },
         del: true,
-        list: 'enabled,duplicate,disp_title,disp_subtitle,episode,pri,start_real,' +
-              'stop_real,duration,filesize,channel,owner,creator,config_name,' +
-              'sched_status,errors,data_errors,comment',
+        list: 'enabled,duplicate,disp_title,disp_subtitle,episode,channel,' +
+              'start_real,stop_real,duration,pri,filesize,' +
+              'sched_status,errors,data_errors,config_name,owner,creator,comment',
         columns: {
             filesize: {
                 renderer: tvheadend.filesizeRenderer()
@@ -455,11 +454,11 @@ tvheadend.dvr_finished = function(panel, index) {
         titleP: _('Finished Recordings'),
         iconCls: 'finishedRec',
         tabIndex: index,
-        edit: { params: { list: tvheadend.admin ? "owner,retention,removal,comment" : "comment" } },
+        edit: { params: { list: tvheadend.admin ? "retention,removal,owner,comment" : "retention,removal,comment" } },
         del: false,
-        list: 'disp_title,disp_subtitle,episode,start_real,stop_real,' +
-              'duration,filesize,channelname,owner,creator,' +
-              'config_name,sched_status,errors,data_errors,url,comment',
+        list: 'disp_title,disp_subtitle,episode,channelname,' +
+              'start_real,stop_real,duration,filesize,' +
+              'sched_status,errors,data_errors,config_name,owner,creator,comment',
         columns: {
             filesize: {
                 renderer: tvheadend.filesizeRenderer()
@@ -590,13 +589,13 @@ tvheadend.dvr_failed = function(panel, index) {
         titleP: _('Failed Recordings'),
         iconCls: 'exclamation',
         tabIndex: index,
-        edit: { params: { list: tvheadend.admin ? "owner,comment" : "comment" } },
+        edit: { params: { list: tvheadend.admin ? "retention,removal,owner,comment" : "retention,removal,comment" } },
         del: true,
         delquestion: _('Do you really want to delete the selected recordings?') + '<br/><br/>' +
                      _('The associated file will be removed from storage.'),
-        list: 'disp_title,disp_subtitle,episode,start_real,stop_real,' +
-              'duration,filesize,channelname,owner,creator,config_name,' +
-              'status,sched_status,errors,data_errors,url,comment',
+        list: 'disp_title,disp_subtitle,episode,channelname,' +
+              'start_real,stop_real,duration,filesize,status,' +
+              'sched_status,errors,data_errors,url,config_name,owner,creator,comment',
         columns: {
             filesize: {
                 renderer: tvheadend.filesizeRenderer()
@@ -679,9 +678,9 @@ tvheadend.dvr_removed = function(panel, index) {
         uilevel: 'expert',
         edit: { params: { list: tvheadend.admin ? "retention,owner,comment" : "retention,comment" } },
         del: true,
-        list: 'disp_title,disp_subtitle,episode,start_real,stop_real,' +
-              'duration,channelname,owner,creator,config_name,' +
-              'sched_status,errors,data_errors,url,comment',
+        list: 'disp_title,disp_subtitle,episode,channelname,' +
+              'start_real,stop_real,duration,filesize,status,' +
+              'sched_status,errors,data_errors,url,config_name,owner,creator,comment',
         sort: {
           field: 'start_real',
           direction: 'ASC'
@@ -724,6 +723,13 @@ tvheadend.dvr_settings = function(panel, index) {
  */
 tvheadend.autorec_editor = function(panel, index) {
 
+    var list = 'name,title,fulltext,channel,start,start_window,weekdays,' + 
+               'record,tag,btype,content_type,minduration,maxduration,' +
+               'dedup,directory,config_name,comment';
+    var elist = 'enabled,start_extra,stop_extra,' +
+                (tvheadend.accessUpdate.admin ?
+                list + ',owner,creator' : list) + ',pri,retention,removal,maxcount,maxsched';
+
     tvheadend.idnode_grid(panel, {
         url: 'api/dvr/autorec',
         titleS: _('Autorec'),
@@ -765,15 +771,19 @@ tvheadend.autorec_editor = function(panel, index) {
         add: {
             url: 'api/dvr/autorec',
             params: {
-               list: 'enabled,name,directory,title,fulltext,channel,tag,btype,content_type,minduration,' +
-                     'maxduration,weekdays,start,start_window,pri,dedup,retention,removal,' +
-                     'maxcount,maxsched,config_name,comment'
+               list: list
             },
             create: { }
         },
+        edit: {
+            params: {
+                list: elist
+            },
+        },
         del: true,
-        list: 'enabled,name,directory,title,fulltext,channel,tag,btype,content_type,minduration,' +
-              'maxduration,weekdays,start,start_window,pri,dedup,config_name,owner,creator,comment',
+        list: 'enabled,name,title,fulltext,channel,tag,start,start_window,' +
+              'weekdays,minduration,maxduration,btype,content_type,' +
+              'pri,dedup,directory,config_name,owner,creator,comment',
         sort: {
           field: 'name',
           direction: 'ASC'
@@ -788,6 +798,12 @@ tvheadend.autorec_editor = function(panel, index) {
  *
  */
 tvheadend.timerec_editor = function(panel, index) {
+
+    var list = 'name,title,channel,start,stop,weekdays,' +
+               'directory,config_name,comment';
+    var elist = 'enabled,' +
+                (tvheadend.accessUpdate.admin ?
+                list + ',owner,creator' : list) + ',pri,retention,removal';
 
     tvheadend.idnode_grid(panel, {
         url: 'api/dvr/timerec',
@@ -818,12 +834,17 @@ tvheadend.timerec_editor = function(panel, index) {
         add: {
             url: 'api/dvr/timerec',
             params: {
-               list: 'enabled,name,directory,title,channel,weekdays,start,stop,pri,config_name,comment'
+               list: list
             },
             create: { }
         },
+        edit: {
+            params: {
+                list: elist
+            },
+        },
         del: true,
-        list: 'enabled,name,directory,title,channel,weekdays,start,stop,pri,config_name,owner,creator,comment',
+        list: 'enabled,name,title,channel,start,stop,weekdays,pri,directory,config_name,owner,creator,comment',
         sort: {
           field: 'name',
           direction: 'ASC'

--- a/src/webui/static/app/epggrab.js
+++ b/src/webui/static/app/epggrab.js
@@ -58,6 +58,7 @@ tvheadend.epggrab_map = function(panel, index) {
         titleP: _('EPG Grabber Channels'),
         iconCls: 'baseconf',
         tabIndex: index,
+        uilevel: 'expert',
         del: true,
         sort: {
           field: 'name',
@@ -81,6 +82,7 @@ tvheadend.epggrab_mod = function(panel, index) {
 
     tvheadend.idnode_form_grid(panel, {
         tabIndex: index,
+        uilevel: 'advanced',
         clazz: 'epggrab_mod',
         comet: 'epggrab_mod',
         titleS: _('EPG Grabber Module'),

--- a/src/webui/static/app/mpegts.js
+++ b/src/webui/static/app/mpegts.js
@@ -349,6 +349,7 @@ tvheadend.mux_sched = function(panel, index)
         titleP: _('Mux Schedulers'),
         iconCls: 'muxSchedulers',
         tabIndex: index,
+        uilevel: 'expert',
         hidemode: true,
         add: {
             url: 'api/mpegts/mux_sched',

--- a/src/webui/static/app/tvheadend.js
+++ b/src/webui/static/app/tvheadend.js
@@ -777,7 +777,7 @@ function accessUpdate(o) {
             tvheadend.caclient(cp, 6);
 
         /* Debug */
-        if (o.uilevel == 'expert') {
+        if (o.uilevel == 'advanced' || o.uilevel == 'expert') {
             var dbg = new Ext.TabPanel({
                 tabIndex: 7,
                 activeTab: 0,

--- a/src/webui/static/app/tvheadend.js
+++ b/src/webui/static/app/tvheadend.js
@@ -777,18 +777,20 @@ function accessUpdate(o) {
             tvheadend.caclient(cp, 6);
 
         /* Debug */
-        var dbg = new Ext.TabPanel({
-            tabIndex: 7,
-            activeTab: 0,
-            autoScroll: true,
-            title: _('Debugging'),
-            iconCls: 'debug',
-            items: []
-        });
-        tvheadend.tvhlog(dbg, 0);
-        tvheadend.memoryinfo(dbg, 1);
+        if (o.uilevel == 'expert') {
+            var dbg = new Ext.TabPanel({
+                tabIndex: 7,
+                activeTab: 0,
+                autoScroll: true,
+                title: _('Debugging'),
+                iconCls: 'debug',
+                items: []
+            });
+            tvheadend.tvhlog(dbg, 0);
+            tvheadend.memoryinfo(dbg, 1);
 
-        cp.add(dbg);
+            cp.add(dbg);
+        }
 
         /* Finish */
         tvheadend.rootTabPanel.add(cp);

--- a/src/webui/static/app/tvhlog.js
+++ b/src/webui/static/app/tvhlog.js
@@ -36,6 +36,7 @@ tvheadend.memoryinfo = function(panel, index)
         titleP: _('Memory Information Entries'),
         iconCls: 'exclamation',
         tabIndex: index,
+        uilevel: 'expert',
         readonly: true
     });
 };


### PR DESCRIPTION
**Flaws with the current code:**
-  inconsistency between dvr, autorec and timerec: Some parameters are tagged as basic for autorec while they are tagged as expert for timerecs. Also parameters are listed in different orders and might not be visible at all. -> see screenshot
-  when adding a entry of any kind (channel,mux,bouquet,acces,etc), it should be enabled as creating a disabled entry doesn't make sense.
-  in many places there are no or almost no differences between the advanced and expert level
-  the user should be able to set up tvheadend when using "basic" mode. This is not always possible. example: adding a channel is possible but assigning a service not, this leaves the user with an unplayable channel.

![dvr_autorec_timerec_inconsistency](https://cloud.githubusercontent.com/assets/2036512/19491758/7490a5cc-9574-11e6-943d-27644c0b120c.png)

**Changes with this PR**
- addressed flaws described above
- prevent the htsp profile for recordings and set the default to "pass" instead of "dvr" (which is an old leftover I guess).
- Basic ui level: (= beginner level) This level should be similar to normal STB's, the user can scan channels, watch them and record them. OTA epg is enabled but the user should not bother (enabled by default)    
- Advanced ui level: (= level for users familiar with tvheadend) The user can acces some settings that require more knowledge from tvheadend (internal/external epg grabber for example).
- Expert ui level (= level for computer/dvb/tcpIp experts) This settings should not be used in 99% of the cases. Everything with string formatting is tagged as expert, as well settings that might harm things or are very experimental,...

@perexg 