### PR TITLE
Fixes +  improvements

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -209,6 +209,8 @@ typedef struct dvr_entry {
   uint32_t de_file_removed;
   uint32_t de_retention;
   uint32_t de_removal;
+  uint32_t de_playcount;    /* Recording play count */
+  uint32_t de_playposition; /* Recording last played position in seconds */
 
   /**
    * EPG information / links
@@ -542,7 +544,8 @@ dvr_entry_update( dvr_entry_t *de, int enabled,
                   const char *desc, const char *lang,
                   time_t start, time_t stop,
                   time_t start_extra, time_t stop_extra,
-                  dvr_prio_t pri, int retention, int removal );
+                  dvr_prio_t pri, int retention, int removal,
+                  int playcount, int playposition);
 
 void dvr_destroy_by_channel(channel_t *ch, int delconf);
 
@@ -603,6 +606,8 @@ htsmsg_t *dvr_entry_class_retention_list ( void *o, const char *lang );
 htsmsg_t *dvr_entry_class_removal_list ( void *o, const char *lang );
 
 int dvr_entry_verify(dvr_entry_t *de, access_t *a, int readonly);
+
+void dvr_entry_changed_notify(dvr_entry_t *de);
 
 void dvr_spawn_cmd(dvr_entry_t *de, const char *cmd, const char *filename, int pre);
 

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -149,6 +149,16 @@ dvr_entry_verify(dvr_entry_t *de, access_t *a, int readonly)
 /*
  *
  */
+void
+dvr_entry_changed_notify(dvr_entry_t *de)
+{
+  idnode_changed(&de->de_id);
+  htsp_dvr_entry_update(de);
+}
+
+/*
+ *
+ */
 int
 dvr_entry_set_state(dvr_entry_t *de, dvr_entry_sched_state_t state,
                     dvr_rs_state_t rec_state, int error_code)
@@ -213,9 +223,7 @@ dvr_entry_dont_rerecord(dvr_entry_t *de, int dont_rerecord)
   if (de->de_dont_rerecord ? 1 : 0 != dont_rerecord) {
     dvr_entry_trace(de, "don't rerecord change %d", dont_rerecord);
     de->de_dont_rerecord = dont_rerecord;
-    idnode_changed(&de->de_id);
-    idnode_notify_changed(&de->de_id);
-    htsp_dvr_entry_update(de);
+    dvr_entry_changed_notify(de);
   }
 }
 
@@ -1550,6 +1558,8 @@ dvr_timer_remove_files(void *aux)
 #define DVR_UPDATED_BROADCAST    (1<<15)
 #define DVR_UPDATED_EPISODE      (1<<16)
 #define DVR_UPDATED_CONFIG       (1<<17)
+#define DVR_UPDATED_PLAYPOS      (1<<18)
+#define DVR_UPDATED_PLAYCOUNT    (1<<19)
 
 static char *dvr_updated_str(char *buf, size_t buflen, int flags)
 {
@@ -1576,7 +1586,8 @@ static dvr_entry_t *_dvr_entry_update
     const char *title, const char *subtitle, const char *desc,
     const char *lang, time_t start, time_t stop,
     time_t start_extra, time_t stop_extra,
-    dvr_prio_t pri, int retention, int removal )
+    dvr_prio_t pri, int retention, int removal,
+    int playcount, int playposition)
 {
   char buf[40];
   int save = 0, updated = 0;
@@ -1607,6 +1618,16 @@ static dvr_entry_t *_dvr_entry_update
     if (save & (DVR_UPDATED_STOP|DVR_UPDATED_STOP_EXTRA)) {
       updated = 1;
       dvr_entry_set_timer(de);
+    }
+    if (de->de_sched_state == DVR_RECORDING || de->de_sched_state == DVR_COMPLETED) {
+      if (playcount >= 0 && playcount != de->de_playcount) {
+        de->de_playcount = playcount;
+        save |= DVR_UPDATED_PLAYCOUNT;
+      }
+      if (playposition >= 0 && playposition != de->de_playposition) {
+        de->de_playposition = playposition;
+        save |= DVR_UPDATED_PLAYPOS;
+      }
     }
     goto dosave;
   }
@@ -1721,8 +1742,7 @@ static dvr_entry_t *_dvr_entry_update
   /* Save changes */
 dosave:
   if (save) {
-    idnode_changed(&de->de_id);
-    htsp_dvr_entry_update(de);
+    dvr_entry_changed_notify(de);
     if (tvhlog_limit(&de->de_update_limit, 60)) {
       tvhinfo(LS_DVR, "\"%s\" on \"%s\": Updated%s (%s)",
               lang_str_get(de->de_title, NULL), DVR_CH_NAME(de),
@@ -1750,12 +1770,12 @@ dvr_entry_update
     const char *desc, const char *lang,
     time_t start, time_t stop,
     time_t start_extra, time_t stop_extra,
-    dvr_prio_t pri, int retention, int removal )
+    dvr_prio_t pri, int retention, int removal, int playcount, int playposition )
 {
   return _dvr_entry_update(de, enabled, dvr_config_uuid,
                            NULL, ch, title, subtitle, desc, lang,
                            start, stop, start_extra, stop_extra,
-                           pri, retention, removal);
+                           pri, retention, removal, playcount, playposition);
 }
 
 /**
@@ -1809,7 +1829,7 @@ dvr_event_replaced(epg_broadcast_t *e, epg_broadcast_t *new_e)
                           gmtime2local(e2->start, t1buf, sizeof(t1buf)),
                           gmtime2local(e2->stop, t2buf, sizeof(t2buf)));
           _dvr_entry_update(de, -1, NULL, e2, NULL, NULL, NULL, NULL, NULL,
-                            0, 0, 0, 0, DVR_PRIO_NOTSET, 0, 0);
+                            0, 0, 0, 0, DVR_PRIO_NOTSET, 0, 0, -1, -1);
           return;
         }
       }
@@ -1851,7 +1871,7 @@ void dvr_event_updated(epg_broadcast_t *e)
     if (de->de_bcast != e)
       continue;
     _dvr_entry_update(de, -1, NULL, e, NULL, NULL, NULL, NULL,
-                      NULL, 0, 0, 0, 0, DVR_PRIO_NOTSET, 0, 0);
+                      NULL, 0, 0, 0, 0, DVR_PRIO_NOTSET, 0, 0, -1, -1);
     found++;
   }
   if (found == 0) {
@@ -1865,7 +1885,7 @@ void dvr_event_updated(epg_broadcast_t *e)
                               epg_broadcast_get_title(e, NULL),
                               channel_get_name(e->channel));
         _dvr_entry_update(de, -1, NULL, e, NULL, NULL, NULL, NULL,
-                          NULL, 0, 0, 0, 0, DVR_PRIO_NOTSET, 0, 0);
+                          NULL, 0, 0, 0, 0, DVR_PRIO_NOTSET, 0, 0, -1, -1);
         break;
       }
     }
@@ -3111,6 +3131,24 @@ const idclass_t dvr_entry_class = {
       .def.i    = DVR_RET_REM_DVRCONFIG,
       .list     = dvr_entry_class_removal_list,
       .opts     = PO_HIDDEN | PO_ADVANCED | PO_DOC_NLIST,
+    },
+    {
+      .type     = PT_U32,
+      .id       = "playposition",
+      .name     = N_("Last played position"),
+      .desc     = N_("Last played position when the recording isn't fully watched yet."),
+      .off      = offsetof(dvr_entry_t, de_playposition),
+      .def.i    = 0,
+      .opts     = PO_HIDDEN | PO_NOUI | PO_DOC_NLIST,
+    },
+    {
+      .type     = PT_U32,
+      .id       = "playcount",
+      .name     = N_("Recording play count"),
+      .desc     = N_("Number of times this recording was played."),
+      .off      = offsetof(dvr_entry_t, de_playcount),
+      .def.i    = 0,
+      .opts     = PO_HIDDEN | PO_EXPERT | PO_DOC_NLIST,
     },
     {
       .type     = PT_STR,

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -2798,7 +2798,7 @@ dvr_entry_class_filesize_get(void *o)
   dvr_entry_t *de = (dvr_entry_t *)o;
   if (de->de_sched_state == DVR_COMPLETED ||
       de->de_sched_state == DVR_RECORDING) {
-    size = dvr_get_filesize(de, DVR_FILESIZE_UPDATE);
+    size = dvr_get_filesize(de, DVR_FILESIZE_UPDATE | DVR_FILESIZE_TOTAL);
     if (size < 0)
       size = 0;
   } else

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1294,14 +1294,22 @@ static dvr_entry_t *_dvr_duplicate_event(dvr_entry_t *de)
       if (de == de2)
         continue;
 
+      // check for valid states
+      if (de2->de_sched_state == DVR_NOSTATE ||
+          de2->de_sched_state == DVR_MISSED_TIME)
+        continue;
+
       // only earlier recordings qualify as master
       if (de2->de_start > de->de_start)
         continue;
 
+      // only enabled upcoming recordings
+      if (de2->de_sched_state == DVR_SCHEDULED && !de2->de_enabled)
+        continue;
+
       // only successful earlier recordings qualify as master
-      if (de2->de_sched_state == DVR_MISSED_TIME ||
-          (de2->de_sched_state == DVR_COMPLETED &&
-           de2->de_last_error != SM_CODE_OK))
+      if ((de2->de_sched_state == DVR_COMPLETED || de2->de_sched_state == DVR_RECORDING) &&
+          de2->de_last_error != SM_CODE_OK)
         continue;
 
       // if titles are not defined or do not match, don't dedup
@@ -1318,14 +1326,22 @@ static dvr_entry_t *_dvr_duplicate_event(dvr_entry_t *de)
       if (de == de2)
         continue;
 
+      // check for valid states
+      if (de2->de_sched_state == DVR_NOSTATE ||
+          de2->de_sched_state == DVR_MISSED_TIME)
+        continue;
+
       // only earlier recordings qualify as master
       if (de2->de_start > de->de_start)
         continue;
 
+      // only enabled upcoming recordings
+      if (de2->de_sched_state == DVR_SCHEDULED && !de2->de_enabled)
+        continue;
+
       // only successful earlier recordings qualify as master
-      if (de2->de_sched_state == DVR_MISSED_TIME ||
-          (de2->de_sched_state == DVR_COMPLETED &&
-           de2->de_last_error != SM_CODE_OK))
+      if ((de2->de_sched_state == DVR_COMPLETED || de2->de_sched_state == DVR_RECORDING) &&
+          de2->de_last_error != SM_CODE_OK)
         continue;
 
       // if titles are not defined or do not match, don't dedup

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -881,7 +881,7 @@ dvr_notify(dvr_entry_t *de)
   if (de->de_last_notify + sec2mono(5) < mclk()) {
     idnode_notify_changed(&de->de_id);
     de->de_last_notify = mclk();
-    htsp_dvr_entry_update(de);
+    htsp_dvr_entry_update_stats(de);
   }
 }
 

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -66,7 +66,7 @@
 
 static void *htsp_server, *htsp_server_2;
 
-#define HTSP_PROTO_VERSION 25
+#define HTSP_PROTO_VERSION 26
 
 #define HTSP_ASYNC_OFF  0x00
 #define HTSP_ASYNC_ON   0x01

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -1936,7 +1936,7 @@ htsp_method_updateDvrEntry(htsp_connection_t *htsp, htsmsg_t *in)
   stop_extra  = htsmsg_get_s64_or_default(in, "stopExtra",  0);
   retention   = htsmsg_get_u32_or_default(in, "retention",  DVR_RET_REM_DVRCONFIG);
   removal     = htsmsg_get_u32_or_default(in, "removal",    DVR_RET_REM_DVRCONFIG);
-  priority    = htsmsg_get_u32_or_default(in, "priority",   DVR_PRIO_NORMAL);
+  priority    = htsmsg_get_u32_or_default(in, "priority",   DVR_PRIO_NOTSET);
   title       = htsmsg_get_str(in, "title");
   subtitle    = htsmsg_get_str(in, "subtitle");
   desc        = htsmsg_get_str(in, "description");

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -1291,6 +1291,18 @@ htsp_method_authenticate(htsp_connection_t *htsp, htsmsg_t *in)
 
   if(!(htsp->htsp_granted_access->aa_rights & HTSP_PRIV_MASK))
     htsmsg_add_u32(r, "noaccess", 1);
+  else if (htsp->htsp_version > 25) {
+    htsmsg_add_u32(r, "admin",          htsp->htsp_granted_access->aa_rights & ACCESS_ADMIN ? 1 : 0);
+    htsmsg_add_u32(r, "streaming",      htsp->htsp_granted_access->aa_rights & ACCESS_HTSP_STREAMING ? 1 : 0);
+    htsmsg_add_u32(r, "dvr",            htsp->htsp_granted_access->aa_rights & ACCESS_HTSP_RECORDER ? 1 : 0);
+    htsmsg_add_u32(r, "anonymous",      htsp->htsp_granted_access->aa_rights & ACCESS_HTSP_ANONYMIZE ? 1 : 0);
+    htsmsg_add_u32(r, "limitall",       htsp->htsp_granted_access->aa_conn_limit);
+    htsmsg_add_u32(r, "limitdvr",       htsp->htsp_granted_access->aa_conn_limit_dvr);
+    htsmsg_add_u32(r, "limitstreaming", htsp->htsp_granted_access->aa_conn_limit_streaming);
+    htsmsg_add_u32(r, "uilevel",        htsp->htsp_granted_access->aa_uilevel == UILEVEL_DEFAULT ?
+        config.uilevel : htsp->htsp_granted_access->aa_uilevel);
+    htsmsg_add_str(r, "uilanguage",     htsp->htsp_granted_access->aa_lang_ui);
+  }
   
   return r;
 }

--- a/src/htsp_server.h
+++ b/src/htsp_server.h
@@ -38,6 +38,7 @@ void htsp_tag_delete(channel_tag_t *ct);
 
 void htsp_dvr_entry_add(dvr_entry_t *de);
 void htsp_dvr_entry_update(dvr_entry_t *de);
+void htsp_dvr_entry_update_stats(dvr_entry_t *de);
 void htsp_dvr_entry_delete(dvr_entry_t *de);
 
 void htsp_autorec_entry_add(dvr_autorec_entry_t *dae);

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -454,11 +454,11 @@ tvheadend.dvr_finished = function(panel, index) {
         titleP: _('Finished Recordings'),
         iconCls: 'finishedRec',
         tabIndex: index,
-        edit: { params: { list: tvheadend.admin ? "retention,removal,owner,comment" : "retention,removal,comment" } },
+        edit: { params: { list: tvheadend.admin ? "playcount,retention,removal,owner,comment" : "retention,removal,comment" } },
         del: false,
         list: 'disp_title,disp_subtitle,episode,channelname,' +
               'start_real,stop_real,duration,filesize,' +
-              'sched_status,errors,data_errors,url,config_name,owner,creator,comment',
+              'sched_status,errors,data_errors,playcount,url,config_name,owner,creator,comment',
         columns: {
             filesize: {
                 renderer: tvheadend.filesizeRenderer()
@@ -589,13 +589,13 @@ tvheadend.dvr_failed = function(panel, index) {
         titleP: _('Failed Recordings'),
         iconCls: 'exclamation',
         tabIndex: index,
-        edit: { params: { list: tvheadend.admin ? "retention,removal,owner,comment" : "retention,removal,comment" } },
+        edit: { params: { list: tvheadend.admin ? "playcount,retention,removal,owner,comment" : "retention,removal,comment" } },
         del: true,
         delquestion: _('Do you really want to delete the selected recordings?') + '<br/><br/>' +
                      _('The associated file will be removed from storage.'),
         list: 'disp_title,disp_subtitle,episode,channelname,' +
               'start_real,stop_real,duration,filesize,status,' +
-              'sched_status,errors,data_errors,url,config_name,owner,creator,comment',
+              'sched_status,errors,data_errors,playcount,url,config_name,owner,creator,comment',
         columns: {
             filesize: {
                 renderer: tvheadend.filesizeRenderer()

--- a/src/webui/webui.c
+++ b/src/webui/webui.c
@@ -1523,6 +1523,12 @@ page_dvrfile(http_connection_t *hc, const char *remain, void *opaque)
     return HTTP_STATUS_UNAUTHORIZED;
   }
 
+  /* Play count + 1 when write access */
+  if (!dvr_entry_verify(de, hc->hc_access, 0)) {
+    de->de_playcount = de->de_playcount + 1;
+    dvr_entry_changed_notify(de);
+  }
+
   fname = tvh_strdupa(filename);
   content = muxer_container_filename2mime(fname, 1);
   charset = de->de_config ? de->de_config->dvr_charset_id : NULL;


### PR DESCRIPTION
Whats changed/fixed:
* HTSP clients can hold old data (epg, channels, tags) while not having acces to it anymore . Sending "channelDelete", "tagDelete", "eventDelete" to all clients (without checking access) should overcome this problem.
* Disabling tags and channels does not disable them in htsp clients.
* Duplicate detection should honor disabled dvr entries.
* Playcount/playposition is implemented in a bit different way than my previous PR. Owner can set and get the position and count. Other users can only get when "all dvr read" is enabled. When "all dvr read/write" is enabled, other users can also set playcount/position. Feel free to drop this commit if it doesn't fit in the tvheadend structure.
* Webui list the wrong filesize when the recording was split up.
* Send access right to clients so that they can inform users about limited access and such.
* some minors

While the filesize for DVR entries is correct now, there is still an issue. Only the newest file is playable through htsp or downloadable from the webui.
Example: 
1) Start recording "show A", filename="show A.ts"
2) Interrupt recording with an other higher priority one for a short time (so steal the tuner device from show A)
3) Recording "show A" resumes, filename="show A-1.ts"
4) When playing "show A" only the second file gets played (htsp and webui)!

@perexg 