### PR TITLE
Bug #3843

### DIFF
--- a/src/httpc.c
+++ b/src/httpc.c
@@ -199,11 +199,12 @@ void
 http_client_unpause( http_client_t *hc )
 {
   if (hc->hc_pause) {
+    int pevents_pause = hc->hc_pevents_pause;
     tvhtrace(LS_HTTPC, "%04X: resuming input", shortid(hc));
-    http_client_poll_dir(hc, hc->hc_pevents_pause & TVHPOLL_IN,
-                             hc->hc_pevents_pause & TVHPOLL_OUT);
     hc->hc_pause = 0;
     hc->hc_pevents_pause = 0;
+    http_client_poll_dir(hc, pevents_pause & TVHPOLL_IN,
+            pevents_pause & TVHPOLL_OUT);
   }
 }
 


### PR DESCRIPTION
This is a fix for bug #3843.

[https://tvheadend.org/issues/3843#change-20135](https://tvheadend.org/issues/3843#change-20135)

I think it was a race condition in http_client_unpause. It was being triggered from a timer thread, but it was possible that the httpc thread could reach the pause check in http_client_run0 before hc_pause was reset.

I've tested on my changes on g817f67e (2236) on Fedora 24 ARM 32, and it seems good.
