### PR TITLE
Removed recordings tweaks

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -33,6 +33,11 @@
 #define DVR_FILESIZE_UPDATE     (1<<0)
 #define DVR_FILESIZE_TOTAL      (1<<1)
 
+#define DVR_FINISHED_ALL        (1<<0)
+#define DVR_FINISHED_SUCCESS    (1<<1)
+#define DVR_FINISHED_REMOVED    (1<<2)
+#define DVR_FINISHED_FAILED     (1<<3)
+
 typedef struct dvr_vfs {
   LIST_ENTRY(dvr_vfs) link;
   tvh_fsid_t fsid;
@@ -602,6 +607,8 @@ htsmsg_t *dvr_entry_class_duration_list(void *o, const char *not_set, int max, i
 htsmsg_t *dvr_entry_class_retention_list ( void *o, const char *lang );
 htsmsg_t *dvr_entry_class_removal_list ( void *o, const char *lang );
 
+int dvr_entry_is_upcoming(dvr_entry_t *entry);
+int dvr_entry_is_finished(dvr_entry_t *entry, int flags);
 int dvr_entry_verify(dvr_entry_t *de, access_t *a, int readonly);
 
 void dvr_spawn_cmd(dvr_entry_t *de, const char *cmd, const char *filename, int pre);

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -594,12 +594,10 @@ dvr_entry_status(dvr_entry_t *de)
       default:
         break;
     }
+    if (dvr_get_filesize(de, 0) == -1 && !de->de_file_removed)
+      return N_("File missing");
     if(de->de_data_errors >= DVR_MAX_DATA_ERRORS) /* user configurable threshold? */
       return N_("Too many data errors");
-    if (de->de_file_removed)
-      return N_("File removed");
-    if (dvr_get_filesize(de, 0) == -1)
-      return N_("File missing");
     if(de->de_last_error)
       return streaming_code2txt(de->de_last_error);
     else

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -124,6 +124,33 @@ dvr_entry_trace_time2_(const char *file, int line,
   va_end(args);
 }
 
+int dvr_entry_is_upcoming(dvr_entry_t *entry)
+{
+  dvr_entry_sched_state_t state = entry->de_sched_state;
+  return state == DVR_RECORDING || state == DVR_SCHEDULED || state == DVR_NOSTATE;
+}
+
+int dvr_entry_is_finished(dvr_entry_t *entry, int flags)
+{
+  if (dvr_entry_is_upcoming(entry))
+    return 0;
+  if (!flags || (flags & DVR_FINISHED_ALL))
+    return 1;
+
+  int removed = entry->de_file_removed ||                                               /* Removed by tvheadend */
+      (entry->de_sched_state != DVR_MISSED_TIME && dvr_get_filesize(entry, 0) == -1);   /* Removed externally? */
+  int success = entry->de_sched_state == DVR_COMPLETED &&
+      !entry->de_last_error && entry->de_data_errors < DVR_MAX_DATA_ERRORS;
+
+  if ((flags & DVR_FINISHED_REMOVED) && removed)
+    return 1;
+  if ((flags & DVR_FINISHED_SUCCESS) && success && !removed)
+    return 1;
+  if ((flags & DVR_FINISHED_FAILED) && !success && !removed)
+    return 1;
+  return 0;
+}
+
 /*
  *
  */
@@ -131,8 +158,7 @@ int
 dvr_entry_verify(dvr_entry_t *de, access_t *a, int readonly)
 {
   if (access_verify2(a, ACCESS_FAILED_RECORDER) &&
-      (de->de_sched_state == DVR_COMPLETED &&
-       de->de_last_error != SM_CODE_OK))
+      dvr_entry_is_finished(de, DVR_FINISHED_FAILED))
     return -1;
 
   if (readonly && !access_verify2(a, ACCESS_ALL_RECORDER))
@@ -1288,10 +1314,10 @@ static dvr_entry_t *_dvr_duplicate_event(dvr_entry_t *de)
       if (de2->de_start > de->de_start)
         continue;
 
-      // only successful earlier recordings qualify as master
-      if (de2->de_sched_state == DVR_MISSED_TIME ||
-          (de2->de_sched_state == DVR_COMPLETED &&
-           de2->de_last_error != SM_CODE_OK))
+      // only successful or removed recordings as master
+      // show should not be rerecorded after (manual) removal,
+      // the user might delete recordings after watching to save diskspace
+      if (dvr_entry_is_finished(de2, DVR_FINISHED_FAILED))
         continue;
 
       // if titles are not defined or do not match, don't dedup
@@ -1312,10 +1338,10 @@ static dvr_entry_t *_dvr_duplicate_event(dvr_entry_t *de)
       if (de2->de_start > de->de_start)
         continue;
 
-      // only successful earlier recordings qualify as master
-      if (de2->de_sched_state == DVR_MISSED_TIME ||
-          (de2->de_sched_state == DVR_COMPLETED &&
-           de2->de_last_error != SM_CODE_OK))
+      // only successful or removed recordings as master
+      // show should not be rerecorded after (manual) removal,
+      // the user might delete recordings after watching to save diskspace
+      if (dvr_entry_is_finished(de2, DVR_FINISHED_FAILED))
         continue;
 
       // if titles are not defined or do not match, don't dedup


### PR DESCRIPTION
* List recordings with missing files as "removed", files may be deleted externally with the file manager, are saved on external storage, etc
* Keep the old recording status for removed recordings in order to keep recording errors visible. 
* Moved finished/failed/removed recording check to one central place to prevent inconsistencies.

@perexg 