### PR TITLE
Fix m3u parsing for extended  #EXTM3U header

### DIFF
--- a/src/misc/m3u.c
+++ b/src/misc/m3u.c
@@ -130,7 +130,7 @@ htsmsg_t *parse_m3u
   while (*data && *data <= ' ') data++;
   p = data;
   data = until_eol(data);
-  if (strcmp(p, "#EXTM3U")) {
+  if (strncmp(p, "#EXTM3U", 7)) {
     htsmsg_add_msg(m, "items", htsmsg_create_list());
     return m;
   }


### PR DESCRIPTION
Some .m3u files have extendend parameters. For example:

`#EXTM3U url-tvg="http://xxx/" m3uautoload=1 cache=500 deinterlace=1`

Compare only the first 7 chars to allow this kind of headers.

Fixes `iptv: unknown playlist format for network ''` when the file is valid.