### PR TITLE
Small fixes and polishing

### DIFF
--- a/src/api/api_dvr.c
+++ b/src/api/api_dvr.c
@@ -115,7 +115,7 @@ api_dvr_entry_grid_removed
   dvr_entry_t *de;
 
   LIST_FOREACH(de, &dvrentries, de_global_link)
-    if (dvr_entry_is_finished(de, DVR_FINISHED_REMOVED))
+    if (dvr_entry_is_finished(de, DVR_FINISHED_REMOVED_SUCCESS | DVR_FINISHED_REMOVED_FAILED))
       idnode_set_add(ins, (idnode_t*)de, &conf->filter, perm->aa_lang_ui);
 }
 

--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -33,10 +33,11 @@
 #define DVR_FILESIZE_UPDATE     (1<<0)
 #define DVR_FILESIZE_TOTAL      (1<<1)
 
-#define DVR_FINISHED_ALL        (1<<0)
-#define DVR_FINISHED_SUCCESS    (1<<1)
-#define DVR_FINISHED_REMOVED    (1<<2)
-#define DVR_FINISHED_FAILED     (1<<3)
+#define DVR_FINISHED_ALL             (1<<0)
+#define DVR_FINISHED_SUCCESS         (1<<1) 
+#define DVR_FINISHED_FAILED          (1<<2) 
+#define DVR_FINISHED_REMOVED_SUCCESS (1<<3) /* Removed recording, was succesful before */
+#define DVR_FINISHED_REMOVED_FAILED  (1<<4) /* Removed recording, was failed before */
 
 typedef struct dvr_vfs {
   LIST_ENTRY(dvr_vfs) link;

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -1193,7 +1193,7 @@ const idclass_t dvr_autorec_entry_class = {
       .type     = PT_U32,
       .id       = "retention",
       .name     = N_("DVR log retention"),
-      .desc     = N_("Number of days to retain infomation about recording."),
+      .desc     = N_("Number of days to retain information about recording."),
       .def.i    = DVR_RET_REM_DVRCONFIG,
       .off      = offsetof(dvr_autorec_entry_t, dae_retention),
       .list     = dvr_entry_class_retention_list,
@@ -1513,11 +1513,6 @@ dvr_autorec_get_retention_days( dvr_autorec_entry_t *dae )
   if (dae->dae_retention > 0) {
     if (dae->dae_retention > DVR_RET_REM_FOREVER)
       return DVR_RET_REM_FOREVER;
-
-    uint32_t removal = dvr_autorec_get_removal_days(dae);
-    /* As we need the db entry when deleting the file on disk */
-    if (removal != DVR_RET_REM_FOREVER && removal > dae->dae_retention)
-      return DVR_RET_ONREMOVE;
 
     return dae->dae_retention;
   }

--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -531,9 +531,6 @@ dvr_config_changed(dvr_config_t *cfg)
   dvr_config_storage_check(cfg);
   if (cfg->dvr_cleanup_threshold_free < 50)
     cfg->dvr_cleanup_threshold_free = 50; // as checking is only periodically, lower is not save
-  if (cfg->dvr_removal_days != DVR_RET_REM_FOREVER &&
-      cfg->dvr_removal_days > cfg->dvr_retention_days)
-    cfg->dvr_retention_days = DVR_RET_ONREMOVE;
   if (cfg->dvr_removal_days > DVR_RET_REM_FOREVER)
     cfg->dvr_removal_days = DVR_RET_REM_FOREVER;
   if (cfg->dvr_retention_days > DVR_RET_REM_FOREVER)

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -46,6 +46,7 @@ static void dvr_entry_deferred_destroy(dvr_entry_t *de);
 static void dvr_entry_set_timer(dvr_entry_t *de);
 static void dvr_timer_rerecord(void *aux);
 static void dvr_timer_expire(void *aux);
+static void dvr_timer_disarm(void *aux);
 static void dvr_timer_remove_files(void *aux);
 static void dvr_entry_start_recording(dvr_entry_t *de, int clone);
 static void dvr_timer_start_recording(void *aux);
@@ -413,11 +414,6 @@ dvr_entry_get_retention_days( dvr_entry_t *de )
     if (de->de_retention > DVR_RET_REM_FOREVER)
       return DVR_RET_REM_FOREVER;
 
-    /* As we need the db entry when deleting the file on disk */
-    if (dvr_entry_get_removal_days(de) != DVR_RET_REM_FOREVER &&
-        dvr_entry_get_removal_days(de) > de->de_retention && !de->de_file_removed)
-      return DVR_RET_ONREMOVE;
-
     return de->de_retention;
   }
   return dvr_retention_cleanup(de->de_config->dvr_retention_days);
@@ -507,6 +503,26 @@ dvr_entry_retention_arm(dvr_entry_t *de, gti_callback_t *cb, time_t when)
 }
 
 /*
+ * Returns 1 if the database entry should be deleted on file removal
+ * NOTE: retention can be postponed when retention < removal
+ */
+static int
+dvr_entry_delete_retention_expired(dvr_entry_t *de)
+{
+  uint32_t retention = dvr_entry_get_retention_days(de);
+  time_t stop;
+
+  if (retention == DVR_RET_ONREMOVE)
+    return 1;
+  if (retention < DVR_RET_ONREMOVE) {
+    stop = time_t_out_of_range((int64_t)de->de_stop + retention * (int64_t)86400);
+    if (stop <= gclk())
+      return 1;
+  }
+  return 0;
+}
+
+/*
  *
  */
 static void
@@ -517,7 +533,7 @@ dvr_entry_retention_timer(dvr_entry_t *de)
   uint32_t retention = dvr_entry_get_retention_days(de);
   int save;
 
-  if ((removal > 0 || retention == 0) && removal < DVR_REM_SPACE && !de->de_file_removed) {
+  if ((removal > 0 || retention == 0) && removal < DVR_REM_SPACE && dvr_get_filesize(de, 0) > 0) {
     stop = time_t_out_of_range((int64_t)de->de_stop + removal * (int64_t)86400);
     if (stop > gclk()) {
       dvr_entry_retention_arm(de, dvr_timer_remove_files, stop);
@@ -525,9 +541,9 @@ dvr_entry_retention_timer(dvr_entry_t *de)
     }
     save = 0;
     if (dvr_get_filename(de))
-      save = dvr_entry_delete(de);    // delete actual file
-    if (retention == DVR_RET_ONREMOVE) {
-      dvr_entry_deferred_destroy(de); // also remove database entry
+      save = dvr_entry_delete(de);                // delete actual file
+    if (dvr_entry_delete_retention_expired(de)) { // in case retention was postponed (retention < removal)
+      dvr_entry_deferred_destroy(de);             // also remove database entry
       return;
     }
     if (save) {
@@ -536,12 +552,14 @@ dvr_entry_retention_timer(dvr_entry_t *de)
     }
   }
 
-  if (retention < DVR_RET_ONREMOVE) {
+  if (retention < DVR_RET_ONREMOVE &&
+      (dvr_get_filesize(de, 0) < 0 || removal == DVR_RET_REM_FOREVER)) { // we need the database entry for later file removal
     stop = time_t_out_of_range((int64_t)de->de_stop + retention * (int64_t)86400);
     dvr_entry_retention_arm(de, dvr_timer_expire, stop);
-  } else {
-    dvr_entry_trace(de, "retention timer - disarm");
-    gtimer_disarm(&de->de_timer);
+  }
+  else {
+    dvr_entry_retention_arm(de, dvr_timer_disarm,
+        dvr_entry_get_rerecord_errors(de) ? INT_MAX : 0); // extend disarm to keep the rerecord logic running
   }
 }
 
@@ -1565,6 +1583,17 @@ dvr_timer_expire(void *aux)
   dvr_entry_destroy(de, 1);
 }
 
+
+/**
+ *
+ */
+static void
+dvr_timer_disarm(void *aux)
+{
+  dvr_entry_t *de = aux;
+  dvr_entry_trace(de, "retention timer - disarm");
+  gtimer_disarm(&de->de_timer);
+}
 
 /**
  *
@@ -3673,12 +3702,13 @@ dvr_entry_cancel_delete_remove(dvr_entry_t *de, int rerecord, int _delete)
     dvr_stop_recording(de, SM_CODE_ABORTED, 1, 0);
   case DVR_MISSED_TIME:
   case DVR_COMPLETED:
-    save = dvr_entry_delete(de); /* Remove files */
-    if (_delete || dvr_entry_get_retention_days(de) == DVR_RET_ONREMOVE)
-      dvr_entry_destroy(de, 1);  /* Delete database */
+    save = dvr_entry_delete(de);                           /* Remove files */
+    if (_delete || dvr_entry_delete_retention_expired(de)) /* In case retention was postponed (retention < removal) */
+      dvr_entry_destroy(de, 1);                            /* Delete database */
     else if (save) {
       idnode_changed(&de->de_id);
       htsp_dvr_entry_update(de);
+      dvr_entry_retention_timer(de);                       /* As retention timer depends on file removal */
     }
     break;
   case DVR_SCHEDULED:

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -764,6 +764,10 @@ dvr_entry_set_timer(dvr_entry_t *de)
       return;
 
   } else if (de->de_sched_state == DVR_RECORDING)  {
+    if (!de->de_enabled) {
+      dvr_stop_recording(de, SM_CODE_ABORTED, 1, 0);
+      return;
+    }
 
 recording:
     dvr_entry_trace_time1(de, "stop", stop, "set timer - arm");
@@ -1684,7 +1688,7 @@ static dvr_entry_t *_dvr_entry_update
       de->de_stop_extra = stop_extra;
       save |= DVR_UPDATED_STOP_EXTRA;
     }
-    if (save & (DVR_UPDATED_STOP|DVR_UPDATED_STOP_EXTRA)) {
+    if (save & (DVR_UPDATED_STOP|DVR_UPDATED_STOP_EXTRA|DVR_UPDATED_ENABLED)) {
       updated = 1;
       dvr_entry_set_timer(de);
     }

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -142,7 +142,9 @@ int dvr_entry_is_finished(dvr_entry_t *entry, int flags)
   int success = entry->de_sched_state == DVR_COMPLETED &&
       !entry->de_last_error && entry->de_data_errors < DVR_MAX_DATA_ERRORS;
 
-  if ((flags & DVR_FINISHED_REMOVED) && removed)
+  if ((flags & DVR_FINISHED_REMOVED_SUCCESS) && removed && success)
+    return 1;
+  if ((flags & DVR_FINISHED_REMOVED_FAILED) && removed && !success)
     return 1;
   if ((flags & DVR_FINISHED_SUCCESS) && success && !removed)
     return 1;
@@ -1332,7 +1334,7 @@ static dvr_entry_t *_dvr_duplicate_event(dvr_entry_t *de)
         continue;
 
       // only successful earlier recordings qualify as master
-      if (dvr_entry_is_finished(de2, DVR_FINISHED_FAILED))
+      if (dvr_entry_is_finished(de2, DVR_FINISHED_FAILED | DVR_FINISHED_REMOVED_FAILED))
         continue;
 
       // if titles are not defined or do not match, don't dedup
@@ -1363,7 +1365,7 @@ static dvr_entry_t *_dvr_duplicate_event(dvr_entry_t *de)
         continue;
 
       // only successful earlier recordings qualify as master
-      if (dvr_entry_is_finished(de2, DVR_FINISHED_FAILED))
+      if (dvr_entry_is_finished(de2, DVR_FINISHED_FAILED | DVR_FINISHED_REMOVED_FAILED))
         continue;
 
       // if titles are not defined or do not match, don't dedup

--- a/src/dvr/dvr_timerec.c
+++ b/src/dvr/dvr_timerec.c
@@ -793,12 +793,7 @@ dvr_timerec_get_retention_days( dvr_timerec_entry_t *dte )
   if (dte->dte_retention > 0) {
     if (dte->dte_retention > DVR_RET_REM_FOREVER)
       return DVR_RET_REM_FOREVER;
-
-    /* As we need the db entry when deleting the file on disk */
-    if (dvr_timerec_get_removal_days(dte) != DVR_RET_REM_FOREVER &&
-        dvr_timerec_get_removal_days(dte) > dte->dte_retention)
-      return DVR_RET_ONREMOVE;
-
+      
     return dte->dte_retention;
   }
   return dvr_retention_cleanup(dte->dte_config->dvr_retention_days);

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -521,6 +521,10 @@ htsp_generate_challenge(htsp_connection_t *htsp)
 static inline int
 htsp_user_access_channel(htsp_connection_t *htsp, channel_t *ch)
 {
+  if (!ch || !ch->ch_enabled || LIST_FIRST(&ch->ch_services) == NULL) /* Don't pass unplayable channels to clients */
+    return 0;
+  if (!htsp)
+    return 1;
   return channel_access(ch, htsp->htsp_granted_access, 0);
 }
 
@@ -3481,7 +3485,7 @@ htsp_channel_add(channel_t *ch)
 void
 htsp_channel_update(channel_t *ch)
 {
-  if (ch->ch_enabled)
+  if (htsp_user_access_channel(NULL, ch))
     _htsp_channel_update(ch, "channelUpdate", NULL);
   else // in case the channel was ever sent to the client
     htsp_channel_delete(ch);

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -1311,7 +1311,8 @@ htsp_method_authenticate(htsp_connection_t *htsp, htsmsg_t *in)
     htsmsg_add_u32(r, "limitstreaming", htsp->htsp_granted_access->aa_conn_limit_streaming);
     htsmsg_add_u32(r, "uilevel",        htsp->htsp_granted_access->aa_uilevel == UILEVEL_DEFAULT ?
         config.uilevel : htsp->htsp_granted_access->aa_uilevel);
-    htsmsg_add_str(r, "uilanguage",     htsp->htsp_granted_access->aa_lang_ui);
+    htsmsg_add_str(r, "uilanguage",     htsp->htsp_granted_access->aa_lang_ui ?
+        htsp->htsp_granted_access->aa_lang_ui : (config.language_ui ? config.language_ui : ""));
   }
   
   return r;

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -679,7 +679,7 @@ tvheadend.dvr_removed = function(panel, index) {
         edit: { params: { list: tvheadend.admin ? "retention,owner,comment" : "retention,comment" } },
         del: true,
         list: 'disp_title,disp_subtitle,episode,channelname,' +
-              'start_real,stop_real,duration,filesize,status,' +
+              'start_real,stop_real,duration,status,' +
               'sched_status,errors,data_errors,url,config_name,owner,creator,comment',
         sort: {
           field: 'start_real',


### PR DESCRIPTION
The major changes:
1) Removed some restrictions regarding retention. 
When setting removal to "maintain space" the retention was forced to "on file removal". 
This means that the database entry will be deleted as soon as the file gets deleted. This can cause an unexpected rerecord by duplicate detection. 
The solution is to remove the retention restrictions and postpone it if necessary (when retention < removal).
@perexg Maybe we can set the default retention to some fixed value like "1 month" or so? 
2) Disabling an active recording is equal as aborting now, before disabling didn't have any effect.
3) Duplicate detection should ignore failed recordings (also the deleted ones)
4) Don't pass unplayable channels to htsp clients 

@perexg 