### PR TITLE
Fix for compiling fdk-aac with GCC6

### DIFF
--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -446,7 +446,7 @@ $(LIB_ROOT)/$(LIBFDKAAC)/.tvh_download:
 $(LIB_ROOT)/$(LIBFDKAAC)/.tvh_build: \
 		$(LIB_ROOT)/$(LIBFDKAAC)/.tvh_download
 	cd $(LIB_ROOT)/$(LIBFDKAAC) && \
-		CXXFLAGS="$(CFLAGS_PI)" CFLAGS="$(CFLAGS_PI)" $(CONFIGURE)
+		CXXFLAGS="$(CFLAGS_PI) -std=c++98" CFLAGS="$(CFLAGS_PI)" $(CONFIGURE)
 	DESTDIR=$(EBUILDIR) \
 		$(MAKE) -C $(LIB_ROOT)/$(LIBFDKAAC) install
 	@touch $@


### PR DESCRIPTION
As noted in issue [4043](https://tvheadend.org/issues/4043), compiling tvheadend with GCC6 fails as the standard defaults to a newer version. The suggested solution, to disable ffmpeg is unfeasible for some setups.

As the original project is rarely updated (noted in https://github.com/mstorsjo/fdk-aac/issues/45), i've implemented a hackish fix until the library is updated.

Feel free to revert/remove this PR, once the library is updated.