### PR TITLE
Make SAT>IP requests for pids=all work

### DIFF
--- a/src/satip/rtsp.c
+++ b/src/satip/rtsp.c
@@ -1116,7 +1116,7 @@ rtsp_parse_cmd
     rs->shutdown_on_close = hc;
 
 play:
-  if (pids.count > 0)
+  if (pids.count > 0 || pids.all > 0)
     mpegts_pid_copy(&rs->pids, &pids);
   if (delpids.count > 0)
     mpegts_pid_del_group(&rs->pids, &delpids);


### PR DESCRIPTION
pids=all would result in only pid 0 being sent. transedit uses this to analyze ts content which is again possible with this patch.