### PR TITLE
Fix weird channel numbers

### DIFF
--- a/src/input/mpegts/mpegts_service.c
+++ b/src/input/mpegts/mpegts_service.c
@@ -506,7 +506,7 @@ int64_t
 mpegts_service_channel_number ( service_t *s )
 {
   mpegts_service_t *ms = (mpegts_service_t*)s;
-  int r = 0;
+  int64_t r = 0;
 
   if (!ms->s_dvb_mux->mm_network->mn_ignore_chnum) {
     r = ms->s_dvb_channel_num * CHANNEL_SPLIT + ms->s_dvb_channel_minor;


### PR DESCRIPTION
When selecting "Use service IDs as channel numbers" in the network settings, the `s_dvb_service_id` (uint16) multiplied by `CHANNEL_SPLIT` (int64), would produce a value that would overflow the `r` variable (int) if the service id is was high enough, causing the result to be weird numbers.