### PR TITLE
Fixes

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -622,6 +622,7 @@ void dvr_spawn_cmd(dvr_entry_t *de, const char *cmd, const char *filename, int p
 void dvr_vfs_refresh_entry(dvr_entry_t *de);
 void dvr_vfs_remove_entry(dvr_entry_t *de);
 int64_t dvr_vfs_update_filename(const char *filename, htsmsg_t *fdata);
+int64_t dvr_vfs_rec_start_check(dvr_config_t *cfg);
 
 void dvr_disk_space_boot(void);
 void dvr_disk_space_init(void);

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -559,7 +559,8 @@ dvr_entry_retention_timer(dvr_entry_t *de)
   }
   else {
     dvr_entry_retention_arm(de, dvr_timer_disarm,
-        dvr_entry_get_rerecord_errors(de) ? INT_MAX : 0); // extend disarm to keep the rerecord logic running
+        dvr_entry_get_rerecord_errors(de) ?
+            time_t_out_of_range((int64_t)de->de_stop + DVR_RET_REM_1MONTH * (int64_t)86400) : 0); // extend disarm to keep the rerecord logic running, give up after one month
   }
 }
 

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -646,6 +646,8 @@ dvr_entry_status(dvr_entry_t *de)
         return N_("User access error");
       case SM_CODE_USER_LIMIT:
         return N_("User limit reached");
+      case SM_CODE_NO_SPACE:
+        return streaming_code2txt(de->de_last_error);
       default:
         break;
     }
@@ -659,7 +661,7 @@ dvr_entry_status(dvr_entry_t *de)
       return N_("Completed OK");
 
   case DVR_MISSED_TIME:
-    if (de->de_last_error == SM_CODE_SVC_NOT_ENABLED)
+    if (de->de_last_error == SM_CODE_SVC_NOT_ENABLED || de->de_last_error == SM_CODE_NO_SPACE)
       return streaming_code2txt(de->de_last_error);
     return N_("Time missed");
 

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -923,6 +923,11 @@ dvr_rec_start(dvr_entry_t *de, const streaming_start_t *ss)
     return -1;
   }
 
+  if (!dvr_vfs_rec_start_check(cfg)) {
+    dvr_rec_fatal_error(de, "Not enough free disk space");
+    return SM_CODE_NO_SPACE;
+  }
+
   if (!(muxer = prch->prch_muxer)) {
     if (profile_chain_reopen(prch, &cfg->dvr_muxcnf, 0)) {
       dvr_rec_fatal_error(de, "Unable to reopen muxer");
@@ -1182,11 +1187,12 @@ dvr_thread_rec_start(dvr_entry_t **_de, streaming_start_t *ss,
     if (!dvr_thread_global_lock(de, run))
       return 0;
     dvr_rec_set_state(de, DVR_RS_WAIT_PROGRAM_START, 0);
-    if(dvr_rec_start(de, ss) == 0) {
+    int code = dvr_rec_start(de, ss);
+    if(code == 0) {
       ret = 1;
       *started = 1;
     } else
-      dvr_stop_recording(de, SM_CODE_INVALID_TARGET, 1, 0);
+      dvr_stop_recording(de, code == SM_CODE_NO_SPACE ? SM_CODE_NO_SPACE : SM_CODE_INVALID_TARGET, 1, 0);
     dvr_thread_global_unlock(de);
   }
   return ret;

--- a/src/dvr/dvr_vfsmgr.c
+++ b/src/dvr/dvr_vfsmgr.c
@@ -174,7 +174,7 @@ dvr_vfs_update_filename(const char *filename, htsmsg_t *fdata)
  * Only "Keep until space needed" recordings are deleted, starting with the oldest one
  */
 static int64_t
-dvr_disk_space_cleanup(dvr_config_t *cfg)
+dvr_disk_space_cleanup(dvr_config_t *cfg, int include_active)
 {
   dvr_entry_t *de, *oldest;
   time_t stoptime;
@@ -264,8 +264,15 @@ dvr_disk_space_cleanup(dvr_config_t *cfg)
       dvr_disk_space_config_lastdelete = mclk();
       dvr_entry_cancel_remove(oldest, 0); /* Remove stored files and mark as "removed" */
     } else {
-      tvhwarn(LS_DVR, "%s \"until space needed\" recordings found for config \"%s\", you are running out of disk space very soon!",
-              loops > 0 ? "Not enough" : "No", configName);
+      /* Stop active recordings if cleanup is not possible */
+      if (loops == 0 && include_active) {
+        tvhwarn(LS_DVR, "No \"until space needed\" recordings found for config \"%s\", aborting active recordings now!", configName);
+        LIST_FOREACH(de, &dvrentries, de_global_link) {
+          if (de->de_sched_state != DVR_RECORDING || !de->de_config || de->de_config != cfg)
+            continue;
+          dvr_stop_recording(de, SM_CODE_NO_SPACE, 1, 0);
+        }
+      }
       goto finish;
     }
 
@@ -336,7 +343,7 @@ dvr_disk_space_check()
           }
 
           /* only cleanup one directory at the time as the system needs time to delete the actual files */
-          dvr_disk_space_cleanup(de->de_config);
+          dvr_disk_space_cleanup(de->de_config, 1);
           cleanupDone = 1;
           dvr_disk_space_config_idx = idx;
           break;
@@ -421,6 +428,37 @@ dvr_get_disk_space_cb(void *aux)
     tasklet_arm(&dvr_disk_space_tasklet, dvr_get_disk_space_tcb, path);
   }
   mtimer_arm_rel(&dvr_disk_space_timer, dvr_get_disk_space_cb, NULL, sec2mono(15));
+}
+
+/**
+ * Returns the available disk space for a new recording.
+ * If '0' (= below configured minimum), a new recording should not be started.
+ */
+int64_t
+dvr_vfs_rec_start_check(dvr_config_t *cfg)
+{
+  struct statvfs diskdata;
+  dvr_vfs_t *dvfs;
+  int64_t availBytes, requiredBytes, usedBytes, maximalBytes, cleanedBytes;
+
+  lock_assert(&global_lock);
+  if (!cfg || !cfg->dvr_enabled || statvfs(cfg->dvr_storage, &diskdata) == -1)
+    return 0;
+  availBytes    = diskdata.f_bsize * (int64_t)diskdata.f_bavail;
+  requiredBytes = MIB(cfg->dvr_cleanup_threshold_free);
+  maximalBytes  = MIB(cfg->dvr_cleanup_threshold_used);
+  dvfs          = dvr_vfs_find(NULL, tvh_fsid(diskdata.f_fsid));
+  usedBytes     = dvfs->used_size;
+
+  if (availBytes < requiredBytes || ((maximalBytes < usedBytes) && cfg->dvr_cleanup_threshold_used)) {
+    /* Not enough space to start recording, check if cleanup helps */
+    cleanedBytes = dvr_disk_space_cleanup(cfg, 0);
+    availBytes += cleanedBytes;
+    usedBytes -= cleanedBytes;
+    if (availBytes < requiredBytes || ((maximalBytes < usedBytes) && cfg->dvr_cleanup_threshold_used))
+      return 0;
+  }
+  return availBytes;
 }
 
 /**

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -1611,6 +1611,7 @@ htsp_method_authenticate(htsp_connection_t *htsp, htsmsg_t *in)
     htsmsg_add_u32(r, "admin",          htsp->htsp_granted_access->aa_rights & ACCESS_ADMIN ? 1 : 0);
     htsmsg_add_u32(r, "streaming",      htsp->htsp_granted_access->aa_rights & ACCESS_HTSP_STREAMING ? 1 : 0);
     htsmsg_add_u32(r, "dvr",            htsp->htsp_granted_access->aa_rights & ACCESS_HTSP_RECORDER ? 1 : 0);
+    htsmsg_add_u32(r, "faileddvr",      htsp->htsp_granted_access->aa_rights & ACCESS_FAILED_RECORDER ? 1 : 0);
     htsmsg_add_u32(r, "anonymous",      htsp->htsp_granted_access->aa_rights & ACCESS_HTSP_ANONYMIZE ? 1 : 0);
     htsmsg_add_u32(r, "limitall",       htsp->htsp_granted_access->aa_conn_limit);
     htsmsg_add_u32(r, "limitdvr",       htsp->htsp_granted_access->aa_conn_limit_dvr);

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -4599,6 +4599,8 @@ _htsp_get_subscription_status(int smcode)
     return "userLimit";
   case SM_CODE_WEAK_STREAM:
     return "weakStream";
+  case SM_CODE_NO_SPACE:
+    return "noDiskSpace";
   default:
     return streaming_code2txt(smcode);
   }

--- a/src/streaming.c
+++ b/src/streaming.c
@@ -481,6 +481,8 @@ streaming_code2txt(int code)
     return N_("No access");
   case SM_CODE_NO_INPUT:
     return N_("No input detected");
+  case SM_CODE_NO_SPACE:
+    return N_("Not enough disk space");
 
   default:
     snprintf(ret, sizeof(ret), _("Unknown reason (%i)"), code);

--- a/src/tvheadend.h
+++ b/src/tvheadend.h
@@ -537,6 +537,7 @@ typedef enum {
 #define SM_CODE_NO_DESCRAMBLER            400
 #define SM_CODE_NO_ACCESS                 401
 #define SM_CODE_NO_INPUT                  402
+#define SM_CODE_NO_SPACE                  403
 
 typedef enum
 {


### PR DESCRIPTION
Biggest changes:
1) Recordings will now be aborted when running out of space, also when the user does not have any "maintain free space" recordings.  Without this, tvheadend will keep recording until file writing fails, at this point the OS can become very unstable. 
2) Improved htsp async methods. The add/update/delete methods are very inconsistent due to different access right. Under some circumstances "update" was sent instead of "add", "delete" was sent to clients which never received the "add", "delete" was never sent due to access right changes,.. 
This does also fix the issue @ksooo reported: failed dvr access is off -> abort recording -> recording is marked as failed so the user does not have access anymore -> because of no access, "dvrEntryDelete" won't be sent to the client -> client thinks it's still recording.
@perexg Do you agree with the solution of keeping a local copy from all added dvrs/tags/channesl/events? In this way we can properly determine when to send add, update or delete.
I also added a fixme as dvr_rec.c calls some htsp functions without global lock, not related to this PR.
 