### PR TITLE
Allow Authorization Header

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -337,7 +337,7 @@ http_send_header(http_connection_t *hc, int rc, const char *content,
     if (config.cors_origin && config.cors_origin[0]) {
       htsbuf_qprintf(&hdrs, "Access-Control-Allow-Origin: %s\r\n", config.cors_origin);
       htsbuf_append_str(&hdrs, "Access-Control-Allow-Methods: POST, GET, OPTIONS\r\n");
-      htsbuf_append_str(&hdrs, "Access-Control-Allow-Headers: x-requested-with\r\n");
+      htsbuf_append_str(&hdrs, "Access-Control-Allow-Headers: x-requested-with,authorization\r\n");
     }
   }
   


### PR DESCRIPTION
Allows Authorization Header to be used by XMLHttpRequest.

If the Authorization Header is not allowed, it's not possible to use Basic-Authentication from Javascript requests in the Browser (Ajax).
A Browser will throw this error: `XMLHttpRequest cannot load http://tvheadend/. Request header field Authorization is not allowed by Access-Control-Allow-Headers in preflight response.`