### PR TITLE
Fix crash in DVR thread 

### DIFF
--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -4117,6 +4117,7 @@ _htsp_get_subscription_status(int smcode)
   case SM_CODE_NO_FREE_ADAPTER:
   case SM_CODE_NO_ADAPTERS:
     return "noFreeAdapter";
+  case SM_CODE_NO_ACCESS:
   case SM_CODE_NO_DESCRAMBLER:
     return "scrambled";
   case SM_CODE_NO_INPUT:


### PR DESCRIPTION
1) Fix crash when recording subscription gets overridden.
`Mutex not held at src/main.c:258

Program received signal SIGABRT, Aborted.
[Switching to Thread 0x7fffd97fa700 (LWP 19941)]
0x00007ffff6265c37 in raise () from /lib/x86_64-linux-gnu/libc.so.6
(gdb) bt full
#0  0x00007ffff6265c37 in raise () from /lib/x86_64-linux-gnu/libc.so.6
No symbol table info available.
#1  0x00007ffff6269028 in abort () from /lib/x86_64-linux-gnu/libc.so.6
No symbol table info available.
#2  0x0000555555679e58 in lock_assert0 (l=0x555555b1cbc0 <global_lock>, file=0x55555578ac78 "src/main.c", line=258) at src/tvheadend.h:101
        file = 0x55555578ac78 "src/main.c"
        l = 0x555555b1cbc0 <global_lock>
#3  mtimer_arm_abs (mti=0x555555b16c00 <save_timer>, callback=0x55555567b7c0 <idnode_save_trigger_thread_cb>, opaque=0x0, when=41244493167) at src/main.c:258
No locals.
#4  0x000055555567bc6d in idnode_save_queue (self=0x555555d9b840) at src/idnode.c:1153
        ise = 0x7fff78001600
#5  0x0000555555680619 in idnode_save_queue (self=<optimized out>) at src/idnode.c:1206
No locals.
#6  idnode_changed (self=<optimized out>) at src/idnode.c:1205
No locals.
#7  0x00005555557013b2 in dvr_thread (aux=<optimized out>) at src/dvr/dvr_rec.c:1450`

2) Htsp clients get not informed when descrambling is not possible.

@perexg 