### PR TITLE
Various little fixes.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: tvheadend
 Section: video
 Priority: extra
 Maintainer: Adam Sutton <aps@tvheadend.org>
-Build-Depends: debhelper (>= 7.0.50), pkg-config, gettext, libavahi-client-dev, libssl-dev, zlib1g-dev, wget, bzip2, libcurl4-gnutls-dev, git-core, liburiparser-dev, python, curl, ca-certificates, cmake
+Build-Depends: debhelper (>= 7.0.50), pkg-config, gettext, libavahi-client-dev, libssl-dev, zlib1g-dev, wget, bzip2, libcurl4-gnutls-dev, git-core, liburiparser-dev, python, curl, ca-certificates, cmake, dvb-apps
 Standards-Version: 3.7.3
 
 Package: tvheadend

--- a/src/access.c
+++ b/src/access.c
@@ -1054,6 +1054,8 @@ access_entry_create(const char *uuid, htsmsg_t *conf)
     ae->ae_change_chrange = 1;
     ae->ae_change_chtags  = 1;
     ae->ae_change_rights  = 1;
+    ae->ae_streaming      = 1;
+    ae->ae_dvr            = 1;
     ae->ae_htsp_streaming = 1;
     ae->ae_htsp_dvr       = 1;
     ae->ae_all_dvr        = 1;

--- a/src/http.c
+++ b/src/http.c
@@ -580,7 +580,7 @@ http_error(http_connection_t *hc, int error)
                    error, errtxt, error, errtxt);
 
     if (error == HTTP_STATUS_UNAUTHORIZED)
-      htsbuf_qprintf(&hc->hc_reply, "<P><A HREF=\"%s/\">Default Login</A></P>",
+      htsbuf_qprintf(&hc->hc_reply, "<P><A HREF=\"%s/logout\">Default Login</A></P>",
                      tvheadend_webroot ? tvheadend_webroot : "");
 
     htsbuf_append_str(&hc->hc_reply, "</BODY></HTML>\r\n");


### PR DESCRIPTION
I noticed that the "Basic" streaming and DVR options weren't set when creating users via the wizard setup. This commit adds those options as default.

Edit: Additional fixes.. I noticed some browsers will try and login using cached details sometimes causing a login loop when clicking the "Default Login" link, replacing it with /logout should hopefully prevent this.