### PR TITLE
Timeshift broken on stream restart, issue #4096

### DIFF
--- a/src/timeshift.c
+++ b/src/timeshift.c
@@ -370,9 +370,12 @@ static void timeshift_input
     }
 
     /* Check for exit */
-    else if (type == SMT_EXIT ||
-        (type == SMT_STOP && sm->sm_code != SM_CODE_SOURCE_RECONFIGURED))
+    else if (type == SMT_EXIT)
       ts->exit = 1;
+
+    // Don't exit timeshift on SMT_STOP as the subscription might restart later on.
+    // i.e. SM_CODE_SOURCE_RECONFIGURED, SM_CODE_SUBSCRIPTION_OVERRIDDEN, ...
+    // else if (type == SMT_STOP)
 
     else if (type == SMT_MPEGTS)
       ts->packet_mode = 0;

--- a/src/timeshift/timeshift_writer.c
+++ b/src/timeshift/timeshift_writer.c
@@ -331,8 +331,8 @@ static void _process_msg
       if (run) *run = 0;
       break;
     case SMT_STOP:
-      if (sm->sm_code != SM_CODE_SOURCE_RECONFIGURED && run)
-        *run = 0;
+      // Don't exit timeshift on SMT_STOP as the subscription might restart later on.
+      // i.e. SM_CODE_SOURCE_RECONFIGURED, SM_CODE_SUBSCRIPTION_OVERRIDDEN, ...
       goto live;
 
     /* Timeshifting */


### PR DESCRIPTION
When a subscription gets overridden (and possible in other "stop" cases too), the timeshift reader and writer threads gets closed. The subscription stays running in idle state, but when it resumes (free tuner for example), timeshift won't be restarted.

This causes 2 problems:
1) subscription hangs and never resumes on the client after an subscription override (or other stop code), even if it is "running" according to the tvheadend status tab.
2) "sm_code" messages not sent to clients when SMT_NOSTART is issued. So the user is left in the dark why playback stopped. 

Related to:
https://tvheadend.org/issues/4096#change-20566

@perexg I'm not sure if this is a "correct" fix, please give your opinion 