### PR TITLE
[Feature #4229] IPTV/RTP input: handle source specific multicast (SSM)

### DIFF
--- a/src/input/mpegts/iptv/iptv_udp.c
+++ b/src/input/mpegts/iptv/iptv_udp.c
@@ -40,7 +40,9 @@ iptv_udp_start ( iptv_mux_t *im, const char *raw, const url_t *url )
 
   mpegts_mux_nice_name((mpegts_mux_t*)im, name, sizeof(name));
 
-  conn = udp_bind(LS_IPTV, name, url->host, url->port,
+  /* Note: url->user is used for specifying multicast source address (SSM)
+     here. The URL format is rtp://<srcaddr>@<grpaddr>:<port> */
+  conn = udp_bind(LS_IPTV, name, url->host, url->port, url->user,
                   im->mm_iptv_interface, IPTV_BUF_SIZE, 4*1024);
   if (conn == UDP_FATAL_ERROR)
     return SM_CODE_TUNING_FAILED;

--- a/src/udp.h
+++ b/src/udp.h
@@ -43,7 +43,7 @@ typedef struct udp_connection {
 
 udp_connection_t *
 udp_bind ( int subsystem, const char *name,
-           const char *bindaddr, int port,
+           const char *bindaddr, int port, const char *multicast_src,
            const char *ifname, int rxsize, int txsize );
 int
 udp_bind_double ( udp_connection_t **_u1, udp_connection_t **_u2,

--- a/src/upnp.c
+++ b/src/upnp.c
@@ -138,11 +138,11 @@ upnp_thread( void *aux )
   int r, delay_ms;
 
   multicast = udp_bind(LS_UPNP, "upnp_thread_multicast",
-                       "239.255.255.250", 1900,
+                       "239.255.255.250", 1900, NULL,
                        NULL, 32*1024, 32*1024);
   if (multicast == NULL || multicast == UDP_FATAL_ERROR)
     goto error;
-  unicast = udp_bind(LS_UPNP, "upnp_thread_unicast", bindaddr, 0,
+  unicast = udp_bind(LS_UPNP, "upnp_thread_unicast", bindaddr, 0, NULL,
                      NULL, 32*1024, 32*1024);
   if (unicast == NULL || unicast == UDP_FATAL_ERROR)
     goto error;


### PR DESCRIPTION
This adds support for source-specific multicast (SSM) for IPTV RTP input. Reference: https://tvheadend.org/issues/4229