### PR TITLE
Htsp playstatus improvement

### DIFF
--- a/.doozer.json
+++ b/.doozer.json
@@ -240,6 +240,28 @@
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--disable-bintray_cache\\ --enable-ccache\\ --enable-hdhomerun_static\\ --disable-ffmpeg_static ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}"
       ]
+    },
+    "fedora24-x86_64": {
+      "buildenv": "fedora24-x86_64",
+      "builddeps": [
+        "rpm-build",
+        "git",
+        "build-essential",
+        "pkg-config",
+        "gettext",
+        "avahi-devel",
+        "openssl-devel",
+        "zlib-devel",
+        "wget",
+        "bzip2",
+        "uriparser-devel",
+        "python",
+        "ccache"
+      ],
+      "buildcmd": [
+        "./configure",
+        "make -C rpm build"
+      ]
     }
   }
 }

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -66,7 +66,7 @@
 
 static void *htsp_server, *htsp_server_2;
 
-#define HTSP_PROTO_VERSION 26
+#define HTSP_PROTO_VERSION 27
 
 #define HTSP_ASYNC_OFF  0x00
 #define HTSP_ASYNC_ON   0x01

--- a/src/htsp_server.h
+++ b/src/htsp_server.h
@@ -22,6 +22,13 @@
 #include "epg.h"
 #include "dvr/dvr.h"
 
+typedef enum {
+  HTSP_DVR_PLAYCOUNT_RESET = 0,
+  HTSP_DVR_PLAYCOUNT_SET   = 1,
+  HTSP_DVR_PLAYCOUNT_KEEP  = INT32_MAX-1,
+  HTSP_DVR_PLAYCOUNT_INCR  = INT32_MAX
+} dvr_playcount_t;
+
 void htsp_init(const char *bindaddr);
 void htsp_register(void);
 void htsp_done(void);


### PR DESCRIPTION
Currently the implemented htsp playstatus methods are kind of useless for some clients.
This for the following reasons:
a) The client might want to set playcount/playposition by itself. For example, some clients do this after 'x' percent/minutes of the show was watched. 
b) The property "watched count" is past tense, so strictly speaking we should increase the count after watching and not before (so on file close instead of file open). 
c) The auto increment conflicts with "htsp_method_updateDvrEntry", they both can increase the playcount and that can cause issues as playcount +2 instead of +1.

a) This will be handled with some new constants, "HTSP_DVR_PLAYCOUNT_KEEP " will ignore tvheadends auto increment when the client wants to set the playcount by itself.
b) Auto increment (when desired) will be done on file closing.
c) Also handled with 1)

@perexg 