### PR TITLE
bintray.py: add component env override

### DIFF
--- a/support/bintray.py
+++ b/support/bintray.py
@@ -27,6 +27,7 @@ DEBUG=False
 BINTRAY_API='https://bintray.com/api/v1'
 BINTRAY_USER=env('BINTRAY_USER')
 BINTRAY_PASS=env('BINTRAY_PASS')
+BINTRAY_COMPONENT=env('BINTRAY_COMPONENT')
 BINTRAY_ORG='tvheadend'
 BINTRAY_PACKAGE='tvheadend'
 
@@ -150,7 +151,7 @@ def get_bintray_params(filename, hint=None):
         debversion, debdistro = debversion.rsplit('~', 1)
         args.version = debversion
         args.path = 'pool/' + get_path(debversion, args.repo) + '/' + args.package
-        extra.append('deb_component=' + get_component(debversion))
+        extra.append('deb_component=' + BINTRAY_COMPONENT or get_component(debversion))
         extra.append('deb_distribution=' + debdistro)
         extra.append('deb_architecture=' + debarch)
     else:


### PR DESCRIPTION
I've been working on getting a spare rpi2 of mine to build tvh in a chroot so I can push the debs to bintray, atleast until doozer supports  jessie "raspbian"/armhf. Because these builds are tests, I didn't want to make them available to the stable, unstable and release components until I'd had time to test them, but I also wanted to be sure they worked fine via apt/bintray. 

This commit modifies bintray.py to allow the component to be overridden. There is no version formatting. I suppose I could modify the get_component method & add a hint param to override {release-*, stable-*, unstable}, which is a lot nicer but this'll do for now.

@perexg 

This doesn't have to be committed if you think it doesn't have any value. While my initial intention for this commit is for rpi builds, it could be useful for providing "light" or bundled builds of tvheadend in the future.

Any input on this would be greatly appreciated! 