### PR TITLE
HTSP Python: function < integer will never return false

### DIFF
--- a/lib/py/tvh/htsmsg.py
+++ b/lib/py/tvh/htsmsg.py
@@ -169,7 +169,7 @@ def deserialize0(data, typ=HMF_MAP):
         dlen = bin2int(data[2:6])
         data = data[6:]
 
-        if len < nlen + dlen: raise Exception('not enough data')
+        if len(data) < nlen + dlen: raise Exception('not enough data')
 
         name = data[:nlen]
         data = data[nlen:]


### PR DESCRIPTION
Sorry, if this is a strange Python thing I don't understand, but to me it looks like this has at best undefined behaviour and will at worst be completely useless because len < nlen+dlen will never be able to return false. (len is a function and needs a parameter to return any useful numeric information)