### PR TITLE
Fix dvr priorities after 33cc05b

### DIFF
--- a/src/api/api_dvr.c
+++ b/src/api/api_dvr.c
@@ -233,7 +233,7 @@ api_dvr_entry_create_by_event
                                        e, 0, 0,
                                        perm->aa_username,
                                        perm->aa_representative,
-                                       NULL, DVR_PRIO_NORMAL, DVR_RET_REM_DVRCONFIG,
+                                       NULL, DVR_PRIO_DEFAULT, DVR_RET_REM_DVRCONFIG,
                                        DVR_RET_REM_DVRCONFIG, comment);
         if (de) {
           if (l == NULL)

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1929,7 +1929,7 @@ dvr_event_replaced(epg_broadcast_t *e, epg_broadcast_t *new_e)
                           gmtime2local(e2->start, t1buf, sizeof(t1buf)),
                           gmtime2local(e2->stop, t2buf, sizeof(t2buf)));
           _dvr_entry_update(de, -1, NULL, e2, NULL, NULL, NULL, NULL, NULL,
-                            0, 0, 0, 0, DVR_PRIO_NOTSET, 0, 0, -1, -1);
+                            0, 0, 0, 0, DVR_PRIO_DEFAULT, 0, 0, -1, -1);
           return;
         }
       }
@@ -1971,7 +1971,7 @@ void dvr_event_updated(epg_broadcast_t *e)
     if (de->de_bcast != e)
       continue;
     _dvr_entry_update(de, -1, NULL, e, NULL, NULL, NULL, NULL,
-                      NULL, 0, 0, 0, 0, DVR_PRIO_NOTSET, 0, 0, -1, -1);
+                      NULL, 0, 0, 0, 0, DVR_PRIO_DEFAULT, 0, 0, -1, -1);
     found++;
   }
   if (found == 0) {
@@ -1985,7 +1985,7 @@ void dvr_event_updated(epg_broadcast_t *e)
                               epg_broadcast_get_title(e, NULL),
                               channel_get_name(e->channel, channel_blank_name));
         _dvr_entry_update(de, -1, NULL, e, NULL, NULL, NULL, NULL,
-                          NULL, 0, 0, 0, 0, DVR_PRIO_NOTSET, 0, 0, -1, -1);
+                          NULL, 0, 0, 0, 0, DVR_PRIO_DEFAULT, 0, 0, -1, -1);
         break;
       }
     }

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -75,7 +75,7 @@ dvr_rec_subscribe(dvr_entry_t *de)
   assert(de->de_chain == NULL);
 
   pri = de->de_pri;
-  if(pri == DVR_PRIO_NOTSET)
+  if(pri == DVR_PRIO_NOTSET || pri == DVR_PRIO_DEFAULT)
     pri = de->de_config->dvr_pri;
   if(pri >= 0 && pri < ARRAY_SIZE(prio2weight))
     weight = prio2weight[de->de_pri];

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -641,7 +641,7 @@ htsp_serierec_convert(htsp_connection_t *htsp, htsmsg_t *in, channel_t *ch, int 
   if (!(retval = htsmsg_get_u32(in, "removal", &u32)) || add)
     htsmsg_add_u32(conf, "removal", !retval ? u32 : DVR_RET_REM_DVRCONFIG);
   if(!(retval = htsmsg_get_u32(in, "priority", &u32)) || add)
-    htsmsg_add_u32(conf, "pri", !retval ? u32 : DVR_PRIO_NORMAL);
+    htsmsg_add_u32(conf, "pri", !retval ? u32 : DVR_PRIO_DEFAULT);
   if ((str = htsmsg_get_str(in, "name")) || add)
     htsmsg_add_str(conf, "name", str ?: "");
   if ((str = htsmsg_get_str(in, "comment")) || add)
@@ -1836,7 +1836,7 @@ htsp_method_addDvrEntry(htsp_connection_t *htsp, htsmsg_t *in)
     ch = e ? e->channel : ch;
   }
   if(htsmsg_get_u32(in, "priority", &priority))
-    priority = DVR_PRIO_NORMAL;
+    priority = DVR_PRIO_DEFAULT;
   if(htsmsg_get_u32(in, "retention", &retention))
     retention = DVR_RET_REM_DVRCONFIG;
   if(htsmsg_get_u32(in, "removal", &removal))
@@ -1971,7 +1971,7 @@ htsp_method_updateDvrEntry(htsp_connection_t *htsp, htsmsg_t *in)
   stop_extra  = htsmsg_get_s64_or_default(in, "stopExtra",  0);
   retention   = htsmsg_get_u32_or_default(in, "retention",  DVR_RET_REM_DVRCONFIG);
   removal     = htsmsg_get_u32_or_default(in, "removal",    DVR_RET_REM_DVRCONFIG);
-  priority    = htsmsg_get_u32_or_default(in, "priority",   DVR_PRIO_NOTSET);
+  priority    = htsmsg_get_u32_or_default(in, "priority",   DVR_PRIO_DEFAULT);
   title       = htsmsg_get_str(in, "title");
   subtitle    = htsmsg_get_str(in, "subtitle");
   desc        = htsmsg_get_str(in, "description");


### PR DESCRIPTION
Use new DVR_PRIO_DEFAULT wherever it should be used (HTSP, API, ...).