### PR TITLE
Compatibility fix for undefined _SC_IOV_MAX

### DIFF
--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -1324,6 +1324,12 @@ dvr_config_init(void)
   dvr_config_t *cfg;
 
   dvr_iov_max = sysconf(_SC_IOV_MAX);
+  if( dvr_iov_max == -1 )
+#ifdef IOV_MAX
+    dvr_iov_max = IOV_MAX;
+#else
+    dvr_iov_max = 16;
+#endif
 
   /* Default settings */
 


### PR DESCRIPTION
This is the last compatibility fix, which has been included in the spksrc cross-compilation framework for tvheadend (downstream) for years. 

To be honest, technically I can see what it does, but I do not know what symptoms it fixes: There might be different reasons for this. Either, because I just do not have an architecture which exposes the corresponding problems, or, because this patch is actually no longer needed. I don't know. With this in mind...

@perexg, can you carefully review, please, and let me know what you think?