### PR TITLE
Small build fixes for FreeBSD support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -681,7 +681,7 @@ include ${ROOTDIR}/support/${OSENV}.mk
 $(BUILDDIR)/timestamp.c: FORCE
 	@mkdir -p $(dir $@)
 	@echo '#include "build.h"' > $@
-	@echo 'const char* build_timestamp = "'`date -Iseconds`'";' >> $@
+	@echo 'const char* build_timestamp = "'`date +%Y-%m-%dT%H:%M:%S%z`'";' >> $@
 
 $(BUILDDIR)/timestamp.o: $(BUILDDIR)/timestamp.c
 	$(pCC) -c -o $@ $<

--- a/src/spawn.c
+++ b/src/spawn.c
@@ -28,6 +28,7 @@
 #include <syslog.h>
 #include <fcntl.h>
 #include <dirent.h>
+#include <signal.h>
 
 #include "tvheadend.h"
 #include "tvhpoll.h"


### PR DESCRIPTION
Submitted fixes were created when compiling tvheadend 4.2.2 on FreeBSD. Please also see the commit logs for more details.