### PR TITLE
linuxdvb: catch FE_SCALE_NOT_AVAILABLE in DVBv5 signal strength

### DIFF
--- a/src/input/mpegts/linuxdvb/linuxdvb_frontend.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_frontend.c
@@ -1011,6 +1011,10 @@ linuxdvb_frontend_monitor ( void *aux )
         mmi->tii_stats.signal = sig_multiply(fe_properties[0].u.st.stat[0].svalue, lfe->lfe_sig_multiplier);
         gotprop = 1;
       }
+      else if(fe_properties[0].u.st.stat[0].scale == FE_SCALE_NOT_AVAILABLE) {
+        mmi->tii_stats.snr_scale = SIGNAL_STATUS_SCALE_UNKNOWN;
+        gotprop = 1;
+      }
       else {
         ioctl_bad(lfe, 1);
         mmi->tii_stats.signal_scale = SIGNAL_STATUS_SCALE_UNKNOWN;


### PR DESCRIPTION
If the scale is reported as FE_SCALE_NOT_AVAILABLE, signal strength shouldn't be marked bad, but rather be retried later since this is a valid state. Currently, when FE_SCALE_NOT_AVAILABLE is reported, one won't see any signal strength at all in the webui, however, some drivers might start reporting this "later" (e.g. when it's done tuning). Change linuxdvb_frontend_monitor to catch FE_SCALE_NOT_AVAILABLE for signalstrength aswell, like for snr.

EDIT: candidate for backport?
EDIT2 (semi-offtopic): With latest master (probably since the statistics multiplier stuff is in), signal strength is now reported in the 42xxx.y dBm range, whereas it should be e.g. -30.0dBm. Driver reports this properly in DVBv5 format. Config values (multiplier) is set to the default of 100. Looks like a sign flip or so.