### PR TITLE
Allow to override build date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -678,10 +678,16 @@ src/webui/extjs.c: make_webui
 include ${ROOTDIR}/support/${OSENV}.mk
 
 # Build files
+DATE_FMT = %Y-%m-%dT%H:%M:%S%z
+ifdef SOURCE_DATE_EPOCH
+	BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)"  2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u "+$(DATE_FMT)")
+else
+	BUILD_DATE ?= $(shell date "+$(DATE_FMT)")
+endif
 $(BUILDDIR)/timestamp.c: FORCE
 	@mkdir -p $(dir $@)
 	@echo '#include "build.h"' > $@
-	@echo 'const char* build_timestamp = "'`date +%Y-%m-%dT%H:%M:%S%z`'";' >> $@
+	@echo 'const char* build_timestamp = "'$(BUILD_DATE)'";' >> $@
 
 $(BUILDDIR)/timestamp.o: $(BUILDDIR)/timestamp.c
 	$(pCC) -c -o $@ $<


### PR DESCRIPTION
to enable reproducible builds

See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

The date calls are designed to work with both GNU date and BSD date

The alternative would be to drop the build timestamps
in favour of version numbers and/or git commit hashes.