### PR TITLE
Fix _dvr_entry_update to allow update of more props for finished and ongoing recordings

### DIFF
--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1726,6 +1726,20 @@ static dvr_entry_t *_dvr_entry_update
         de->de_playposition = playposition;
         save |= DVR_UPDATED_PLAYPOS;
       }
+      if (retention && (retention != de->de_retention)) {
+        de->de_retention = retention;
+        save |= DVR_UPDATED_RETENTION;
+      }
+      if (removal && (removal != de->de_removal)) {
+        de->de_removal = removal;
+        save |= DVR_UPDATED_REMOVAL;
+      }
+      if (title) {
+        save |= lang_str_set(&de->de_title, title, lang) ? DVR_UPDATED_TITLE : 0;
+      }
+      if (subtitle) {
+        save |= lang_str_set(&de->de_subtitle, subtitle, lang) ? DVR_UPDATED_SUBTITLE : 0;
+      }
     }
     goto dosave;
   }

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -66,7 +66,7 @@
 
 static void *htsp_server, *htsp_server_2;
 
-#define HTSP_PROTO_VERSION 27
+#define HTSP_PROTO_VERSION 28
 
 #define HTSP_ASYNC_OFF  0x00
 #define HTSP_ASYNC_ON   0x01


### PR DESCRIPTION
Fix _dvr_entry_update to allow update of retention, removal, title and subtitle for finished and ongoing recordings. htsp version bump to v28 needed to allow clients to identify the fix.

@Glenn-1990 fyi