### PR TITLE
epggrab xmltv: support grabbing "summary" field

### DIFF
--- a/src/epggrab/module/xmltv.c
+++ b/src/epggrab/module/xmltv.c
@@ -472,6 +472,7 @@ static int _xmltv_parse_programme_tags
   char *suri = NULL, *uri = NULL;
   lang_str_t *title = NULL;
   lang_str_t *desc = NULL;
+  lang_str_t *summary = NULL;
   lang_str_t *subtitle = NULL;
   time_t first_aired = 0;
   int8_t bw = -1;
@@ -489,6 +490,11 @@ static int _xmltv_parse_programme_tags
   _xmltv_parse_lang_str(&desc, tags, "desc");
   if (desc)
     save3 |= epg_broadcast_set_description(ebc, desc, &changes);
+
+  /* summary */
+  _xmltv_parse_lang_str(&summary, tags, "summary");
+  if (summary)
+    save3 |= epg_broadcast_set_summary(ebc, summary, &changes);
 
   /* Quality metadata */
   save |= xmltv_parse_vid_quality(ebc, htsmsg_get_map(tags, "video"), &bw, &changes);
@@ -576,6 +582,7 @@ static int _xmltv_parse_programme_tags
   if (title)    lang_str_destroy(title);
   if (subtitle) lang_str_destroy(subtitle);
   if (desc)     lang_str_destroy(desc);
+  if (summary)     lang_str_destroy(summary);
   
   return save | save2 | save3;
 }

--- a/src/epggrab/module/xmltv.c
+++ b/src/epggrab/module/xmltv.c
@@ -582,7 +582,7 @@ static int _xmltv_parse_programme_tags
   if (title)    lang_str_destroy(title);
   if (subtitle) lang_str_destroy(subtitle);
   if (desc)     lang_str_destroy(desc);
-  if (summary)     lang_str_destroy(summary);
+  if (summary)  lang_str_destroy(summary);
   
   return save | save2 | save3;
 }


### PR DESCRIPTION
"summary" field should be supported by XMLTV EPG grabber (https://tvheadend.org/projects/tvheadend/wiki/Epgdb)

This fix adds support that according to documentation should have already been there.