### PR TITLE
Add a button to quickly play a channel in EPG view (#3926)

### DIFF
--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -361,12 +361,16 @@ tvheadend.epg = function() {
     var detailsfcn = function(grid, rec, act, row) {
         new tvheadend.epgDetails(grid.getStore().getAt(row).data);
     };
+    var watchfcn = function(grid, rec, act, row) {
+        var item = grid.getStore().getAt(row);
+        new tvheadend.VideoPlayer(item.data.channelUuid);
+    };
 
     var actions = new Ext.ux.grid.RowActions({
         id: 'details',
         header: _('Details'),
         tooltip: _('Details'),
-        width: 45,
+        width: 67,
         dataIndex: 'actions',
         callbacks: {
             'recording':      detailsfcn,
@@ -380,6 +384,11 @@ tvheadend.epg = function() {
                 iconCls: 'broadcast_details',
                 qtip: _('Broadcast details'),
                 cb: detailsfcn
+            },
+            {
+                iconCls: 'watchTv',
+                qtip: _('Watch TV'),
+                cb: watchfcn
             },
             {
                 iconIndex: 'dvrState'
@@ -940,6 +949,9 @@ tvheadend.epg = function() {
                    /* do not restore sorting and filters */
                    state.sort = {};
                    state.filters = {};
+                   /* Otherwise this non-resizable column will not expand to newly set width */
+                   if (state.columns)
+                       state.columns[0].width = actions.width;
                }
             }
         }

--- a/src/webui/static/app/tvheadend.js
+++ b/src/webui/static/app/tvheadend.js
@@ -487,11 +487,17 @@ tvheadend.playLink = function(link, title) {
 /**
  * Displays a mediaplayer using the html5 video element
  */
-tvheadend.VideoPlayer = function(url) {
+tvheadend.VideoPlayer = function(channelId) {
 
     var videoPlayer = new tv.ui.VideoPlayer({
         params: { }
     });
+    
+    var initialChannelName;
+    if (channelId) {
+        var record = tvheadend.channels.getById(channelId);
+        initialChannelName = record.data.val;
+    }
 
     var selectChannel = new Ext.form.ComboBox({
         loadingText: _('Loading...'),
@@ -501,7 +507,8 @@ tvheadend.VideoPlayer = function(url) {
         mode: 'local',
         editable: true,
         triggerAction: 'all',
-        emptyText: _('Select channel...')
+        emptyText: _('Select channel...'),
+        value: initialChannelName
     });
 
     selectChannel.on('select', function(c, r) {
@@ -631,8 +638,13 @@ tvheadend.VideoPlayer = function(url) {
         win.getTopToolbar().add(new Ext.Toolbar.Spacer());
         win.getTopToolbar().add(new Ext.Toolbar.Spacer());
         win.getTopToolbar().add(sliderLabel);
-    });
 
+        // Zap to initial channel when the player is ready
+        if (channelId) {
+            videoPlayer.zapTo(channelId);
+        }
+    });
+    
     win.on('close', function() {
         videoPlayer.stop();
     });


### PR DESCRIPTION
When scrolling through EPG view, I miss a button that would quickly open "Watch TV" with given channel. This implements such a feature.