### PR TITLE
Add Delete Autorec to API

### DIFF
--- a/src/api/api_dvr.c
+++ b/src/api/api_dvr.c
@@ -463,7 +463,7 @@ api_dvr_autorec_create_by_series
 static void
 api_dvr_autorec_entry_cancel(access_t *perm, idnode_t *self)
 {
-  autorec_entry_destroy((dvr_entry_t *)self, 0);
+  autorec_entry_destroy((dvr_autorec_entry_t *)self, 0);
 }
 
 static int

--- a/src/api/api_dvr.c
+++ b/src/api/api_dvr.c
@@ -461,6 +461,19 @@ api_dvr_autorec_create_by_series
 }
 
 static void
+api_dvr_autorec_entry_cancel(access_t *perm, idnode_t *self)
+{
+  autorec_entry_destroy((dvr_entry_t *)self, 0);
+}
+
+static int
+api_dvr_autorec_cancel
+  ( access_t *perm, void *opaque, const char *op, htsmsg_t *args, htsmsg_t **resp )
+{
+  return api_idnode_handler(perm, args, resp, api_dvr_autorec_entry_cancel, "cancel", 0);
+}
+
+static void
 api_dvr_timerec_grid
   ( access_t *perm, idnode_set_t *ins, api_idnode_grid_conf_t *conf, htsmsg_t *args )
 {
@@ -540,6 +553,7 @@ void api_dvr_init ( void )
     { "dvr/autorec/grid",          ACCESS_RECORDER, api_idnode_grid,  api_dvr_autorec_grid },
     { "dvr/autorec/create",        ACCESS_RECORDER, api_dvr_autorec_create, NULL },
     { "dvr/autorec/create_by_series", ACCESS_RECORDER, api_dvr_autorec_create_by_series, NULL },
+    { "dvr/autorec/cancel",        ACCESS_RECORDER, api_dvr_autorec_cancel, NULL },
 
     { "dvr/timerec/class",         ACCESS_RECORDER, api_idnode_class, (void*)&dvr_timerec_entry_class },
     { "dvr/timerec/grid",          ACCESS_RECORDER, api_idnode_grid,  api_dvr_timerec_grid },

--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -690,7 +690,7 @@ void autorec_destroy_by_channel_tag(channel_tag_t *ct, int delconf);
 
 void autorec_destroy_by_id(const char *id, int delconf);
 
-static void autorec_entry_destroy(dvr_autorec_entry_t *dae, int delconf);
+void autorec_entry_destroy(dvr_autorec_entry_t *dae, int delconf);
 
 void dvr_autorec_init(void);
 

--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -690,6 +690,8 @@ void autorec_destroy_by_channel_tag(channel_tag_t *ct, int delconf);
 
 void autorec_destroy_by_id(const char *id, int delconf);
 
+static void autorec_entry_destroy(dvr_autorec_entry_t *dae, int delconf);
+
 void dvr_autorec_init(void);
 
 void dvr_autorec_done(void);

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -385,7 +385,7 @@ dvr_autorec_add_series_link(const char *dvr_config_name,
 /**
  *
  */
-static void
+void
 autorec_entry_destroy(dvr_autorec_entry_t *dae, int delconf)
 {
   char ubuf[UUID_HEX_SIZE];


### PR DESCRIPTION
This PR adds the ability to delete an Autorec via the HTTP API using the new URL api/dvr/autorec/cancel. Tested on UK Freeview using 'Series Link' autorecs.