### PR TITLE
WebUI: add return to sort-by-date when toggling back to 'All' from 'Now'

### DIFF
--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -892,6 +892,8 @@ tvheadend.epg = function() {
             // Change ordering to ordering by number asc, because that's what users would expect to see
             epgStore.sortInfo = { field: 'channelNumber', direction: 'ASC' };
         }
+        else
+            epgStore.sortInfo = { field: 'start', direction: 'date' };
         epgView.reset();
     });
 


### PR DESCRIPTION
.. as discussed on https://github.com/tvheadend/tvheadend/commit/620c50b9883b9e767e9addcc68afc56af3d72b36#commitcomment-23309464

... this forces an EPG sort by start time when toggling back to "All" view from "Now" (currently-running) view. Without it, the sort remains by channel number; a quick test suggests that simply removing any sort order and the EPG defaults to sorting by duration, which is unlikely to be useful. 