### PR TITLE
Issue in Fr translation

### DIFF
--- a/intl/tvheadend.fr.po
+++ b/intl/tvheadend.fr.po
@@ -5531,7 +5531,7 @@ msgstr ""
 
 #: src/dvr/dvr_autorec.c:777
 msgid "Sat"
-msgstr "Satellite"
+msgstr "Sam"
 
 #: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1422
 msgid "Satconf"


### PR DESCRIPTION
For autorec, Sat means Saturday (Samedi in French), not Satellite.
Changed the string into Sam ("Samedi" abreviated)