### PR TITLE
DVR: Record segmented programmes identified by EIT (issue 1303)

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -193,6 +193,7 @@ typedef struct dvr_entry {
 
   time_t de_start_extra;
   time_t de_stop_extra;
+  time_t de_segment_stop_extra; /* Automatic extra time for segmented prog (from EPG) */
 
   time_t de_running_start;
   time_t de_running_stop;


### PR DESCRIPTION
A broadcaster can split a programme in to multiple segments. These
are identified by the segments having a CRID containing an IMI
(a hash character followed by an ID). Segments have identical
values for this CRID and IMI and the segments start within three
hours of the end of the previous segment.

These rules are documented in this spec in section 7.1.7:
http://www.freeviewnz.tv/media/1055/freeview_dtt_transmission_rules_2_1.pdf
This document is based on the UK transmission specification.

For example, a movie may be broadcast as:
  21:00--22:00 movie segment 1
  22:00--22:05 five minute news
  22:05--23:30 movie segment 2

The xmltv guides typically merges this segments in to one
programme such as:
  21:00--23:30 movie (including news)

In theory, a programme can be split in to numerous segments.
In practice I have only seen a programme split in to two
segments as shown above.

To simplify recording these programmes, we identify segmented
programmes and extend the stop time. So, in the above case,
if the user records the 9pm showing then we will automatically
extend the stop time to be 23:30 instead of 22:00.

This patch explicitly disables "epg running state" for stopping
the recording. This is because the recording is tied to the first
showing and we don't want the recording to stop at 22:00 in the
above example.

We cache the calculated stop time to avoid any overheads, but
explicitly recalculate it at the start of the programme. This ensures
we detect any recent changes.

No modification is done of the actual EPG data to attempt to
merge the programme segments.

The consequence of this is that the EPG will only show a "recording"
marker against the first segment of the programme and not against
the second segment, which is unfortunate, however it is consistent
with recordings which have an extra stop time. The upcoming
recordings tab correctly shows the end time.

The duration of the finished recording is currently incorrectly
reported due to #3706. So the movie above would be reported as
60 minutes instead of 2h30.

Although the CRID processing is believed to be a global standard,
if other countries do not follow the UK/NZ specification then
the dvr_entry_get_segment_stop_extra could be updated to check a
(bitmask) config variable to enable/disable specific CRID processing.

I believe the overhead of the strcmp for the CRID check is minimal,
even on low-spec machines. If necessary we could cache to indicate
the CRID check has failed.

There are three extra info logs to verify correct behaviour: when 
calculating the extra duration, when starting a recording for any
programme, and when stopping an extended recording.

Issue: #1303