### PR TITLE
DVR: Prefer autorec rule name if comment field is empty (#4500)

### DIFF
--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1463,9 +1463,11 @@ dvr_entry_create_by_autorec(int enabled, epg_broadcast_t *e, dvr_autorec_entry_t
     }
   }
 
+  /* Prefer the recording comment or the name of the rule to an empty string */
+  const char *comment_suffix = dae->dae_comment && *dae->dae_comment ? dae->dae_comment : dae->dae_name;
   snprintf(buf, sizeof(buf), _("Auto recording%s%s"),
-           dae->dae_comment ? ": " : "",
-           dae->dae_comment ?: "");
+           comment_suffix ? ": " : "",
+           comment_suffix ?: "");
 
   dvr_entry_create_by_event(enabled, idnode_uuid_as_str(&dae->dae_config->dvr_id, ubuf),
                             e, dae->dae_start_extra, dae->dae_stop_extra,


### PR DESCRIPTION
Currently the Upcoming recordings tab has a comment field that says
"Auto recording" or "Auto recording: comment from autorec rule".
This helps to identify why a recording is scheduled.

This patch ensures we continue to use the autorec comment field if
it is non-empty (keeping existing behaviour), but fallback to using
the recording rule name. If both are empty then we keep the
existing behaviour of fallback to an empty string.

This avoids the user having to duplicate the rule name in to
the comment string for manually created autorec rules.

So, in the above case it would be "Auto recording: comment",
"Auto recording: rule name", otherwise "Auto recording".

Issue: #4500.