### PR TITLE
Travis: build and publish targets including those not currently supported by doozer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,80 @@
-#
-# Basic Build Setup
-#
-
-sudo: required
-dist: trusty
 language: c
+sudo: required
+services:
+  - docker
+cache: ccache
+
+env:
+  global:
+    - GIT_BRANCH: "test-builds"
+matrix:
+    include:
+      - os: linux
+        dist: trusty
+        env:
+          - BUILD_NAME: "stretch-amd64"
+          - AUTOBUILD_TARGET: "stretch-amd64"
+          - DOCKER_IMAGE: "debian:stretch-slim"
+          - AUTOBUILD_CONFIGURE_EXTRA: ""
+      - os: linux
+        dist: trusty
+        env:
+          - BUILD_NAME: "debian-unstable-amd64"
+          - AUTOBUILD_TARGET: "sid-amd64"
+          - DOCKER_IMAGE: "debian:sid-slim"
+          - AUTOBUILD_CONFIGURE_EXTRA: ""
+      - os: linux
+        dist: trusty
+        env:
+          - BUILD_NAME: "debian-unstable-amd64"
+          - AUTOBUILD_TARGET: "sid-i386"
+          - DOCKER_IMAGE: "i386/debian:sid-slim"
+          - AUTOBUILD_CONFIGURE_EXTRA: ""
+      - os: linux
+        dist: trusty
+        env:
+          - BUILD_NAME: "artful-amd64"
+          - AUTOBUILD_TARGET: "artful-amd64"
+          - DOCKER_IMAGE: "ubuntu:artful"
+          - AUTOBUILD_CONFIGURE_EXTRA: ""
+      - os: linux
+        dist: trusty
+        env:
+          - BUILD_NAME: "artful-i386"
+          - AUTOBUILD_TARGET: "artful-i386"
+          - DOCKER_IMAGE: "i386/ubuntu:artful"
+          - AUTOBUILD_CONFIGURE_EXTRA: ""
+      - os: linux
+        dist: trusty
+        env:
+          - BUILD_NAME: "zesty-amd64"
+          - AUTOBUILD_TARGET: "zesty-amd64"
+          - DOCKER_IMAGE: "ubuntu:zesty"
+          - AUTOBUILD_CONFIGURE_EXTRA: ""
+      - os: linux
+        dist: trusty
+        env:
+          - BUILD_NAME: "zesty-i386"
+          - AUTOBUILD_TARGET: "zesty-i386"
+          - DOCKER_IMAGE: "i386/ubuntu:zesty"
+          - AUTOBUILD_CONFIGURE_EXTRA: ""
+      - os: linux
+        dist: trusty
+        env:
+          - BUILD_NAME: "stretch-i386"
+          - AUTOBUILD_TARGET: "stretch-i386"
+          - DOCKER_IMAGE: "i386/debian:stretch-slim"
+          - AUTOBUILD_CONFIGURE_EXTRA: ""
+      - os: linux
+        dist: trusty
+        env:
+          - BUILD_NAME: "jessie-i386"
+          - AUTOBUILD_TARGET: "jessie-i386"
+          - DOCKER_IMAGE: "i386/debian:jessie-slim"
+          - AUTOBUILD_CONFIGURE_EXTRA: ""
 before_install:
-  - sudo apt-get -qqy update && sudo apt-get install fakeroot -qqy
   - git fetch --unshallow
-  - sudo ./Autobuild.sh -t trusty-amd64 -o deps
+  - git checkout -qf ${TRAVIS_COMMIT}
 script:
-  - sudo ./Autobuild.sh -t trusty-amd64
+  - docker pull ${DOCKER_IMAGE}
+  - docker run -v ${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR} ${DOCKER_IMAGE} /bin/sh -c "apt-get -qqy update && apt-get install -qqy git && cd ${TRAVIS_BUILD_DIR} && ./Autobuild.sh -t ${AUTOBUILD_TARGET} -o deps && AUTOBUILD_CONFIGURE_EXTRA=${AUTOBUILD_CONFIGURE_EXTRA} ./Autobuild.sh -t ${AUTOBUILD_TARGET} && BINTRAY_USER=${BINTRAY_USER} BINTRAY_PASS=${BINTRAY_PASS} BINTRAY_ORG=${BINTRAY_ORG} GIT_BRANCH=${GIT_BRANCH} python ./support/bintray.py publish filelist.txt"

--- a/Autobuild/artful-amd64.sh
+++ b/Autobuild/artful-amd64.sh
@@ -1,0 +1,3 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --arch=x86_64"
+DEBDIST=artful
+source Autobuild/debian.sh

--- a/Autobuild/artful-i386.sh
+++ b/Autobuild/artful-i386.sh
@@ -1,0 +1,4 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --arch=i686"
+DEBDIST=artful
+source Autobuild/debian.sh
+

--- a/Autobuild/sid-amd64.sh
+++ b/Autobuild/sid-amd64.sh
@@ -1,0 +1,3 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --arch=x86_64"
+DEBDIST=sid
+source Autobuild/debian.sh

--- a/Autobuild/sid-i386.sh
+++ b/Autobuild/sid-i386.sh
@@ -1,0 +1,3 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --arch=i686"
+DEBDIST=sid
+source Autobuild/debian.sh

--- a/Autobuild/zesty-amd64.sh
+++ b/Autobuild/zesty-amd64.sh
@@ -1,0 +1,3 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --arch=x86_64"
+DEBDIST=zesty
+source Autobuild/debian.sh

--- a/Autobuild/zesty-i386.sh
+++ b/Autobuild/zesty-i386.sh
@@ -1,0 +1,4 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --arch=i686"
+DEBDIST=artful
+source Autobuild/debian.sh
+

--- a/support/bintray.py
+++ b/support/bintray.py
@@ -30,6 +30,7 @@ BINTRAY_PASS=env('BINTRAY_PASS')
 BINTRAY_COMPONENT=env('BINTRAY_COMPONENT')
 BINTRAY_ORG=env('BINTRAY_ORG') or 'tvheadend'
 BINTRAY_PACKAGE='tvheadend'
+GIT_BRANCH=env('GIT_BRANCH')
 
 PACKAGE_DESC='Tvheadend is a TV streaming server and recorder for Linux, FreeBSD and Android'
 
@@ -130,6 +131,8 @@ def get_component(version):
         if git and git.find('~') > 0:
             return 'stable-%s.%s' % (major, minor)
         return 'release-%s.%s' % (major, minor)
+        if GIT_BRANCH:
+            return str(GIT_BRANCH) + '%s-%s' % (major, minor)
     return 'unstable'
 
 def get_repo(filename, hint=None):
@@ -196,6 +199,9 @@ def do_publish(*args):
                 b = b[1:]
             b = b.strip()
             if b == 'master' or b.startswith('release/'):
+                ok = 1
+                break
+            if GIT_BRANCH:
                 ok = 1
                 break
         if not ok:


### PR DESCRIPTION
This basically uses Docker on Travis-CI to build various targets, including some not currently supported by Doozer, It's mainly as a backup.

I've been testing this for a while & it seems to work okay, it's not the nicest in the least and may need some fixing, especially the GIT_BRANCH "hack" I added which doesn't work right yet, but that can be ignored (or even stripped out).

The uploads are done in docker, so the ENV variables [BINTRAY_USER, BINTRAY_PASS] etc need to be set (securely) in Travis, See the docker run line for the rest. These are slow builds & I mean slow, but that should be fine as a backup as the upload fails with 409 conflict if Doozer uploads first.

---
This can be rejected if not up to standard, or used as people see fit.