### PR TITLE
xmltv scrape extra information (credits, keywords, etc) (issue #4441)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,7 @@ SRCS-1 = \
 	src/profile.c \
 	src/bouquet.c \
 	src/lock.c \
+	src/string_list.c \
 	src/wizard.c \
 	src/memoryinfo.c
 SRCS = $(SRCS-1)

--- a/src/api/api_epg.c
+++ b/src/api/api_epg.c
@@ -185,6 +185,9 @@ api_epg_entry ( epg_broadcast_t *eb, const char *lang, access_t *perm, const cha
     if (ee->age_rating)
       htsmsg_add_u32(m, "ageRating", ee->age_rating);
 
+    if (ee->copyright_year)
+      htsmsg_add_u32(m, "copyrightYear", ee->copyright_year);
+
     /* Content Type */
     m2 = NULL;
     LIST_FOREACH(eg, &ee->genre, link) {

--- a/src/api/api_epg.c
+++ b/src/api/api_epg.c
@@ -25,6 +25,7 @@
 #include "imagecache.h"
 #include "dvr/dvr.h"
 #include "lang_codes.h"
+#include "string_list.h"
 
 static htsmsg_t *
 api_epg_get_list ( const char *s )
@@ -119,6 +120,15 @@ api_epg_entry ( epg_broadcast_t *eb, const char *lang, access_t *perm, const cha
     htsmsg_add_str(m, "summary", s);
   if ((s = epg_broadcast_get_description(eb, lang)))
     htsmsg_add_str(m, "description", s);
+  if (eb->credits) {
+    htsmsg_add_msg(m, "credits", htsmsg_copy(eb->credits));
+  }
+  if (eb->category) {
+    htsmsg_add_msg(m, "category", string_list_to_htsmsg(eb->category));
+  }
+  if (eb->keyword) {
+    htsmsg_add_msg(m, "keyword", string_list_to_htsmsg(eb->keyword));
+  }
 
   if (eb->is_new)
     htsmsg_add_u32(m, "new", eb->is_new);

--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -209,7 +209,7 @@ typedef struct dvr_entry {
   lang_str_t *de_subtitle;   /* Subtitle in UTF-8 (from EPG) */
   lang_str_t *de_desc;       /* Description in UTF-8 (from EPG) */
   uint32_t de_content_type;  /* Content type (from EPG) (only code) */
-
+  uint16_t de_copyright_year; /* Copyright year (from EPG) */
   uint16_t de_dvb_eid;
 
   int de_pri;

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -275,6 +275,12 @@ autorec_cmp(dvr_autorec_entry_t *dae, epg_broadcast_t *e)
       if (!ls && e->description)
         RB_FOREACH(ls, e->description, link)
           if (!regex_match(&dae->dae_title_regex, ls->str)) break;
+      if (!ls && e->credits_cached)
+        RB_FOREACH(ls, e->credits_cached, link)
+          if (!regex_match(&dae->dae_title_regex, ls->str)) break;
+      if (!ls && e->keyword_cached)
+        RB_FOREACH(ls, e->keyword_cached, link)
+          if (!regex_match(&dae->dae_title_regex, ls->str)) break;
     }
     if (!ls) return 0;
   }

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -983,6 +983,8 @@ dvr_entry_create_(int enabled, const char *config_uuid, epg_broadcast_t *e,
       lang_str_serialize(e->episode->summary, conf, "description");
     if (e->episode && (s = dvr_entry_get_episode(e, tbuf, sizeof(tbuf))))
       htsmsg_add_str(conf, "episode", s);
+    if (e->episode && e->episode->copyright_year)
+      htsmsg_add_u32(conf, "copyright_year", e->episode->copyright_year);
   } else if (title) {
     l = lang_str_create();
     lang_str_add(l, title, lang, 0);
@@ -3435,6 +3437,14 @@ const idclass_t dvr_entry_class = {
       .list     = dvr_entry_class_content_type_list,
       .off      = offsetof(dvr_entry_t, de_content_type),
       .opts     = PO_RDONLY | PO_SORTKEY,
+    },
+    {
+      .type     = PT_U16,
+      .id       = "copyright_year",
+      .name     = N_("The copyright year of the program."),
+      .desc     = N_("The copyright year of the program."),
+      .off      = offsetof(dvr_entry_t, de_copyright_year),
+      .opts     = PO_RDONLY | PO_EXPERT,
     },
     {
       .type     = PT_U32,

--- a/src/epg.c
+++ b/src/epg.c
@@ -1030,6 +1030,8 @@ int epg_episode_change_finish
     save |= epg_episode_set_age_rating(episode, 0, NULL);
   if (!(changes & EPG_CHANGED_FIRST_AIRED))
     save |= epg_episode_set_first_aired(episode, 0, NULL);
+  if (!(changes & EPG_CHANGED_COPYRIGHT_YEAR))
+    save |= epg_episode_set_copyright_year(episode, 0, NULL);
   return save;
 }
 
@@ -1216,6 +1218,14 @@ int epg_episode_set_star_rating
                             changed, EPG_CHANGED_STAR_RATING);
 }
 
+int epg_episode_set_copyright_year
+  ( epg_episode_t *episode, uint16_t year, uint32_t *changed )
+{
+  if (!episode) return 0;
+  return _epg_object_set_u16(episode, &episode->copyright_year, year,
+                            changed, EPG_CHANGED_COPYRIGHT_YEAR);
+}
+
 int epg_episode_set_age_rating
   ( epg_episode_t *episode, uint8_t age, uint32_t *changed )
 {
@@ -1349,6 +1359,8 @@ htsmsg_t *epg_episode_serialize ( epg_episode_t *episode )
     htsmsg_add_u32(m, "is_bw", 1);
   if (episode->star_rating)
     htsmsg_add_u32(m, "star_rating", episode->star_rating);
+  if (episode->copyright_year)
+    htsmsg_add_u32(m, "copyright_year", episode->copyright_year);
   if (episode->age_rating)
     htsmsg_add_u32(m, "age_rating", episode->age_rating);
   if (episode->first_aired)
@@ -1422,6 +1434,9 @@ epg_episode_t *epg_episode_deserialize ( htsmsg_t *m, int create, int *save )
 
   if (!htsmsg_get_u32(m, "star_rating", &u32))
     *save |= epg_episode_set_star_rating(ee, u32, &changes);
+
+  if (!htsmsg_get_u32(m, "copyright_year", &u32))
+    *save |= epg_episode_set_copyright_year(ee, u32, &changes);
 
   if (!htsmsg_get_u32(m, "age_rating", &u32))
     *save |= epg_episode_set_age_rating(ee, u32, &changes);

--- a/src/epg.c
+++ b/src/epg.c
@@ -365,6 +365,8 @@ static int FNNAME \
 
 
 EPG_OBJECT_SET_FN(_epg_object_set_lang_str,    lang_str_t,    lang_str_destroy,    lang_str_compare,    lang_str_copy)
+EPG_OBJECT_SET_FN(_epg_object_set_string_list, string_list_t, string_list_destroy, string_list_cmp,     string_list_copy)
+EPG_OBJECT_SET_FN(_epg_object_set_htsmsg,      htsmsg_t,      htsmsg_destroy,      htsmsg_cmp,          htsmsg_copy)
 #undef EPG_OBJECT_SET_FN
 
 static int _epg_object_set_u8
@@ -1878,6 +1880,11 @@ static void _epg_broadcast_destroy ( void *eo )
   if (ebc->serieslink)  _epg_serieslink_rem_broadcast(ebc->serieslink, ebc);
   if (ebc->summary)     lang_str_destroy(ebc->summary);
   if (ebc->description) lang_str_destroy(ebc->description);
+  if (ebc->credits)     htsmsg_destroy(ebc->credits);
+  if (ebc->credits_cached) lang_str_destroy(ebc->credits_cached);
+  if (ebc->category)    string_list_destroy(ebc->category);
+  if (ebc->keyword)     string_list_destroy(ebc->keyword);
+  if (ebc->keyword_cached) lang_str_destroy(ebc->keyword_cached);
   _epg_object_destroy(eo, NULL);
   free(ebc);
 }
@@ -1974,6 +1981,12 @@ int epg_broadcast_change_finish
     save |= epg_broadcast_set_summary(broadcast, NULL, NULL);
   if (!(changes & EPG_CHANGED_DESCRIPTION))
     save |= epg_broadcast_set_description(broadcast, NULL, NULL);
+  if (!(changes & EPG_CHANGED_CREDITS))
+    save |= epg_broadcast_set_credits(broadcast, NULL, NULL);
+  if (!(changes & EPG_CHANGED_CATEGORY))
+    save |= epg_broadcast_set_category(broadcast, NULL, NULL);
+  if (!(changes & EPG_CHANGED_KEYWORD))
+    save |= epg_broadcast_set_keyword(broadcast, NULL, NULL);
   return save;
 }
 
@@ -1999,6 +2012,9 @@ epg_broadcast_t *epg_broadcast_clone
     *save |= epg_broadcast_set_is_new(ebc, src->is_new, &changes);
     *save |= epg_broadcast_set_is_repeat(ebc, src->is_repeat, &changes);
     *save |= epg_broadcast_set_summary(ebc, src->summary, &changes);
+    *save |= epg_broadcast_set_credits(ebc, src->credits, &changes);
+    *save |= epg_broadcast_set_category(ebc, src->category, &changes);
+    *save |= epg_broadcast_set_keyword(ebc, src->keyword, &changes);
     *save |= epg_broadcast_set_description(ebc, src->description, &changes);
     *save |= epg_broadcast_set_serieslink(ebc, src->serieslink, &changes);
     *save |= epg_broadcast_set_episode(ebc, src->episode, &changes);
@@ -2172,6 +2188,72 @@ int epg_broadcast_set_description
                                   changed, EPG_CHANGED_DESCRIPTION);
 }
 
+int epg_broadcast_set_credits
+( epg_broadcast_t *b, htsmsg_t *credits, uint32_t *changed )
+{
+  if (!b) return 0;
+  const int mod = _epg_object_set_htsmsg(b, &b->credits, credits, changed, EPG_CHANGED_CREDITS);
+  if (mod) {
+      /* Copy in to cached csv for regex searching in autorec/GUI.
+       * We use just one string (rather than regex across each entry
+       * separately) so you could do a regex of "Douglas.*Stallone"
+       * to match the movies with the two actors.
+       */
+      if (!b->credits_cached) {
+          b->credits_cached = lang_str_create();
+      }
+      lang_str_set(&b->credits_cached, "", NULL);
+
+      if (b->credits) {
+        int add_sep = 0;
+        htsmsg_field_t *f;
+        HTSMSG_FOREACH(f, b->credits) {
+          if (add_sep) {
+            lang_str_append(b->credits_cached, ", ", NULL);
+          } else {
+            add_sep = 1;
+          }
+          lang_str_append(b->credits_cached, f->hmf_name, NULL);
+        }
+      } else {
+        if (b->credits_cached) {
+          lang_str_destroy(b->credits_cached);
+          b->credits_cached = NULL;
+        }
+      }
+  }
+  return mod;
+}
+
+int epg_broadcast_set_category
+( epg_broadcast_t *b, string_list_t *msg, uint32_t *changed )
+{
+  if (!b) return 0;
+  return _epg_object_set_string_list(b, &b->category, msg, changed, EPG_CHANGED_CATEGORY);
+}
+
+int epg_broadcast_set_keyword
+( epg_broadcast_t *b, string_list_t *msg, uint32_t *changed )
+{
+  if (!b) return 0;
+  const int mod = _epg_object_set_string_list(b, &b->keyword, msg, changed, EPG_CHANGED_KEYWORD);
+  if (mod) {
+    /* Copy in to cached csv for regex searching in autorec/GUI. */
+    if (msg) {
+      /* 1==>human readable */
+      char *str = string_list_2_csv(msg, ',', 1);
+      lang_str_set(&b->keyword_cached, str, NULL);
+      free(str);
+    } else {
+      if (b->keyword_cached) {
+        lang_str_destroy(b->keyword_cached);
+        b->keyword_cached = NULL;
+      }
+    }
+  }
+  return mod;
+}
+
 epg_broadcast_t *epg_broadcast_get_next ( epg_broadcast_t *broadcast )
 {
   if ( !broadcast ) return NULL;
@@ -2194,6 +2276,18 @@ const char *epg_broadcast_get_summary ( epg_broadcast_t *b, const char *lang )
 {
   if (!b || !b->summary) return NULL;
   return lang_str_get(b->summary, lang);
+}
+
+const char *epg_broadcast_get_credits_cached ( epg_broadcast_t *b, const char *lang)
+{
+  if (!b || !b->credits_cached) return NULL;
+  return lang_str_get(b->credits_cached, lang);
+}
+
+const char *epg_broadcast_get_keyword_cached ( epg_broadcast_t *b, const char *lang)
+{
+  if (!b || !b->keyword_cached) return NULL;
+  return lang_str_get(b->keyword_cached, lang);
 }
 
 const char *epg_broadcast_get_description ( epg_broadcast_t *b, const char *lang )
@@ -2238,6 +2332,15 @@ htsmsg_t *epg_broadcast_serialize ( epg_broadcast_t *broadcast )
     lang_str_serialize(broadcast->summary, m, "summary");
   if (broadcast->description)
     lang_str_serialize(broadcast->description, m, "description");
+  if (broadcast->credits)
+      htsmsg_add_msg(m, "credits", htsmsg_copy(broadcast->credits));
+  /* No need to serialize credits_cached since it is rebuilt from credits. */
+  if (broadcast->category)
+    string_list_serialize(broadcast->category, m, "category");
+  if (broadcast->keyword)
+    string_list_serialize(broadcast->keyword, m, "keyword");
+  /* No need to serialize keyword_cached since it is rebuilt from keyword */
+
   if (broadcast->serieslink)
     htsmsg_add_str(m, "serieslink", broadcast->serieslink->uri);
   
@@ -2252,6 +2355,8 @@ epg_broadcast_t *epg_broadcast_deserialize
   epg_episode_t *ee;
   epg_serieslink_t *esl;
   lang_str_t *ls;
+  htsmsg_t *hm;
+  string_list_t *sl;
   const char *str;
   uint32_t eid, u32, changes = 0, changes2 = 0;
   int64_t start, stop;
@@ -2311,6 +2416,18 @@ epg_broadcast_t *epg_broadcast_deserialize
   if ((ls = lang_str_deserialize(m, "description"))) {
     *save |= epg_broadcast_set_description(ebc, ls, &changes);
     lang_str_destroy(ls);
+  }
+
+  if ((hm = htsmsg_get_map(m, "credits"))) {
+      *save |= epg_broadcast_set_credits(ebc, hm, &changes);
+  }
+
+  if ((sl = string_list_deserialize(m, "keyword"))) {
+      *save |= epg_broadcast_set_keyword(ebc, sl, &changes);
+  }
+
+  if ((sl = string_list_deserialize(m, "category"))) {
+      *save |= epg_broadcast_set_category(ebc, sl, &changes);
   }
 
   /* Series link */
@@ -2778,7 +2895,13 @@ _eq_add ( epg_query_t *eq, epg_broadcast_t *e )
             regex_match(&eq->stitle_re, s)) {
           if ((s = epg_broadcast_get_description(e, lang)) == NULL ||
               regex_match(&eq->stitle_re, s)) {
-            return;
+            if ((s = epg_broadcast_get_credits_cached(e, lang)) == NULL ||
+                regex_match(&eq->stitle_re, s)) {
+              if ((s = epg_broadcast_get_keyword_cached(e, lang)) == NULL ||
+                  regex_match(&eq->stitle_re, s)) {
+                return;
+              }
+            }
           }
         }
       }

--- a/src/epg.h
+++ b/src/epg.h
@@ -30,6 +30,7 @@
 struct channel;
 struct channel_tag;
 struct epggrab_module;
+struct string_list;
 
 /*
  * Map/List types
@@ -126,6 +127,9 @@ typedef enum epg_object_type
 #define EPG_CHANGED_SUMMARY       (1<<3)
 #define EPG_CHANGED_DESCRIPTION   (1<<4)
 #define EPG_CHANGED_IMAGE         (1<<5)
+#define EPG_CHANGED_CREDITS       (1<<6)
+#define EPG_CHANGED_CATEGORY      (1<<7)
+#define EPG_CHANGED_KEYWORD       (1<<8)
 #define EPG_CHANGED_SLAST         2
 
 typedef struct epg_object_ops {
@@ -511,7 +515,13 @@ struct epg_broadcast
   /* Broadcast level text */
   lang_str_t                *summary;          ///< Summary
   lang_str_t                *description;      ///< Description
-
+  htsmsg_t                  *credits;          ///< Cast/Credits map of name -> role type (actor, presenter, director, etc).
+  lang_str_t                *credits_cached;   ///< Comma separated cast (for regex searching in GUI/autorec). Kept in sync with cast_map
+  struct string_list        *category;         ///< Extra categories (typically from xmltv) such as "Western" or "Sumo Wrestling".
+                                               ///< These extra categories are often a superset of our EN 300 468 DVB genre.
+                                               ///< Currently not explicitly searchable in GUI.
+  struct string_list        *keyword;          ///< Extra keywords (typically from xmltv) such as "Wild West" or "Unicorn".
+  lang_str_t                *keyword_cached;   ///< Cached CSV version for regex searches.
   RB_ENTRY(epg_broadcast)    sched_link;       ///< Schedule link
   LIST_ENTRY(epg_broadcast)  ep_link;          ///< Episode link
   epg_episode_t             *episode;          ///< Episode shown
@@ -578,6 +588,15 @@ int epg_broadcast_set_summary
 int epg_broadcast_set_description
   ( epg_broadcast_t *b, const lang_str_t *str, uint32_t *changed )
   __attribute__((warn_unused_result));
+int epg_broadcast_set_credits
+( epg_broadcast_t *b, htsmsg_t* msg, uint32_t *changed )
+  __attribute__((warn_unused_result));
+int epg_broadcast_set_category
+( epg_broadcast_t *b, struct string_list* msg, uint32_t *changed )
+  __attribute__((warn_unused_result));
+int epg_broadcast_set_keyword
+( epg_broadcast_t *b, struct string_list* msg, uint32_t *changed )
+  __attribute__((warn_unused_result));
 int epg_broadcast_set_serieslink
   ( epg_broadcast_t *b, epg_serieslink_t *sl, uint32_t *changed )
   __attribute__((warn_unused_result));
@@ -591,6 +610,11 @@ const char *epg_broadcast_get_subtitle
 const char *epg_broadcast_get_summary
   ( epg_broadcast_t *b, const char *lang );
 const char *epg_broadcast_get_description
+  ( epg_broadcast_t *b, const char *lang );
+/* Get the cached (csv) version for regex searching */
+const char *epg_broadcast_get_credits_cached
+  ( epg_broadcast_t *b, const char *lang );
+const char *epg_broadcast_get_keyword_cached
   ( epg_broadcast_t *b, const char *lang );
 
 /* Serialization */

--- a/src/epg.h
+++ b/src/epg.h
@@ -304,6 +304,7 @@ epg_season_t *epg_season_deserialize ( htsmsg_t *m, int create, int *save );
 #define EPG_CHANGED_FIRST_AIRED  (1<<(EPG_CHANGED_SLAST+12))
 #define EPG_CHANGED_BRAND        (1<<(EPG_CHANGED_SLAST+13))
 #define EPG_CHANGED_SEASON       (1<<(EPG_CHANGED_SLAST+14))
+#define EPG_CHANGED_COPYRIGHT_YEAR (1<<(EPG_CHANGED_SLAST+15))
 
 /* Episode numbering object - this is for some back-compat and also
  * to allow episode information to be "collated" into easy to use object
@@ -337,7 +338,11 @@ struct epg_episode
   uint8_t                    star_rating;    ///< Star rating
   uint8_t                    age_rating;     ///< Age certificate
   time_t                     first_aired;    ///< Original airdate
-
+  uint16_t                   copyright_year; ///< xmltv DTD gives a tag "date" (separate to previously-shown/first aired).
+                                             ///< This is the date programme was "finished...probably the copyright date."
+                                             ///< We'll call it copyright_year since words like "complete" and "finished"
+                                             ///< sound too similar to dvr recorded functionality. We'll only store the
+                                             ///< year since we only get year not month and day.
   LIST_ENTRY(epg_episode)    blink;         ///< Brand link
   LIST_ENTRY(epg_episode)    slink;         ///< Season link
   epg_brand_t               *brand;         ///< (Grand-)Parent brand
@@ -408,6 +413,9 @@ int epg_episode_set_first_aired
   __attribute__((warn_unused_result));
 int epg_episode_set_star_rating
   ( epg_episode_t *e, uint8_t stars, uint32_t *changed )
+  __attribute__((warn_unused_result));
+int epg_episode_set_copyright_year
+  ( epg_episode_t *e, uint16_t stars, uint32_t *changed )
   __attribute__((warn_unused_result));
 int epg_episode_set_age_rating
   ( epg_episode_t *e, uint8_t age, uint32_t *changed )

--- a/src/epggrab.h
+++ b/src/epggrab.h
@@ -178,6 +178,9 @@ struct epggrab_module_int
   const char                   *args;     ///< Extra arguments
 
   int                           xmltv_chnum;
+  int                           xmltv_scrape_extra; ///< Scrape actors and extra details
+  int                           xmltv_scrape_onto_desc; ///< Include scraped actors
+    ///< and extra details on to programme description for viewing by legacy clients.
 
   /* Handle data */
   char*     (*grab)   ( void *mod );

--- a/src/epggrab/module/xmltv.c
+++ b/src/epggrab/module/xmltv.c
@@ -35,6 +35,7 @@
 #include "spawn.h"
 #include "file.h"
 #include "htsstr.h"
+#include "string_list.h"
 
 #include "lang_str.h"
 #include "epg.h"
@@ -380,7 +381,15 @@ static int _xmltv_parse_star_rating
 /*
  * Tries to get age ratingform <rating> element.
  * Expects integer representing minimal age of watcher.
- * Other rating types (non-integer, for example MPAA or VCHIP) are ignored.
+ * Other rating types (non-integer, for example MPAA or VCHIP) are
+ * mostly ignored, but we have some basic mappings for common
+ * ratings such as TV-MA which may only be the only ratings for
+ * some movies.
+ *
+ * We use the first rating that we find that returns a usable age.  Of
+ * course that means some programmes might not have the rating you
+ * expect for your country. For example one episode of a cooking
+ * programme has BBFC 18 but VCHIP TV-G.
  *
  * Attribute system is ignored.
  *
@@ -388,9 +397,8 @@ static int _xmltv_parse_star_rating
  * <rating system="pl"><value>16</value></rating>
  *
  * Currently non-working example:
- *    <rating system="MPAA">
- *     <value>PG</value>
- *     <icon src="pg_symbol.png" />
+ *    <rating system="CSA">
+ *     <value>-12</value>
  *   </rating>
  *
  * TODO - support for other rating systems:
@@ -406,13 +414,36 @@ static int _xmltv_parse_age_rating
   const char *s1;
 
   if (!ee || !body) return 0;
-  if (!(rating = htsmsg_get_map(body, "rating"))) return 0;
-  if (!(tags  = htsmsg_get_map(rating, "tags"))) return 0;
-  if (!(s1 = htsmsg_xml_get_cdata_str(tags, "value"))) return 0;
 
-  age = atoi(s1);
-
-  return epg_episode_set_age_rating(ee, age, changes);
+  htsmsg_field_t *f;
+  HTSMSG_FOREACH(f, body) {
+    if (!strcmp(f->hmf_name, "rating") && (rating = htsmsg_get_map_by_field(f))) {
+      if ((tags  = htsmsg_get_map(rating, "tags"))) {
+        if ((s1 = htsmsg_xml_get_cdata_str(tags, "value"))) {
+          /* We map some common ratings since some movies only
+           * have one of these flags rather than an age rating.
+           */
+          if (!strcmp(s1, "TV-G") || !strcmp(s1, "U"))
+            age = 3;
+          else if (!strcmp(s1, "TV-Y7") || !strcmp(s1, "PG"))
+            age = 7;
+          else if (!strcmp(s1, "TV-14"))
+            age = 14;
+          else if (!strcmp(s1, "TV-MA"))
+            age = 17;
+          else
+            age = atoi(s1);
+          /* Since age is uint8_t it means some rating systems can
+           * underflow and become very large, for example CSA has age
+           * rating of -10.
+           */
+          if (age > 0 && age < 22)
+            return epg_episode_set_age_rating(ee, age, changes);
+        }
+      }
+    }
+  }
+  return 0;
 }
 
 /*
@@ -454,6 +485,80 @@ _xmltv_parse_lang_str ( lang_str_t **ls, htsmsg_t *tags, const char *tname )
   }
 }
 
+/// Make a string list from the contents of all tags in the message
+/// that have tagname.
+__attribute__((warn_unused_result))
+static string_list_t *
+ _xmltv_make_str_list_from_matching(htsmsg_t *tags, const char *tagname)
+{
+  htsmsg_t *e;
+  htsmsg_field_t *f;
+  string_list_t *tag_list = NULL;
+
+  HTSMSG_FOREACH(f, tags) {
+    if (!strcmp(f->hmf_name, tagname) && (e = htsmsg_get_map_by_field(f))) {
+      const char *str = htsmsg_get_str(e, "cdata");
+      if (str && *str) {
+        if (!tag_list) tag_list = string_list_create();
+        string_list_insert(tag_list, str);
+      }
+    }
+  }
+
+  return tag_list;
+}
+
+
+/// Parse credits from the message tags and store the name/type (such
+/// as actor, director) in to out_credits (created if necessary).
+/// Also return a string list of the names only.
+///
+/// Sample input:
+/// <credits>
+///   <actor role="Bob">Fred Foo</actor>
+///   <actor role="Walt">Vic Vicson</actor>
+///   <director>Simon Scott</director>
+/// </credits>
+///
+/// Returns string list of {"Fred Foo", "Simon Scott", "Vic Vicson"} and
+/// out_credits containing the names and actor/director.
+__attribute__((warn_unused_result))
+static string_list_t *
+_xmltv_parse_credits(htsmsg_t **out_credits, htsmsg_t *tags)
+{
+  htsmsg_t *credits = htsmsg_get_map(tags, "credits");
+  if (!credits)
+    return NULL;
+  htsmsg_t *credits_tags;
+  if (!(credits_tags  = htsmsg_get_map(credits, "tags")))
+    return NULL;
+
+  string_list_t *credits_names = NULL;
+  htsmsg_t *e;
+  htsmsg_field_t *f;
+
+  HTSMSG_FOREACH(f, credits_tags) {
+    if ((!strcmp(f->hmf_name, "actor") ||
+         !strcmp(f->hmf_name, "director") ||
+         !strcmp(f->hmf_name, "guest") ||
+         !strcmp(f->hmf_name, "presenter") ||
+         !strcmp(f->hmf_name, "writer")
+         ) &&
+        (e = htsmsg_get_map_by_field(f)))  {
+      const char* str = htsmsg_get_str(e, "cdata");
+      if (str) {
+        if (!credits_names) credits_names = string_list_create();
+        string_list_insert(credits_names, str);
+
+        if (!*out_credits) *out_credits = htsmsg_create_map();
+        htsmsg_add_str(*out_credits, str, f->hmf_name);
+      }
+    }
+  }
+
+  return credits_names;
+}
+
 /**
  * Parse tags inside of a programme
  */
@@ -462,6 +567,8 @@ static int _xmltv_parse_programme_tags
    time_t start, time_t stop, const char *icon,
    epggrab_stats_t *stats)
 {
+  const int scrape_extra = ((epggrab_module_ext_t *)mod)->xmltv_scrape_extra;
+  const int scrape_onto_desc = ((epggrab_module_ext_t *)mod)->xmltv_scrape_onto_desc;
   int save = 0, save2 = 0, save3 = 0;
   epg_episode_t *ee = NULL;
   epg_serieslink_t *es = NULL;
@@ -488,8 +595,64 @@ static int _xmltv_parse_programme_tags
 
   /* Description (wait for episode first) */
   _xmltv_parse_lang_str(&desc, tags, "desc");
-  if (desc)
+
+  /* If user has requested it then retrieve additional information
+   * from programme such as credits and keywords.
+   */
+  if (scrape_extra || scrape_onto_desc) {
+    htsmsg_t      *credits        = NULL;
+    string_list_t *credits_names  = _xmltv_parse_credits(&credits, tags);
+    string_list_t *category       = _xmltv_make_str_list_from_matching(tags, "category");
+    string_list_t *keyword        = _xmltv_make_str_list_from_matching(tags, "keyword");
+
+    if (scrape_extra && credits) {
+      save3 |= epg_broadcast_set_credits(ebc, credits, &changes);
+    }
+
+    if (scrape_extra && category) {
+      save3 |= epg_broadcast_set_category(ebc, category, &changes);
+    }
+
+    if (scrape_extra && keyword) {
+      save3 |= epg_broadcast_set_keyword(ebc, keyword, &changes);
+    }
+
+    /* Convert the string list VAR to a human-readable csv and append
+     * it to the desc with a prefix of NAME.
+     */
+#define APPENDIT(VAR,NAME) \
+    if (VAR) { \
+      char *str = string_list_2_csv(VAR, ',', 1); \
+      if (str) {                                  \
+        lang_str_append(desc, "\n\n", NULL);      \
+        lang_str_append(desc, NAME, NULL);        \
+        lang_str_append(desc, str, NULL);         \
+        free(str);                                \
+      }                                           \
+    }
+
+    /* Append the details on to the description, mainly for legacy
+     * clients. This allow you to view the details in the description
+     * on old boxes/tablets that don't parse the newer fields or
+     * don't display them.
+     */
+    if (desc && scrape_onto_desc) {
+      APPENDIT(credits_names, N_("Credits: "));
+      APPENDIT(category, N_("Categories: "));
+      APPENDIT(keyword, N_("Keywords: "));
+    }
+
+    if (credits)          htsmsg_destroy(credits);
+    if (credits_names)    string_list_destroy(credits_names);
+    if (category)         string_list_destroy(category);
+    if (keyword)          string_list_destroy(keyword);
+
+#undef APPENDIT
+  } /* desc */
+
+  if (desc) {
     save3 |= epg_broadcast_set_description(ebc, desc, &changes);
+  } /* desc */
 
   /* summary */
   _xmltv_parse_lang_str(&summary, tags, "summary");
@@ -583,7 +746,6 @@ static int _xmltv_parse_programme_tags
   if (subtitle) lang_str_destroy(subtitle);
   if (desc)     lang_str_destroy(desc);
   if (summary)  lang_str_destroy(summary);
-  
   return save | save2 | save3;
 }
 
@@ -760,6 +922,29 @@ static int _xmltv_parse
   N_("Try to obtain channel numbers from the display-name xml tag. " \
      "If the first word is number, it is used as the channel number.")
 
+#define SCRAPE_EXTRA_NAME N_("Scrape credits and extra information")
+#define SCRAPE_EXTRA_DESC \
+  N_("Obtain list of credits (actors, etc.), keywords and extra information from the xml tags (if available). "  \
+     "Some xmltv providers supply a list of actors and additional keywords to " \
+     "describe programmes. This option will retrieve this additional information. " \
+     "This can be very detailed (20+ actors per movie) " \
+     "and will take a lot of memory and resources on this box, and will " \
+     "pass this information to your client machines and GUI too, using " \
+     "memory and resources on those boxes too. " \
+     "Do not enable on low-spec machines.")
+
+#define SCRAPE_ONTO_DESC_NAME N_("Alter programme description to include detailed information")
+#define SCRAPE_ONTO_DESC_DESC \
+  N_("If enabled then this will alter the programme descriptions to " \
+     "include information about actors, keywords and categories (if available from the xmltv file). " \
+     "This is useful for legacy clients that can not parse newer Tvheadend messages " \
+     "containing this information or do not display the information. "\
+     "For example the modified description might include 'Starring: Lorem Ipsum'. " \
+     "The description is altered for all clients, both legacy, modern, and GUI. "\
+     "Enabling scraping of detailed information can use significant resources (memory and CPU). "\
+     "You should not enable this if you use 'duplicate detect if different description' " \
+     "since the descriptions will change due to added information.")
+
 static htsmsg_t *
 xmltv_dn_chnum_list ( void *o, const char *lang )
 {
@@ -786,6 +971,22 @@ const idclass_t epggrab_mod_int_xmltv_class = {
       .opts   = PO_DOC_NLIST,
       .group  = 1
     },
+    {
+      .type   = PT_BOOL,
+      .id     = "scrape_extra",
+      .name   = SCRAPE_EXTRA_NAME,
+      .desc   = SCRAPE_EXTRA_DESC,
+      .off    = offsetof(epggrab_module_int_t, xmltv_scrape_extra),
+      .group  = 1
+    },
+    {
+      .type   = PT_BOOL,
+      .id     = "scrape_onto_desc",
+      .name   = SCRAPE_ONTO_DESC_NAME,
+      .desc   = SCRAPE_ONTO_DESC_DESC,
+      .off    = offsetof(epggrab_module_int_t, xmltv_scrape_onto_desc),
+      .group  = 1
+    },
     {}
   }
 };
@@ -802,6 +1003,22 @@ const idclass_t epggrab_mod_ext_xmltv_class = {
       .desc   = DN_CHNUM_DESC,
       .off    = offsetof(epggrab_module_ext_t, xmltv_chnum),
       .opts   = PO_DOC_NLIST,
+      .group  = 1
+    },
+    {
+      .type   = PT_BOOL,
+      .id     = "scrape_extra",
+      .name   = SCRAPE_EXTRA_NAME,
+      .desc   = SCRAPE_EXTRA_DESC,
+      .off    = offsetof(epggrab_module_int_t, xmltv_scrape_extra),
+      .group  = 1
+    },
+    {
+      .type   = PT_BOOL,
+      .id     = "scrape_onto_desc",
+      .name   = SCRAPE_ONTO_DESC_NAME,
+      .desc   = SCRAPE_ONTO_DESC_DESC,
+      .off    = offsetof(epggrab_module_int_t, xmltv_scrape_onto_desc),
       .group  = 1
     },
     {}

--- a/src/htsmsg.c
+++ b/src/htsmsg.c
@@ -175,7 +175,7 @@ htsmsg_field_add(htsmsg_t *msg, const char *name, int type, int flags, size_t es
  *
  */
 htsmsg_field_t *
-htsmsg_field_find(htsmsg_t *msg, const char *name)
+htsmsg_field_find(const htsmsg_t *msg, const char *name)
 {
   htsmsg_field_t *f;
 
@@ -905,7 +905,7 @@ htsmsg_get_str_multi(htsmsg_t *msg, ...)
  *
  */
 htsmsg_t *
-htsmsg_get_list(htsmsg_t *msg, const char *name)
+htsmsg_get_list(const htsmsg_t *msg, const char *name)
 {
   htsmsg_field_t *f;
 
@@ -1039,7 +1039,7 @@ htsmsg_print(htsmsg_t *msg)
  *
  */
 static void
-htsmsg_copy_i(htsmsg_t *src, htsmsg_t *dst)
+htsmsg_copy_i(const htsmsg_t *src, htsmsg_t *dst)
 {
   htsmsg_field_t *f;
   htsmsg_t *sub;
@@ -1080,7 +1080,7 @@ htsmsg_copy_i(htsmsg_t *src, htsmsg_t *dst)
 }
 
 htsmsg_t *
-htsmsg_copy(htsmsg_t *src)
+htsmsg_copy(const htsmsg_t *src)
 {
   htsmsg_t *dst;
   if (src == NULL) return NULL;
@@ -1093,7 +1093,7 @@ htsmsg_copy(htsmsg_t *src)
  *
  */
 int
-htsmsg_cmp(htsmsg_t *m1, htsmsg_t *m2)
+htsmsg_cmp(const htsmsg_t *m1, const htsmsg_t *m2)
 {
   htsmsg_field_t *f1, *f2;
 

--- a/src/htsmsg.h
+++ b/src/htsmsg.h
@@ -295,7 +295,7 @@ int htsmsg_get_bin(htsmsg_t *msg, const char *name, const void **binp,
  * @return NULL if the field can not be found or not of list type.
  *         Otherwise a htsmsg is returned.
  */
-htsmsg_t *htsmsg_get_list(htsmsg_t *msg, const char *name);
+htsmsg_t *htsmsg_get_list(const htsmsg_t *msg, const char *name);
 
 htsmsg_t *htsmsg_field_get_list(htsmsg_field_t *f);
 
@@ -401,7 +401,7 @@ htsmsg_field_t *htsmsg_field_add(htsmsg_t *msg, const char *name,
 /**
  * Get a field, return NULL if it does not exist
  */
-htsmsg_field_t *htsmsg_field_find(htsmsg_t *msg, const char *name);
+htsmsg_field_t *htsmsg_field_find(const htsmsg_t *msg, const char *name);
 
 /**
  * Get a last field, return NULL if it does not exist
@@ -412,12 +412,12 @@ htsmsg_field_t *htsmsg_field_last(htsmsg_t *msg);
 /**
  * Clone a message.
  */
-htsmsg_t *htsmsg_copy(htsmsg_t *src);
+htsmsg_t *htsmsg_copy(const htsmsg_t *src);
 
 /**
  * Compare a message.
  */
-int htsmsg_cmp(htsmsg_t *m1, htsmsg_t *m2);
+int htsmsg_cmp(const htsmsg_t *m1, const htsmsg_t *m2);
 
 #define HTSMSG_FOREACH(f, msg) TAILQ_FOREACH(f, &(msg)->hm_fields, hmf_link)
 

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -1229,6 +1229,8 @@ htsp_build_event
       htsmsg_add_u32(out, "ageRating", ee->age_rating);
     if (ee->star_rating)
       htsmsg_add_u32(out, "starRating", ee->star_rating);
+    if (ee->copyright_year)
+      htsmsg_add_u32(out, "copyrightYear", ee->copyright_year);
     if (ee->first_aired)
       htsmsg_add_s64(out, "firstAired", ee->first_aired);
     epg_episode_get_epnum(ee, &epnum);

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -35,6 +35,7 @@
 #include "descrambler/caid.h"
 #include "notify.h"
 #include "htsmsg_json.h"
+#include "string_list.h"
 #include "lang_codes.h"
 #if ENABLE_TIMESHIFT
 #include "timeshift.h"
@@ -1194,6 +1195,17 @@ htsp_build_event
       htsmsg_add_str(out, "summary", str);
   } else if((str = epg_broadcast_get_summary(e, lang)))
     htsmsg_add_str(out, "description", str);
+
+  if (e->credits) {
+    htsmsg_add_msg(out, "credits", htsmsg_copy(e->credits));
+  }
+  if (e->category) {
+    htsmsg_add_msg(out, "category", string_list_to_htsmsg(e->category));
+  }
+  if (e->keyword) {
+    htsmsg_add_msg(out, "keyword", string_list_to_htsmsg(e->keyword));
+  }
+
   if (e->serieslink) {
     htsmsg_add_u32(out, "serieslinkId", e->serieslink->id);
     if (e->serieslink->uri)

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -968,6 +968,8 @@ htsp_build_dvrentry(htsp_connection_t *htsp, dvr_entry_t *de, const char *method
       htsmsg_add_str(out, "creator", de->de_creator);
     if(de->de_comment)
       htsmsg_add_str(out, "comment", de->de_comment);
+    if (de->de_copyright_year)
+      htsmsg_add_u32(out, "copyrightYear", de->de_copyright_year);
 
     last = NULL;
     if (!htsmsg_is_empty(de->de_files) && de->de_config) {

--- a/src/lang_str.h
+++ b/src/lang_str.h
@@ -64,9 +64,11 @@ lang_str_t     *lang_str_deserialize
 /* Compare */
 int             lang_str_compare ( const lang_str_t *ls1, const lang_str_t *ls2 );
 
-/* Empty */
-int             strempty(const char* c);
-int             lang_str_empty(lang_str_t* str);
+/* Is string empty? */
+int             strempty(const char* c)
+    __attribute__((warn_unused_result));
+int             lang_str_empty(lang_str_t* str)
+    __attribute__((warn_unused_result));
 
 /* Size in bytes */
 size_t          lang_str_size ( const lang_str_t *ls );

--- a/src/string_list.c
+++ b/src/string_list.c
@@ -1,0 +1,174 @@
+/*
+ *  Sorted String List Functions
+ *  Copyright (C) 2017 Tvheadend Foundation CIC
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "string_list.h"
+
+#include <string.h>
+#include "htsmsg.h"
+
+/// Sorted string list helper functions.
+void
+string_list_init(string_list_t *l)
+{
+  RB_INIT(l);
+}
+
+string_list_t *
+string_list_create(void)
+{
+  string_list_t *ret = calloc(1, sizeof(string_list_t));
+  string_list_init(ret);
+  return ret;
+}
+
+
+void
+string_list_destroy(string_list_t *l)
+{
+  if (!l) return;
+
+  string_list_item_t *item;
+  while ((item = RB_FIRST(l))) {
+    RB_REMOVE(l, item, h_link);
+    free(item->id);
+  }
+}
+
+static inline int
+string_list_item_cmp(const void *a, const void *b)
+{
+  return strcmp(((const string_list_item_t*)a)->id, ((const string_list_item_t*)b)->id);
+}
+
+void
+string_list_insert(string_list_t *l, const char *id)
+{
+  if (!id) return;
+
+  string_list_item_t *item = calloc(1, sizeof(string_list_item_t));
+  item->id = strdup(id);
+  if (RB_INSERT_SORTED(l, item, h_link, string_list_item_cmp)) {
+    /* Duplicate, so not inserted. */
+    free(item->id);
+    free(item);
+  }
+}
+
+htsmsg_t *
+string_list_to_htsmsg(const string_list_t *l)
+{
+  htsmsg_t *ret = NULL;
+  string_list_item_t *item;
+  RB_FOREACH(item, l, h_link) {
+    if (!ret) ret = htsmsg_create_list();
+    const char *id = item->id;
+    htsmsg_add_str(ret, NULL, id);
+  }
+  return ret;
+}
+
+string_list_t *
+htsmsg_to_string_list(const htsmsg_t *m)
+{
+  string_list_t *ret = NULL;
+  htsmsg_field_t *f;
+  HTSMSG_FOREACH(f, m) {
+    if (f->hmf_type == HMF_STR) {
+      const char *str = f->hmf_str;
+      if (str && *str) {
+        if (!ret) ret = string_list_create();
+
+        string_list_insert(ret, str);
+      }
+    }
+  }
+  return ret;
+}
+
+void
+string_list_serialize(const string_list_t *l, htsmsg_t *m, const char *f)
+{
+    if (!l) return;
+
+    htsmsg_t *msg = string_list_to_htsmsg(l);
+    if (msg)
+      htsmsg_add_msg(m, f, msg);
+}
+
+string_list_t *
+string_list_deserialize(const htsmsg_t *m, const char *n)
+{
+  htsmsg_t *sub = htsmsg_get_list(m, n);
+  if (!sub) return NULL;
+  return htsmsg_to_string_list(sub);
+}
+
+char *
+string_list_2_csv(const string_list_t *l, char delim, int human)
+{
+  if (!l) return NULL;
+
+  htsmsg_t *msg = string_list_to_htsmsg(l);
+  if (!msg) return NULL;
+
+  char *ret = htsmsg_list_2_csv(msg, delim, human);
+  htsmsg_destroy(msg);
+  return ret;
+}
+
+int
+string_list_cmp(const string_list_t *m1, const string_list_t *m2)
+{
+  /* Algorithm based on htsmsg_cmp */
+  if (m1 == NULL && m2 == NULL)
+    return 0;
+  if (m1 == NULL || m2 == NULL)
+    return 1;
+
+  string_list_item_t *i1;
+  string_list_item_t *i2 = RB_FIRST(m2);
+  RB_FOREACH(i1, m1, h_link) {
+    if (i2 == NULL)
+      return 1;
+    const int cmp = strcmp(i1->id, i2->id);
+    /* Not equal? */
+    if (cmp)
+      return cmp;
+
+    i2 = RB_NEXT(i2, h_link);
+  }
+
+  if (i2)
+    return 1;
+
+  return 0;
+}
+
+string_list_t *
+string_list_copy(const string_list_t *src)
+{
+  if (!src) return NULL;
+  string_list_t *ret = string_list_create();
+  string_list_item_t *item;
+  RB_FOREACH(item, src, h_link) {
+    const char *id = item->id;
+    string_list_insert(ret, id);
+  }
+
+  return ret;
+}

--- a/src/string_list.h
+++ b/src/string_list.h
@@ -1,0 +1,75 @@
+/*
+ *  Sorted String List Functions
+ *  Copyright (C) 2017 Tvheadend Foundation CIC
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef STRING_LIST_H
+#define STRING_LIST_H
+
+#include "redblack.h"
+
+/*
+ * External forward decls
+ */
+struct htsmsg;
+
+/// Simple _sorted_ string list type and helper functions.
+/// The htsmsg implements lists and maps but they are unsorted.
+/// This implements a simple api for keeping track of sorted
+/// strings. Only one copy of the string is kept in the list
+/// (duplicates are not stored). The list owns the memory
+/// for the strings (takes a copy).
+///
+/// Example:
+/// string_list_create_t *l = string_list_create();
+/// string_list_insert(l, "str1");
+/// string_list_insert(l, "str2");
+/// string_list_destroy(l);
+
+typedef struct string_list_item
+{
+  char* id;
+  RB_ENTRY(string_list_item) h_link;
+} string_list_item_t;
+typedef RB_HEAD(string_list, string_list_item) string_list_t;
+
+/// Initialize the memory used by the list.
+void string_list_init(string_list_t *l);
+/// Dynamically allocate and initialize a list.
+string_list_t *string_list_create(void);
+
+/// Free up the memory used by the list.
+void string_list_destroy(string_list_t *l);
+
+/// Insert a copy of id in to the sorted string list.
+void string_list_insert(string_list_t *l, const char *id);
+
+/// Conversion function from sorted string list to an htsmsg.
+/// @return NULL if empty.
+struct htsmsg *string_list_to_htsmsg(const string_list_t *l)
+    __attribute__((warn_unused_result));
+string_list_t * htsmsg_to_string_list(const struct htsmsg *m)
+    __attribute__((warn_unused_result));
+void string_list_serialize(const string_list_t *l, struct htsmsg *m, const char *f);
+string_list_t *string_list_deserialize(const struct htsmsg *m, const char *f)
+    __attribute__((warn_unused_result));
+char *string_list_2_csv(const string_list_t *l, char delim, int human)
+    __attribute__((warn_unused_result));
+int string_list_cmp(const string_list_t *m1, const string_list_t *m2)
+    __attribute__((warn_unused_result));
+/// Deep clone (shares no pointers, so have to string_list_destroy both.
+string_list_t *string_list_copy(const string_list_t *src)
+    __attribute__((warn_unused_result));
+#endif

--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -128,6 +128,54 @@ tvheadend.epgDetails = function(event) {
       content += '<div class="x-epg-desc">' + event.description + '</div>';
     if (event.summary || event.description)
       content += '<hr class="x-epg-hr"/>';
+
+    // Helper function for common code to sort an array, convert to CSV and
+    // return the string to add to the content.
+    function sortAndAddArray(arr, title) {
+      arr.sort();
+      var csv = arr.join(", ");
+      if (csv)
+        return '<div class="x-epg-meta"><span class="x-epg-prefix">' + title + ':</span><span class="x-epg-body">' + csv + '</span></div>';
+      else
+        return '';
+    }
+
+    if (event.credits) {
+      // Our cast (credits) map contains details of actors, writers,
+      // etc. so split in to separate categories for displaying.
+      var castArr = [];
+      var crewArr = [];
+      var directorArr = [];
+      var writerArr = [];
+      var cast = ["actor", "guest", "presenter"];
+      // We use arrays here in case more tags in the future map on to
+      // director/writer, e.g., SchedulesDirect breaks it down in to
+      // writer, writer (adaptation) writer (screenplay), etc. but
+      // currently we just have them all as writer.
+      var director = ["director"];
+      var writer = ["writer"];
+
+      for (key in event.credits) {
+        var type = event.credits[key];
+        if (cast.indexOf(type) != -1)
+          castArr.push(key);
+        else if (director.indexOf(type) != -1)
+          directorArr.push(key);
+        else if (writer.indexOf(type) != -1)
+          writerArr.push(key);
+        else
+          crewArr.push(key);
+      };
+
+      content += sortAndAddArray(castArr, _('Starring'));
+      content += sortAndAddArray(directorArr, _('Director'));
+      content += sortAndAddArray(writerArr, _('Writer'));
+      content += sortAndAddArray(crewArr, _('Crew'));
+    }
+    if (event.keyword)
+      content += sortAndAddArray(event.keyword, _('Keywords'));
+    if (event.category)
+      content += sortAndAddArray(event.category, _('Categories'));
     if (event.starRating)
       content += '<div class="x-epg-meta"><span class="x-epg-prefix">' + _('Star Rating') + ':</span><span class="x-epg-body">' + event.starRating + '</span></div>';
     if (event.ageRating)
@@ -429,6 +477,9 @@ tvheadend.epg = function() {
                 dateFormat: 'U' /* unix time */
             },
             { name: 'starRating' },
+            { name: 'credits' },
+            { name: 'category' },
+            { name: 'keyword' },
             { name: 'ageRating' },
             { name: 'genre' },
             { name: 'dvrUuid' },

--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -105,6 +105,8 @@ tvheadend.epgDetails = function(event) {
     content += '<div class="x-epg-title">' + event.title;
     if (event.subtitle)
         content += "&nbsp;:&nbsp;" + event.subtitle;
+    if (event.copyrightYear)
+        content += "&nbsp;(" + event.copyrightYear + ")";
     content += '</div>';
     if (event.episodeOnscreen)
         content += '<div class="x-epg-title">' + event.episodeOnscreen + '</div>';
@@ -481,6 +483,7 @@ tvheadend.epg = function() {
             { name: 'category' },
             { name: 'keyword' },
             { name: 'ageRating' },
+            { name: 'copyrightYear' },
             { name: 'genre' },
             { name: 'dvrUuid' },
             { name: 'dvrState' },

--- a/src/webui/xmltv.c
+++ b/src/webui/xmltv.c
@@ -21,6 +21,7 @@
 #include "webui.h"
 #include "channels.h"
 #include "http.h"
+#include "string_list.h"
 
 /*
  *
@@ -79,6 +80,22 @@ http_xmltv_channel_add(htsbuf_queue_t *hq, const char *hostpath, channel_t *ch)
   htsbuf_append_str(hq, "</channel>\n");
 }
 
+
+/// Write each entry in the string list to the xml queue using the given tag_name.
+static void
+_http_xmltv_programme_write_string_list(htsbuf_queue_t *hq, const string_list_t* sl, const char* tag_name)
+{
+  if (!hq || !sl)
+    return;
+
+  const string_list_item_t *item;
+  RB_FOREACH(item, sl, h_link) {
+    htsbuf_qprintf(hq, "  <%s>", tag_name);
+    htsbuf_append_and_escape_xml(hq, item->id);
+    htsbuf_qprintf(hq, "</%s>\n", tag_name);
+  }
+}
+
 /*
  *
  */
@@ -112,6 +129,18 @@ http_xmltv_programme_one(htsbuf_queue_t *hq, const char *hostpath,
       htsbuf_append_and_escape_xml(hq, lse->str);
       htsbuf_append_str(hq, "</desc>\n");
     }
+  if (ebc->credits) {
+    htsbuf_append_str(hq, "  <credits>\n");
+    htsmsg_field_t *f;
+    HTSMSG_FOREACH(f, ebc->credits) {
+      htsbuf_qprintf(hq, "    <%s>", f->u.str);
+      htsbuf_append_and_escape_xml(hq, f->hmf_name);
+      htsbuf_qprintf(hq, "</%s>\n", f->u.str);
+    }
+    htsbuf_append_str(hq, "  </credits>\n");
+  }
+  _http_xmltv_programme_write_string_list(hq, ebc->category, "category");
+  _http_xmltv_programme_write_string_list(hq, ebc->keyword, "keyword");
   htsbuf_append_str(hq, "</programme>\n");
 }
 


### PR DESCRIPTION
The xmltv provides additional information about programmes such as                                                                                                                
keywords ("Zookeeper", "Newscast", "Lion", "Mystery"), and categories                                                                                                             
("Crime drama", "Movie", "Series"). It can also provide detailed                                                                                                                  
information about actors, writers, editors, composers, etc.                                                                                                                       
                                                                                                                                                                                  
We parse this information and allow it to be searched from the GUI.                                                                                                               
I've not made any changes to Kodi's pvr.hts to parse this informaiton                                                                                                             
since I have no environment configured for compiling and testing it.                                                                                                                    
                                                                                                                                                                                  
We make this scraping configurable since having 20+ actors and                                                                                                                    
keywords per movie can increase memory usage of the server and the                                                                                                                
clients to which we send this information.                                                                                                                                        
                                                                                                                                                                                  
We also offer an option to append this information on to the                                                                                                                      
description. This allows people with old clients to see the                                                                                                                       
information. So it will append "Starring: X, Y, Z", a bit like a 
normal tv guide.                                                                                                                                                                    
                                                                                                                                                                                  
We also parse a few more age ratings and prevent underflow that                                                                                                                   
currently occurs due to one ratings agency using negative numbers.                                                                                                                
                                                                                                                                                                                  
The date field from the xmltv dtd is also parsed to give a                                                                                                                        
"copyrightYear" field. I chose that name because "finished date" (used                                                                                                            
in the xmltv DTD) sounded too similar to DVR functionality such as                                                                                                                
stop time, and the DTD said the date is typically the copyright date anyway.                                                                                                                                                                        
                                                                                                                                                                                  
I added a new file "string_list" to keep a sorted unique list of                                                                                                                  
strings, which required adding a few "const" qualifiers to htsmsg.                                                                                                                
                                                                                                                                                                                  
The htsp has been updated to have the extra information, for example:

{                                                                                                                                                                                 
'category': ['Action', 'Drama', 'Episode', 'Series', 'series'],                                                                                                                   
'credits': { 'Branscombe Richmond': 'guest',                                                                                                                                      
'Bruce Glover': 'guest',                                                                                                                                                          
'Cherie Michan': 'guest',                                                                                                                                                         
'Craig R. Baxley': 'director',                                                                                                                                                    
'Dennis Franz': 'guest',                                                                                                                                                          
'Dirk Benedict': 'actor',                                                                                                                                                         
'Dwight Schultz': 'actor',                                                                                                                                                        
'Garnett Smith': 'guest',                                                                                                                                                         
'George Peppard': 'actor',                                                                                                                                                        
'Lloyd Bochner': 'guest',                                                                                                                                                         
'Maylo McCashlin': 'guest',                                                                                                                                                       
'Mr. T': 'actor'},                                                                                                                                                                
'method': 'eventAdd',                                                                                                                                                             
...                                                                                                                                                                               
                                                                                                                                                                                  
Example:                                                                                                                                                                          
                                                                                                                                                                                  
{                                                                                                                                                                                 
'category': ['Feature Film', 'Movie', 'Western', 'movie'],                                                                                                                        
'copyrightYear': 1947,                                                                                                                                                            
'credits': { 'Andre de Toth': 'director',                                                                                                                                         
'Arleen Whelan': 'actor',                                                                                                                                                         
...                                                                                                                                                        
'Veronica Lake': 'actor'},                                                                                                                                                        
'keyword': [ '1880s',...                                                                                                                                                          
'Tense'],                                                                                                                                                                         
'method': 'eventUpdate',                                                                                                                                                          
...                                                                                                                                                                               
                                                                                                                                                                                
I did not scrape "country" from the xmltv (as suggested by bug) since                                                                                                             
I could not see this being currently used by Kodi and it is only one of
the countries used during production, so is probably best just grabbed
from online sources that give all countries.

Also, looking at the original Kodi request, it appears it was only for
EPG information, hence information like "year" still can't be passed to it for
recorded programmes.
