### PR TITLE
An option to restart the recording if streams get reconfigured.

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -72,6 +72,7 @@ typedef struct dvr_config {
   uint32_t dvr_warm_time;
   uint32_t dvr_extra_time_pre;
   uint32_t dvr_extra_time_post;
+  int dvr_reconfigure_restart;
   uint32_t dvr_update_window;
   int dvr_running;
   uint32_t dvr_cleanup_threshold_free;

--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -997,6 +997,20 @@ const idclass_t dvr_config_class = {
       .group    = 1,
     },
     {
+      .type     = PT_BOOL,
+      .id       = "reconfigure-restart",
+      .name     = N_("Restart after reconfigure"),
+      .desc     = N_("Restart the recording if the streams are "
+                     "reconfigured during the recording. "
+                     "Default is unchecked, but try checking this if "
+                     "you have trouble playing the recordings, especially "
+                     ".mkv files and players may have problems."),
+      .off      = offsetof(dvr_config_t, dvr_reconfigure_restart),
+      .opts     = PO_ADVANCED,
+      .def.i    = 1,
+      .group    = 1,
+    },
+    {
       .type     = PT_U32,
       .id       = "epg-update-window",
       .name     = N_("EPG update window"),

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -1458,6 +1458,10 @@ dvr_thread(void *aux)
        if (sm->sm_code == SM_CODE_SOURCE_RECONFIGURED) {
 	 // Subscription is restarting, wait for SMT_START
 
+         if(de->de_config->dvr_reconfigure_restart) {
+           muxing = 0;
+         }
+
        } else if(sm->sm_code == 0) {
 	 // Recording is completed
 


### PR DESCRIPTION
This PR implements the patch discussed in issue #4538 (https://tvheadend.org/issues/4538) and allows (but does not force) a workaround for the issue.
I prefer recording to .mkv, as tvh preserves the EPG metadata nicely there. The problem is (at least with the way tvh 4.2 and video player software do it today) that if the stream properties change (audio streams change or get added or dvb_subtitle streams change) the resulting .mkv file is very hard to play (video hangs, seek times are very long...).

The developer JK (see the issue discussion) proposed a one line patch that effectively restores the behaviour tvh had in 4.0.9, that is, the recording restarts if the streams are reconfigured, resulting in file.mkv, file-1.mkv, file-2.mkv etc., with no conflicting streams. Plus I get the actual program with virtually no padding, at least that's how it works here where I live.

 This PR adds a tickbox in recording settings tab, just under the padding file options, to restart the recording if the stream is reconfigured.

The underlying cause of the problematic recording of reconfiguring streams is unresolved, and a universal fix might appear in the future.

The PR tries to offer a subtle option to the workaround. I guess it's ready for review, but be warned: I am not a programmer/developer, I don't even really know C. I only had the patch, and I replicated the code used in the other options. So I probably won't be able to turn this in to something more.

One improvement (in the future) might be that if the option to restart recordings is selected, the recording would not be registered in the "Failed recordings" at all (due to "source reconfigured"), but in "Finished recordings" instead. But it's really not hard to transfer the recordings manually to "Finished". And the user (like me) might still want to know if there was a reconfigured stream.
