### PR TITLE
xmltv: Only parse channel number from display-name if config allows. (#4615)

### DIFF
--- a/src/epggrab/module/xmltv.c
+++ b/src/epggrab/module/xmltv.c
@@ -662,38 +662,42 @@ static int _xmltv_parse_channel
     if (!(subtag = htsmsg_field_get_map(f))) continue;
     if (strcmp(f->hmf_name, "display-name") == 0) {
       name = htsmsg_get_str(subtag, "cdata");
-      int major = 0;
-      int minor = 0;
       const char *cur = name;
 
-      /* Some xmltv providers supply a display-name that is the
-       * channel number. So attempt to grab it.
-       */
+      if (chnum && cur) {
+        /* Some xmltv providers supply a display-name that is the
+         * channel number. So attempt to grab it.
+         * But only if chnum (enum meaning to process numbers).
+         */
 
-      /* Check and grab major part of channel number */
-      while (isdigit(*cur))
-        major = (major * 10) + *cur++ - '0';
+        int major = 0;
+        int minor = 0;
 
-      /* If a period then it's an atsc-style number of major.minor.
-       * So skip the period and parse the minor.
-       */
-      if (major && *cur == '.') {
-        ++cur;
+        /* Check and grab major part of channel number */
         while (isdigit(*cur))
-          minor = (minor * 10) + *cur++ - '0';
-      }
+          major = (major * 10) + *cur++ - '0';
 
-      /* If we have a channel number and then either end of string
-       * or (if chnum is 'first words') a space, then save the channel.
-       * The space is necessary to avoid channels such as "4Music"
-       * being treated as channel number 4.
-       *
-       * We assume channel number has to be >0.
-       */
-      if (major && (!*cur || (*cur == ' ' && chnum == 1))) {
-        save |= epggrab_channel_set_number(ch, major, minor);
-        /* Skip extra spaces between channel number and actual name */
-        while (*cur == ' ') ++cur;
+        /* If a period then it's an atsc-style number of major.minor.
+         * So skip the period and parse the minor.
+         */
+        if (major && *cur == '.') {
+          ++cur;
+          while (isdigit(*cur))
+            minor = (minor * 10) + *cur++ - '0';
+        }
+
+        /* If we have a channel number and then either end of string
+         * or (if chnum is 'first words') a space, then save the channel.
+         * The space is necessary to avoid channels such as "4Music"
+         * being treated as channel number 4.
+         *
+         * We assume channel number has to be >0.
+         */
+        if (major && (!*cur || (*cur == ' ' && chnum == 1))) {
+          save |= epggrab_channel_set_number(ch, major, minor);
+          /* Skip extra spaces between channel number and actual name */
+          while (*cur == ' ') ++cur;
+        }
       }
 
       if (cur && *cur)


### PR DESCRIPTION
I'm sorry but my earlier commit (a803e6, parse atsc numbers) accidentally removed the check for user configuration option (chnum) when parsing the display-name in xmltv files. This means that leading digits in an xmltv display-name would always be stripped even if the config is disabled.

The patch is actually just re-adding the test and moving the variables inside the test, but the re-indent shows most lines changed.

I used the same commit issue as the original bug (for parsing atsc numbers).
