### PR TITLE
webui: Mark upcoming recording duplicates with a line-through in grid (#4632)

### DIFF
--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -195,6 +195,21 @@ tvheadend.filesizeRenderer = function(st) {
     }
 }
 
+/** Render an entry differently if it is a duplicate */
+tvheadend.displayWithDuplicateRenderer = function(value, meta, record) {
+    return function() {
+        return function(value, meta, record) {
+            if (value == null)
+                return '';
+            var is_dup = record.data['duplicate'];
+            if (is_dup)
+                return "<span class='x-epg-duplicate'>" + value + "</span>";
+            else
+                return value;
+        }
+    }
+}
+
 /**
  *
  */
@@ -305,6 +320,12 @@ tvheadend.dvr_upcoming = function(panel, index) {
               'start_real,stop_real,duration,pri,filesize,' +
               'sched_status,errors,data_errors,config_name,owner,creator,comment',
         columns: {
+            disp_title: {
+              renderer: tvheadend.displayWithDuplicateRenderer()
+            },
+            disp_subtitle: {
+              renderer: tvheadend.displayWithDuplicateRenderer()
+            },
             filesize: {
                 renderer: tvheadend.filesizeRenderer()
             }

--- a/src/webui/static/app/ext.css
+++ b/src/webui/static/app/ext.css
@@ -749,6 +749,10 @@
     margin-left: 5px;
 }
 
+.x-epg-duplicate {
+    text-decoration: line-through;
+}
+
 .tv-video-player {
     margin-right: auto;
     margin-left : auto;


### PR DESCRIPTION
The advanced and expert views on the upcoming tab have a column for the
duplicate date ("rerun of"). But on the basic view there is no indication of
duplicates unless you click information on the entry.

So we now render title/subtitle for duplicates with a css style that has line-through.
This puts a strikeout line through the title/subtitle and makes it clear they are duplicates
that will not be recorded.

Issue: #4632