### PR TITLE
upgrade to libhdhomerun_20170815

### DIFF
--- a/Makefile.hdhomerun
+++ b/Makefile.hdhomerun
@@ -32,10 +32,10 @@ endif
 # Upstream Packages
 # ###########################################################################
 
-LIBHDHR         = libhdhomerun_20161117
+LIBHDHR         = libhdhomerun_20170815
 LIBHDHR_TB      = $(LIBHDHR).tgz
 LIBHDHR_URL     = http://download.silicondust.com/hdhomerun/$(LIBHDHR_TB)
-LIBHDHR_SHA1    = d066e2ed99c4e4e52ffdd50d4a52b430a5067880
+LIBHDHR_SHA1    = 8c6a0e03ffac6bc82029f17377aae2367e0c33d3
 
 # ###########################################################################
 # Library Config


### PR DESCRIPTION
This upgrades the static libhdhomerun to 20170815.
If possible, please also merge with the upcoming 4.2.4 release.