### PR TITLE
doozer.io: add raspbian jessie and stretch builds

### DIFF
--- a/.doozer.json
+++ b/.doozer.json
@@ -239,6 +239,58 @@
         "support/bintray.py publish filelist.txt"
       ]
     },
+    "raspbian-jessie": {
+      "buildenv": "raspbian-jessie",
+      "builddeps": [
+        "cmake",
+        "git",
+        "build-essential",
+        "pkg-config",
+        "gettext",
+        "libavahi-client-dev",
+        "libssl-dev",
+        "zlib1g-dev",
+        "wget",
+        "bzip2",
+        "git-core",
+        "liburiparser-dev",
+        "libpcre3-dev",
+        "python",
+        "dvb-apps",
+        "debhelper",
+        "ccache"
+      ],
+      "buildcmd": [
+        "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-hdhomerun_static\\ --disable-ffmpeg_static ./Autobuild.sh -t raspbianjessie-armhf -j ${PARALLEL} -w ${WORKDIR}",
+        "support/bintray.py publish filelist.txt"
+      ]
+    },
+    "raspbian-stretch": {
+      "buildenv": "raspbian-stretch",
+      "builddeps": [
+        "cmake",
+        "git",
+        "build-essential",
+        "pkg-config",
+        "gettext",
+        "libavahi-client-dev",
+        "libssl-dev",
+        "zlib1g-dev",
+        "wget",
+        "bzip2",
+        "git-core",
+        "liburiparser-dev",
+        "libpcre2-dev",
+        "python",
+        "dvb-apps",
+        "debhelper",
+        "ccache"
+      ],
+      "buildcmd": [
+        "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-hdhomerun_static\\ --disable-ffmpeg_static ./Autobuild.sh -t raspbianstretch-armhf -j ${PARALLEL} -w ${WORKDIR}",
+        "support/bintray.py publish filelist.txt"
+      ]
+    },
     "xenial-arm64": {
       "buildenv": "xenial-arm64",
       "builddeps": [


### PR DESCRIPTION
Doozer can now build for jessie and stretch. This adds those in.

~~Additionally, commit 049cba99157da175163f9c6a6fa8a686f3fafa54 needs to be applied to release/4.2 to avoid the dirty tagging.  it may need modifying to fit with 4.2 doozer.json, I'm happy to do it if required.~~ Fixed in doozer so no longer required see [IRC log](http://colabti.org/irclogger/irclogger_log/hts?date=2017-10-05#l192)