### PR TITLE
dvr: allow autorec by category (#4665)

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -354,6 +354,7 @@ typedef struct dvr_autorec_entry {
   char *dae_cat1;                 /** Simple single category from drop-down selection boxes */
   char *dae_cat2;                 /** Simple single category from drop-down selection boxes */
   char *dae_cat3;                 /** Simple single category from drop-down selection boxes */
+  uint16_t dae_star_rating;       /** Minimum star rating: we use u16 instead of u8 since no PT_U8 type */
 
   int dae_start;        /* Minutes from midnight */
   int dae_start_window; /* Minutes (duration) */

--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -347,6 +347,13 @@ typedef struct dvr_autorec_entry {
   int dae_fulltext;
   
   uint32_t dae_content_type;
+  /* These categories (mainly from xmltv) such as Cooking, Dog racing, Movie.
+   * This allows user to easily do filtering such as '"Movie" "Martial arts"'
+   * or '"Children" "Animated" "Movie"'
+   */
+  char *dae_cat1;                 /** Simple single category from drop-down selection boxes */
+  char *dae_cat2;                 /** Simple single category from drop-down selection boxes */
+  char *dae_cat3;                 /** Simple single category from drop-down selection boxes */
 
   int dae_start;        /* Minutes from midnight */
   int dae_start_window; /* Minutes (duration) */

--- a/src/epg.h
+++ b/src/epg.h
@@ -527,7 +527,7 @@ struct epg_broadcast
   lang_str_t                *credits_cached;   ///< Comma separated cast (for regex searching in GUI/autorec). Kept in sync with cast_map
   struct string_list        *category;         ///< Extra categories (typically from xmltv) such as "Western" or "Sumo Wrestling".
                                                ///< These extra categories are often a superset of our EN 300 468 DVB genre.
-                                               ///< Currently not explicitly searchable in GUI.
+                                               ///< Used with drop-down lists in the GUI.
   struct string_list        *keyword;          ///< Extra keywords (typically from xmltv) such as "Wild West" or "Unicorn".
   lang_str_t                *keyword_cached;   ///< Cached CSV version for regex searches.
   RB_ENTRY(epg_broadcast)    sched_link;       ///< Schedule link

--- a/src/string_list.c
+++ b/src/string_list.c
@@ -172,3 +172,16 @@ string_list_copy(const string_list_t *src)
 
   return ret;
 }
+
+int
+string_list_contains_string(const string_list_t *src, const char *find)
+{
+  string_list_item_t skel;
+  skel.id = (char*)find;
+
+  string_list_item_t *item = RB_FIND(src, &skel, h_link, string_list_item_cmp);
+  /* Can't just return item due to compiler settings preventing ptr to
+   * int conversion
+   */
+  return item != NULL;
+}

--- a/src/string_list.h
+++ b/src/string_list.h
@@ -72,4 +72,8 @@ int string_list_cmp(const string_list_t *m1, const string_list_t *m2)
 /// Deep clone (shares no pointers, so have to string_list_destroy both.
 string_list_t *string_list_copy(const string_list_t *src)
     __attribute__((warn_unused_result));
+
+/// Searching
+int string_list_contains_string(const string_list_t *src, const char *find);
+
 #endif

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -746,7 +746,7 @@ tvheadend.autorec_editor = function(panel, index) {
 
     var list = 'name,title,fulltext,channel,start,start_window,weekdays,' +
                'record,tag,btype,content_type,cat1,cat2,cat3,minduration,maxduration,' +
-               'dedup,directory,config_name,comment';
+               'star_rating,dedup,directory,config_name,comment';
     var elist = 'enabled,start_extra,stop_extra,' +
                 (tvheadend.accessUpdate.admin ?
                 list + ',owner,creator' : list) + ',pri,retention,removal,maxcount,maxsched';
@@ -787,6 +787,7 @@ tvheadend.autorec_editor = function(panel, index) {
             removal:      { width: 80 },
             maxcount:     { width: 80 },
             maxsched:     { width: 80 },
+            star_rating:  { width: 80 },
             config_name:  { width: 120 },
             owner:        { width: 100 },
             creator:      { width: 200 },
@@ -807,7 +808,7 @@ tvheadend.autorec_editor = function(panel, index) {
         del: true,
         list: 'enabled,name,title,fulltext,channel,tag,start,start_window,' +
               'weekdays,minduration,maxduration,btype,content_type,cat1,cat2,cat3' +
-              'pri,dedup,directory,config_name,owner,creator,comment',
+              'star_rating,pri,dedup,directory,config_name,owner,creator,comment',
         sort: {
           field: 'name',
           direction: 'ASC'

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -745,7 +745,7 @@ tvheadend.dvr_settings = function(panel, index) {
 tvheadend.autorec_editor = function(panel, index) {
 
     var list = 'name,title,fulltext,channel,start,start_window,weekdays,' +
-               'record,tag,btype,content_type,minduration,maxduration,' +
+               'record,tag,btype,content_type,cat1,cat2,cat3,minduration,maxduration,' +
                'dedup,directory,config_name,comment';
     var elist = 'enabled,start_extra,stop_extra,' +
                 (tvheadend.accessUpdate.admin ?
@@ -767,6 +767,9 @@ tvheadend.autorec_editor = function(panel, index) {
             tag:          { width: 200 },
             btype:        { width: 50 },
             content_type: { width: 100 },
+            cat1:         { width: 300 },
+            cat2:         { width: 300 },
+            cat3:         { width: 300 },
             minduration:  { width: 100 },
             maxduration:  { width: 100 },
             weekdays:     { width: 160 },
@@ -803,7 +806,7 @@ tvheadend.autorec_editor = function(panel, index) {
         },
         del: true,
         list: 'enabled,name,title,fulltext,channel,tag,start,start_window,' +
-              'weekdays,minduration,maxduration,btype,content_type,' +
+              'weekdays,minduration,maxduration,btype,content_type,cat1,cat2,cat3' +
               'pri,dedup,directory,config_name,owner,creator,comment',
         sort: {
           field: 'name',


### PR DESCRIPTION
The xmltv import supports categories such as "movie", "animated", "biography", so allow autorec to record via these categories. Also allow recording with a minimum star rating.

This allows you to record all movies with a rating of 80% that are animated; or all sumo wrestling, etc. and can be combined with the existing regex to filter matches further such as "all movie, comedy which match full text of Stallone".

I've not bumped the HTSP_PROTO_VERSION since I have another feature I'll submit tomorrow and then increment the version for both patches so clients know the feature is available rather than having merge conflicts on both patches changing the same version number. I believe this patch could be merged even without incrementing the version, it just means frontends won't yet know the backend supports recording by category.
