### PR TITLE
Makefile.hdhomerun: Update to 20170930

### DIFF
--- a/Makefile.hdhomerun
+++ b/Makefile.hdhomerun
@@ -32,10 +32,10 @@ endif
 # Upstream Packages
 # ###########################################################################
 
-LIBHDHR         = libhdhomerun_20170815
+LIBHDHR         = libhdhomerun_20170930
 LIBHDHR_TB      = $(LIBHDHR).tgz
 LIBHDHR_URL     = http://download.silicondust.com/hdhomerun/$(LIBHDHR_TB)
-LIBHDHR_SHA1    = 8c6a0e03ffac6bc82029f17377aae2367e0c33d3
+LIBHDHR_SHA1    = 8a25839abeb6cae25878912c01426db4dccd3192
 
 # ###########################################################################
 # Library Config


### PR DESCRIPTION
This adds support for the newly-released HDHR5 models.