### PR TITLE
dvr: Add format specifier to simplify scraping/separate movies and shows (#4667)

### DIFF
--- a/docs/property/pathname.md
+++ b/docs/property/pathname.md
@@ -19,6 +19,7 @@ Format    | Description                                      | Example
 `$x`      | Filename extension (from the active stream muxer | mkv
 `%F`      | ISO 8601 date format                             | 2011-03-19
 `%R`      | The time in 24-hour notation                     | 14:12
+
 The format strings `$t`,`$s`,`%e`,`$c` also have delimiter variants such as 
 `$ t` (space after the dollar character), `$-t`, `$_t`,
 `$.t`, `$,t`, `$;t`. In these cases, the delimiter is applied 

--- a/docs/property/pathname.md
+++ b/docs/property/pathname.md
@@ -11,11 +11,14 @@ Format    | Description                                      | Example
 `$e`      | Event episode name                               | S02-E06
 `$c`      | Channel name                                     | SkySport
 `$g`      | Content type                                     | Movie : Science fiction
+`$Q`      | Scraper friendly (see below)                     | Gladiator (2000)
+ 〃       | 〃                                               | Bones - S02E06
+`$q`      | Scraper friendly with directories (see below)    | tvshows/Bones/Bones - S02E06
+ 〃       | 〃                                               | tvmovies/Gladiator (2000)
 `$n`      | Unique number added when the file already exists | -1
 `$x`      | Filename extension (from the active stream muxer | mkv
 `%F`      | ISO 8601 date format                             | 2011-03-19
 `%R`      | The time in 24-hour notation                     | 14:12
-
 The format strings `$t`,`$s`,`%e`,`$c` also have delimiter variants such as 
 `$ t` (space after the dollar character), `$-t`, `$_t`,
 `$.t`, `$,t`, `$;t`. In these cases, the delimiter is applied 
@@ -24,3 +27,47 @@ only when the substituted string is not empty.
 For $t and $s format strings, you may also limit the number of output
 characters using $99-t format string where 99 means the limit. As you can
 see, the delimiter can be also applied.
+
+The format strings `$q` and `$Q` generate filenames that are suitable
+for many external scrapers. They rely on correct schedule data that correctly
+identifies episodes and genres. If your guide data incorrectly
+identifies movies as shows then the filenames will be incorrect and
+show could be identifies as movies or vice-versa. Any xmltv guide data
+should contain the category "movie" for movies.
+
+The `$q` format will create sub-directories `tvmovies` and `tvshows`
+based on the genre in the guide data. For tvshows a second-level
+directory based on the title of the show is created.
+
+Examples are:
+- tvmovies/Gladiator (2000)
+- tvshows/Countdown/Countdown
+- tvshows/Bones/Bones - S05E11
+- tvshows/Bones/Bones - S05E11 - The X in the Files
+
+The `$Q` format is similar to `$q` but does not use genre sub-directories.
+Sub-directories are still created for tvshow episodes.
+Examples are below based on different information in the EPG:
+- Gladiator (2000) (movie)
+- Bones/Bones - S05 E11 (episode with guide season/episode information)
+- Countdown/Countdown (episode without guide season/episode information)
+
+The `$Q` and `$q` formats also have two numeric modifiers to select
+variant formats and can be used as `$1Q`, `$2Q`, `$1q`, and `$2q`.
+
+The number 1 variant forces the recording to be formatted as a movie,
+ignoring the genre from the schedule.
+
+Whereas the number 2 variant forces the recording to be formatted as a
+tv series.
+
+These variants can be useful to work-around bad schedule data that gives
+incorrect genres for programmes.
+
+Typically the `$q` and `$Q` formats would be combined with other
+modifiers to generate a complete filename such as `$q$n.$x`.
+
+Even with correct guide information, external scrapers can retrieve
+incorrect results. A famous example being the detective tv series
+"Castle" is often incorrectly retrieved as a much earlier tv show
+about castles.

--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -96,6 +96,8 @@ typedef struct dvr_config {
   int dvr_skip_commercials;
   int dvr_subtitle_in_title;
   int dvr_windows_compatible_filenames;
+  char *dvr_format_tvmovies_subdir;
+  char *dvr_format_tvshows_subdir;
 
   struct dvr_entry_list dvr_entries;
   struct dvr_autorec_entry_list dvr_autorec_entries;

--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -264,6 +264,8 @@ dvr_config_destroy(dvr_config_t *cfg, int delconf)
   free(cfg->dvr_preproc);
   free(cfg->dvr_postproc);
   free(cfg->dvr_postremove);
+  free(cfg->dvr_format_tvmovies_subdir);
+  free(cfg->dvr_format_tvshows_subdir);
   free(cfg);
 }
 
@@ -1299,6 +1301,34 @@ const idclass_t dvr_config_class = {
                      "or converted."),
       .doc      = prop_doc_dvrconfig_windows,
       .off      = offsetof(dvr_config_t, dvr_windows_compatible_filenames),
+      .opts     = PO_ADVANCED,
+      .group    = 6,
+    },
+    {
+      .type     = PT_STR,
+      .id       = "format-tvmovies-subdir",
+      .name     = N_("Subdirectory for tvmovies for $q format specifier"),
+      .desc     = N_("Subdirectory to use for tvmovies when using the $q specifier. "
+                     "Default value is \"tvmovies\". "
+                     "This can contain any alphanumeric "
+                     "characters (A-Za-z0-9). Other characters may be supported depending "
+                     "on your OS and filesystem."
+                     ),
+      .off      = offsetof(dvr_config_t, dvr_format_tvmovies_subdir),
+      .opts     = PO_ADVANCED,
+      .group    = 6,
+    },
+    {
+      .type     = PT_STR,
+      .id       = "format-tvshows-subdir",
+      .name     = N_("Subdirectory for tvshows for $q format specifier"),
+      .desc     = N_("Subdirectory to use for tvshows when using the $q specifier. "
+                     "Default value is \"tvshows\". "
+                     "This can contain any alphanumeric "
+                     "characters (A-Za-z0-9). Other characters may be supported depending "
+                     "on your OS and filesystem."
+                    ),
+      .off      = offsetof(dvr_config_t, dvr_format_tvshows_subdir),
       .opts     = PO_ADVANCED,
       .group    = 6,
     },

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -472,6 +472,7 @@ _dvr_sub_scraper_friendly(const char *id, const char *fmt, const void *aux, char
    */
 
   size_t offset = 0;
+  const dvr_config_t *config = de->de_config;
 
   if (is_movie) {
     /* TV movies are probably best saved in one folder rather than
@@ -485,7 +486,12 @@ _dvr_sub_scraper_friendly(const char *id, const char *fmt, const void *aux, char
      *   "title (yyyy)"                     (without genre_subdir)
      *   "title"                            (without genre_subdir, no airdate)
      */
-    if (with_genre_subdir)   tvh_strlcatf(tmp, tmplen, offset, "tvmovies/");
+    if (with_genre_subdir) {
+      const char *subdir = config && config->dvr_format_tvmovies_subdir && *config->dvr_format_tvmovies_subdir ?
+        config->dvr_format_tvmovies_subdir : "tvmovies";
+      tvh_strlcatf(tmp, tmplen, offset, "%s/", subdir);
+    }
+
     if (*title_buf)          tvh_strlcatf(tmp, tmplen, offset, "%s", title_buf);
     /* Movies don't have anything relevant in sub-titles field so
      * anything there should be ignored. I think some channels store a
@@ -507,7 +513,11 @@ _dvr_sub_scraper_friendly(const char *id, const char *fmt, const void *aux, char
      *   "title - subtitle_2001-05-04"             (without genre_subdir, long running show)
      *   "title - subtitle"                        (without genre_subdir, no epg info on show)
      */
-    if (with_genre_subdir) tvh_strlcatf(tmp, tmplen, offset, "tvshows/");
+    if (with_genre_subdir) {
+      const char *subdir = config && config->dvr_format_tvshows_subdir && *config->dvr_format_tvshows_subdir ?
+                config->dvr_format_tvshows_subdir : "tvshows";
+      tvh_strlcatf(tmp, tmplen, offset, "%s/", subdir);
+    }
     if (*title_buf)        tvh_strlcatf(tmp, tmplen, offset, "%s/%s", title_buf, title_buf);
     if (*episode_buf)      tvh_strlcatf(tmp, tmplen, offset, " - %s", episode_buf);
     if (*subtitle_buf)     tvh_strlcatf(tmp, tmplen, offset, " - %s", subtitle_buf);

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -359,8 +359,8 @@ dvr_sub_episode(const char *id, const char *fmt, const void *aux, char *tmp, siz
 static const char *
 _dvr_sub_scraper_friendly(const char *id, const char *fmt, const void *aux, char *tmp, size_t tmplen, int with_genre_subdir)
 {
-  char date_buf[MAX(PATH_MAX, 512)] = { 0 };
-  char episode_buf[MAX(PATH_MAX, 512)] = { 0 };
+  char date_buf[512] = { 0 };
+  char episode_buf[512] = { 0 };
   const dvr_entry_t *de = aux;
   /* Can't be const due to call to epg_episode_number_format */
   /*const*/ epg_episode_t *episode = de->de_bcast ? de->de_bcast->episode : 0;
@@ -379,8 +379,8 @@ _dvr_sub_scraper_friendly(const char *id, const char *fmt, const void *aux, char
     subtitle = desc = NULL;
   }
 
-  char title_buf[MAX(PATH_MAX, 512)] = { 0 };
-  char subtitle_buf[MAX(PATH_MAX, 512)] = { 0 };
+  char title_buf[512] = { 0 };
+  char subtitle_buf[512] = { 0 };
   /* Copy a cleaned version in to our buffers.
    * Since dvr_clean_directory_separator _can_ modify source if source!=dest
    * it means we have to remove our const when we call it.

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -376,7 +376,7 @@ _dvr_sub_scraper_friendly(const char *id, const char *fmt, const void *aux, char
      * put in to both subtitle and description. So we really don't
      * want this to be used as the subtitle field.
      */
-    subtitle = desc = NULL;
+    subtitle = NULL;
   }
 
   char title_buf[512] = { 0 };

--- a/src/string_list.c
+++ b/src/string_list.c
@@ -172,3 +172,16 @@ string_list_copy(const string_list_t *src)
 
   return ret;
 }
+
+int
+string_list_contains_string(const string_list_t *src, const char *find)
+{
+  string_list_item_t skel;
+  skel.id = (char*)find;
+
+  string_list_item_t *item = RB_FIND(src, &skel, h_link, string_list_item_cmp);
+  /* Can't just return item due to compiler settings preventing ptr to
+   * int conversion
+   */
+  return item != NULL;
+}

--- a/src/string_list.h
+++ b/src/string_list.h
@@ -72,4 +72,8 @@ int string_list_cmp(const string_list_t *m1, const string_list_t *m2)
 /// Deep clone (shares no pointers, so have to string_list_destroy both.
 string_list_t *string_list_copy(const string_list_t *src)
     __attribute__((warn_unused_result));
+
+/// Searching
+int string_list_contains_string(const string_list_t *src, const char *find);
+
 #endif


### PR DESCRIPTION
Add a new format specifier "$q" to generate "queryable" (scrapable) names for recordings. This relies on good guide data, typically xmltv data that contains "movie".

This format specifier helps split movies and shows in to separate hierarchies without needing post-processing and makes it easier for users who want easy setup.

Examples are:
- tvmovies/Gladiator (2000)
- tvshows/Countdown/Countdown
- tvshows/Bones/Bones - S05E11 - The X in the Files

A couple of other modifiers are also added for cases where guide data is not good so recordings can be forced to be movie or tvshow for cases where a user has separate recording profiles for movies and shows.

I'm not too happy with the names for the variants $1q, $2q for forcing a programme to be formatted as a movie or show. I chose those names to make it easy to extend in the future to have other variants as necessary ($3q, $4q) and to avoid any potential confusion with other specifiers. For example having "$tq" meaning tvshow queryable would be confused with "$t" for title followed by letter q; using $TQ would then remove another letter from future specifiers. So $1q was a compromise.


