### PR TITLE
dvr: add new dedup method by programid (#4652)

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -203,6 +203,7 @@ typedef struct dvr_entry {
   char *de_owner;
   char *de_creator;
   char *de_comment;
+  char *de_uri;                 /* Programme unique ID */
   htsmsg_t *de_files; /* List of all used files */
   char *de_directory; /* Can be set for autorec entries, will override any 
                          directory setting from the configuration */

--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -302,6 +302,7 @@ typedef struct dvr_entry {
 
 typedef enum {
   DVR_AUTOREC_RECORD_ALL = 0,
+  DVR_AUTOREC_RECORD_UNIQUE = 14, /// Unique episode in EPG/XMLTV, typically used for movies/series, and not useful for news or sport.
   DVR_AUTOREC_RECORD_DIFFERENT_EPISODE_NUMBER = 1,
   DVR_AUTOREC_RECORD_DIFFERENT_SUBTITLE = 2,
   DVR_AUTOREC_RECORD_DIFFERENT_DESCRIPTION = 3,
@@ -315,7 +316,7 @@ typedef enum {
   DVR_AUTOREC_LRECORD_ONCE_PER_MONTH = 13,
   DVR_AUTOREC_LRECORD_ONCE_PER_WEEK = 10,
   DVR_AUTOREC_LRECORD_ONCE_PER_DAY = 11,
-  /* last free value == 14 */
+  /* first free value == 15 */
 } dvr_autorec_dedup_t;
 
 typedef enum {

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -942,6 +942,8 @@ dvr_autorec_entry_class_dedup_list ( void *o, const char *lang )
   static const struct strtab tab[] = {
     { N_("Record all"),
         DVR_AUTOREC_RECORD_ALL },
+    { N_("All: Record if EPG/XMLTV indicates it is a unique programme"),
+        DVR_AUTOREC_RECORD_UNIQUE },
     { N_("All: Record if different episode number"),
         DVR_AUTOREC_RECORD_DIFFERENT_EPISODE_NUMBER },
     { N_("All: Record if different subtitle"),

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -990,6 +990,8 @@ dvr_entry_create_(int enabled, const char *config_uuid, epg_broadcast_t *e,
       htsmsg_add_str(conf, "episode", s);
     if (e->episode && e->episode->copyright_year)
       htsmsg_add_u32(conf, "copyright_year", e->episode->copyright_year);
+    if (e->episode && e->episode->uri)
+      htsmsg_add_str(conf, "uri", e->episode->uri);
   } else if (title) {
     l = lang_str_create();
     lang_str_add(l, title, lang, 0);
@@ -3469,6 +3471,14 @@ const idclass_t dvr_entry_class = {
       .desc     = N_("The recorded file was removed intentionally"),
       .off      = offsetof(dvr_entry_t, de_file_removed),
       .opts     = PO_HIDDEN | PO_NOUI,
+    },
+    {
+      .type     = PT_STR,
+      .id       = "uri",
+      .name     = N_("Program unique ID (from grabber)"),
+      .desc     = N_("Program unique ID (from grabber), such as MV101010101.0000"),
+      .off      = offsetof(dvr_entry_t, de_uri),
+      .opts     = PO_RDONLY | PO_EXPERT
     },
     {
       .type     = PT_STR,

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -67,7 +67,7 @@
 
 static void *htsp_server, *htsp_server_2;
 
-#define HTSP_PROTO_VERSION 30
+#define HTSP_PROTO_VERSION 31
 
 #define HTSP_ASYNC_OFF  0x00
 #define HTSP_ASYNC_ON   0x01


### PR DESCRIPTION
This patch implements a new dedup method based on using the unique id from xmltv or the crid from OTA.

The idea is that if the ids are equal then the programmes must be equal. So an xmltvid of MV12345 will always refer to the same movie.

If the entries don't have equal ids then we try and compare various fields for equality to try and just work. So, if they have season and episodes then we can use that as a differentiator.

This dedup method only work for unique programmes, so sports and news typically have non-unique details and so cannot be deduped with this method and the user needs to use existing "once per day" methods.

I've also bumped the htsp_protocol_version so clients know the dedup method is supported.

This patch has mostly been tested with xmltv data.
