### PR TITLE
ui: Send episode image URL to UI for upcoming recordings. (#4681).

### DIFF
--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -2995,6 +2995,17 @@ dvr_entry_class_channel_icon_url_get(void *o)
 }
 
 static const void *
+dvr_entry_class_image_url_get(void *o)
+{
+  dvr_entry_t *de = (dvr_entry_t *)o;
+  static const char *s = "";
+  if (!de->de_bcast || !de->de_bcast->episode || !de->de_bcast->episode->image)
+      return &s;
+  snprintf(prop_sbuf, PROP_SBUF_LEN, "%s", de->de_bcast->episode->image);
+  return &prop_sbuf_ptr;
+}
+
+static const void *
 dvr_entry_class_duplicate_get(void *o)
 {
   static time_t null = 0;
@@ -3167,6 +3178,14 @@ const idclass_t dvr_entry_class = {
       .set      = dvr_entry_class_channel_name_set,
       .off      = offsetof(dvr_entry_t, de_channel_name),
       .opts     = PO_RDONLY,
+    },
+    {
+      .type     = PT_STR,
+      .id       = "image", /* Name chosen to be compatible with api_epg */
+      .name     = N_("Episode image"),
+      .desc     = N_("Episode image."),
+      .get      = dvr_entry_class_image_url_get,
+      .opts     = PO_HIDDEN | PO_RDONLY | PO_NOSAVE | PO_NOUI,
     },
     {
       .type     = PT_LANGSTR,

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -23,6 +23,7 @@ tvheadend.dvrDetails = function(uuid) {
         var duplicate = params[11].value;
         var autorec_caption = params[12].value;
         var timerec_caption = params[13].value;
+        var image = params[14].value;
         var content = '';
         var but;
 
@@ -54,6 +55,10 @@ tvheadend.dvrDetails = function(uuid) {
             content += '</div>'; /* x-epg-left */
             content += '<div class="x-epg-bottom">';
         }
+        if (image != null && image.length > 0) {
+          content += '<img class="x-epg-image" src="' + image + '">';
+        }
+
         content += '<hr class="x-epg-hr"/>';
         if (desc) {
             content += '<div class="x-epg-desc">' + desc + '</div>';
@@ -118,7 +123,7 @@ tvheadend.dvrDetails = function(uuid) {
             uuid: uuid,
             list: 'channel_icon,disp_title,disp_subtitle,episode,start_real,stop_real,' +
                   'duration,disp_description,status,filesize,comment,duplicate,' +
-                  'autorec_caption,timerec_caption'
+                  'autorec_caption,timerec_caption,image'
         },
         success: function(d) {
             d = json_decode(d);
@@ -302,6 +307,7 @@ tvheadend.dvr_upcoming = function(panel, index) {
         },
         del: true,
         list: 'enabled,duplicate,disp_title,disp_subtitle,episode,channel,' +
+              'image,' +
               'start_real,stop_real,duration,pri,filesize,' +
               'sched_status,errors,data_errors,config_name,owner,creator,comment',
         columns: {


### PR DESCRIPTION
Previously the image was only visible in the EPG tab. However it is useful to have it in the upcoming recordings tab too.

Issue: #4681