### PR TITLE
dvr: Allow scheduled programmes to be stopped (never record). (#4506)

### DIFF
--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -2098,7 +2098,7 @@ dvr_stop_recording(dvr_entry_t *de, int stopcode, int saveconf, int clone)
   dvr_rs_state_t rec_state = de->de_rec_state;
   dvr_autorec_entry_t *dae = de->de_autorec;
 
-  if (!clone)
+  if (!clone && de->de_s)
     dvr_rec_unsubscribe(de);
 
   de->de_dont_reschedule = 1;
@@ -3669,7 +3669,11 @@ dvr_entry_move(dvr_entry_t *de, int failed)
 dvr_entry_t *
 dvr_entry_stop(dvr_entry_t *de)
 {
-  if(de->de_sched_state == DVR_RECORDING) {
+  /* Allow stopping a scheduled item. This will then mark it as file missing.
+   * This is useful if you have auto_rec rule that matches programmes you
+   * don't want to record such as episodes you've already seen.
+   */
+  if(de->de_sched_state == DVR_RECORDING || de->de_sched_state == DVR_SCHEDULED) {
     dvr_stop_recording(de, SM_CODE_OK, 1, 0);
     return de;
   }

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -268,11 +268,14 @@ tvheadend.dvr_upcoming = function(panel, index) {
 
     function selected(s, abuttons) {
         var recording = 0;
+        var scheduled = 0;
         s.each(function(s) {
             if (s.data.sched_status.indexOf('recording') == 0)
                 recording++;
+            if (s.data.sched_status.indexOf('scheduled') == 0)
+                scheduled++;
         });
-        abuttons.stop.setDisabled(recording < 1);
+        abuttons.stop.setDisabled(recording < 1 && scheduled < 1);
         abuttons.abort.setDisabled(recording < 1);
     }
 


### PR DESCRIPTION
Previously you could not stop an upcoming scheduled programme from
recording.

You could delete it, but it would only unschedule that showing and
restarting tvheadend would cause it to be scheduled again, and any
future showings would also be recorded.

So we now allow the user to "stop" an upcoming recording to mark
that the user does not want that programme or any future showings
of the programme to be recorded.

We do this by marking it as "file removed". This allows you to unschedule
a programme and not have it record. This is useful if an autorec
rule is matching programmes you don't want to record such as episodes
you've already seen.

Once in the file removed section you can re-record it if necessary
by deleting it from the file removed which then causes the autorec
rule to re-match the recording.

The extra check for de->de_s is because we don't have a subscription
stream for upcoming recordings so can't unsubscribe.

Issue: #4506