### PR TITLE
Makefile: fix build if iptv disabled and ffmpeg enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -526,9 +526,11 @@ DEPS-LIBAV = \
 	src/tvhlog.c
 SRCS-LIBAV = \
 	src/libav.c \
-	src/input/mpegts/iptv/iptv_libav.c \
 	src/muxer/muxer_libav.c \
 	src/api/api_codec.c
+ifeq ($(CONFIG_IPTV),yes)
+SRCS-LIBAV += src/input/mpegts/iptv/iptv_libav.c
+endif
 SRCS-LIBAV += $(wildcard src/transcoding/*.c)
 SRCS-LIBAV += $(wildcard src/transcoding/transcode/*.c)
 SRCS-LIBAV += $(SRCS-HWACCELS)


### PR DESCRIPTION
Otherwise build failures for undefined references when ffmpeg enabled and iptv disabled by configuration;

tvheadend-9999/build.linux/src/input/mpegts/iptv/iptv_libav.o: In function `iptv_libav_start':
tvheadend-9999/src/input/mpegts/iptv/iptv_libav.c:189: undefined reference to `iptv_input_fd_started'
tvheadend-9999/src/input/mpegts/iptv/iptv_libav.c:195: undefined reference to `iptv_input_mux_started'
tvheadend-9999/build.linux/src/input/mpegts/iptv/iptv_libav.o: In function `iptv_libav_init':
tvheadend-9999/src/input/mpegts/iptv/iptv_libav.c:259: undefined reference to `iptv_handler_register'
collect2: error: ld returned 1 exit status
