### PR TITLE
Added default 1 as DVB CAM limit

### DIFF
--- a/src/descrambler/dvbcam.c
+++ b/src/descrambler/dvbcam.c
@@ -385,6 +385,7 @@ caclient_t *dvbcam_create(void)
   dc->cac_start        = dvbcam_service_start;
   dc->cac_conf_changed = dvbcam_conf_changed;
   dc->cac_caid_update  = dvbcam_caid_update;
+  dc->limit            = 1;
   return (caclient_t *)dc;
 }
 


### PR DESCRIPTION
A CAM can decode at least one service.

Signed-off-by: Jasmin Jessich <jasmin@anw.at>