### PR TITLE
Fix uk freesat accurate record

### DIFF
--- a/src/api/api_epg.c
+++ b/src/api/api_epg.c
@@ -528,12 +528,12 @@ api_epg_alternative
   epg_broadcast_t *e;
   char *lang;
 
-  if (!htsmsg_get_u32(args, "eventId", &id))
+  if (htsmsg_get_u32(args, "eventId", &id))
     return -EINVAL;
 
   /* Main Job */
-  pthread_mutex_lock(&global_lock);
   lang = access_get_lang(perm, htsmsg_get_str(args, "lang"));
+  pthread_mutex_lock(&global_lock);
   e = epg_broadcast_find_by_id(id);
   if (e && e->episode)
     api_epg_episode_broadcasts(perm, l, lang, e->episode, &entries, e);
@@ -558,12 +558,12 @@ api_epg_related
   epg_episode_t *ep, *ep2;
   char *lang;
   
-  if (!htsmsg_get_u32(args, "eventId", &id))
+  if (htsmsg_get_u32(args, "eventId", &id))
     return -EINVAL;
 
   /* Main Job */
-  pthread_mutex_lock(&global_lock);
   lang = access_get_lang(perm, htsmsg_get_str(args, "lang"));
+  pthread_mutex_lock(&global_lock);
   e = epg_broadcast_find_by_id(id);
   ep = e ? e->episode : NULL;
   if (ep && ep->brand) {

--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -590,6 +590,8 @@ void dvr_event_updated(epg_broadcast_t *e);
 
 void dvr_event_running(epg_broadcast_t *e, epg_source_t esrc, epg_running_t running);
 
+void dvr_update_dvb_id(epg_broadcast_t *e, uint16_t old_eid, uint16_t new_eid);
+
 dvr_entry_t *dvr_entry_find_by_id(int id);
 
 static inline dvr_entry_t *dvr_entry_find_by_uuid(const char *uuid)

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -2385,6 +2385,24 @@ void dvr_event_running(epg_broadcast_t *e, epg_source_t esrc, epg_running_t runn
 }
 
 /**
+ * Update dvr_eid 
+ */
+void dvr_update_dvb_id(epg_broadcast_t *e, uint16_t old_eid, uint16_t new_eid)
+{
+  dvr_entry_t *de;
+
+  LIST_FOREACH(de, &e->channel->ch_dvrs, de_channel_link) {
+    if (de->de_dvb_eid == old_eid) {
+      de->de_dvb_eid = new_eid;
+      dvr_entry_changed_notify(de);
+      tvhtrace(LS_DVR, "Update dvb eid for %s on %s",
+               epg_broadcast_get_title(e, NULL),
+               channel_get_name(e->channel, channel_blank_name));
+    }
+  }
+}
+
+/**
  *
  */
 void

--- a/src/epggrab/module/eit.c
+++ b/src/epggrab/module/eit.c
@@ -619,6 +619,12 @@ static int _eit_process_event_one
 
   *save |= epg_broadcast_set_dvb_eid(ebc, eid, &changes2);
 
+  /* If dvb_eid is different in EIT to EPG update any DVR entries */
+  if (ebc->dvb_eid != eid) {
+    dvr_update_dvb_id(ebc, ebc->dvb_eid, eid);
+  }
+  
+  
   /* Summary/Description */
   if (ev.summary)
     *save |= epg_broadcast_set_summary(ebc, ev.summary, &changes2);


### PR DESCRIPTION
Fixes a problem with accurate recording (using EIT running status) for certain UK channels when using the UK Freesat EPG.  Root cause of missed recordings is that the event ID in the EIT data does not match the event ID in the Freesat EPG so the recording is missed.  Issue has been discussed in the following forum thread:

https://tvheadend.org/boards/5/topics/29031

It could be argued that there might be neater ways to implement this fix.  For example, it could be argued that eit.c already calls "epg_broadcast_set_dvb_eid" to update the EPG event ID so perhaps it should be "epg_broadcast_set_dvb_eid" that updates the dvr entry - after all, if the EPG eid has changed then surely you would ALWAYS want to update any dvr entries related to this wouldn't you?  I guess you would but I can't be sure (as I don't know the history of tvh very well).  So to play safe I have implemented this fix during EIT processing which, personally, I think reads fairly well from an understanding the code point of view because the mis-matched eid in the EIT is what has driven the DVR entry to be updated in the first place.  

Not my call to determine how this fix is ultimately implemented.  What I can tell you is that prior to this fix, recordings on the UK channel ITV HD using accurate recording and the Freesat EPG were very, very hit and miss.  Since implementing this fix I have recorded more approximately 15 ITV programmes with 100% success rate.  