### PR TITLE
Fixed crash on CAM remove

### DIFF
--- a/src/descrambler/dvbcam.c
+++ b/src/descrambler/dvbcam.c
@@ -245,10 +245,11 @@ dvbcam_service_destroy(th_descrambler_t *td)
   pthread_mutex_lock(&dvbcam_mutex);
   ac = as->ac;
   if (as->last_pmt) {
-    linuxdvb_ca_enqueue_capmt(ac->ca, ac->slot, as->last_pmt,
-                              as->last_pmt_len,
-                              CA_LIST_MANAGEMENT_UPDATE,
-                              CA_PMT_CMD_ID_NOT_SELECTED);
+    if (ac)
+      linuxdvb_ca_enqueue_capmt(ac->ca, ac->slot, as->last_pmt,
+                                as->last_pmt_len,
+                                CA_LIST_MANAGEMENT_UPDATE,
+                                CA_PMT_CMD_ID_NOT_SELECTED);
     free(as->last_pmt);
     do_active_programs = 1;
   }


### PR DESCRIPTION
When TVH is terminated with <cntrl-c> and there is a CAM opened,
dvbcam_unregister_cam is executed prior to dvbcam_service_destroy.
dvbcam_unregister_cam will remove "as->ac" so linuxdvb_ca_enqueue_capmt,
executed in dvbcam_service_destroy will crash.
This should also fix a possible crash (not tested), when removing the
CAM with an active stream.

Signed-off-by: Jasmin Jessich <jasmin@anw.at>