### PR TITLE
Persist image url so it is available for recorded programmes (#4685)

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -688,6 +688,7 @@ htsmsg_t * dvr_autorec_entry_class_time_list(void *o, const char *null);
 htsmsg_t * dvr_autorec_entry_class_weekdays_get(uint32_t weekdays);
 htsmsg_t * dvr_autorec_entry_class_weekdays_list (void *o, const char *list);
 char * dvr_autorec_entry_class_weekdays_rend(uint32_t weekdays, const char *lang);
+const char *dvr_entry_class_image_url_get(const dvr_entry_t *o);
 
 void dvr_autorec_check_event(epg_broadcast_t *e);
 void dvr_autorec_check_brand(epg_brand_t *b);

--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -206,6 +206,7 @@ typedef struct dvr_entry {
   char *de_creator;
   char *de_comment;
   char *de_uri;                 /* Programme unique ID */
+  char *de_image;               /* Programme Image */
   htsmsg_t *de_files; /* List of all used files */
   char *de_directory; /* Can be set for autorec entries, will override any 
                          directory setting from the configuration */

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -3295,16 +3295,23 @@ static const void *
 dvr_entry_class_image_url_get_as_property(void *o)
 {
   dvr_entry_t *de = (dvr_entry_t *)o;
+  static const char *s = "";
+  /* We prefer the image from the broadcast to the one currently
+   * persisted.  This is because a programme scheduled far in the
+   * future may have a generic image that will be updated nearer the
+   * broadcast date with a more specific image.
+   */
+  if (de->de_bcast && de->de_bcast->episode && de->de_bcast->episode->image) {
+    snprintf(prop_sbuf, PROP_SBUF_LEN, "%s", de->de_bcast->episode->image);
+    return &prop_sbuf_ptr;
+  }
+
   if (de->de_image) {
     prop_ptr = de->de_image;
     return &prop_ptr;
   }
 
-  static const char *s = "";
-  if (!de->de_bcast || !de->de_bcast->episode || !de->de_bcast->episode->image)
-      return &s;
-  snprintf(prop_sbuf, PROP_SBUF_LEN, "%s", de->de_bcast->episode->image);
-  return &prop_sbuf_ptr;
+  return &s;
 }
 
 const char *
@@ -3501,7 +3508,7 @@ const idclass_t dvr_entry_class = {
       .desc     = N_("Episode image."),
       .get      = dvr_entry_class_image_url_get_as_property,
       .off      = offsetof(dvr_entry_t, de_image),
-      .opts     = PO_HIDDEN,
+      .opts     = PO_HIDDEN | PO_RDONLY,
     },
     {
       .type     = PT_LANGSTR,

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -3292,7 +3292,7 @@ dvr_entry_class_channel_icon_url_get(void *o)
 }
 
 static const void *
-dvr_entry_class_image_url_get(void *o)
+dvr_entry_class_image_url_get_as_property(void *o)
 {
   dvr_entry_t *de = (dvr_entry_t *)o;
   if (de->de_image) {
@@ -3306,6 +3306,19 @@ dvr_entry_class_image_url_get(void *o)
   snprintf(prop_sbuf, PROP_SBUF_LEN, "%s", de->de_bcast->episode->image);
   return &prop_sbuf_ptr;
 }
+
+const char *
+dvr_entry_class_image_url_get(const dvr_entry_t *o)
+{
+    const void *image = dvr_entry_class_image_url_get_as_property((void*)o);
+    if (!image) return NULL;
+    const char *image_str = *(const char**)image;
+    if (!image_str) return NULL;
+    if (!*image_str) return NULL;
+    return image_str;
+}
+
+
 
 static const void *
 dvr_entry_class_duplicate_get(void *o)
@@ -3486,7 +3499,7 @@ const idclass_t dvr_entry_class = {
       .id       = "image", /* Name chosen to be compatible with api_epg */
       .name     = N_("Episode image"),
       .desc     = N_("Episode image."),
-      .get      = dvr_entry_class_image_url_get,
+      .get      = dvr_entry_class_image_url_get_as_property,
       .off      = offsetof(dvr_entry_t, de_image),
       .opts     = PO_HIDDEN,
     },

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -993,6 +993,8 @@ dvr_entry_create_(int enabled, const char *config_uuid, epg_broadcast_t *e,
       htsmsg_add_u32(conf, "copyright_year", e->episode->copyright_year);
     if (e->episode && e->episode->uri)
       htsmsg_add_str(conf, "uri", e->episode->uri);
+    if (e->episode && e->episode->image)
+      htsmsg_add_str(conf, "image", e->episode->image);
   } else if (title) {
     l = lang_str_create();
     lang_str_add(l, title, lang, 0);
@@ -3293,6 +3295,11 @@ static const void *
 dvr_entry_class_image_url_get(void *o)
 {
   dvr_entry_t *de = (dvr_entry_t *)o;
+  if (de->de_image) {
+    prop_ptr = de->de_image;
+    return &prop_ptr;
+  }
+
   static const char *s = "";
   if (!de->de_bcast || !de->de_bcast->episode || !de->de_bcast->episode->image)
       return &s;
@@ -3480,7 +3487,8 @@ const idclass_t dvr_entry_class = {
       .name     = N_("Episode image"),
       .desc     = N_("Episode image."),
       .get      = dvr_entry_class_image_url_get,
-      .opts     = PO_HIDDEN | PO_RDONLY | PO_NOSAVE | PO_NOUI,
+      .off      = offsetof(dvr_entry_t, de_image),
+      .opts     = PO_HIDDEN,
     },
     {
       .type     = PT_LANGSTR,

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -1003,8 +1003,13 @@ htsp_build_dvrentry(htsp_connection_t *htsp, dvr_entry_t *de, const char *method
       htsmsg_add_str(out, "creator", de->de_creator);
     if(de->de_comment)
       htsmsg_add_str(out, "comment", de->de_comment);
-    if(de->de_image && *de->de_image)
-      htsmsg_add_str(out, "image", de->de_image);
+    /* We use the accessor since it will also try to get
+     * an image from current EPG if recording does not have
+     * an associated image.
+     */
+    const char *image = dvr_entry_class_image_url_get(de);
+    if(image && *image)
+      htsmsg_add_str(out, "image", image);
     if (de->de_copyright_year)
       htsmsg_add_u32(out, "copyrightYear", de->de_copyright_year);
 

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -1003,6 +1003,8 @@ htsp_build_dvrentry(htsp_connection_t *htsp, dvr_entry_t *de, const char *method
       htsmsg_add_str(out, "creator", de->de_creator);
     if(de->de_comment)
       htsmsg_add_str(out, "comment", de->de_comment);
+    if(de->de_image && *de->de_image)
+      htsmsg_add_str(out, "image", de->de_image);
     if (de->de_copyright_year)
       htsmsg_add_u32(out, "copyrightYear", de->de_copyright_year);
 


### PR DESCRIPTION
The Kodi pvr.hts currently currently uses a channel icon for recorded programmes. Since some xmltv providers supply an image icon, we now persist this URL so it can be sent to the client for recorded programmes.

Example htsp message:
`'image': 'https://s3.amazonaws.com/schedulesdirect/assets/p8648012_d_v8_aa.jpg',                                                                                                                
'method': 'dvrEntryAdd',
`
I changed the image property to just be HIDDEN, whereas previously it had NOUI, NOSAVE and RDONLY. The other removals I think are correct, but I'm not sure about the removal of RDONLY. It could (presumably) in the future make it possible for the user at the UI to alter the image used such as using a better poster image, so I think removing RDONLY is the right thing.
