### PR TITLE
channel: Allow optional fuzzy matching when merging services. (#4709)

### DIFF
--- a/src/channels.h
+++ b/src/channels.h
@@ -130,6 +130,13 @@ channel_t *channel_create0
 void channel_delete(channel_t *ch, int delconf);
 
 channel_t *channel_find_by_name(const char *name);
+/// Apply fuzzy matching when finding a channel such as ignoring
+/// whitespace, case, and stripping HD suffix. This means that
+/// 'Channel 5+1', 'Channel 5 +1', 'Channel 5+1HD' and
+/// 'Channel 5 +1HD' can all be merged together.
+/// Since channel names aren't unique, this returns the
+/// first match (similar to channel_find_by_name).
+channel_t *channel_find_by_name_fuzzy(const char *name);
 #define channel_find_by_uuid(u)\
   (channel_t*)idnode_find(u, &channel_class, NULL)
 

--- a/src/service_mapper.c
+++ b/src/service_mapper.c
@@ -224,8 +224,13 @@ service_mapper_process
 
   /* Find existing channel */
   name = service_get_channel_name(s);
-  if (!bq && conf->merge_same_name && name && *name)
+  if (!bq && conf->merge_same_name && name && *name) {
+    /* Try exact match first */
     chn = channel_find_by_name(name);
+    if (!chn && conf->merge_same_name_fuzzy) {
+      chn = channel_find_by_name_fuzzy(name);
+    }
+  }
   if (!chn) {
     chn = channel_create(NULL, NULL, NULL);
     chn->ch_bouquet = bq;
@@ -526,6 +531,19 @@ static const idclass_t service_mapper_conf_class = {
       .name   = N_("Merge same name"),
       .desc   = N_("Merge services with the same name into one channel."),
       .off    = offsetof(service_mapper_t, d.merge_same_name),
+    },
+    {
+      .type   = PT_BOOL,
+      .id     = "merge_same_name_fuzzy",
+      .name   = N_("Use fuzzy mapping if merging same name"),
+      .desc   = N_("If merge same name is enabled then "
+                   "merge services with the same name into one channel but "
+                   "using fuzzy logic such as ignoring whitespace, case and "
+                   "some channel suffixes such as HD. So 'Channel 5+1', "
+                   "'Channel 5 +1', 'Channel 5+1HD' and 'Channel 5 +1HD' would "
+                   "all merge in to the same channel. The exact name chosen "
+                   "depends on the order the channels are mapped."),
+      .off    = offsetof(service_mapper_t, d.merge_same_name_fuzzy),
     },
     {
       .type   = PT_BOOL,

--- a/src/service_mapper.h
+++ b/src/service_mapper.h
@@ -26,6 +26,7 @@ typedef struct service_mapper_conf
   int check_availability; ///< Check service is receivable
   int encrypted;          ///< Include encrypted services
   int merge_same_name;    ///< Merge entries with the same name
+  int merge_same_name_fuzzy;    ///< Merge entries with the same name with fuzzy matching (ignore case, etc)
   int type_tags;          ///< Create tags based on the service type (SDTV/HDTV/Radio)
   int provider_tags;      ///< Create tags based on provider name
   int network_tags;       ///< Create tags based on network name (useful for multi adapter equipments)


### PR DESCRIPTION
For historical reasons, our DVB-T and DVB-S have different names
for the same channels. They often differ in case and spacing.
So we have 'One' and 'ONE', '5+1HD' and '5 +1HD'.

So allow an optional fuzzy matching checkbox to ignore whitespace
and HD markers. This allows the channels to be merged. The
exact name chosen depends on the order of mapping, so if the
HD channel is mapped first then they would all merge in to this
name, but if a non-HD channel is the first one created then that
name is chosen. However the name could be subsequently modified
by the user if they desire.

This also ensures merging of channels on DVB-T or DVB-S will
allow automatic merging of HD and non-HD channels ("5" and "5HD")
to allow the "preferred service video type" to work without needing
manual merging by the user.

Issue: #4709