### PR TITLE
configure: Fix libsystemd dependency for Stretch and later

### DIFF
--- a/configure
+++ b/configure
@@ -730,7 +730,7 @@ fi
 # systemd
 #
 if enabled_or_auto libsystemd_daemon; then
-  if check_pkg libsystemd-daemon; then
+  if check_pkg libsystemd-daemon || check_pkg libsystemd; then
     enable libsystemd_daemon
   elif enabled libsystemd_daemon; then
     die "libsystemd-daemon development support not found (use --disable-systemd_daemon)"


### PR DESCRIPTION
Debian Stretch now has libsystemd instead of libsystemd-daemon. 
This configure update will allow building for older Debian targets as well as newer ones. This has been tested on Debian Jessie and Debian Stretch.

Signed-off-by: Sam Nazarko <email@samnazarko.co.uk>