### PR TITLE
channel: fuzzy merge channels in bouquet, tidy names, new user api call, fixes #4714, #4715

### DIFF
--- a/src/api/api_channel.c
+++ b/src/api/api_channel.c
@@ -96,6 +96,23 @@ api_channel_create
 }
 
 static int
+api_channel_rename
+  ( access_t *perm, void *opaque, const char *op, htsmsg_t *args, htsmsg_t **resp )
+{
+  const char *from, *to;
+  if (!(from = htsmsg_get_str(args, "from")))
+    return -EINVAL;
+  if (!(to = htsmsg_get_str(args, "to")))
+    return -EINVAL;
+  /* We need the lock since we are altering details */
+  pthread_mutex_lock(&global_lock);
+  const int num_match = channel_rename_and_save(from, to);
+  pthread_mutex_unlock(&global_lock);
+
+  return num_match > 0 ? 0 : -ENOENT;
+}
+
+static int
 api_channel_tag_list
   ( access_t *perm, void *opaque, const char *op, htsmsg_t *args, htsmsg_t **resp )
 {
@@ -205,6 +222,7 @@ void api_channel_init ( void )
     { "channel/grid",    ACCESS_ANONYMOUS, api_idnode_grid,  api_channel_grid },
     { "channel/list",    ACCESS_ANONYMOUS, api_channel_list, NULL },
     { "channel/create",  ACCESS_ADMIN,     api_channel_create, NULL },
+    { "channel/rename",  ACCESS_ADMIN,     api_channel_rename, NULL }, /* User convenience function */
 
     { "channeltag/class",ACCESS_ANONYMOUS, api_idnode_class, (void*)&channel_tag_class },
     { "channeltag/grid", ACCESS_ANONYMOUS, api_idnode_grid,  api_channel_tag_grid },

--- a/src/bouquet.c
+++ b/src/bouquet.c
@@ -292,6 +292,7 @@ bouquet_map_channel(bouquet_t *bq, service_t *t)
     .encrypted          = 1,
     .merge_same_name    = 0,
     .merge_same_name_fuzzy = 0,
+    .tidy_channel_name  = 0,
     .type_tags          = 0,
     .provider_tags      = 0,
     .network_tags       = 0
@@ -315,6 +316,7 @@ bouquet_map_channel(bouquet_t *bq, service_t *t)
     sm_conf.encrypted = bq->bq_mapencrypted;
     sm_conf.merge_same_name = bq->bq_mapmergename;
     sm_conf.merge_same_name_fuzzy = bq->bq_mapmergefuzzy;
+    sm_conf.tidy_channel_name = bq->bq_tidychannelname;
     sm_conf.type_tags = bq->bq_chtag_type_tags;
     sm_conf.provider_tags = bq->bq_chtag_provider_tags;
     sm_conf.network_tags = bq->bq_chtag_network_tags;
@@ -754,6 +756,11 @@ static idnode_slist_t bouquest_class_mapopt_slist[] = {
     .id   = "merge_same_name_fuzzy",
     .name = N_("Use fuzzy mapping if merging same name"),
     .off  = offsetof(bouquet_t, bq_mapmergefuzzy),
+  },
+  {
+    .id   = "tidy_channel_name",
+    .name = N_("Tidy channel name (e.g., stripping HD/UHD suffix)"),
+    .off  = offsetof(bouquet_t, bq_tidychannelname),
   },
   {}
 };

--- a/src/bouquet.c
+++ b/src/bouquet.c
@@ -291,6 +291,7 @@ bouquet_map_channel(bouquet_t *bq, service_t *t)
     .check_availability = 0,
     .encrypted          = 1,
     .merge_same_name    = 0,
+    .merge_same_name_fuzzy = 0,
     .type_tags          = 0,
     .provider_tags      = 0,
     .network_tags       = 0
@@ -313,6 +314,7 @@ bouquet_map_channel(bouquet_t *bq, service_t *t)
   if (!ilm) {
     sm_conf.encrypted = bq->bq_mapencrypted;
     sm_conf.merge_same_name = bq->bq_mapmergename;
+    sm_conf.merge_same_name_fuzzy = bq->bq_mapmergefuzzy;
     sm_conf.type_tags = bq->bq_chtag_type_tags;
     sm_conf.provider_tags = bq->bq_chtag_provider_tags;
     sm_conf.network_tags = bq->bq_chtag_network_tags;
@@ -747,6 +749,11 @@ static idnode_slist_t bouquest_class_mapopt_slist[] = {
     .id   = "merge_name",
     .name = N_("Merge same name"),
     .off  = offsetof(bouquet_t, bq_mapmergename),
+  },
+  {
+    .id   = "merge_same_name_fuzzy",
+    .name = N_("Use fuzzy mapping if merging same name"),
+    .off  = offsetof(bouquet_t, bq_mapmergefuzzy),
   },
   {}
 };

--- a/src/bouquet.h
+++ b/src/bouquet.h
@@ -40,6 +40,7 @@ typedef struct bouquet {
   int           bq_mapradio;
   int           bq_mapencrypted;
   int           bq_mapmergename;
+  int           bq_mapmergefuzzy;
   int           bq_chtag;
   int           bq_chtag_type_tags;
   int           bq_chtag_provider_tags;

--- a/src/bouquet.h
+++ b/src/bouquet.h
@@ -41,6 +41,7 @@ typedef struct bouquet {
   int           bq_mapencrypted;
   int           bq_mapmergename;
   int           bq_mapmergefuzzy;
+  int           bq_tidychannelname;
   int           bq_chtag;
   int           bq_chtag_type_tags;
   int           bq_chtag_provider_tags;

--- a/src/channels.c
+++ b/src/channels.c
@@ -562,7 +562,7 @@ const idclass_t channel_class = {
 // Note: since channel names are no longer unique this method will simply
 //       return the first entry encountered, so could be somewhat random
 channel_t *
-channel_find_by_name ( const char *name )
+channel_find_by_name_and_bouquet ( const char *name, const struct bouquet *bq )
 {
   channel_t *ch;
   const char *s;
@@ -573,11 +573,17 @@ channel_find_by_name ( const char *name )
     if (!ch->ch_enabled) continue;
     s = channel_get_name(ch, NULL);
     if (s == NULL) continue;
+    if (bq && ch->ch_bouquet != bq) continue;
     if (strcmp(s, name) == 0) break;
   }
   return ch;
 }
 
+channel_t *
+channel_find_by_name(const char *name)
+{
+  return channel_find_by_name_and_bouquet(name, NULL);
+}
 
 /// Copy name without space and HD suffix, lowercase in to a new
 /// buffer
@@ -605,7 +611,7 @@ channel_make_fuzzy_name(const char *name)
 }
 
 channel_t *
-channel_find_by_name_fuzzy ( const char *name )
+channel_find_by_name_bouquet_fuzzy ( const char *name, const struct bouquet *bq )
 {
   channel_t *ch;
   const char *s;
@@ -617,6 +623,7 @@ channel_find_by_name_fuzzy ( const char *name )
 
   CHANNEL_FOREACH(ch) {
     if (!ch->ch_enabled) continue;
+    if (bq && ch->ch_bouquet != bq) continue;
     s = channel_get_name(ch, NULL);
     if (s == NULL) continue;
     /* We need case insensitive since historical constraints means we
@@ -1628,7 +1635,6 @@ channel_tag_find_by_name(const char *name, int create)
   idnode_changed(&ct->ct_id);
   return ct;
 }
-
 
 /**
  *

--- a/src/channels.c
+++ b/src/channels.c
@@ -783,6 +783,30 @@ channel_set_name ( channel_t *ch, const char *name )
   return save;
 }
 
+int
+channel_rename_and_save ( const char *from, const char *to )
+{
+  channel_t *ch;
+  const char *s;
+  int num_match = 0;
+
+  if (!from || !to || !*from || !*to)
+    return 0;
+
+  CHANNEL_FOREACH(ch) {
+    if (!ch->ch_enabled) continue;
+    s = channel_get_name(ch, NULL);
+    if (s == NULL) continue;
+    if (strcmp(s, from) == 0) {
+      ++num_match;
+      if (channel_set_name(ch, to)) {
+        idnode_changed(&ch->ch_id);
+      }
+    }
+  }
+  return num_match;
+}
+
 int64_t
 channel_get_number ( channel_t *ch )
 {

--- a/src/channels.c
+++ b/src/channels.c
@@ -585,7 +585,7 @@ channel_find_by_name(const char *name)
   return channel_find_by_name_and_bouquet(name, NULL);
 }
 
-/// Copy name without space and HD suffix, lowercase in to a new
+/// Copy name without space and (U)HD suffix, lowercase in to a new
 /// buffer
 static char *
 channel_make_fuzzy_name(const char *name)
@@ -599,6 +599,9 @@ channel_make_fuzzy_name(const char *name)
   for (; *ch ; ++ch) {
     /* Strip trailing 'HD'. */
     if (*ch == 'H' && *(ch+1) == 'D' && *(ch+2) == 0)
+      break;
+    /* Strip trailing 'UHD'. */
+    if (*ch == 'U' && *(ch+1) == 'H' && *(ch+2) == 'D' && *(ch+3) == 0)
       break;
 
     if (!isspace(*ch)) {

--- a/src/channels.h
+++ b/src/channels.h
@@ -176,6 +176,10 @@ int channel_tag_access(channel_tag_t *ct, struct access *a, int disabled);
 
 const char *channel_get_name ( channel_t *ch, const char *blank );
 int channel_set_name ( channel_t *ch, const char *name );
+/// User API convenience function to rename all channels that
+/// match "from". Lock must be held prior to call.
+/// @return number channels that matched "from".
+int channel_rename_and_save ( const char *from, const char *to );
 
 #define CHANNEL_SPLIT ((int64_t)1000000)
 

--- a/src/channels.h
+++ b/src/channels.h
@@ -129,6 +129,7 @@ channel_t *channel_create0
 
 void channel_delete(channel_t *ch, int delconf);
 
+channel_t *channel_find_by_name_and_bouquet(const char *name, const struct bouquet *bq);
 channel_t *channel_find_by_name(const char *name);
 /// Apply fuzzy matching when finding a channel such as ignoring
 /// whitespace, case, and stripping HD suffix. This means that
@@ -136,7 +137,8 @@ channel_t *channel_find_by_name(const char *name);
 /// 'Channel 5 +1HD' can all be merged together.
 /// Since channel names aren't unique, this returns the
 /// first match (similar to channel_find_by_name).
-channel_t *channel_find_by_name_fuzzy(const char *name);
+/// @param bouquet - Bouquet to use: can be NULL
+channel_t *channel_find_by_name_bouquet_fuzzy(const char *name, const struct bouquet *bq);
 #define channel_find_by_uuid(u)\
   (channel_t*)idnode_find(u, &channel_class, NULL)
 

--- a/src/service_mapper.c
+++ b/src/service_mapper.c
@@ -224,14 +224,23 @@ service_mapper_process
 
   /* Find existing channel */
   name = service_get_channel_name(s);
-  if (!bq && conf->merge_same_name && name && *name) {
+  if (conf->merge_same_name && name && *name) {
     /* Try exact match first */
-    chn = channel_find_by_name(name);
+    chn = channel_find_by_name_and_bouquet(name, bq);
     if (!chn && conf->merge_same_name_fuzzy) {
-      chn = channel_find_by_name_fuzzy(name);
+      chn = channel_find_by_name_bouquet_fuzzy(name, bq);
     }
   }
-  if (!chn) {
+  /* If using bouquets then we want to only merge
+   * with channels on the same bouquet. This is because
+   * you can disable all channels on a bouquet through
+   * the bouquet menu so if we merged between bouquets then
+   * you'd get odd results.
+   *
+   * The chn should already be for the correct bouquet
+   * but we'll safety-check here.
+   */
+  if (!chn || (bq && chn->ch_bouquet != bq)) {
     chn = channel_create(NULL, NULL, NULL);
     chn->ch_bouquet = bq;
   }

--- a/src/service_mapper.h
+++ b/src/service_mapper.h
@@ -27,6 +27,7 @@ typedef struct service_mapper_conf
   int encrypted;          ///< Include encrypted services
   int merge_same_name;    ///< Merge entries with the same name
   int merge_same_name_fuzzy;    ///< Merge entries with the same name with fuzzy matching (ignore case, etc)
+  int tidy_channel_name;  ///< Tidy channel name by removing trailing HD/UHD.
   int type_tags;          ///< Create tags based on the service type (SDTV/HDTV/Radio)
   int provider_tags;      ///< Create tags based on provider name
   int network_tags;       ///< Create tags based on network name (useful for multi adapter equipments)


### PR DESCRIPTION
The fuzzy merge of channels names was previously implemented on the map services. This adds the functionality to bouquets. It also adds an option to "tidy" the channel name for automatically stripping HD/UHD suffix so "History HD" will just be called "History".

As far as I could tell, the existing "merge bouquet channel by name" always explicitly created a new channel if bq, so never actually merged. So I added a new function to search for channels on a bouquet and allow merging with that channel on the same bouquet. I don't allow a channel to be merged across bouquets since we'd have to update to have a list of bouquets for channels, and each bouquet could have conflicting mapping options, so I'll wait to see if people need that functionality.

I added a new user-convenience API call to allow users to easily rename channels from an external script. This is based on the dvr filemoved code. This new call allows users to fix-up channels such as channel names that start with a lower-case letter so are sorted incorrectly in many UIs, or other fixups and avoids having large extra logic and numerous checkboxes in the core Tvheadend. I know they could use idnode/save but this allows them to rename without having to fetch a list of channels, parse ids, then form a valid message.
