### PR TITLE
debian: add a note to tvheadend.default explaining where to add/edit args

### DIFF
--- a/debian/tvheadend.default
+++ b/debian/tvheadend.default
@@ -6,6 +6,10 @@
 OPTIONS="-u hts -g video"
 
 # sysvinit
+# 
+# Editing the following variables has no effect when using systemd
+# modify the OPTIONS variable (above) instead.
+#
 # TVH_ENABLED
 #   set to 0 to disable upstart job
 TVH_ENABLED=1


### PR DESCRIPTION
People seem to be getting confused by the systemd change, this should make it a bit more obvious :)