### PR TITLE
ui/epg: rename field 'new' to 'is_new', use genre if no category (#4594)

### DIFF
--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -164,7 +164,7 @@ tvheadend.epgDetails = function(event) {
       tags.push(_('UHDTV'));
     else if (event.hd > 0)
       tags.push(_('HDTV'));
-    if ('new' in event)
+    if ('new' in event && event.new)
       tags.push(_('New#EPG').split('#')[0]);
     if (event.repeat)
       tags.push(_('Repeat#EPG').split('#')[0]);

--- a/src/webui/static/app/tvheadend.js
+++ b/src/webui/static/app/tvheadend.js
@@ -229,7 +229,7 @@ tvheadend.getContentTypeIcons = function(rec) {
   }
 
   var ret = "";
-  if (rec.new)
+  if ('new' in rec && rec.new)
     ret += "&#x1f195;";         // Squared New
   return ret + tvheadend.uniqueArray(ret_major).join("") + tvheadend.uniqueArray(ret_minor).join("");
 }

--- a/src/webui/static/app/tvheadend.js
+++ b/src/webui/static/app/tvheadend.js
@@ -201,7 +201,16 @@ tvheadend.getContentTypeIcons = function(rec) {
       l = catmap_minor[v];
       if (l) ret_minor.push(l)
     }
-  } else {
+  }
+
+  // If we have not mapped any categories, either
+  // due to only having OTA genres or due to categories
+  // not generating any matches, then check the genres.
+  // By default we don't do both category and genre
+  // mappings if we matched any categories since
+  // category mappings are normally more specific
+  // than genres.
+  if (ret_major.length == 0 && ret_minor.length == 0) {
     // Genre code
     var gen = rec.genre;
     if (gen) {


### PR DESCRIPTION
I renamed the ui field 'new' to 'is_new' to avoid any potential confusion with keywords. This may fix the cause of the browser of @mpmc always showing 'parameter: new' in the dialog.

When displaying icons, if categories don't map to any icons then we try genre mappings to icons. Previously we would not do genre mappings if there was a category string even if the category string didn't match any icons.
