### PR TITLE
dvbcam: Fix NULL pointer usage

### DIFF
--- a/src/descrambler/dvbcam.c
+++ b/src/descrambler/dvbcam.c
@@ -410,8 +410,10 @@ dvbcam_service_start(caclient_t *cac, service_t *t)
 
   /* is there already a CAM associated to the service? */
   TAILQ_FOREACH(as, &dvbcam_active_services, global_link) {
-    if (as->td_service == t)
+    if (as->td_service == t) {
+      ac = as->ac;
       goto update_pid;
+    }
   }
 
   /*


### PR DESCRIPTION
When there is already a CAM assigned to the service, we jump to
update_pid. In commit 7f81d726af1f92b268d031c08cf5d00f0f77a4c6 a
tvhtrace call which prints the CAM name has been added. The name
is accessed by "ac->ca->lca_name", which requires ac set to a
proper value.
This commit adds the ac setting before it jumps to "update_pid".

Signed-off-by: Jasmin Jessich <jasmin@anw.at>