### PR TITLE
Fixes for FreeBSD and Darwin/macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -478,7 +478,7 @@ I18N-C += $(SRCS-AVAHI)
 # Bonjour
 SRCS-BONJOUR = \
 	src/bonjour.c
-SRCS-$(CONFIG_BONJOUR) = $(SRCS-BONJOUR)
+SRCS-$(CONFIG_BONJOUR) += $(SRCS-BONJOUR)
 I18N-C += $(SRCS-BONJOUR)
 
 # codecs

--- a/src/bonjour.c
+++ b/src/bonjour.c
@@ -26,8 +26,8 @@
 #include <CoreServices/CoreServices.h>
 
 typedef struct {
-  char *key;
-  char *value;
+  const char *key;
+  const char *value;
 } txt_rec_t;
 
 pthread_t bonjour_tid;
@@ -43,7 +43,7 @@ bonjour_callback(CFNetServiceRef theService, CFStreamError* error, void* info)
 }
 
 static void
-bonjour_start_service(CFNetServiceRef *svc, char *service_type,
+bonjour_start_service(CFNetServiceRef *svc, const char *service_type,
                       uint32_t port, txt_rec_t *txt)
 {
   CFStringRef str;

--- a/src/compat.h
+++ b/src/compat.h
@@ -39,6 +39,10 @@
 #define inotify_init1(IN_CLOEXEC) inotify_init()
 #endif
 
+#if (defined(PLATFORM_DARWIN) || defined(PLATFORM_FREEBSD)) && !defined(MSG_MORE)
+#define MSG_MORE 0
+#endif
+
 #endif /* TVH_COMPAT_H */
 
 #ifdef COMPAT_IPTOS

--- a/src/descrambler/descrambler.c
+++ b/src/descrambler/descrambler.c
@@ -71,6 +71,7 @@ static inline int extractpid(const uint8_t *tsb)
   return (tsb[1] & 0x1f) << 8 | tsb[2];
 }
 
+#if DEBUG2
 static inline const char *keystr(const uint8_t *tsb)
 {
   uint8_t b = tsb[3];
@@ -78,6 +79,7 @@ static inline const char *keystr(const uint8_t *tsb)
     return (b & 0x40) ? "odd" : "even";
   return (b & 0x40) ? "none2" : "none";
 }
+#endif
 
 /*
  *

--- a/src/http.c
+++ b/src/http.c
@@ -40,6 +40,7 @@
 #include "channels.h"
 #include "config.h"
 #include "htsmsg_json.h"
+#include "compat.h"
 
 #if ENABLE_ANDROID
 #include <sys/socket.h>

--- a/src/intlconv.c
+++ b/src/intlconv.c
@@ -20,12 +20,7 @@ static inline size_t
 tvh_iconv(iconv_t cd, char **inbuf, size_t *inbytesleft,
                       char **outbuf, size_t *outbytesleft)
 {
-#ifdef PLATFORM_FREEBSD
-  return iconv(cd, (const char **)inbuf, inbytesleft,
-                   (const char **)outbuf, outbytesleft);
-#else
   return iconv(cd, inbuf, inbytesleft, outbuf, outbytesleft);
-#endif
 }
 
 void

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -30,8 +30,8 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <signal.h>
-#include <netinet/ip.h>
 #include <netinet/in.h>
+#include <netinet/ip.h>
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
 #include <sys/types.h>

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -22,6 +22,10 @@
 #include "htsbuf.h"
 #include "htsmsg.h"
 
+#if defined(PLATFORM_FREEBSD)
+#include <sys/socket.h>
+#endif
+
 #define IP_AS_V4(storage, f) ((struct sockaddr_in *)&(storage))->sin_##f
 #define IP_AS_V6(storage, f) ((struct sockaddr_in6 *)&(storage))->sin6_##f
 #define IP_IN_ADDR(storage) \

--- a/src/tvh_endian.h
+++ b/src/tvh_endian.h
@@ -24,8 +24,10 @@
 #define bswap_32(x) _OSSwapInt32(x)
 #define bswap_64(x) _OSSwapInt64(x)
 #elif defined(PLATFORM_FREEBSD)
-#include <byteswap.h>
 #include <sys/endian.h>
+#define bswap_16(x) bswap16(x)
+#define bswap_32(x) bswap32(x)
+#define bswap_64(x) bswap64(x)
 #else
 #include <byteswap.h>
 #include <endian.h>

--- a/src/tvhpoll.c
+++ b/src/tvhpoll.c
@@ -131,6 +131,9 @@ int tvhpoll_add
            evs[i].fd, rc);
         return -1;
       }
+    } else {
+      EV_SET(tp->ev+i, evs[i].fd, EVFILT_WRITE,  EV_DELETE, 0, 0, NULL);
+      kevent(tp->fd, tp->ev+i, 1, NULL, 0, NULL);
     }
     if (evs[i].events & TVHPOLL_IN){
       EV_SET(tp->ev+i, evs[i].fd, EVFILT_READ, EV_ADD, 0, 0, (intptr_t*)evs[i].data.u64);
@@ -139,6 +142,9 @@ int tvhpoll_add
         tvherror(LS_TVHPOLL, "failed to add kqueue READ filter [%d|%d]", evs[i].fd, rc);
         return -1;
       }
+    } else {
+      EV_SET(tp->ev+i, evs[i].fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);
+      kevent(tp->fd, tp->ev+i, 1, NULL, 0, NULL);
     }
   }
   return 0;

--- a/src/tvhvfs.c
+++ b/src/tvhvfs.c
@@ -15,10 +15,12 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <sys/sysmacros.h>
-#include <sys/stat.h>
 #include "tvheadend.h"
 #include "tvhvfs.h"
+#if !defined(PLATFORM_DARWIN) && !defined(PLATFORM_FREEBSD)
+#include <sys/sysmacros.h>
+#endif
+#include <sys/stat.h>
 
 int tvh_vfs_fsid_build(const char *path, struct statvfs *vfs, tvh_fsid_t *dst)
 {

--- a/src/webui/webui.c
+++ b/src/webui/webui.c
@@ -1680,7 +1680,7 @@ http_serve_file(http_connection_t *hc, const char *fname,
       sendfile(fd, hc->hc_fd, 0, chunk, NULL, &r, 0);
 #elif defined(PLATFORM_DARWIN)
       r = chunk;
-      sendfile(fd, hc->hc_fd, 0, NULL, &r, 0);
+      sendfile(fd, hc->hc_fd, 0, &r, NULL, 0);
 #endif
       if(r < 0) {
         ret = -1;

--- a/src/wrappers.c
+++ b/src/wrappers.c
@@ -199,6 +199,10 @@ tvhthread_renice(int value)
   pid_t tid;
   tid = gettid();
   ret = setpriority(PRIO_PROCESS, tid, value);
+#elif defined(PLATFORM_DARWIN)
+  /* Currently not possible */
+#elif defined(PLATFORM_FREEBSD)
+  /* Currently not possible */
 #else
 #warning "Implement renice for your platform!"
 #endif
@@ -234,11 +238,20 @@ tvh_cond_init
 
   pthread_condattr_t attr;
   pthread_condattr_init(&attr);
+#if defined(PLATFORM_DARWIN)
+  /*
+   * pthread_condattr_setclock() not supported on platform Darwin.
+   * We use pthread_cond_timedwait_relative_np() which doesn't
+   * need it.
+   */
+   r = 0;
+#else
   r = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
   if (r) {
     fprintf(stderr, "Unable to set monotonic clocks for conditions! (%d)", r);
     abort();
   }
+#endif
   return pthread_cond_init(&cond->cond, &attr);
 }
 
@@ -270,11 +283,24 @@ int
 tvh_cond_timedwait
   ( tvh_cond_t *cond, pthread_mutex_t *mutex, int64_t monoclock )
 {
+#if defined(PLATFORM_DARWIN)
+  /* Use a relative timedwait implementation */
+  int64_t now = getmonoclock();
+  int64_t relative = monoclock - now;
+
+  struct timespec ts;
+  ts.tv_sec  = relative / MONOCLOCK_RESOLUTION;
+  ts.tv_nsec = (relative % MONOCLOCK_RESOLUTION) *
+               (1000000000ULL/MONOCLOCK_RESOLUTION);
+
+  return pthread_cond_timedwait_relative_np(&cond->cond, mutex, &ts);
+#else
   struct timespec ts;
   ts.tv_sec = monoclock / MONOCLOCK_RESOLUTION;
   ts.tv_nsec = (monoclock % MONOCLOCK_RESOLUTION) *
                (1000000000ULL/MONOCLOCK_RESOLUTION);
   return pthread_cond_timedwait(&cond->cond, mutex, &ts);
+#endif
 }
 
 /*
@@ -301,6 +327,9 @@ tvh_safe_usleep(int64_t us)
 int64_t
 tvh_usleep(int64_t us)
 {
+#if defined(PLATFORM_DARWIN)
+  return usleep(us);
+#else
   struct timespec ts;
   int64_t val;
   int r;
@@ -313,11 +342,18 @@ tvh_usleep(int64_t us)
   if (ERRNO_AGAIN(r))
     return val;
   return r ? -r : 0;
+#endif
 }
 
 int64_t
 tvh_usleep_abs(int64_t us)
 {
+#if defined(PLATFORM_DARWIN)
+  /* Convert to relative wait */
+  int64_t now = getmonoclock();
+  int64_t relative = us - now;
+  return tvh_usleep(relative);
+#else
   struct timespec ts;
   int64_t val;
   int r;
@@ -330,6 +366,7 @@ tvh_usleep_abs(int64_t us)
   if (ERRNO_AGAIN(r))
     return val;
   return r ? -r : 0;
+#endif
 }
 
 /*


### PR DESCRIPTION
These are some fixes to make master compile on macOS (tested on 10.12) and FreeBSD (tested on 11.1).

The two major items:

1. A working implementation of wrappers.c for macOS that doesn't make the CPU spin needlessly due to a mixup of clocks in pthread_cond_wait().

2. Fix for a bug in the kqueue implementation that also caused needless busy-waiting on FreeBSD and macOS.

Taken those two together, tvheadend now idles at 0-5% CPU even when receiving a stream from SatIP.
