### PR TITLE
xmltv/core: Fix several memory leaks/make more const correct. (#4773)

### DIFF
--- a/src/avahi.c
+++ b/src/avahi.c
@@ -295,7 +295,7 @@ avahi_thread(void *aux)
     }
 
     name = NULL;
-    free(name2);
+    avahi_free(name2);
 
   } while (tvheadend_is_running() && avahi_do_restart);
 

--- a/src/epg.c
+++ b/src/epg.c
@@ -2228,7 +2228,7 @@ int epg_broadcast_set_description
 }
 
 int epg_broadcast_set_credits
-( epg_broadcast_t *b, htsmsg_t *credits, uint32_t *changed )
+( epg_broadcast_t *b, const htsmsg_t *credits, uint32_t *changed )
 {
   if (!b) return 0;
   const int mod = _epg_object_set_htsmsg(b, &b->credits, credits, changed, EPG_CHANGED_CREDITS);
@@ -2265,14 +2265,14 @@ int epg_broadcast_set_credits
 }
 
 int epg_broadcast_set_category
-( epg_broadcast_t *b, string_list_t *msg, uint32_t *changed )
+( epg_broadcast_t *b, const string_list_t *msg, uint32_t *changed )
 {
   if (!b) return 0;
   return _epg_object_set_string_list(b, &b->category, msg, changed, EPG_CHANGED_CATEGORY);
 }
 
 int epg_broadcast_set_keyword
-( epg_broadcast_t *b, string_list_t *msg, uint32_t *changed )
+( epg_broadcast_t *b, const string_list_t *msg, uint32_t *changed )
 {
   if (!b) return 0;
   const int mod = _epg_object_set_string_list(b, &b->keyword, msg, changed, EPG_CHANGED_KEYWORD);
@@ -2463,10 +2463,12 @@ epg_broadcast_t *epg_broadcast_deserialize
 
   if ((sl = string_list_deserialize(m, "keyword"))) {
       *save |= epg_broadcast_set_keyword(ebc, sl, &changes);
+      string_list_destroy(sl);
   }
 
   if ((sl = string_list_deserialize(m, "category"))) {
       *save |= epg_broadcast_set_category(ebc, sl, &changes);
+      string_list_destroy(sl);
   }
 
   /* Series link */

--- a/src/epg.h
+++ b/src/epg.h
@@ -598,13 +598,13 @@ int epg_broadcast_set_description
   ( epg_broadcast_t *b, const lang_str_t *str, uint32_t *changed )
   __attribute__((warn_unused_result));
 int epg_broadcast_set_credits
-( epg_broadcast_t *b, htsmsg_t* msg, uint32_t *changed )
+( epg_broadcast_t *b, const htsmsg_t* msg, uint32_t *changed )
   __attribute__((warn_unused_result));
 int epg_broadcast_set_category
-( epg_broadcast_t *b, struct string_list* msg, uint32_t *changed )
+( epg_broadcast_t *b, const struct string_list* msg, uint32_t *changed )
   __attribute__((warn_unused_result));
 int epg_broadcast_set_keyword
-( epg_broadcast_t *b, struct string_list* msg, uint32_t *changed )
+( epg_broadcast_t *b, const struct string_list* msg, uint32_t *changed )
   __attribute__((warn_unused_result));
 int epg_broadcast_set_serieslink
   ( epg_broadcast_t *b, epg_serieslink_t *sl, uint32_t *changed )

--- a/src/epggrab/module/xmltv.c
+++ b/src/epggrab/module/xmltv.c
@@ -734,6 +734,8 @@ static int _xmltv_parse_programme_tags
    */
   if (uri) {
     ee = epg_episode_find_by_uri(uri, mod, 1, &save3, &changes3);
+    free(uri);
+    uri = NULL;
   } else {
     ee = epg_episode_find_by_broadcast(ebc, mod, 1, &save3, &changes3);
   }

--- a/src/string_list.c
+++ b/src/string_list.c
@@ -46,7 +46,9 @@ string_list_destroy(string_list_t *l)
   while ((item = RB_FIRST(l))) {
     RB_REMOVE(l, item, h_link);
     free(item->id);
+    free(item);
   }
+  free(l);
 }
 
 static inline int


### PR DESCRIPTION
Fix a few places where there are memory leaks. Valgrind only showed a few minor leaks remaining (<2k of memory leaked) from init methods.
