### PR TITLE
dvr: Add autorec for new-only. (#1167).

### DIFF
--- a/src/api/api_epg.c
+++ b/src/api/api_epg.c
@@ -343,6 +343,7 @@ api_epg_grid
   if (str)
     eq.stitle = strdup(str);
   eq.fulltext = htsmsg_get_bool_or_default(args, "fulltext", 0);
+  eq.new_only = htsmsg_get_bool_or_default(args, "new", 0);
   str = htsmsg_get_str(args, "channel");
   if (str)
     eq.channel = strdup(str);

--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -325,8 +325,9 @@ typedef enum {
 
 typedef enum {
   DVR_AUTOREC_BTYPE_ALL = 0,
-  DVR_AUTOREC_BTYPE_NEW = 1,
-  DVR_AUTOREC_BTYPE_REPEAT = 2
+  DVR_AUTOREC_BTYPE_NEW_OR_UNKNOWN = 1,
+  DVR_AUTOREC_BTYPE_REPEAT = 2,
+  DVR_AUTOREC_BTYPE_NEW = 3,
 } dvr_autorec_btype_t;
 
 /**

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -182,9 +182,11 @@ autorec_cmp(dvr_autorec_entry_t *dae, epg_broadcast_t *e)
   }
 
   if(dae->dae_btype != DVR_AUTOREC_BTYPE_ALL) {
-    if (dae->dae_btype == DVR_AUTOREC_BTYPE_NEW && e->is_repeat)
+    if (dae->dae_btype == DVR_AUTOREC_BTYPE_NEW_OR_UNKNOWN && e->is_repeat)
       return 0;
-    if (dae->dae_btype == DVR_AUTOREC_BTYPE_REPEAT && e->is_repeat == 0)
+    else if (dae->dae_btype == DVR_AUTOREC_BTYPE_NEW && !e->is_new)
+      return 0;
+    else if (dae->dae_btype == DVR_AUTOREC_BTYPE_REPEAT && e->is_repeat == 0)
       return 0;
   }
 
@@ -1046,6 +1048,8 @@ dvr_autorec_entry_class_btype_list ( void *o, const char *lang )
     { N_("Any"),
         DVR_AUTOREC_BTYPE_ALL },
     { N_("New / premiere / unknown"),
+        DVR_AUTOREC_BTYPE_NEW_OR_UNKNOWN },
+    { N_("New / premiere"),
         DVR_AUTOREC_BTYPE_NEW },
     { N_("Repeated"),
         DVR_AUTOREC_BTYPE_REPEAT },

--- a/src/epg.c
+++ b/src/epg.c
@@ -2927,6 +2927,10 @@ _eq_add ( epg_query_t *eq, epg_broadcast_t *e )
     }
     if (!r) return;
   }
+  if (eq->new_only) {
+    if (!e->is_new)
+      return;
+  }
   if (fulltext) {
     if ((s = epg_episode_get_title(ep, lang)) == NULL ||
         regex_match(&eq->stitle_re, s)) {

--- a/src/epg.h
+++ b/src/epg.h
@@ -692,6 +692,7 @@ typedef struct epg_query {
   char             *stitle;
   tvh_regex_t       stitle_re;
   int               fulltext;
+  int               new_only;
   char             *channel;
   char             *channel_tag;
   uint32_t          genre_count;

--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -727,6 +727,10 @@ tvheadend.epg = function() {
         width: 20
     });
 
+    var epgFilterNewOnly = new Ext.form.Checkbox({
+        width: 20
+    });
+
     // Channels, uses global store
 
     var epgFilterChannels = new Ext.form.ComboBox({
@@ -833,6 +837,11 @@ tvheadend.epg = function() {
         epgFilterFulltext.setValue(0);
     };
 
+    clearNewOnlyFilter = function() {
+        delete epgStore.baseParams.newOnly;
+        epgFilterNewOnly.setValue(0);
+    }
+
     clearChannelFilter = function() {
         delete epgStore.baseParams.channel;
         epgFilterChannels.setValue("");
@@ -863,6 +872,7 @@ tvheadend.epg = function() {
         clearModeFilter();
         clearTitleFilter();
         clearFulltextFilter();
+        clearNewOnlyFilter();
         clearChannelFilter();
         clearChannelTagsFilter();
         clearDurationFilter();
@@ -953,6 +963,13 @@ tvheadend.epg = function() {
         }
     });
 
+    epgFilterNewOnly.on('check', function(c, value) {
+        if (epgStore.baseParams.new !== value) {
+            epgStore.baseParams.new = value;
+            epgView.reset();
+        }
+    });
+
     var epgView = new Ext.ux.grid.livegrid.GridView({
         nearLimit: 100,
         loadMask: {
@@ -977,7 +994,7 @@ tvheadend.epg = function() {
 
     var tbar = [
         epgMode, '-',
-        epgFilterTitle, { text: _('Fulltext') }, epgFilterFulltext, '-',
+        epgFilterTitle, { text: _('Fulltext') }, epgFilterFulltext, { text: _('New only') }, epgFilterNewOnly, '-',
         epgFilterChannels, '-',
         epgFilterChannelTags, '-',
         epgFilterContentGroup, '-',
@@ -1143,6 +1160,9 @@ tvheadend.epg = function() {
         var fulltext = epgStore.baseParams.fulltext ?
                 " <i>(" + _("Fulltext") + ")</i>"
                 : "";
+        var newOnly = epgStore.baseParams.new ?
+                " <i>(" + _("New only") + ")</i>"
+                : "";
         var channel = epgStore.baseParams.channel ?
                 tvheadend.channelLookupName(epgStore.baseParams.channel)
                 : "<i>" + _("Don't care") + "</i>";
@@ -1159,7 +1179,7 @@ tvheadend.epg = function() {
         Ext.MessageBox.confirm(_('Auto Recorder'), _('This will create an automatic rule that '
                 + 'continuously scans the EPG for programs '
                 + 'to record that match this query') + ': ' + '<br><br>'
-                + '<div class="x-smallhdr">' + _('Title') + ':</div>' + title + fulltext + '<br>'
+                + '<div class="x-smallhdr">' + _('Title') + ':</div>' + title + fulltext + newOnly + '<br>'
                 + '<div class="x-smallhdr">' + _('Channel') + ':</div>' + channel + '<br>'
                 + '<div class="x-smallhdr">' + _('Tag') + ':</div>' + tag + '<br>'
                 + '<div class="x-smallhdr">' + _('Genre') + ':</div>' + contentType + '<br>'
@@ -1182,6 +1202,7 @@ tvheadend.epg = function() {
         };
         if (params.title) conf.title = params.title;
         if (params.fulltext) conf.fulltext = params.fulltext;
+        if (params.new) conf.btype = 3; // DVR_AUTOREC_BTYPE_NEW in dvr.h has value 3.
         if (params.channel) conf.channel = params.channel;
         if (params.channelTag) conf.tag = params.channelTag;
         if (params.contentType) conf.content_type = params.contentType;


### PR DESCRIPTION
Previously we had "all", "new/unknown", and "repeat", but
no ability to only record episodes marked as "new". So we
rename DVR_AUTOREC_BTYPE_NEW to DVR_AUTOREC_BTYPE_NEW_OR_UNKNOWN
to remain backward compatibility with existing autorec
rules and add new semantics for DVR_AUTOREC_BTYPE_NEW.

This helps with OTA "scrape new" where broadcasters mark shows as new,
but all other shows aren't marked as repeat so remain as "unknown".

We don't update htsp since it currently does not send the
broadcast type field.

Also alter DVR_AUTOREC_BTYPE_NEW_OR_UNKNOWN since
previously we never checked 'new' but instead checked 'repeat'.
However, SD has a previously-shown for all programmes (even first
showings) which causes us to mark programmes as repeat.

It is difficult to fix the repeat logic without breaking existing
behaviour since in the US a programme can be a premiere but have
a previously-shown of the previous day due to timezone differences
on the coasts. Similarly, programmes can be premiere outside the US
but have a previously shown date from the US or from a different channel.
For that reason we now check 'new' instead of 'repeat'.

Real example: Programme is shown on channel A at 9pm and on A+1 timeshift
channel at 10pm. Both are marked as "new" in the paper/OTA tv guide. However,
the programme was actually first shown three years ago on a premium
channel, so it's actually also a repeat since it has been shown before.
So the programme is both a new episode and a repeat episode.

Similarly, one of my tv channel insists Roger Moore Bond films from the
1970s are "new" even though most people would consider them a repeat,
but since it's the first time that particular channel has aired it
they use the "new" tag.

Issue: #1167.