### PR TITLE
ui: Allow filtering by categories (#4777)

### DIFF
--- a/src/api/api_epg.c
+++ b/src/api/api_epg.c
@@ -349,6 +349,15 @@ api_epg_grid
   str = htsmsg_get_str(args, "channelTag");
   if (str)
     eq.channel_tag = strdup(str);
+  str = htsmsg_get_str(args, "cat1");
+  if (str)
+    eq.cat1 = strdup(str);
+  str = htsmsg_get_str(args, "cat2");
+  if (str)
+    eq.cat2 = strdup(str);
+  str = htsmsg_get_str(args, "cat3");
+  if (str)
+    eq.cat3 = strdup(str);
 
   if (mode != NULL) {
       if (!strcmp(mode, "now")) {

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -222,6 +222,11 @@ autorec_cmp(dvr_autorec_entry_t *dae, epg_broadcast_t *e)
       return 0;
     if (dae->dae_cat3 && *dae->dae_cat3 && !string_list_contains_string(e->category, dae->dae_cat3))
       return 0;
+  } else if ((dae->dae_cat1 && *dae->dae_cat1) ||
+             (dae->dae_cat2 && *dae->dae_cat2) ||
+             (dae->dae_cat3 && *dae->dae_cat3)) {
+    /* No category in event but autorec has category, so no match. */
+    return 0;
   }
 
   if(dae->dae_start >= 0 && dae->dae_start_window >= 0 &&

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1024,6 +1024,12 @@ dvr_entry_create_(int enabled, const char *config_uuid, epg_broadcast_t *e,
   {
     htsmsg_add_str(conf, "autorec", idnode_uuid_as_str(&dae->dae_id, ubuf));
     htsmsg_add_str(conf, "directory", dae->dae_directory ?: "");
+    if (dae->dae_cat1 && *dae->dae_cat1)
+      htsmsg_add_str(conf, "cat1", dae->dae_cat1);
+    if (dae->dae_cat2 && *dae->dae_cat2)
+      htsmsg_add_str(conf, "cat2", dae->dae_cat2);
+    if (dae->dae_cat3 && *dae->dae_cat3)
+      htsmsg_add_str(conf, "cat3", dae->dae_cat3);
   }
   if (dte)
   {

--- a/src/epg.c
+++ b/src/epg.c
@@ -2915,6 +2915,28 @@ _eq_add ( epg_query_t *eq, epg_broadcast_t *e )
     if (_eq_comp_num(&eq->channel_num, channel_get_number(e->channel))) return;
   if (eq->channel_name.comp != EC_NO)
     if (_eq_comp_str(&eq->channel_name, channel_get_name(e->channel, NULL))) return;
+  if (eq->cat1 && *eq->cat1) {
+      /* No category? Can't match our requested category */
+      if (!e->category)
+          return;
+      if (!string_list_contains_string(e->category, eq->cat1))
+          return;
+  }
+  if (eq->cat2 && *eq->cat2) {
+      /* No category? Can't match our requested category */
+      if (!e->category)
+          return;
+      if (!string_list_contains_string(e->category, eq->cat2))
+          return;
+  }
+  if (eq->cat3 && *eq->cat3) {
+      /* No category? Can't match our requested category */
+      if (!e->category)
+          return;
+      if (!string_list_contains_string(e->category, eq->cat3))
+          return;
+  }
+
   if (eq->genre_count) {
     epg_genre_t genre;
     uint32_t i, r = 0;
@@ -3275,6 +3297,10 @@ fin:
   free(eq->channel); eq->channel = NULL;
   free(eq->channel_tag); eq->channel_tag = NULL;
   free(eq->stitle); eq->stitle = NULL;
+  free(eq->cat1); eq->cat1 = NULL;
+  free(eq->cat2); eq->cat2 = NULL;
+  free(eq->cat3); eq->cat3 = NULL;
+
   if (eq->genre != eq->genre_static)
     free(eq->genre);
   eq->genre = NULL;

--- a/src/epg.h
+++ b/src/epg.h
@@ -697,6 +697,9 @@ typedef struct epg_query {
   uint32_t          genre_count;
   uint8_t          *genre;
   uint8_t           genre_static[16];
+  char             *cat1;
+  char             *cat2;
+  char             *cat3;
 
   enum {
     ESK_START,


### PR DESCRIPTION
If the server has parsed xmltv categories then we create a second toolbar below the existing one to add category filters and pass them to the  rule.

We use a second toolbar since the primary toolbar is too cramped to add additional filters.

Also fix a small memory leak on the api filter and fix bug where an autorec with a category would match OTA programmes without categories.
