### PR TITLE
api: 4.2: Fix small memory leak on filter. (#4773).

### DIFF
--- a/src/api/api_epg.c
+++ b/src/api/api_epg.c
@@ -475,6 +475,10 @@ api_epg_grid
 
   epg_query_free(&eq);
   free(lang);
+  if (eq.lang)        free(eq.lang);
+  if (eq.stitle)      free(eq.stitle);
+  if (eq.channel)     free(eq.channel);
+  if (eq.channel_tag) free(eq.channel_tag);
 
   /* Build response */
   *resp = htsmsg_create_map();


### PR DESCRIPTION
This is backport from same fix in #1050 since I believe 4.2 would have the same problems based on a look of its code. (Not tested on 4.2, but tested on 4.3).
 
