### PR TITLE
codacy: Fix couple of problems identified by codacy. (#4773).

### DIFF
--- a/src/descrambler/cccam.c
+++ b/src/descrambler/cccam.c
@@ -1111,7 +1111,7 @@ cccam_send_cli_data(cccam_t *cccam)
   memcpy(buf + 20, cccam->cccam_nodeid, 8);
   buf[28] = 0; // TODO: wantemus = 1;
   memcpy(buf + 29, cccam_version_str[cccam->cccam_version], 32);
-  memcpy(buf + 61, "tvh", 32); // build number (ascii)
+  memcpy(buf + 61, "tvh", 3); // build number (ascii)
   cccam_send_msg(cccam, MSG_CLI_DATA, buf, 20 + 8 + 1 + 64, 0, 0, 0);
 }
 

--- a/src/epggrab/module/xmltv.c
+++ b/src/epggrab/module/xmltv.c
@@ -380,7 +380,7 @@ static int _xmltv_parse_date_finished
           year_buf[5] = 0;
           const uint16_t year = atoi(year_buf);
           /* Sanity check the year before copying it over. */
-          if (year && year > 1800 && year < 2500) {
+          if (year > 1800 && year < 2500) {
               return epg_episode_set_copyright_year(ee, year, changes);
           }
       }


### PR DESCRIPTION
Fixed two issues identified by codacy in issue 4773.
- buffer overrun in memcpy (I believe 3 is correct value since buf is already memset 0);
- redundant condition in xmltv.c.

Codacy also spotted a local variable returned at src/htsp_server.c:3385. I thought of making it static, but then it doesn't look like it's actually returned since it's nulled at 3471. But since it's added to a LIST_INSERT_HEAD at 3400 (but then removed soon later) and used in another thread, I _think_ this variable should be malloc'd but haven't worked it out to be sure, so I've not made any changes to it.
