### PR TITLE
dvr: check autorec timers after programme update and on start (#4760, #4299)

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -597,6 +597,7 @@ void dvr_event_removed(epg_broadcast_t *e);
 void dvr_event_updated(epg_broadcast_t *e);
 
 void dvr_event_running(epg_broadcast_t *e, epg_running_t running);
+int dvr_entry_assign_broadcast(dvr_entry_t *de, epg_broadcast_t *bcast);
 
 dvr_entry_t *dvr_entry_find_by_id(int id);
 
@@ -718,6 +719,14 @@ void dvr_autorec_init(void);
 void dvr_autorec_done(void);
 
 void dvr_autorec_update(void);
+
+/// @return 1 if the event 'e' is matched by the autorec rule 'dae'
+int dvr_autorec_cmp(const dvr_autorec_entry_t *dae, const epg_broadcast_t *e);
+/// Purge any autorec timers that are obsolete since they no longer match any events.
+void dvr_autorec_purge_obsolete_timers(void);
+/// @return 1 if entry is an autorec and can be purged since it no longer matches its event.
+int dvr_autorec_entry_can_be_purged(const dvr_entry_t *de);
+
 
 static inline int
   dvr_autorec_entry_verify(dvr_autorec_entry_t *dae, access_t *a, int readonly)

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -104,6 +104,56 @@ dvr_autorec_purge_spawns(dvr_autorec_entry_t *dae, int del, int disabled)
   return bcast;
 }
 
+
+/// If autorec entry no longer matches autorec rule then it can be purged.
+/// @return 1 if it can be purged
+int
+dvr_autorec_entry_can_be_purged(const dvr_entry_t *de)
+{
+  /* Not an autorec so ignore */
+  if (!de->de_autorec)
+    return 0;
+
+  /* Entry is not scheduled (for example finished) so can not be purged */
+  if (de->de_sched_state != DVR_SCHEDULED)
+    return 0;
+
+  /* No broadcast matched when entry was reloaded from dvr/log */
+  if (!de->de_bcast)
+    return 1;
+
+  /* Confirm autorec still matches the broadcast */
+  return !dvr_autorec_cmp(de->de_autorec, de->de_bcast);
+}
+
+/// Purge any dvr_entry for autorec entries that
+/// no longer match the current schedule.
+void
+dvr_autorec_purge_obsolete_timers(void)
+{
+  dvr_entry_t *de;
+  int num_purged = 0;
+
+  LIST_FOREACH(de, &dvrentries, de_global_link) {
+    if (dvr_autorec_entry_can_be_purged(de)) {
+      char ubuf[UUID_HEX_SIZE];
+      char t1buf[32], t2buf[32];
+      tvhinfo(LS_DVR, "Entry %s can be purged for \"%s\" start %s stop %s",
+              idnode_uuid_as_str(&de->de_id, ubuf),
+              lang_str_get(de->de_title, NULL),
+              gmtime2local(de->de_start, t1buf, sizeof(t1buf)),
+              gmtime2local(de->de_stop, t2buf, sizeof(t2buf)));
+
+      dvr_entry_assign_broadcast(de, NULL);
+      dvr_entry_destroy(de, 1);
+      ++num_purged;
+    }
+  }
+  if (num_purged)
+    tvhinfo(LS_DVR, "Purged %d autorec entries that no longer match schedule", num_purged);
+}
+
+
 /**
  * Handle maxcount
  */
@@ -143,13 +193,14 @@ dvr_autorec_completed(dvr_autorec_entry_t *dae, int error_code)
 /**
  * return 1 if the event 'e' is matched by the autorec rule 'dae'
  */
-static int
-autorec_cmp(dvr_autorec_entry_t *dae, epg_broadcast_t *e)
+int
+dvr_autorec_cmp(const dvr_autorec_entry_t *dae, const epg_broadcast_t *e)
 {
   idnode_list_mapping_t *ilm;
   dvr_config_t *cfg;
   double duration;
 
+  if (!e) return 0;
   if (!e->channel) return 0;
   if (!e->episode) return 0;
   if(dae->dae_enabled == 0 || dae->dae_weekdays == 0)
@@ -1500,7 +1551,7 @@ dvr_autorec_check_event(epg_broadcast_t *e)
   if (e->channel && !e->channel->ch_enabled)
     return;
   TAILQ_FOREACH(dae, &autorec_entries, dae_link)
-    if(autorec_cmp(dae, e))
+    if(dvr_autorec_cmp(dae, e))
       dvr_entry_create_by_autorec(1, e, dae);
   // Note: no longer updating event here as it will be done from EPG
   //       anyway
@@ -1540,7 +1591,7 @@ dvr_autorec_changed(dvr_autorec_entry_t *dae, int purge)
   CHANNEL_FOREACH(ch) {
     if (!ch->ch_enabled) continue;
     RB_FOREACH(e, &ch->ch_epg_schedule, sched_link) {
-      if(autorec_cmp(dae, e)) {
+      if(dvr_autorec_cmp(dae, e)) {
         enabled = 1;
         if (disabled) {
           for (p = disabled; *p && *p != e; p++);

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -235,7 +235,7 @@ dvr_entry_set_state(dvr_entry_t *de, dvr_entry_sched_state_t state,
 /*
  *
  */
-static int
+int
 dvr_entry_assign_broadcast(dvr_entry_t *de, epg_broadcast_t *bcast)
 {
   char id[16];
@@ -2179,6 +2179,19 @@ dosave:
                lang_str_get(de->de_title, NULL), DVR_CH_NAME(de),
                updated ? " Timer" : "",
                dvr_updated_str(buf, sizeof(buf), save));
+    }
+    /* The updates could mean the autorec rule no longer matches the event,
+     * so we have to destroy the de and the conf and let the autorec rule
+     * re-create when it next matches.
+     *
+     * If de is not scheduled (i.e., recording) then do nothing with the
+     * rule since don't want to cancel items that are recording.
+     * Also if no event then this autorec can't match it so we should delete
+     * it.
+     */
+    if (dvr_autorec_entry_can_be_purged(de)) {
+        dvr_entry_assign_broadcast(de, NULL);
+        dvr_entry_destroy(de, 1);
     }
   }
 
@@ -4376,6 +4389,13 @@ dvr_entry_init(void)
     }
     htsmsg_destroy(l);
   }
+  /* We update the autorec entries so any that are no longer matching
+   * the current schedule get deleted. This avoids the problem where
+   * autorec entries remain even when user has deleted the epgdb
+   * or modified their settings between runs.
+   */
+  tvhinfo(LS_DVR, "Purging obsolete autorec entries for current schedule");
+  dvr_autorec_purge_obsolete_timers();
   dvr_in_init = 0;
   /* process parent/child mapping */
   HTSMSG_FOREACH(f, rere) {

--- a/src/tvhregex.h
+++ b/src/tvhregex.h
@@ -54,7 +54,7 @@ typedef struct {
 #endif
 } tvh_regex_t;
 
-static inline int regex_match(tvh_regex_t *regex, const char *str)
+static inline int regex_match(const tvh_regex_t *regex, const char *str)
 {
 #if ENABLE_PCRE
   int vec[30];


### PR DESCRIPTION
An autorec for "title A" can match a programme. When the next xmltv update comes in, it can update the title, description and other fields so that the event is now "title B" and so should no longer match the rule "title A".

So, we now do an autorec_cmp after a programme update to ensure such bad timers are deleted. They will be automatically respawned on any new programme that matches the rule.

This happens with surprising regularity on some channels since the SD xmltv guide for today+>8 days is often fuzzy and programmes are completely replaced as they get nearer to broadcast.

On startup, we now also purge all autorec timers that no longer match an event. This ensures that bad autorec timers are deleted for cases where the user has deleted the epgdb to fix some major problem. This is a change in behaviour since previously we'd keep the autorec timers even though they no longer matched anything, but I think the new behaviour is equally valid and I imagine most people keep the persisted db so experience no difference. I don't delete the manually set timers on the assumption that the user should manually delete manually set timers.

A minor change was renaming autorec_cmp to be dvr_autorec_cmp and no longer be static, and make it take const arguments so needing a const on the regex function.
