### PR TITLE
xmltv: optional disable mapping xmltv category to genre (#3753)

### DIFF
--- a/src/epggrab.h
+++ b/src/epggrab.h
@@ -182,6 +182,7 @@ struct epggrab_module_int
   int                           xmltv_scrape_extra; ///< Scrape actors and extra details
   int                           xmltv_scrape_onto_desc; ///< Include scraped actors
     ///< and extra details on to programme description for viewing by legacy clients.
+  int                           xmltv_use_category_not_genre; ///< Use category tags and don't map to DVB genres.
 
   /* Handle data */
   char*     (*grab)   ( void *mod );

--- a/src/epggrab/module/xmltv.c
+++ b/src/epggrab/module/xmltv.c
@@ -607,6 +607,7 @@ static int _xmltv_parse_programme_tags
 {
   const int scrape_extra = ((epggrab_module_ext_t *)mod)->xmltv_scrape_extra;
   const int scrape_onto_desc = ((epggrab_module_ext_t *)mod)->xmltv_scrape_onto_desc;
+  const int use_category_not_genre = ((epggrab_module_int_t *)mod)->xmltv_use_category_not_genre;
   int save = 0, save2 = 0, save3 = 0;
   epg_episode_t *ee = NULL;
   epg_serieslink_t *es = NULL;
@@ -752,7 +753,7 @@ static int _xmltv_parse_programme_tags
     if (subtitle)
       save3 |= epg_episode_set_subtitle(ee, subtitle, &changes3);
 
-    if ((egl = _xmltv_parse_categories(tags))) {
+    if (!use_category_not_genre && (egl = _xmltv_parse_categories(tags))) {
       save3 |= epg_episode_set_genre(ee, egl, &changes3);
       epg_genre_list_destroy(egl);
     }
@@ -1013,6 +1014,16 @@ static int _xmltv_parse
      "You should not enable this if you use 'duplicate detect if different description' " \
      "since the descriptions will change due to added information.")
 
+#define USE_CATEGORY_NOT_GENRE_NAME N_("Use category instead of genre")
+#define USE_CATEGORY_NOT_GENRE_DESC \
+  N_("Some xmltv providers supply multiple category tags, however mapping "\
+     "to genres is imprecise and many categories have no genre mapping "\
+     "at all. Some frontends will only pass through categories " \
+     "unchanged if there is no genre so for these we can " \
+     "avoid the genre mappings and only use categories. " \
+     "If this option is not ticked then we continue to map " \
+     "xmltv categories to genres and supply both to clients.")
+
 static htsmsg_t *
 xmltv_dn_chnum_list ( void *o, const char *lang )
 {
@@ -1055,6 +1066,14 @@ const idclass_t epggrab_mod_int_xmltv_class = {
       .off    = offsetof(epggrab_module_int_t, xmltv_scrape_onto_desc),
       .group  = 1
     },
+    {
+      .type   = PT_BOOL,
+      .id     = "use_category_not_genre",
+      .name   = USE_CATEGORY_NOT_GENRE_NAME,
+      .desc   = USE_CATEGORY_NOT_GENRE_DESC,
+      .off    = offsetof(epggrab_module_int_t, xmltv_use_category_not_genre),
+      .group  = 1
+    },
     {}
   }
 };
@@ -1087,6 +1106,14 @@ const idclass_t epggrab_mod_ext_xmltv_class = {
       .name   = SCRAPE_ONTO_DESC_NAME,
       .desc   = SCRAPE_ONTO_DESC_DESC,
       .off    = offsetof(epggrab_module_int_t, xmltv_scrape_onto_desc),
+      .group  = 1
+    },
+    {
+      .type   = PT_BOOL,
+      .id     = "use_category_not_genre",
+      .name   = USE_CATEGORY_NOT_GENRE_NAME,
+      .desc   = USE_CATEGORY_NOT_GENRE_DESC,
+      .off    = offsetof(epggrab_module_int_t, xmltv_use_category_not_genre),
       .group  = 1
     },
     {}

--- a/src/epggrab/module/xmltv.c
+++ b/src/epggrab/module/xmltv.c
@@ -605,8 +605,8 @@ static int _xmltv_parse_programme_tags
    time_t start, time_t stop, const char *icon,
    epggrab_stats_t *stats)
 {
-  const int scrape_extra = ((epggrab_module_ext_t *)mod)->xmltv_scrape_extra;
-  const int scrape_onto_desc = ((epggrab_module_ext_t *)mod)->xmltv_scrape_onto_desc;
+  const int scrape_extra = ((epggrab_module_int_t *)mod)->xmltv_scrape_extra;
+  const int scrape_onto_desc = ((epggrab_module_int_t *)mod)->xmltv_scrape_onto_desc;
   const int use_category_not_genre = ((epggrab_module_int_t *)mod)->xmltv_use_category_not_genre;
   int save = 0, save2 = 0, save3 = 0;
   epg_episode_t *ee = NULL;


### PR DESCRIPTION
Some frontends (such as Kodi) can only use categories if we have no genre. Often genre mapping from xmltv is imprecise since xmltv programmes often have a number of categories and one happens to match a genre. For example opera was "non-music" due to matching a minor-category tag of "performing arts", but not matching the major category tags such as "opera".

Tested by edit4ever ! in comment 28 of bug report.

Also a minor change to cast to epggrab_module_int_t instead of epggrab_module_ext_t for existing scrape config options since these are in the base struct.