### PR TITLE
ui: Rename "Category Type" icons column to "Category Icons" (#4594).

### DIFF
--- a/src/webui/static/app/tvheadend.js
+++ b/src/webui/static/app/tvheadend.js
@@ -284,8 +284,8 @@ tvheadend.displayCategoryIcon = function(value, meta, record, ri, ci, store) {
 tvheadend.contentTypeAction = {
   width: 75,
   id: 'category',
-  header: _("Content Type"),
-  tooltip: _("Content Type"),
+  header: _("Content Icons"),
+  tooltip: _("Content Icons"),
   dataIndex: 'category',
   renderer: tvheadend.displayCategoryIcon,
 };


### PR DESCRIPTION
In the forum, it was mentioned that we have two EPG columns called "Content Type", so rename the one with icons to be called "Category Icons" to avoid any confusion.
