### PR TITLE
sbuf: fix uClibc compilation error

### DIFF
--- a/src/sbuf.h
+++ b/src/sbuf.h
@@ -23,6 +23,7 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <unistd.h>
 
 /**
  * Simple dynamically growing buffer


### PR DESCRIPTION
Fixes build error with uClibc

tvheadend-e06ffd87beff16103c47d6fa542df2374fca6fd3/src/sbuf.h:77:1:
 error: unknown type name 'ssize_t'; did you mean 'size_t'?
 ssize_t sbuf_read(sbuf_t *sb, int fd);