### PR TITLE
Little user friendly changes on webui

### DIFF
--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -355,6 +355,8 @@ tvheadend.dvr_upcoming = function(panel, index) {
         },
         callback: function(conf, e, store, select) {
             duplicates ^= 1;
+            Ext.getCmp('idnode_grid').getColumnModel().setHidden(3, !duplicates);
+            Ext.getCmp('idnode_grid').getBottomToolbar().changePage(0);
             this.setText(duplicates ? _('Hide duplicates') : _('Show duplicates'));
             store.baseParams.duplicates = duplicates;
             store.reload();
@@ -570,7 +572,8 @@ tvheadend.dvr_finished = function(panel, index) {
                 }
             }],
         tbar: [removeButton, downloadButton, rerecordButton, moveButton],
-        selected: selected
+        selected: selected,
+        grouping: true
     });
 
     return panel;
@@ -668,7 +671,7 @@ tvheadend.dvr_failed = function(panel, index) {
         },
         sort: {
           field: 'start_real',
-          direction: 'ASC'
+          direction: 'DESC'
         },
         plugins: [actions],
         lcol: [
@@ -742,7 +745,7 @@ tvheadend.dvr_removed = function(panel, index) {
         },
         sort: {
           field: 'start_real',
-          direction: 'ASC'
+          direction: 'DESC'
         },
         plugins: [actions],
         lcol: [actions],

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -295,6 +295,7 @@ tvheadend.dvr_upcoming = function(panel, index) {
                 list + ',owner,creator' : list) + ',retention,removal';
     var duplicates = 0;
     var buttonFcn = tvheadend.dvrButtonFcn;
+    var columnId = null;
 
     var stopButton = {
         name: 'stop',
@@ -355,7 +356,6 @@ tvheadend.dvr_upcoming = function(panel, index) {
         },
         callback: function(conf, e, store, select) {
             duplicates ^= 1;
-            var columnId = select.grid.colModel.findColumnIndex('duplicate');
             select.grid.colModel.setHidden(columnId, !duplicates);
             select.grid.bottomToolbar.changePage(0);
             this.setText(duplicates ? _('Hide duplicates') : _('Show duplicates'));
@@ -378,6 +378,11 @@ tvheadend.dvr_upcoming = function(panel, index) {
     function beforeedit(e, grid) {
         if (e.record.data.sched_status == 'recording')
             return false;
+    }
+
+    function viewready(grid) {
+       columnId = grid.colModel.findColumnIndex('duplicate');
+       grid.colModel.setHidden(columnId, true);
     }
 
     tvheadend.idnode_grid(panel, {
@@ -445,7 +450,7 @@ tvheadend.dvr_upcoming = function(panel, index) {
         tbar: [stopButton, abortButton, prevrecButton, dupButton],
         selected: selected,
         beforeedit: beforeedit,
-        hideColumn: 'duplicate'
+        viewready: viewready
     });
 
     return panel;

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -355,8 +355,9 @@ tvheadend.dvr_upcoming = function(panel, index) {
         },
         callback: function(conf, e, store, select) {
             duplicates ^= 1;
-            Ext.getCmp('idnode_grid').getColumnModel().setHidden(3, !duplicates);
-            Ext.getCmp('idnode_grid').getBottomToolbar().changePage(0);
+            var columnId = select.grid.colModel.findColumnIndex('duplicate');
+            select.grid.colModel.setHidden(columnId, !duplicates);
+            select.grid.bottomToolbar.changePage(0);
             this.setText(duplicates ? _('Hide duplicates') : _('Show duplicates'));
             store.baseParams.duplicates = duplicates;
             store.reload();
@@ -443,7 +444,8 @@ tvheadend.dvr_upcoming = function(panel, index) {
         ],
         tbar: [stopButton, abortButton, prevrecButton, dupButton],
         selected: selected,
-        beforeedit: beforeedit
+        beforeedit: beforeedit,
+        hideColumn: 'duplicate'
     });
 
     return panel;
@@ -573,7 +575,8 @@ tvheadend.dvr_finished = function(panel, index) {
             }],
         tbar: [removeButton, downloadButton, rerecordButton, moveButton],
         selected: selected,
-        grouping: true
+        grouping: true,
+        groupField: 'disp_title'
     });
 
     return panel;

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -381,8 +381,13 @@ tvheadend.dvr_upcoming = function(panel, index) {
     }
 
     function viewready(grid) {
-       columnId = grid.colModel.findColumnIndex('duplicate');
-       grid.colModel.setHidden(columnId, true);
+        if(!grid.store.baseParams.duplicates){
+            columnId = grid.colModel.findColumnIndex('duplicate');
+            grid.colModel.setHidden(columnId, true);
+        }else{
+            var buttonIndex = grid.topToolbar.items.findIndex('text','Show duplicates');
+            grid.topToolbar.items.item(buttonIndex).setText(_('Hide duplicates'));
+        }
     }
 
     tvheadend.idnode_grid(panel, {

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -529,6 +529,30 @@ tvheadend.dvr_finished = function(panel, index) {
         }
     };
 
+    var groupingButton = {
+        name: 'grouping',
+        builder: function() {
+            return new Ext.Toolbar.Button({
+                tooltip: _('When enabled, group the recordings by the selected column.'),
+                iconCls: 'duprec',
+                text: _('Enable grouping')
+            });
+        },
+        callback: function(conf, e, store, select) {
+            this.setText(store.groupField ? _('Enable grouping') : _('Disable grouping'));
+            if (!store.groupField){
+                select.grid.view.enableGrouping = true;
+                select.grid.store.groupBy(store.sortInfo.field);
+                select.grid.fireEvent('groupchange', select.grid, store.getGroupState());
+                select.grid.view.refresh();
+            }else{
+                store.clearGrouping();
+                select.grid.view.enableGrouping = false;
+                select.grid.fireEvent('groupchange', select.grid, null);
+            }
+        }
+    };
+
     function selected(s, abuttons) {
         var r = s.getSelections();
         var b = r.length > 0 && r[0].data.filesize > 0;
@@ -536,6 +560,11 @@ tvheadend.dvr_finished = function(panel, index) {
         abuttons.rerecord.setDisabled(!b);
         abuttons.move.setDisabled(!b);
         abuttons.remove.setDisabled(!b);
+    }
+
+    function viewready(grid) {
+        var buttonIndex = grid.topToolbar.items.findIndex('text','Enable grouping');
+        grid.topToolbar.items.item(buttonIndex).setText(grid.store.groupField ? _('Disable grouping') : _('Enable grouping'));
     }
 
     tvheadend.idnode_grid(panel, {
@@ -578,10 +607,9 @@ tvheadend.dvr_finished = function(panel, index) {
                     return tvheadend.playLink('play/dvrfile/' + r.id, title);
                 }
             }],
-        tbar: [removeButton, downloadButton, rerecordButton, moveButton],
+        tbar: [removeButton, downloadButton, rerecordButton, moveButton, groupingButton],
         selected: selected,
-        grouping: true,
-        groupField: 'disp_title'
+        viewready: viewready
     });
 
     return panel;

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -534,7 +534,7 @@ tvheadend.dvr_finished = function(panel, index) {
         builder: function() {
             return new Ext.Toolbar.Button({
                 tooltip: _('When enabled, group the recordings by the selected column.'),
-                iconCls: 'duprec',
+                iconCls: 'grouping',
                 text: _('Enable grouping')
             });
         },

--- a/src/webui/static/app/ext.css
+++ b/src/webui/static/app/ext.css
@@ -232,6 +232,10 @@
     background-image: url(../icons/control_repeat_blue.png) !important;
 }
 
+.grouping {
+    background-image: url(../icons/control_repeat_blue.png) !important;
+}
+
 .cancel {
     background-image: url(../icons/cancel.png) !important;
 }

--- a/src/webui/static/app/idnode.js
+++ b/src/webui/static/app/idnode.js
@@ -1736,6 +1736,10 @@ tvheadend.idnode_grid = function(panel, conf)
             idProperty: 'uuid'
         });
 
+        var groupField = false;
+        if (conf.groupField)
+            groupField = conf.groupField;
+
         store = new Ext.data.GroupingStore({
             url: conf.gridURL || (conf.url + '/grid'),
             baseParams: params,
@@ -1744,7 +1748,7 @@ tvheadend.idnode_grid = function(panel, conf)
             remoteSort: true, //  We lost multi sort at server side :-(, maybe perexg has a better idea
             reader: groupreader,
             remoteGroup: true,
-            groupField: 'disp_title',
+            groupField: groupField,
             groupDir: 'ASC',
             groupOnSort: false,
             /*multiSort: true,
@@ -2105,7 +2109,6 @@ tvheadend.idnode_grid = function(panel, conf)
 
         plugins.push(filter);
         var gconf = {
-            id: 'idnode_grid',
             stateful: true,
             stateId: conf.gridURL || conf.url,
             stripeRows: true,
@@ -2139,8 +2142,10 @@ tvheadend.idnode_grid = function(panel, conf)
         if (conf.beforeedit)
             grid.on('beforeedit', conf.beforeedit);
 
-        if (fields.indexOf('duplicate') !== -1)
-            grid.getColumnModel().setHidden(3, true);
+        if (conf.hideColumn){
+            var columnId = grid.getColumnModel().findColumnIndex(conf.hideColumn);
+            grid.getColumnModel().setHidden(columnId, true);
+        }
 
         dpanel.add(grid);
         dpanel.doLayout(false, true);

--- a/src/webui/static/app/idnode.js
+++ b/src/webui/static/app/idnode.js
@@ -1747,7 +1747,7 @@ tvheadend.idnode_grid = function(panel, conf)
             remoteGroup: true,
             groupField: conf.groupField ? conf.groupField : false,
             groupDir: 'ASC',
-            groupOnSort: false,
+            groupOnSort: true,
             /*multiSort: true,
             multiSortInfo:{
                sorters: [{field : 'disp_title', direction : 'ASC'},

--- a/src/webui/static/app/idnode.js
+++ b/src/webui/static/app/idnode.js
@@ -1626,7 +1626,7 @@ tvheadend.idnode_grid = function(panel, conf)
     var event = null;
     var auto = null;
     var idnode = null;
-    var groupreader = null;
+    var groupReader = null;
 
     var update = function(o) {
         if ((o.create || o.moveup || o.movedown || 'delete' in o) && auto.getValue()) {
@@ -1729,16 +1729,13 @@ tvheadend.idnode_grid = function(panel, conf)
         var params = {};
         if (conf.all) params['all'] = 1;
         if (conf.extraParams) conf.extraParams(params);
-        groupreader = new Ext.data.JsonReader({
+
+        groupReader = new Ext.data.JsonReader({
             totalProperty: 'total',
             root: 'entries',
             fields: fields,
             idProperty: 'uuid'
         });
-
-        var groupField = false;
-        if (conf.groupField)
-            groupField = conf.groupField;
 
         store = new Ext.data.GroupingStore({
             url: conf.gridURL || (conf.url + '/grid'),
@@ -1746,9 +1743,9 @@ tvheadend.idnode_grid = function(panel, conf)
             autoLoad: true,
             id: 'uuid',
             remoteSort: true, //  We lost multi sort at server side :-(, maybe perexg has a better idea
-            reader: groupreader,
+            reader: groupReader,
             remoteGroup: true,
-            groupField: groupField,
+            groupField: conf.groupField ? conf.groupField : false,
             groupDir: 'ASC',
             groupOnSort: false,
             /*multiSort: true,
@@ -1760,9 +1757,6 @@ tvheadend.idnode_grid = function(panel, conf)
             pruneModifiedRecords: true,
             sortInfo: conf.sort ? conf.sort : null
         });
-
-        if (!conf.grouping)
-            store.clearGrouping();
 
         /* Model */
         var model = new Ext.grid.ColumnModel({
@@ -2139,13 +2133,12 @@ tvheadend.idnode_grid = function(panel, conf)
         grid.on('filterupdate', function() {
             page.changePage(0);
         });
+
         if (conf.beforeedit)
             grid.on('beforeedit', conf.beforeedit);
 
-        if (conf.hideColumn){
-            var columnId = grid.getColumnModel().findColumnIndex(conf.hideColumn);
-            grid.getColumnModel().setHidden(columnId, true);
-        }
+        if (conf.viewready)
+            grid.on('viewready', conf.viewready);
 
         dpanel.add(grid);
         dpanel.doLayout(false, true);


### PR DESCRIPTION
I have made some user friendly changes on the webui:

- When show / hide the duplicates recordings, now it show / hide the "rerun of" column. 

- Added the grouping option, is only  enabled by default at "Finished Recordings" (but it can be used in the other tabs) and the group are collapsed, so you can expand the needed group and show the recordings.

I wish it will usefull for others.