### PR TITLE
eit: add language identifier for scraper regexes (#4820)

### DIFF
--- a/data/conf/epggrab/eit/scrape/README
+++ b/data/conf/epggrab/eit/scrape/README
@@ -122,6 +122,38 @@ A useful reference on the differences between POSIX, PCRE and PCRE2
 regular expressions is at
 http://www.regular-expressions.info/refbasic.html.
 
+Languages
+---------
+
+By default, regular expressions are applied to input text in any language.
+You can specify that a regular expression is appropriate only for a
+particular language or group of languages by using an expanded definition
+with a "lang" component. This component may be either a string with a single
+language identifier, or a list of language identifier strings. For
+example:
+
+{
+  "scrape_subtitle": [
+      {
+          "pattern": "^[.][.][.][^:.?!]*[.:?!] +(.*)",
+          "lang": "eng"
+      },
+      {
+          "pattern": "^[0-9]+/[0-9]+[.] +(.*)",
+          "lang": ["eng", "fre"]
+      },
+      "^([^:]+): "
+  ]
+}
+
+If the regular expression is marked with a language or group of languages,
+and the input text language does not match one of those specified for
+the regular expression, the regular expression is ignored and processing
+continues with the next regular expression in the list.
+
+Language codes must be 3 character ISO 639-2 B codes as listed in
+src/lang_codes.c.
+
 Testing
 -------
 

--- a/src/epggrab/module/eit.c
+++ b/src/epggrab/module/eit.c
@@ -480,7 +480,7 @@ _eit_scrape_episode(lang_str_t *str,
 
   /* search for season number */
   RB_FOREACH(se, str, link) {
-    if (eit_pattern_apply_list(buffer, sizeof(buffer), se->str, &eit_mod->p_snum))
+    if (eit_pattern_apply_list(buffer, sizeof(buffer), se->str, se->lang, &eit_mod->p_snum))
       if ((ev->en.s_num = positive_atoi(buffer))) {
         tvhtrace(LS_TBL_EIT,"  extract season number %d using %s", ev->en.s_num, eit_mod->id);
         break;
@@ -489,7 +489,7 @@ _eit_scrape_episode(lang_str_t *str,
 
   /* ...for episode number */
   RB_FOREACH(se, str, link) {
-   if (eit_pattern_apply_list(buffer, sizeof(buffer), se->str, &eit_mod->p_enum))
+    if (eit_pattern_apply_list(buffer, sizeof(buffer), se->str, se->lang, &eit_mod->p_enum))
      if ((ev->en.e_num = positive_atoi(buffer))) {
        tvhtrace(LS_TBL_EIT,"  extract episode number %d using %s", ev->en.e_num, eit_mod->id);
        break;
@@ -498,7 +498,7 @@ _eit_scrape_episode(lang_str_t *str,
 
   /* Extract original air date year */
   RB_FOREACH(se, str, link) {
-    if (eit_pattern_apply_list(buffer, sizeof(buffer), se->str, &eit_mod->p_airdate)) {
+    if (eit_pattern_apply_list(buffer, sizeof(buffer), se->str, se->lang, &eit_mod->p_airdate)) {
       if (strlen(buffer) == 4) {
         /* Year component only, so assume it is the copyright year. */
         ev->copyright_year = positive_atoi(buffer);
@@ -509,7 +509,7 @@ _eit_scrape_episode(lang_str_t *str,
 
   /* Extract is_new flag. Any match is assumed to mean "new" */
   RB_FOREACH(se, str, link) {
-    if (eit_pattern_apply_list(buffer, sizeof(buffer), se->str, &eit_mod->p_is_new)) {
+    if (eit_pattern_apply_list(buffer, sizeof(buffer), se->str, se->lang, &eit_mod->p_is_new)) {
       ev->is_new = 1;
       break;
     }
@@ -540,7 +540,7 @@ _eit_scrape_text(eit_module_t *eit_mod, eit_event_t *ev)
     RB_FOREACH(se, ev->title, link) {
       snprintf(title_summary, sizeof(title_summary), "%s %s",
                se->str, lang_str_get(ev->summary, se->lang));
-      if (eit_pattern_apply_list(buffer, sizeof(buffer), title_summary, &eit_mod->p_scrape_title)) {
+      if (eit_pattern_apply_list(buffer, sizeof(buffer), title_summary, se->lang, &eit_mod->p_scrape_title)) {
         tvhtrace(LS_TBL_EIT, "  scrape title '%s' from '%s' using %s",
                  buffer, title_summary, eit_mod->id);
         lang_str_set(&ls, buffer, se->lang);
@@ -552,7 +552,7 @@ _eit_scrape_text(eit_module_t *eit_mod, eit_event_t *ev)
 
   if (eit_mod->scrape_subtitle) {
     RB_FOREACH(se, ev->summary, link) {
-      if (eit_pattern_apply_list(buffer, sizeof(buffer), se->str, &eit_mod->p_scrape_subtitle)) {
+      if (eit_pattern_apply_list(buffer, sizeof(buffer), se->str, se->lang, &eit_mod->p_scrape_subtitle)) {
         tvhtrace(LS_TBL_EIT, "  scrape subtitle '%s' from '%s' using %s",
                  buffer, se->str, eit_mod->id);
         lang_str_set(&ev->subtitle, buffer, se->lang);
@@ -563,7 +563,7 @@ _eit_scrape_text(eit_module_t *eit_mod, eit_event_t *ev)
   if (eit_mod->scrape_summary) {
     lang_str_t *ls = lang_str_create();
     RB_FOREACH(se, ev->summary, link) {
-      if (eit_pattern_apply_list(buffer, sizeof(buffer), se->str, &eit_mod->p_scrape_summary)) {
+      if (eit_pattern_apply_list(buffer, sizeof(buffer), se->str, se->lang, &eit_mod->p_scrape_summary)) {
         tvhtrace(LS_TBL_EIT, "  scrape summary '%s' from '%s' using %s",
                  buffer, se->str, eit_mod->id);
         lang_str_set(&ls, buffer, se->lang);

--- a/src/epggrab/module/eitpatternlist.h
+++ b/src/epggrab/module/eitpatternlist.h
@@ -27,6 +27,7 @@ typedef struct eit_pattern
   char                        *text;
   tvh_regex_t                 compiled;
   int                         filter;
+  char                        *langs;
   TAILQ_ENTRY(eit_pattern)    p_links;
 } eit_pattern_t;
 
@@ -45,6 +46,6 @@ void eit_pattern_compile_named_list ( eit_pattern_list_t *list, htsmsg_t *m, con
  * match in buf which is of size size_buf.
  * Return the buf or NULL if no match.
  */
-void *eit_pattern_apply_list(char *buf, size_t size_buf, const char *text, eit_pattern_list_t *l);
+void *eit_pattern_apply_list(char *buf, size_t size_buf, const char *text, const char *lang, eit_pattern_list_t *l);
 void eit_pattern_free_list ( eit_pattern_list_t *l );
 #endif

--- a/src/epggrab/module/opentv.c
+++ b/src/epggrab/module/opentv.c
@@ -371,7 +371,7 @@ opentv_parse_event_section_one
         tvhdebug(LS_OPENTV, "    title '%s'", ev.title);
 
         /* try to cleanup the title */
-        if (eit_pattern_apply_list(buffer, sizeof(buffer), ev.title, &mod->p_cleanup_title)) {
+        if (eit_pattern_apply_list(buffer, sizeof(buffer), ev.title, lang, &mod->p_cleanup_title)) {
           tvhtrace(LS_OPENTV, "  clean title '%s'", buffer);
           s = buffer;
         } else {
@@ -392,15 +392,15 @@ opentv_parse_event_section_one
 
         memset(&en, 0, sizeof(en));
         /* search for season number */
-        if (eit_pattern_apply_list(buffer, sizeof(buffer), ev.summary, &mod->p_snum))
+        if (eit_pattern_apply_list(buffer, sizeof(buffer), ev.summary, lang, &mod->p_snum))
           if ((en.s_num = atoi(buffer)))
             tvhtrace(LS_OPENTV,"  extract season number %d", en.s_num);
         /* ...for episode number */
-        if (eit_pattern_apply_list(buffer, sizeof(buffer), ev.summary, &mod->p_enum))
+        if (eit_pattern_apply_list(buffer, sizeof(buffer), ev.summary, lang, &mod->p_enum))
           if ((en.e_num = atoi(buffer)))
             tvhtrace(LS_OPENTV,"  extract episode number %d", en.e_num);
         /* ...for part number */
-        if (eit_pattern_apply_list(buffer, sizeof(buffer), ev.summary, &mod->p_pnum)) {
+        if (eit_pattern_apply_list(buffer, sizeof(buffer), ev.summary, lang, &mod->p_pnum)) {
           if (buffer[0] >= 'a' && buffer[0] <= 'z')
             en.p_num = buffer[0] - 'a' + 1;
           else
@@ -414,7 +414,7 @@ opentv_parse_event_section_one
           save |= epg_episode_set_epnum(ee, &en, &changes3);
 
         /* ...for subtitle */
-        if (eit_pattern_apply_list(buffer, sizeof(buffer), ev.summary, &mod->p_subt)) {
+        if (eit_pattern_apply_list(buffer, sizeof(buffer), ev.summary, lang, &mod->p_subt)) {
           tvhtrace(LS_OPENTV, "  extract subtitle '%s'", buffer);
           ls = lang_str_create2(buffer, lang);
           save |= epg_episode_set_subtitle(ee, ls, &changes3);

--- a/support/testdata/eitscrape/README
+++ b/support/testdata/eitscrape/README
@@ -15,6 +15,8 @@ Input:
 
 - "summary" - summary field from EIT broadcast that will be scraped.
 
+- "language" - optional 3 character ISO 639-2 B language code
+               string specifying the title and summary language.
 
 Expected Result:
 


### PR DESCRIPTION
Allow scraper regexes to be tagged with a single language identifier or
a list of language identifiers.

Tagged regexes will only be used against input text in languages
matching the tag. Otherwise the regex is skipped.

I don't have access to EIT with multilingual text. I have tested the mechanism, but it would be nice to confirm it works under live firing conditions. :-)