### PR TITLE
HTSP: Expose recording files' start and stop time.

### DIFF
--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -942,7 +942,7 @@ htsp_build_dvrentry(htsp_connection_t *htsp, dvr_entry_t *de, const char *method
   htsmsg_field_t *f;
   const char *s = NULL, *error = NULL, *subscriptionError = NULL;
   const char *p, *last;
-  int64_t fsize = -1;
+  int64_t fsize = -1, start, stop;
   uint32_t u32;
   char ubuf[UUID_HEX_SIZE];
 
@@ -1026,6 +1026,11 @@ htsp_build_dvrentry(htsp_connection_t *htsp, dvr_entry_t *de, const char *method
           info = htsmsg_get_list(m, "info");
           if (info)
             htsmsg_set_msg(e, "info", htsmsg_copy(info));
+          if (!htsmsg_get_s64(m, "start", &start))
+            htsmsg_set_s64(e, "start", start);
+          if (!htsmsg_get_s64(m, "stop", &stop))
+            htsmsg_set_s64(e, "stop", stop);
+
           htsmsg_add_msg(l, NULL, e);
         }
       }


### PR DESCRIPTION
The start/stop times of the recording files are needed by Kodi's tvheadend PVR client addon (pvr.hts) to calculate proper recording play times.

It would be great if this PR could also be applied to the 4.2 branch as without this fix Kodi can only work with tvh master (4.3). 