### PR TITLE
Fix: Rerecord of an event added as "previously recorded", typo mismatch and missing "Episode" column in webui 

### DIFF
--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -3238,7 +3238,7 @@ dvr_entry_class_disp_episode_get(void *o)
   if (de->de_epnum.e_num) {
     lang = idnode_lang(o);
     snprintf(buf1, sizeof(buf1), "%s %%d", tvh_gettext_lang(lang, N_("Season")));
-    snprintf(buf1, sizeof(buf1), "%s %%d", tvh_gettext_lang(lang, N_("Episode")));
+    snprintf(buf2, sizeof(buf2), "%s %%d", tvh_gettext_lang(lang, N_("Episode")));
     epg_episode_epnum_format(&de->de_epnum, prop_sbuf, PROP_SBUF_LEN, NULL,
                              buf1, ".", buf2, "/%d");
     return &prop_sbuf_ptr;

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1609,7 +1609,7 @@ static dvr_entry_t *_dvr_duplicate_event(dvr_entry_t *de)
         continue;
 
       // only earlier recordings qualify as master
-      if (de2->de_start > de->de_start)
+      if (de2->de_start > de->de_start && de2->de_last_error != SM_CODE_PREVIOUSLY_RECORDED)
         continue;
 
       // only enabled upcoming recordings
@@ -1640,7 +1640,7 @@ static dvr_entry_t *_dvr_duplicate_event(dvr_entry_t *de)
         continue;
 
       // only earlier recordings qualify as master
-      if (de2->de_start > de->de_start)
+      if (de2->de_start > de->de_start && de2->de_last_error != SM_CODE_PREVIOUSLY_RECORDED)
         continue;
 
       // only enabled upcoming recordings

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -144,7 +144,7 @@ tvheadend.dvrDetails = function(uuid) {
         url: 'api/idnode/load',
         params: {
             uuid: uuid,
-            list: 'channel_icon,disp_title,disp_subtitle,disp_summary,episode,start_real,stop_real,' +
+            list: 'channel_icon,disp_title,disp_subtitle,disp_summary,episode_disp,start_real,stop_real,' +
                   'duration,disp_description,status,filesize,comment,duplicate,' +
                   'autorec_caption,timerec_caption,image,copyright_year,credits,keyword,category,' +
                   'first_aired,genre',
@@ -419,7 +419,7 @@ tvheadend.dvr_upcoming = function(panel, index) {
             }
         },
         del: true,
-        list: 'category,enabled,duplicate,disp_title,disp_subtitle,disp_summary,episode,' +
+        list: 'category,enabled,duplicate,disp_title,disp_subtitle,disp_summary,episode_disp,' +
               'channel,image,copyright_year,start_real,stop_real,duration,pri,filesize,' +
               'sched_status,errors,data_errors,config_name,owner,creator,comment,genre',
         columns: {
@@ -597,7 +597,7 @@ tvheadend.dvr_finished = function(panel, index) {
             }
         },
         del: false,
-        list: 'disp_title,disp_subtitle,disp_summary,episode,channelname,' +
+        list: 'disp_title,disp_subtitle,disp_summary,episode_disp,channelname,' +
               'start_real,stop_real,duration,filesize,copyright_year,' +
               'sched_status,errors,data_errors,playcount,url,config_name,owner,creator,comment,',
         columns: {
@@ -621,8 +621,8 @@ tvheadend.dvr_finished = function(panel, index) {
                 tooltip: _("Play"),
                 renderer: function(v, o, r) {
                     var title = r.data['disp_title'];
-                    if (r.data['episode'])
-                        title += ' / ' + r.data['episode'];
+                    if (r.data['episode_disp'])
+                        title += ' / ' + r.data['episode_disp'];
                     return tvheadend.playLink('play/dvrfile/' + r.id, title);
                 }
             }],
@@ -713,7 +713,7 @@ tvheadend.dvr_failed = function(panel, index) {
         del: true,
         delquestion: _('Do you really want to delete the selected recordings?') + '<br/><br/>' +
                      _('The associated file will be removed from storage.'),
-        list: 'disp_title,disp_subtitle,disp_summary,episode,channelname,' +
+        list: 'disp_title,disp_subtitle,disp_summary,episode_disp,channelname,' +
               'image,copyright_year,start_real,stop_real,duration,filesize,status,' +
               'sched_status,errors,data_errors,playcount,url,config_name,owner,creator,comment',
         columns: {
@@ -737,8 +737,8 @@ tvheadend.dvr_failed = function(panel, index) {
                 tooltip: _("Play"),
                 renderer: function(v, o, r) {
                     var title = r.data['disp_title'];
-                    if (r.data['episode'])
-                        title += ' / ' + r.data['episode'];
+                    if (r.data['episode_disp'])
+                        title += ' / ' + r.data['episode_disp'];
                     return tvheadend.playLink('play/dvrfile/' + r.id, title);
                 }
             }],
@@ -788,7 +788,7 @@ tvheadend.dvr_removed = function(panel, index) {
         uilevel: 'expert',
         edit: { params: { list: tvheadend.admin ? "retention,owner,comment" : "retention,comment" } },
         del: true,
-        list: 'disp_title,disp_subtitle,disp_summary,episode,channelname,image,' +
+        list: 'disp_title,disp_subtitle,disp_summary,episode_disp,channelname,image,' +
               'copyright_year,start_real,stop_real,duration,status,' +
               'sched_status,errors,data_errors,url,config_name,owner,creator,comment',
         columns: {


### PR DESCRIPTION
Since we added the "previously recorded" option, I have been observing that an event added as previously recorded is rescheduled for record if the start time change to an early time. An example:

Event added as previously recorded with a start time of "14/01/2018 15:15:00" (Spanish date format),
If the next time we reimport the xmltv file it has a start time change like: "14/01/2018 15:14:00" then the event will be rescheduled.

After commit #37db5d9 episode column name was changed but not updated in webui.