### PR TITLE
src/epggrab/module.c: Presumed typo in xmltv unix socket listen() call

### DIFF
--- a/src/epggrab/module.c
+++ b/src/epggrab/module.c
@@ -660,7 +660,7 @@ epggrab_module_activate_socket ( void *m, int a )
       return 0;
     }
 
-    if (listen(mod->sock, 5) != 0) {
+    if (listen(sock, 5) != 0) {
       tvherror(mod->subsys, "%s: failed to listen on socket: %s", mod->id, strerror(errno));
       close(sock);
       return 0;


### PR DESCRIPTION
With "mod->sock", the xmltv epg module fails startup with invalid file descriptor, and connections fail with "connection refused".  With "sock", connections succeed and data is accepted.