### PR TITLE
doozer: use git to pull in dvb-scan-tables

### DIFF
--- a/support/getmuxlist
+++ b/support/getmuxlist
@@ -5,7 +5,9 @@
 
 # Arguments
 [ -z "$BRANCH" ] && BRANCH=tvheadend
-[ -z "$URL" ] && URL=https://github.com/tvheadend/dtv-scan-tables.git
+URL_SCHEME=https
+[ ! -z "$DOOZER_JOBID" ] && URL_SCHEME=git
+[ -z "$URL" ] && URL=${URL_SCHEME}://github.com/tvheadend/dtv-scan-tables.git
 DIR="$1" && [ -z "$DIR" ] && DIR=$(dirname "$0")/../data/dvb-scan
 
 # Update


### PR DESCRIPTION
This only applies if DOOZER_JOBID exists.