### PR TITLE
Insert card into card list before setting EMM state (issue #4988)

### DIFF
--- a/src/descrambler/cclient.c
+++ b/src/descrambler/cclient.c
@@ -198,6 +198,8 @@ cc_new_card(cclient_t *cc, uint16_t caid, uint32_t cardid, uint8_t *ua,
   if (j > 0)
     tvhdebug(cc->cc_subsys, "%s: Providers: ID:%08x CAID:%04X:[%s]",
              cc->cc_name, cardid, caid, buf);
+  if (allocated)
+    LIST_INSERT_HEAD(&cc->cc_cards, pcard, cs_card);
   if (cc->cc_emm && ua) {
     ua = pcard->cs_ra.ua;
     i = ua[0] || ua[1] || ua[2] || ua[3] ||
@@ -207,8 +209,6 @@ cc_new_card(cclient_t *cc, uint16_t caid, uint32_t cardid, uint8_t *ua,
   }
 
   pcard->cs_running = 1;
-  if (allocated)
-    LIST_INSERT_HEAD(&cc->cc_cards, pcard, cs_card);
   return pcard;
 }
 


### PR DESCRIPTION
This fixes the bug I described here: https://tvheadend.org/issues/4988

`cc_emm_set_allowed()` expects the card to be already present in `cc->cc_cards`.