### PR TITLE
Update dvr_db.c

### DIFF
--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -2096,7 +2096,7 @@ static dvr_entry_t *_dvr_entry_update
   }
 
   /* Subtitle */
-  if (e &&& e->subtitle) {
+  if (e && e->subtitle) {
     save |= lang_str_set2(&de->de_subtitle, e->subtitle) ? DVR_UPDATED_SUBTITLE : 0;
   } else if (subtitle) {
     save |= lang_str_set(&de->de_subtitle, subtitle, lang) ? DVR_UPDATED_SUBTITLE : 0;


### PR DESCRIPTION
Fix typo -- &&& should have been &&.

Caught by compiling with clang:
src/dvr/dvr_db.c:2099:16: error: address of 'e->subtitle' will always evaluate to 'true' [-Werror,-Wpointer-bool-conversion]