### PR TITLE
Upgrade to libhdhomerun_20171221

### DIFF
--- a/Makefile.hdhomerun
+++ b/Makefile.hdhomerun
@@ -32,10 +32,10 @@ endif
 # Upstream Packages
 # ###########################################################################
 
-LIBHDHR         = libhdhomerun_20170930
+LIBHDHR         = libhdhomerun_20171221
 LIBHDHR_TB      = $(LIBHDHR).tgz
 LIBHDHR_URL     = http://download.silicondust.com/hdhomerun/$(LIBHDHR_TB)
-LIBHDHR_SHA1    = 8a25839abeb6cae25878912c01426db4dccd3192
+LIBHDHR_SHA1    = 6b019728eadea3af7a5686ed5ba44e970bca7365
 
 # ###########################################################################
 # Library Config


### PR DESCRIPTION
This upgrades the static libhdhomerun to 20171221.
If possible, please also merge with the upcoming 4.2.6 release.