### PR TITLE
Fix server crash in satip_server_http_page

### DIFF
--- a/src/satip/server.c
+++ b/src/satip/server.c
@@ -264,11 +264,11 @@ int
 satip_server_http_page(http_connection_t *hc,
                        const char *remain, void *opaque)
 {
-  if (strcmp(remain, "desc.xml") == 0)
+  if (remain && strcmp(remain, "desc.xml") == 0)
     return satip_server_http_xml(hc);
-  if (strcmp(remain, "satip.m3u") == 0)
+  if (remain && strcmp(remain, "satip.m3u") == 0)
     return satip_server_satip_m3u(hc);
-  return 0;
+  return HTTP_STATUS_BAD_REQUEST;
 }
 
 /*


### PR DESCRIPTION
Accessing http://your.ip:9981/satip_server/ crashes TVHeadend. The fix also returns Bad Request for unexpected filenames.