### PR TITLE
Virtual channel tuning support (ATSC and CableCARD networks)

### DIFF
--- a/src/input/mpegts/dvb.h
+++ b/src/input/mpegts/dvb.h
@@ -611,7 +611,7 @@ typedef struct dvb_mux_conf
   dvb_fe_delivery_system_t    dmc_fe_delsys;
   dvb_fe_modulation_t         dmc_fe_modulation;
   uint32_t                    dmc_fe_freq;
-  dvb_fe_vchant_t	          dmc_fe_vchan;
+  dvb_fe_vchan_t	          dmc_fe_vchan;
   dvb_fe_spectral_inversion_t dmc_fe_inversion;
   dvb_fe_rolloff_t            dmc_fe_rolloff;
   dvb_fe_pilot_t              dmc_fe_pilot;

--- a/src/input/mpegts/dvb.h
+++ b/src/input/mpegts/dvb.h
@@ -16,7 +16,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* 
+/*
  * Based on:
  *
  * ITU-T Recommendation H.222.0 / ISO standard 13818-1
@@ -599,12 +599,19 @@ typedef struct dvb_isdbt_config {
   } layers[3];
 } dvb_isdbt_config_t;
 
+typedef struct dvb_fe_vchan {
+	uint32_t	num;
+	uint16_t	minor;
+	char	   *name;
+} dvb_fe_vchan_t;
+
 typedef struct dvb_mux_conf
 {
   dvb_fe_type_t               dmc_fe_type;
   dvb_fe_delivery_system_t    dmc_fe_delsys;
   dvb_fe_modulation_t         dmc_fe_modulation;
   uint32_t                    dmc_fe_freq;
+  dvb_fe_vchant_t	          dmc_fe_vchan;
   dvb_fe_spectral_inversion_t dmc_fe_inversion;
   dvb_fe_rolloff_t            dmc_fe_rolloff;
   dvb_fe_pilot_t              dmc_fe_pilot;
@@ -620,7 +627,7 @@ typedef struct dvb_mux_conf
 
   // For scan file configurations
   LIST_ENTRY(dvb_mux_conf)    dmc_link;
-  
+
 } dvb_mux_conf_t;
 
 /* conversion routines */

--- a/src/input/mpegts/dvb_support.c
+++ b/src/input/mpegts/dvb_support.c
@@ -252,7 +252,7 @@ static inline size_t dvb_convert(int conv,
 
 int
 dvb_get_string
-  (char *dst, size_t dstlen, const uint8_t *src, size_t srclen, 
+  (char *dst, size_t dstlen, const uint8_t *src, size_t srclen,
    const char *dvb_charset, dvb_string_conv_t *conv)
 {
   int ic = -1;
@@ -302,7 +302,7 @@ dvb_get_string
     ic = convert_iso_8859[src[2]];
     src+=3; srclen-=3;
     break;
-    
+
   case 0x11:
     ic = convert_ucs2;
     src++; srclen--;
@@ -376,7 +376,7 @@ dvb_get_string
 
 
 int
-dvb_get_string_with_len(char *dst, size_t dstlen, 
+dvb_get_string_with_len(char *dst, size_t dstlen,
 			const uint8_t *buf, size_t buflen, const char *dvb_charset,
       dvb_string_conv_t *conv)
 {
@@ -1105,9 +1105,27 @@ dvb_mux_conf_str_isdb_t ( dvb_mux_conf_t *dmc, char *buf, size_t bufsize )
            dmc->u.dmc_fe_isdbt.layers[2].time_interleaving);
 }
 
+static int
+dvb_mux_conf_str_vchan(dvb_mux_conf_t *dmc, char *buf, size_t bufsize)
+{
+	if (!dmc->dmc_fe_vchan.minor)
+		return snprintf(buf, bufsize,
+		  "%s channel %u",
+		  dvb_type2str(dmc->dmc_fe_type),
+		  dmc->dmc_fe_vchan.num);
+	else
+		return snprintf(buf, bufsize,
+		  "%s channel %u.%u",
+		  dvb_type2str(dmc->dmc_fe_type),
+		  dmc->dmc_fe_vchan.num,
+		  dmc->dmc_fe_vchan.minor);
+}
+
 int
 dvb_mux_conf_str ( dvb_mux_conf_t *dmc, char *buf, size_t bufsize )
 {
+	if (dmc->dmv_fe_vchan.num)
+		return dvb_mux_conf_str_vchan(dmc, buf, bufsize);
   switch (dmc->dmc_fe_type) {
   case DVB_TYPE_NONE:
     return

--- a/src/input/mpegts/dvb_support.c
+++ b/src/input/mpegts/dvb_support.c
@@ -1124,7 +1124,7 @@ dvb_mux_conf_str_vchan(dvb_mux_conf_t *dmc, char *buf, size_t bufsize)
 int
 dvb_mux_conf_str ( dvb_mux_conf_t *dmc, char *buf, size_t bufsize )
 {
-	if (dmc->dmv_fe_vchan.num)
+	if (dmc->dmc_fe_vchan.num)
 		return dvb_mux_conf_str_vchan(dmc, buf, bufsize);
   switch (dmc->dmc_fe_type) {
   case DVB_TYPE_NONE:

--- a/src/input/mpegts/mpegts_mux_dvb.c
+++ b/src/input/mpegts/mpegts_mux_dvb.c
@@ -555,7 +555,7 @@ dvb_mux_class_vchan_set(void *o, const void *v)
 	r = sscanf(v, "%u%*[.-]%hu",
 	  &lm->lm_tuning.dmc_fe_vchan.num,
 	  &lm->lm_tuning.dmc_fe_vchan.minor);
-	switch r {
+	switch (r) {
 	case 0:
 		return 1;
 	case 1:

--- a/src/input/mpegts/mpegts_mux_dvb.c
+++ b/src/input/mpegts/mpegts_mux_dvb.c
@@ -550,11 +550,17 @@ static int
 dvb_mux_class_vchan_set(void *o, const void *v)
 {
 	dvb_mux_t *lm = (dvb_mux_t *)o;
+	int r;
 
-	lm->lm_tuning.dmc_fe_vchan.minor = 0;
-	sscanf(v, "%u%*[.-]%hu",
+	r = sscanf(v, "%u%*[.-]%hu",
 	  &lm->lm_tuning.dmc_fe_vchan.num,
 	  &lm->lm_tuning.dmc_fe_vchan.minor);
+	switch r {
+	case 0:
+		return 1;
+	case 1:
+		lm->tm_tuning.dmc_fe_vchan.minor = 0;
+	}
 	return 0;
 }
 

--- a/src/input/mpegts/mpegts_mux_dvb.c
+++ b/src/input/mpegts/mpegts_mux_dvb.c
@@ -559,7 +559,7 @@ dvb_mux_class_vchan_set(void *o, const void *v)
 	case 0:
 		return 1;
 	case 1:
-		lm->tm_tuning.dmc_fe_vchan.minor = 0;
+		lm->lm_tuning.dmc_fe_vchan.minor = 0;
 	}
 	return 0;
 }

--- a/src/input/mpegts/mpegts_network_dvb.c
+++ b/src/input/mpegts/mpegts_network_dvb.c
@@ -47,7 +47,7 @@ dvb_network_class_delete ( idnode_t *in )
   char ubuf[UUID_HEX_SIZE];
 
   /* remove config */
-  hts_settings_remove("input/dvb/networks/%s", 
+  hts_settings_remove("input/dvb/networks/%s",
                       idnode_uuid_as_str(in, ubuf));
 
   /* Parent delete */
@@ -792,10 +792,23 @@ noop:
 }
 
 static mpegts_service_t *
-dvb_network_create_service
-  ( mpegts_mux_t *mm, uint16_t sid, uint16_t pmt_pid )
+dvb_network_create_service(mpegts_mux_t *mm, uint16_t sid, uint16_t pmt_pid)
 {
-  return mpegts_service_create1(NULL, mm, sid, pmt_pid, NULL);
+	dvb_mux_t	        *lm = (dvb_mux_t *)mm;
+	mpegts_network_t	*ln = mm->mn_network;
+	mpegts_service_t	*s;
+
+	s = mpegts_service_create1(NULL, mm, sid, pmt_pid, NULL);
+	if (lm->lm_tuning.dmc_fe_vchan.num) {
+		if (!s->s_dvb_provider && ln->mn_provider_network_name)
+			s->s_dvb_provider = strdup(ln->mn_provider_network_name);
+		if (!s->s_dvb_channel_num)
+			s->s_dvb_channel_num = lm->lm_tuning.dmc_fe_vchan.num;
+		if (!s->s_dvb_channel_minor && lm->lm_tuning.dmc_fe_vchan.minor)
+			s->s_dvb_channel_minor = lm->lm_tuning.dmc_fe_vchan.minor;
+		if (!s->s_dvb_svcname && lm->lm_tuning.dmc_fe_vchan.name)
+			s->s_dvb_svcname = lm->lm_tuning.dmc_fe_vchan.name;
+	}
 }
 
 static mpegts_mux_t *
@@ -829,7 +842,7 @@ dvb_network_create0
   if (!(ln = (dvb_network_t*)mpegts_network_create0((void*)ln,
                                      idc, uuid, NULL, conf)))
     return NULL;
-  
+
   /* Callbacks */
   ln->mn_create_mux     = dvb_network_create_mux;
   ln->mn_create_service = dvb_network_create_service;
@@ -912,7 +925,7 @@ void dvb_network_init ( void )
   for (i = 0; i < ARRAY_SIZE(dvb_network_classes); i++)
     mpegts_network_register_builder(dvb_network_classes[i],
                                     dvb_network_builder);
-  
+
   /* Load settings */
   if (!(c = hts_settings_load_r(1, "input/dvb/networks")))
     return;

--- a/src/input/mpegts/mpegts_network_dvb.c
+++ b/src/input/mpegts/mpegts_network_dvb.c
@@ -795,7 +795,7 @@ static mpegts_service_t *
 dvb_network_create_service(mpegts_mux_t *mm, uint16_t sid, uint16_t pmt_pid)
 {
 	dvb_mux_t	        *lm = (dvb_mux_t *)mm;
-	mpegts_network_t	*ln = mm->mn_network;
+	mpegts_network_t	*ln = mm->mm_network;
 	mpegts_service_t	*s;
 
 	s = mpegts_service_create1(NULL, mm, sid, pmt_pid, NULL);
@@ -809,6 +809,7 @@ dvb_network_create_service(mpegts_mux_t *mm, uint16_t sid, uint16_t pmt_pid)
 		if (!s->s_dvb_svcname && lm->lm_tuning.dmc_fe_vchan.name)
 			s->s_dvb_svcname = lm->lm_tuning.dmc_fe_vchan.name;
 	}
+	return s;
 }
 
 static mpegts_mux_t *

--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
@@ -323,6 +323,8 @@ static void tvhdhomerun_device_create(struct hdhomerun_discover_device_t *dInfo)
   } else {
     if (strstr(hd->hd_info.deviceModel, "_atsc"))
       type = DVB_TYPE_ATSC_T;
+    if (strstr(hd->hd_info.deviceModel, "_cablecard"))
+      type = DVB_TYPE_ATSC_C;
   }
 
   hd->hd_override_type = strdup(dvb_type2str(type));

--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c
@@ -254,6 +254,18 @@ tvhdhomerun_frontend_monitor_cb( void *aux )
       tvhdebug(LS_TVHDHOMERUN, "locked");
       hfe->hf_locked = 1;
 
+      /* Set vchan.name from status */
+      dvb_mux_t *lm = (dvb_mux_t *)mm;
+      struct hdhomerun_tuner_vstatus_t tuner_vstatus;
+      char *tuner_vstatus_str;
+      pthread_mutex_lock(&hfe->hf_hdhomerun_device_mutex);
+      res = hdhomerun_device_get_tuner_vstatus(hfe->hf_hdhomerun_tuner,
+        &tuner_vstatus_str, &tuner_vstatus);
+      pthread_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
+      if (res < 1)
+        tvhwarn(LS_TVHDHOMERUN, "tuner_vstatus (%d)", res);
+      lm->lm_tuning.dmc_fe_vchan.name = strdup(tuner_vstatus.name);
+
       /* start input thread */
       tvh_pipe(O_NONBLOCK, &hfe->hf_input_thread_pipe);
       pthread_mutex_lock(&hfe->hf_input_thread_mutex);
@@ -304,6 +316,11 @@ tvhdhomerun_frontend_monitor_cb( void *aux )
 }
 
 static void tvhdhomerun_device_open_pid(tvhdhomerun_frontend_t *hfe, int pid) {
+  /* PID filtering unneeded with virtual channels */
+  dvb_mux_t *lm = (dvb_mux_t *)hfe->hf_mmi->mmi_mux;
+  if (lm->lm_tuning.dmc_fe_vchan.num)
+    return;
+
   char *pfilter;
   char buf[1024];
   int res;
@@ -366,56 +383,63 @@ static int tvhdhomerun_frontend_tune(tvhdhomerun_frontend_t *hfe, mpegts_mux_ins
   int res;
   char *perror;
 
-  /* resolve the modulation type */
-  switch (dmc->dmc_fe_type) {
-    case DVB_TYPE_C:
-      /* the symbol rate */
-      symbol_rate = dmc->u.dmc_fe_qam.symbol_rate / 1000;
-      switch(dmc->dmc_fe_modulation) {
-        case DVB_MOD_QAM_64:
-          snprintf(channel_buf, sizeof(channel_buf), "a8qam64-%d:%u", symbol_rate, dmc->dmc_fe_freq);
-          break;
-        case DVB_MOD_QAM_256:
-          snprintf(channel_buf, sizeof(channel_buf), "a8qam256-%d:%u", symbol_rate, dmc->dmc_fe_freq);
-          break;
-        default:
-          snprintf(channel_buf, sizeof(channel_buf), "auto:%u", dmc->dmc_fe_freq);
-          break;
-      }
-      break;
-    case DVB_TYPE_T:
-      bandwidth = dmc->u.dmc_fe_ofdm.bandwidth / 1000UL;
-      switch (dmc->dmc_fe_modulation) {
-        case DVB_MOD_AUTO:
-            if (dmc->u.dmc_fe_ofdm.bandwidth == DVB_BANDWIDTH_AUTO) {
-                snprintf(channel_buf, sizeof(channel_buf), "auto:%u", dmc->dmc_fe_freq);
-            } else {
-                snprintf(channel_buf, sizeof(channel_buf), "auto%dt:%u", bandwidth, dmc->dmc_fe_freq);
-            }
+  if (dmc->dmc_fe_vchan.num) {
+    if (!dmc->dmc_fe_vchan.minor)
+      snprintf(channel_buf, sizeof(channel_buf), "%u", dmc->dmc_fe_vchan.num);
+    else
+      snprintf(channel_buf, sizeof(channel_buf), "%u.%u", dmc->dmc_fe_vchan.num, dmc->dmc_fe_vchan.minor);
+  } else {
+    /* resolve the modulation type */
+    switch (dmc->dmc_fe_type) {
+      case DVB_TYPE_C:
+        /* the symbol rate */
+        symbol_rate = dmc->u.dmc_fe_qam.symbol_rate / 1000;
+        switch(dmc->dmc_fe_modulation) {
+          case DVB_MOD_QAM_64:
+            snprintf(channel_buf, sizeof(channel_buf), "a8qam64-%d:%u", symbol_rate, dmc->dmc_fe_freq);
             break;
-        case DVB_MOD_QAM_256:
-            if (dmc->dmc_fe_delsys == DVB_SYS_DVBT2) {
-                snprintf(channel_buf, sizeof(channel_buf), "tt%dqam256:%u", bandwidth, dmc->dmc_fe_freq);
-            } else {
-                snprintf(channel_buf, sizeof(channel_buf), "t%dqam256:%u", bandwidth, dmc->dmc_fe_freq);
-            }
+          case DVB_MOD_QAM_256:
+            snprintf(channel_buf, sizeof(channel_buf), "a8qam256-%d:%u", symbol_rate, dmc->dmc_fe_freq);
             break;
-        case DVB_MOD_QAM_64:
-            if (dmc->dmc_fe_delsys == DVB_SYS_DVBT2) {
-                snprintf(channel_buf, sizeof(channel_buf), "tt%dqam64:%u", bandwidth, dmc->dmc_fe_freq);
-            } else {
-                snprintf(channel_buf, sizeof(channel_buf), "t%dqam64:%u", bandwidth, dmc->dmc_fe_freq);
-            }
-            break;
-        default:
-            /* probably won't work but never mind */
+          default:
             snprintf(channel_buf, sizeof(channel_buf), "auto:%u", dmc->dmc_fe_freq);
             break;
-      }
-      break;
-    default:
-      snprintf(channel_buf, sizeof(channel_buf), "auto:%u", dmc->dmc_fe_freq);
-      break;
+        }
+        break;
+      case DVB_TYPE_T:
+        bandwidth = dmc->u.dmc_fe_ofdm.bandwidth / 1000UL;
+        switch (dmc->dmc_fe_modulation) {
+          case DVB_MOD_AUTO:
+              if (dmc->u.dmc_fe_ofdm.bandwidth == DVB_BANDWIDTH_AUTO) {
+                  snprintf(channel_buf, sizeof(channel_buf), "auto:%u", dmc->dmc_fe_freq);
+              } else {
+                  snprintf(channel_buf, sizeof(channel_buf), "auto%dt:%u", bandwidth, dmc->dmc_fe_freq);
+              }
+              break;
+          case DVB_MOD_QAM_256:
+              if (dmc->dmc_fe_delsys == DVB_SYS_DVBT2) {
+                  snprintf(channel_buf, sizeof(channel_buf), "tt%dqam256:%u", bandwidth, dmc->dmc_fe_freq);
+              } else {
+                  snprintf(channel_buf, sizeof(channel_buf), "t%dqam256:%u", bandwidth, dmc->dmc_fe_freq);
+              }
+              break;
+          case DVB_MOD_QAM_64:
+              if (dmc->dmc_fe_delsys == DVB_SYS_DVBT2) {
+                  snprintf(channel_buf, sizeof(channel_buf), "tt%dqam64:%u", bandwidth, dmc->dmc_fe_freq);
+              } else {
+                  snprintf(channel_buf, sizeof(channel_buf), "t%dqam64:%u", bandwidth, dmc->dmc_fe_freq);
+              }
+              break;
+          default:
+              /* probably won't work but never mind */
+              snprintf(channel_buf, sizeof(channel_buf), "auto:%u", dmc->dmc_fe_freq);
+              break;
+        }
+        break;
+      default:
+        snprintf(channel_buf, sizeof(channel_buf), "auto:%u", dmc->dmc_fe_freq);
+        break;
+    }
   }
 
   tvhinfo(LS_TVHDHOMERUN, "tuning to %s", channel_buf);
@@ -427,7 +451,10 @@ static int tvhdhomerun_frontend_tune(tvhdhomerun_frontend_t *hfe, mpegts_mux_ins
     tvherror(LS_TVHDHOMERUN, "failed to acquire lockkey: %s", perror);
     return SM_CODE_TUNING_FAILED;
   }
-  res = hdhomerun_device_set_tuner_channel(hfe->hf_hdhomerun_tuner, channel_buf);
+  if (dmc->dmc_fe_vchan.num)
+    res = hdhomerun_device_set_tuner_vchannel(hfe->hf_hdhomerun_tuner, channel_buf);
+  else
+    res = hdhomerun_device_set_tuner_channel(hfe->hf_hdhomerun_tuner, channel_buf);
   pthread_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
   if(res < 1) {
     tvherror(LS_TVHDHOMERUN, "failed to tune to %s", channel_buf);


### PR DESCRIPTION
This adds the ability for muxes to have virtual channels defined to give an alternative means of tuning information; it is presently only exposed for ATSC-T and ATSC-C networks.

Additionally, if virtual channel tuning information is present in a mux, HDHomeRun tuners will use that information as the preferred tuning method, ignoring any frequency and other tuning information present in the mux. This makes it possible to natively use the HDHomeRun Prime CableCARD tuner as an ATSC-C device using the tvhdhomerun drivers, as opposed to IPTV sources.

Channel number and service/provider information is also retrieved from the mux and passed on to any service created from a mux tuned by virtual channel number if the service stream does not have that information in it.

For more information, please see: http://tvheadend.org/boards/5/topics/32553