### PR TITLE
Upgrade to libhdhomerun_20180327

### DIFF
--- a/Makefile.hdhomerun
+++ b/Makefile.hdhomerun
@@ -32,10 +32,10 @@ endif
 # Upstream Packages
 # ###########################################################################
 
-LIBHDHR         = libhdhomerun_20171221
+LIBHDHR         = libhdhomerun_20180327
 LIBHDHR_TB      = $(LIBHDHR).tgz
 LIBHDHR_URL     = http://download.silicondust.com/hdhomerun/$(LIBHDHR_TB)
-LIBHDHR_SHA1    = 6b019728eadea3af7a5686ed5ba44e970bca7365
+LIBHDHR_SHA1    = a6b0ce4a8b5ea103a9de2d1d9cada4b36e13c74f
 
 # ###########################################################################
 # Library Config


### PR DESCRIPTION
This upgrades the embedded libhdhomerun to version 20180327.
Please also apply to the release/4.2 branch.