### PR TITLE
fix - error: 'strncpy' output truncated before terminating...

### DIFF
--- a/src/filebundle.c
+++ b/src/filebundle.c
@@ -261,7 +261,7 @@ int fb_scandir ( const char *path, fb_dirent ***list )
     i = 0;
     while (fb) {
       (*list)[i] = calloc(1, sizeof(fb_dirent));
-      strncpy((*list)[i]->name, fb->name, sizeof((*list)[i]->name));
+      memcpy((*list)[i]->name, fb->name, sizeof((*list)[i]->name));
       (*list)[i]->name[sizeof((*list)[i]->name)-1] = '\0';
       fb = fb->next;
       i++;

--- a/src/lang_str.c
+++ b/src/lang_str.c
@@ -97,7 +97,7 @@ lang_str_ele_t *lang_str_get2
   /* Check config/requested langs */
   if ((langs = lang_code_split(lang)) != NULL) {
     for (i = 0; i < langs->codeslen; i++) {
-      strncpy(skel.lang, langs->codes[i]->code2b, sizeof(skel.lang));
+      memcpy(skel.lang, langs->codes[i]->code2b, sizeof(skel.lang));
       if ((e = RB_FIND(ls, &skel, link, _lang_cmp)))
         break;
     }
@@ -130,7 +130,7 @@ static int _lang_str_add
   /* Create */
   if (!e) {
     e = malloc(sizeof(*e) + strlen(str) + 1);
-    strncpy(e->lang, lang, sizeof(e->lang));
+    memcpy(e->lang, lang, sizeof(e->lang));
     strcpy(e->str, str);
     RB_INSERT_SORTED(ls, e, link, _lang_cmp);
     save = 1;

--- a/src/rtsp.c
+++ b/src/rtsp.c
@@ -55,7 +55,7 @@ rtsp_send_ext( http_client_t *hc, http_cmd_t cmd,
       http_arg_init(&h);
     }
     strncpy(buf_body, body, sizeof(buf_body));
-    strncat(buf_body, "\r\n", 2);
+    strcat(buf_body, "\r\n");
     snprintf(buf2, sizeof(buf2), "%"PRIu64, (uint64_t)(size + 2));
     http_arg_set(hdr, "Content-Length", buf2);
   }

--- a/src/transcoding/codec/codec.c
+++ b/src/transcoding/codec/codec.c
@@ -102,7 +102,7 @@ codec_get_title(AVCodec *self)
         str_snprintf(codec_title, sizeof(codec_title),
             self->long_name ? "%s: %s%s" : "%s%s%s",
             self->name, self->long_name ? self->long_name : "",
-            (self->capabilities & CODEC_CAP_EXPERIMENTAL) ? " (Experimental)" : "")
+            (self->capabilities & AV_CODEC_CAP_EXPERIMENTAL) ? " (Experimental)" : "")
        ) {
         return NULL;
     }

--- a/src/transcoding/transcode/context.c
+++ b/src/transcoding/transcode/context.c
@@ -498,7 +498,7 @@ tvh_context_open_filters(TVHContext *self,
     struct {
         const AVClass *class;
     } logctx = { &logclass };
-    AVFilter *iavflt = NULL, *oavflt = NULL;
+    const AVFilter *iavflt = NULL, *oavflt = NULL;
     AVFilterInOut *iavfltio = NULL, *oavfltio = NULL;
     AVBufferSrcParameters *par = NULL;
     int i, ret = -1;

--- a/src/wrappers.c
+++ b/src/wrappers.c
@@ -197,8 +197,8 @@ tvhthread_create
     pthread_attr_setstacksize(&_attr, 2*1024*1024);
     attr = &_attr;
   }
-  strncpy(ts->name, "tvh:", 4);
-  strncpy(ts->name+4, name, sizeof(ts->name)-4);
+  memcpy(ts->name, "tvh:", 4);
+  memcpy(ts->name+4, name, sizeof(ts->name)-4);
   ts->name[sizeof(ts->name)-1] = '\0';
   ts->run  = start_routine;
   ts->arg  = arg;


### PR DESCRIPTION
https://tvheadend.org/issues/5112

src/wrappers.c: In function 'tvhthread_create':
src/wrappers.c:200:3: error: 'strncpy' output truncated before terminating nul copying 4 bytes from a string of the same length [-Werror=stringop-truncation]
strncpy(ts->name, "tvh:", 4);
^~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:704: /home/docmax/.cache/pacaur/tvheadend-git/src/tvheadend-git/build.linux/src/wrappers.o] Error 1
==> ERROR: A failure occurred in build().
Aborting...
:: failed to build tvheadend-git package(s)