### PR TITLE
debian: always use gzip compression for deb files (bintray issue) - fixes #5091

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,9 @@ export DH_VERBOSE=1
 %:
 	dh $@ --with-systemd
 
+override_dh_builddeb:
+	dh_builddeb -- -Zgzip
+
 override_dh_auto_configure:
 	dh_auto_configure -- ${AUTOBUILD_CONFIGURE_EXTRA} ${JOBSARGS}
 


### PR DESCRIPTION
This fixes Bintray barf about malformed deb files (it seems to have issues with tar.xz files).

@perexg This needs to be backported to release/4.2 as well :)