### PR TITLE
FreeBSD: Fix recv problem if no data received.

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -454,8 +454,11 @@ tcp_socket_dead(int fd)
   if (err)
     return -err;
 #ifdef PLATFORM_FREEBSD
-  if (recv(fd, NULL, 0, MSG_PEEK | MSG_DONTWAIT) < 0)
+  err = recv(fd, NULL, 0, MSG_PEEK | MSG_DONTWAIT);
+  if (err < 0)
     return -errno;
+  else if (err == 0)
+      return -EIO;
 #else
   if (recv(fd, NULL, 0, MSG_PEEK | MSG_DONTWAIT) == 0)
     return -EIO;


### PR DESCRIPTION
If using satip then we would frequently fail to read the data and then disconnect with errno 0.

So, we now make the FreeBSD socket read consistent with the Linux version and return EIO on non-error (timeout).

We're returning -errno on error, which is what the FreeBSD path used to return.

The github view below of "show changed file" cuts out just before the end of the function where 0 is returned if neither error nor timeout.
