### PR TITLE
WebUI: fix channel tag lookup for autorec (local, not global)

### DIFF
--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -69,7 +69,7 @@ tvheadend.channelLookupName = function(key) {
 tvheadend.channelTagLookupName = function(key) {
     var s = "";
     var tags = tvheadend.getChannelTags();
-    var index = tvheadend.tags.find('key', key);
+    var index = tags.find('key', key);
     if (index !== -1)
         s = tags.getAt(index).get('val');
     return s;


### PR DESCRIPTION
This has been bugging me for some time, and I finally got round to looking at it. It looks like the code references a global store and method (tvheadend.tags.find) when the store is actually local to this function. As such, any "Create Autorec" from the EPG will fail if a channel tag is set, because the lookup of the channel tag won't work.