### PR TITLE
BugFix: SATIP_SETUP_SPECINV0 and SATIP_SETUP_SPECINV1 has the same definition

### DIFF
--- a/src/input/mpegts/satip/satip_private.h
+++ b/src/input/mpegts/satip/satip_private.h
@@ -287,7 +287,7 @@ satip_satconf_t *satip_satconf_get_position
 #define SATIP_SETUP_PIDS21   (1<<3)
 #define SATIP_SETUP_FE       (1<<4)
 #define SATIP_SETUP_SPECINV0 (1<<5)
-#define SATIP_SETUP_SPECINV1 (1<<5)
+#define SATIP_SETUP_SPECINV1 (1<<6)
 
 int
 satip_rtsp_setup( http_client_t *hc,


### PR DESCRIPTION
SATIP_SETUP_SPECINV0 and SATIP_SETUP_SPECINV1 has the same definition.
Because of that specinv=0 is always set in the RTSP header. 
This causes problems with the AVM FritzBox 6590.