### PR TITLE
dvr: Prefer earlier/better schedule events for autorecs.

### DIFF
--- a/src/channels.c
+++ b/src/channels.c
@@ -894,7 +894,7 @@ channel_rename_and_save ( const char *from, const char *to )
 }
 
 int64_t
-channel_get_number ( channel_t *ch )
+channel_get_number ( const channel_t *ch )
 {
   int64_t n = 0;
   idnode_list_mapping_t *ilm;
@@ -1968,4 +1968,23 @@ channel_tag_done ( void )
   while ((ct = TAILQ_FIRST(&channel_tags)) != NULL)
     channel_tag_destroy(ct, 0);
   pthread_mutex_unlock(&global_lock);
+}
+
+int
+channel_has_correct_service_filter(const channel_t *ch, int svf)
+{
+  const idnode_list_mapping_t *ilm;
+  const service_t *service;
+  if (!ch || !svf || svf == PROFILE_SVF_NONE)
+    return 1;
+
+  LIST_FOREACH(ilm, &ch->ch_services, ilm_in2_link) {
+    service = (const service_t*)ilm->ilm_in1;
+    if ((svf == PROFILE_SVF_SD && service_is_sdtv(service)) ||
+        (svf == PROFILE_SVF_HD && service_is_hdtv(service)) ||
+        (svf == PROFILE_SVF_UHD && service_is_uhdtv(service))) {
+      return 1;
+    }
+  }
+  return 0;
 }

--- a/src/channels.h
+++ b/src/channels.h
@@ -197,7 +197,7 @@ char *channel_get_ename ( channel_t *ch, char *dst, size_t dstlen,
 static inline uint32_t channel_get_major ( int64_t chnum ) { return chnum / CHANNEL_SPLIT; }
 static inline uint32_t channel_get_minor ( int64_t chnum ) { return chnum % CHANNEL_SPLIT; }
 
-int64_t channel_get_number ( channel_t *ch );
+int64_t channel_get_number ( const channel_t *ch );
 int channel_set_number ( channel_t *ch, uint32_t major, uint32_t minor );
 
 char *channel_get_number_as_str ( channel_t *ch, char *dst, size_t dstlen );
@@ -220,5 +220,6 @@ channel_t **channel_get_sorted_list_for_tag
   ( const char *sort_type, channel_tag_t *tag, int *_count );
 channel_tag_t **channel_tag_get_sorted_list
   ( const char *sort_type, int *_count );
+int channel_has_correct_service_filter(const channel_t *ch, int svf);
 
 #endif /* CHANNELS_H */

--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -76,6 +76,7 @@ typedef struct dvr_config {
   char *dvr_storage;
   int dvr_pri;
   int dvr_clone;
+  int dvr_complex_scheduling;
   uint32_t dvr_rerecord_errors;
   uint32_t dvr_retention_days;
   uint32_t dvr_removal_days;

--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -973,6 +973,23 @@ const idclass_t dvr_config_class = {
       .group    = 1,
     },
     {
+      .type     = PT_BOOL,
+      .id       = "complex-scheduling",
+      .name     = N_("For autorecs, attempt to find better time slots"),
+      .desc     = N_("When scheduling an autorec, this option attempts "
+                     "to schedule at the earliest time and on the 'best' "
+                     "channel (such as channel with the most failover services). "
+                     "This is useful when multiple timeshift "
+                     "and repeat channels are available. Without this option "
+                     "autorecs may get scheduled on timeshift channels "
+                     "instead of on primary channels. "
+                     "This scheduling "
+                     "requires extra overhead so is disabled by default."),
+      .off      = offsetof(dvr_config_t, dvr_complex_scheduling),
+      .opts     = PO_ADVANCED,
+      .group    = 1,
+    },
+    {
       .type     = PT_STR,
       .id       = "comment",
       .name     = N_("Comment"),

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1715,6 +1715,12 @@ dvr_is_better_recording_timeslot(const epg_broadcast_t *new_bcast, const dvr_ent
   if (!new_channel) return 0;
   if (!old_channel) return 1;
 
+  /* If programme is recording then it is the "best", even if a better
+   * schedule is found after recording starts.
+   */
+  if (old_de->de_sched_state != DVR_SCHEDULED)
+    return 0;
+
   /* Always prefer a recording that has the correct service profile
    * (UHD, HD, SD).  Someone mentioned (#1846) that some channels can
    * show a recording earlier in the week in SD then later in the week

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1809,7 +1809,14 @@ dvr_entry_create_by_autorec(int enabled, epg_broadcast_t *e, dvr_autorec_entry_t
   LIST_FOREACH(de, &dvrentries, de_global_link) {
     if (de->de_bcast == e || epg_episode_match(de->de_bcast, e))
       if (strcmp(dae->dae_owner ?: "", de->de_owner ?: "") == 0) {
-        /* See if our new broadcast is better than our existing schedule */
+        /* See if our new broadcast is better than our existing schedule,
+         * but only if user want this overhead.
+         */
+        if (!dae->dae_config || !dae->dae_config->dvr_profile)
+          return;
+
+        if (!dae->dae_config->dvr_complex_scheduling)
+          return;
 
         /* Our autorec can never be better than a manually scheduled programme
          * since user might schedule to avoid conflicts.

--- a/src/service.c
+++ b/src/service.c
@@ -815,7 +815,7 @@ service_data_timeout(void *aux)
 }
 
 int
-service_is_sdtv(service_t *t)
+service_is_sdtv(const service_t *t)
 {
   char s_type;
   if(t->s_type_user == ST_UNSET)
@@ -834,7 +834,7 @@ service_is_sdtv(service_t *t)
 }
 
 int
-service_is_hdtv(service_t *t)
+service_is_hdtv(const service_t *t)
 {
   char s_type;
   if(t->s_type_user == ST_UNSET)
@@ -854,7 +854,7 @@ service_is_hdtv(service_t *t)
 }
 
 int
-service_is_uhdtv(service_t *t)
+service_is_uhdtv(const service_t *t)
 {
   char s_type;
   if(t->s_type_user == ST_UNSET)
@@ -876,7 +876,7 @@ service_is_uhdtv(service_t *t)
  *
  */
 int
-service_is_radio(service_t *t)
+service_is_radio(const service_t *t)
 {
   int ret = 0;
   char s_type;
@@ -902,7 +902,7 @@ service_is_radio(service_t *t)
  * Is encrypted
  */
 int
-service_is_encrypted(service_t *t)
+service_is_encrypted(const service_t *t)
 {
   elementary_stream_t *st;
   if (((mpegts_service_t *)t)->s_dvb_forcecaid == 0xffff)

--- a/src/service.h
+++ b/src/service.h
@@ -428,16 +428,16 @@ const char *service_servicetype_txt(service_t *t);
 static inline uint16_t service_id16(void *t)
   { return ((service_t *)t)->s_components.set_service_id; }
 
-int service_is_sdtv(service_t *t);
-int service_is_uhdtv(service_t *t);
-int service_is_hdtv(service_t *t);
-int service_is_radio(service_t *t);
-int service_is_other(service_t *t);
+int service_is_sdtv(const service_t *t);
+int service_is_uhdtv(const service_t *t);
+int service_is_hdtv(const service_t *t);
+int service_is_radio(const service_t *t);
+int service_is_other(const service_t *t);
 
-static inline int service_is_tv( service_t *s)
+static inline int service_is_tv( const service_t *s)
   { return service_is_hdtv(s) || service_is_sdtv(s) || service_is_uhdtv(s); }
 
-int service_is_encrypted ( service_t *t );
+int service_is_encrypted ( const service_t *t );
 
 void service_set_enabled ( service_t *t, int enabled, int _auto );
 


### PR DESCRIPTION
We now try to avoid scheduling on a timeshift channel X+1 if we have
the same programme on channel X. If a programme is on at the same time
on multiple channels then we will try and schedule on a better
channel, such as one with more services (such as mixed DVB-T/DVB-S) to
allow service switching fallback on tuner conflict.

An example of the new log entry:

dvr: Autorecord "movie misc" Replacing existing dvr recording entry of
"The Departed" on ITV4+1 @ start 2018-09-20;00:35:00(+0100) with
recording on ITV4 @ start 2018-09-19;23:35:00(+0100)

Context for the change is below:

In some areas, a broadcast programme might be shown at the same time
on multiple channels, or at different times on various timeshift,
repeat, or regional channels.

An example of this is the Astra 28.2E satellite where BBC1 has
multiple (26) regional channels that (mostly) show the same
programmes, but sometimes a region might have a +30m or +1h timeshift
for a single programme.

Similarly the commercial channel "Channel 4" has "Channel 4+1", and a
repeat channel of "4Seven" and various associated HD channels. Homes
receive all these regional channels via one dish and are required for
BBC to manually switch between HD/SD versions for local interest
programmes such as regional news.

Previously, when setting an autorec, the item chosen to record was
based on the first broadcast that matched the criteria (such as film
title). However, this broadcast is not necessarily the earliest or the
best.

So this meant that with timeshift channels, a programme could be
scheduled on X+1 instead of X, so record at 21:00 instead of 20:00.

On other setups, the event might correctly record at 20:00, since
scheduling depended on internal structures and which broadcasts are
found first (such as via OTA updates).

Similarly, in countries where the same programme can be received but
on different channels in different qualities, it was possible to
schedule on a non-HD channel, even though the user wanted HD purely
because the non-HD broadcast was found first and the channels were not
merged.

So we now check our recording list to determine if the event is better
than the already scheduled event. If so, the existing recording event
is replaced.

For our criteria, "better" is defined in the function
dvr_is_better_recording_timeslot, and has a variety of criteria such
as "matches service filter", "earlier start", and "has more services"
(so more likely to be able to failover if there is a problem).  If
other criteria are equal, then we use the channel with the lowest
channel number since Europe EPG has lower channel numbers for
'better' channels.

When determining if an autorec can be scheduled in a better timeslot,
we must only check against other autorecs and not a manually scheduled
entry since the user might schedule a recording at a later date
specifically to avoid conflicts.

This is achieved by replacing the old scheduled recording with a new
scheduled recording. A new log message indicates when this occurs.

Performance: Initial testing suggests that this rescheduling can occur
between zero and two times per programme (when there is an initial
schedule on +1, then a reschedule on non-timeshift SD, then final
schedule on HD). However, it should not add significant runtime
overhead for most people.