### PR TITLE
Upgrade to libhdhomerun_20180817

### DIFF
--- a/Makefile.hdhomerun
+++ b/Makefile.hdhomerun
@@ -32,10 +32,10 @@ endif
 # Upstream Packages
 # ###########################################################################
 
-LIBHDHR         = libhdhomerun_20180327
+LIBHDHR         = libhdhomerun_20180817
 LIBHDHR_TB      = $(LIBHDHR).tgz
 LIBHDHR_URL     = http://download.silicondust.com/hdhomerun/$(LIBHDHR_TB)
-LIBHDHR_SHA1    = a6b0ce4a8b5ea103a9de2d1d9cada4b36e13c74f
+LIBHDHR_SHA1    = 052868bde3a5713c55b4d060b77e0bc3a0d891d6
 
 # ###########################################################################
 # Library Config


### PR DESCRIPTION
This upgrades the embedded libhdhomerun to version 20180817.
Please also apply to the release/4.2 branch.