### PR TITLE
FreeBSD: Check for fdatasync system call

### DIFF
--- a/configure
+++ b/configure
@@ -173,6 +173,12 @@ int test(int argc, char **argv) {
   return 0;
 }'
 
+check_cc_snippet fdatasync '#include <unistd.h>
+int test(int argc, char **argv) {
+  fdatasync(0);
+  return 0;
+}'
+
 check_cc_snippet getloadavg '#include <stdlib.h>
 void test() { getloadavg(NULL,0); }'
 

--- a/src/muxer.c
+++ b/src/muxer.c
@@ -29,10 +29,13 @@
 #include "muxer/muxer_libav.h"
 #endif
 
+/* Newer platforms such as FreeBSD 11.1 support fdatasync so only alias on older systems */
+#ifndef CONFIG_FDATASYNC
 #if defined(PLATFORM_DARWIN)
 #define fdatasync(fd)       fcntl(fd, F_FULLFSYNC)
 #elif defined(PLATFORM_FREEBSD)
 #define fdatasync(fd)       fsync(fd)
+#endif
 #endif
 
 /**


### PR DESCRIPTION
It's supported on FreeBSD 11.1 and later, so add check to configure.
