### PR TITLE
Clang remove no-incompatible-pointers Makefile option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ endif
 ifeq ($(COMPILER), clang)
 CFLAGS  += -Wno-microsoft -Qunused-arguments -Wno-unused-function
 CFLAGS  += -Wno-unused-value -Wno-tautological-constant-out-of-range-compare
-CFLAGS  += -Wno-parentheses-equality -Wno-incompatible-pointer-types
+CFLAGS  += -Wno-parentheses-equality
 endif
 
 

--- a/src/descrambler/caid.c
+++ b/src/descrambler/caid.c
@@ -81,7 +81,7 @@ const char *
 caid2name(uint16_t caid)
 {
   const char *s = NULL;
-  static char __thread buf[20];
+  static __thread char buf[20];
   struct caid_tab *tab;
   int i;
 

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -48,7 +48,7 @@ static void *dvr_thread(void *aux);
 static void dvr_thread_epilog(dvr_entry_t *de, const char *dvr_postproc);
 
 
-const static int prio2weight[6] = {
+static const int prio2weight[6] = {
   [DVR_PRIO_IMPORTANT]   = 500,
   [DVR_PRIO_HIGH]        = 400,
   [DVR_PRIO_NORMAL]      = 300,

--- a/src/epg.c
+++ b/src/epg.c
@@ -1929,7 +1929,7 @@ static const char **_epg_genre_names[16][16] = {
 
 static const char *_genre_get_name(int a, int b, const char *lang)
 {
-  static char __thread name[64];
+  static __thread char name[64];
   size_t l = 0;
   const char **p = _epg_genre_names[a][b];
   name[0] = '\0';

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -3951,7 +3951,7 @@ htsp_event_delete(epg_broadcast_t *ebc)
   htsp_async_send(m, HTSP_ASYNC_EPG, HTSP_ASYNC_AUX_EPG, ebc);
 }
 
-const static char frametypearray[PKT_NTYPES] = {
+static const char frametypearray[PKT_NTYPES] = {
   [PKT_I_FRAME] = 'I',
   [PKT_P_FRAME] = 'P',
   [PKT_B_FRAME] = 'B',

--- a/src/http.c
+++ b/src/http.c
@@ -1526,7 +1526,7 @@ http_arg_get(http_arg_list_t *list, const char *name)
 char *
 http_arg_get_remove(struct http_arg_list *list, const char *name)
 {
-  static char __thread buf[128];
+  static __thread char buf[128];
   int empty;
   http_arg_t *ra;
   TAILQ_FOREACH(ra, list, link)

--- a/src/input/mpegts/dvb.h
+++ b/src/input/mpegts/dvb.h
@@ -693,7 +693,7 @@ int dvb_mux_conf_str ( dvb_mux_conf_t *conf, char *buf, size_t bufsize );
 
 const char *dvb_sat_position_to_str( int position, char *buf, size_t buflen );
 
-const int dvb_sat_position_from_str( const char *buf );
+int dvb_sat_position_from_str( const char *buf );
 
 static inline int dvb_modulation_is_none_or_auto ( int modulation )
 {

--- a/src/input/mpegts/dvb_support.c
+++ b/src/input/mpegts/dvb_support.c
@@ -660,7 +660,7 @@ static int dvb_verify(int val, int *table)
 
 const char *dvb_rolloff2str(int p)
 {
-  static char __thread buf[16];
+  static __thread char buf[16];
   const char *res = dvb_common2str(p);
   if (res)
     return res;
@@ -682,7 +682,7 @@ int dvb_str2rolloff(const char *p)
   return dvb_verify(atoi(p) * 10, rolloff_table);
 }
 
-const static struct strtab delsystab[] = {
+static const struct strtab delsystab[] = {
   { "NONE",         DVB_SYS_NONE },
   { "DVB-C",        DVB_SYS_DVBC_ANNEX_A },
   { "DVBC/ANNEX_A", DVB_SYS_DVBC_ANNEX_A },
@@ -765,7 +765,7 @@ dvb_delsys2type ( mpegts_network_t *ln, dvb_fe_delivery_system_t delsys )
 
 const char *dvb_fec2str(int p)
 {
-  static char __thread buf[16];
+  static __thread char buf[16];
   const char *res = dvb_common2str(p);
   if (res)
     return res;
@@ -821,7 +821,7 @@ int dvb_str2fec(const char *p)
   return dvb_verify(hi * 100 + lo, fec_table);
 }
 
-const static struct strtab qamtab[] = {
+static const struct strtab qamtab[] = {
   { "NONE",      DVB_MOD_NONE },
   { "AUTO",      DVB_MOD_AUTO },
   { "QPSK",      DVB_MOD_QPSK },
@@ -863,7 +863,7 @@ dvb_str2val(qam);
 
 const char *dvb_bw2str(int p)
 {
-  static char __thread buf[17];
+  static __thread char buf[17];
   const char *res = dvb_common2str(p);
   if (res)
     return res;
@@ -897,7 +897,7 @@ int dvb_str2bw(const char *p)
   return dvb_verify(hi, bw_table);
 }
 
-const static struct strtab invertab[] = {
+static const struct strtab invertab[] = {
   { "NONE",  DVB_INVERSION_UNDEFINED },
   { "AUTO",  DVB_INVERSION_AUTO },
   { "ON",    DVB_INVERSION_ON },
@@ -905,7 +905,7 @@ const static struct strtab invertab[] = {
 };
 dvb_str2val(inver);
 
-const static struct strtab modetab[] = {
+static const struct strtab modetab[] = {
   { "NONE",  DVB_TRANSMISSION_MODE_NONE },
   { "AUTO",  DVB_TRANSMISSION_MODE_AUTO },
   { "1k",    DVB_TRANSMISSION_MODE_1K },
@@ -919,7 +919,7 @@ const static struct strtab modetab[] = {
 };
 dvb_str2val(mode);
 
-const static struct strtab guardtab[] = {
+static const struct strtab guardtab[] = {
   { "NONE",   DVB_GUARD_INTERVAL_NONE },
   { "AUTO",   DVB_GUARD_INTERVAL_AUTO },
   { "1/4",    DVB_GUARD_INTERVAL_1_4 },
@@ -935,7 +935,7 @@ const static struct strtab guardtab[] = {
 };
 dvb_str2val(guard);
 
-const static struct strtab hiertab[] = {
+static const struct strtab hiertab[] = {
   { "NONE", DVB_HIERARCHY_NONE },
   { "AUTO", DVB_HIERARCHY_AUTO },
   { "1",    DVB_HIERARCHY_1 },
@@ -944,7 +944,7 @@ const static struct strtab hiertab[] = {
 };
 dvb_str2val(hier);
 
-const static struct strtab poltab[] = {
+static const struct strtab poltab[] = {
   { "V", DVB_POLARISATION_VERTICAL },
   { "H", DVB_POLARISATION_HORIZONTAL },
   { "L", DVB_POLARISATION_CIRCULAR_LEFT },
@@ -953,7 +953,7 @@ const static struct strtab poltab[] = {
 };
 dvb_str2val(pol);
 
-const static struct strtab typetab[] = {
+static const struct strtab typetab[] = {
   {"DVB-T",     DVB_TYPE_T},
   {"DVB-C",     DVB_TYPE_C},
   {"DVB-S",     DVB_TYPE_S},
@@ -976,7 +976,7 @@ const static struct strtab typetab[] = {
 };
 dvb_str2val(type);
 
-const static struct strtab pilottab[] = {
+static const struct strtab pilottab[] = {
   {"NONE", DVB_PILOT_NONE},
   {"AUTO", DVB_PILOT_AUTO},
   {"ON",   DVB_PILOT_ON},
@@ -984,7 +984,7 @@ const static struct strtab pilottab[] = {
 };
 dvb_str2val(pilot);
 
-const static struct strtab plsmodetab[] = {
+static const struct strtab plsmodetab[] = {
   {"ROOT", DVB_PLS_ROOT},
   {"GOLD", DVB_PLS_GOLD},
   {"COMBO", DVB_PLS_COMBO},
@@ -1165,7 +1165,7 @@ dvb_sat_position_to_str(int position, char *buf, size_t buflen)
   return buf;
 }
 
-const int
+int
 dvb_sat_position_from_str( const char *buf )
 {
   const char *s = buf;

--- a/src/input/mpegts/linuxdvb/linuxdvb_ddci.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_ddci.c
@@ -534,7 +534,7 @@ linuxdvb_ddci_rd_thread_statistic_clr ( linuxdvb_ddci_rd_thread_t *ddci_rd_threa
   ddci_rd_thread->lddci_recv_pkgCntSL = 0;
 }
 
-static int inline
+static inline int
 ddci_ts_sync_count ( const uint8_t *tsb, int len )
 {
   const uint8_t *start = tsb;

--- a/src/input/mpegts/mpegts_input.c
+++ b/src/input/mpegts/mpegts_input.c
@@ -1111,7 +1111,7 @@ static int data_noise ( mpegts_packet_t *mp )
 static inline int data_noise( mpegts_packet_t *mp ) { return 0; }
 #endif
 
-static int inline
+static inline int
 get_pcr ( const uint8_t *tsb, int64_t *rpcr )
 {
   int_fast64_t pcr;
@@ -1133,7 +1133,7 @@ get_pcr ( const uint8_t *tsb, int64_t *rpcr )
   return 1;
 }
 
-static int inline
+static inline int
 ts_sync_count ( const uint8_t *tsb, int len )
 {
   const uint8_t *start = tsb;

--- a/src/intlconv.c
+++ b/src/intlconv.c
@@ -92,7 +92,7 @@ intlconv_charset_id( const char *charset,
                      int transil,
                      int ignore_bad_chars )
 {
-  static char __thread buf[128];
+  static __thread char buf[128];
   const char *delim;
 
   if (charset == NULL || charset[0] == '\0' ||

--- a/src/parsers/parsers.c
+++ b/src/parsers/parsers.c
@@ -727,7 +727,7 @@ parse_aac(parser_t *t, parser_es_t *st, const uint8_t *data,
 /**
  * MPEG layer 1/2/3 parser
  */
-const static int mpa_br[2][3][16] = {
+static const int mpa_br[2][3][16] = {
 {
   {0, 32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448, 0},
   {0, 32, 48, 56,  64,  80,  96, 112, 128, 160, 192, 224, 256, 320, 384, 0},
@@ -740,8 +740,8 @@ const static int mpa_br[2][3][16] = {
 }
 };
 
-const static int mpa_sr[4]  = {44100, 48000, 32000, 0};
-const static int mpa_sri[4] = {4,     3,     5,     0};
+static const int mpa_sr[4]  = {44100, 48000, 32000, 0};
+static const int mpa_sri[4] = {4,     3,     5,     0};
 
 static inline int
 mpa_valid_frame(uint32_t h)
@@ -851,9 +851,9 @@ static void parse_pes_mpa(parser_t *t, parser_es_t *st,
 /**
  * (E)AC3 audio parser
  */
-const static int ac3_freq_tab[4] = {48000, 44100, 32000, 0};
+static const int ac3_freq_tab[4] = {48000, 44100, 32000, 0};
 
-const static uint16_t ac3_frame_size_tab[38][3] = {
+static const uint16_t ac3_frame_size_tab[38][3] = {
     { 64,   69,   96   },
     { 64,   70,   96   },
     { 80,   87,   120  },

--- a/src/profile.c
+++ b/src/profile.c
@@ -1103,7 +1103,7 @@ profile_chain_raw_open(profile_chain_t *prch, void *id, size_t qsize, int muxer)
  *
  */
 
-const static int prio2weight[] = {
+static const int prio2weight[] = {
   [PROFILE_SPRIO_DVR_IMPORTANT]   = 525,
   [PROFILE_SPRIO_DVR_HIGH]        = 425,
   [PROFILE_SPRIO_DVR_NORMAL]      = 325,

--- a/src/prop.c
+++ b/src/prop.c
@@ -36,7 +36,7 @@ const char *prop_ptr;
 /**
  *
  */
-const static struct strtab typetab[] = {
+static const struct strtab typetab[] = {
   { "bool",    PT_BOOL },
   { "int",     PT_INT },
   { "str",     PT_STR },

--- a/src/transcoding/codec/codec.c
+++ b/src/transcoding/codec/codec.c
@@ -95,7 +95,7 @@ codec_get_type_string(AVCodec *self)
 const char *
 codec_get_title(AVCodec *self)
 {
-    static char __thread codec_title[TVH_TITLE_LEN];
+    static __thread char codec_title[TVH_TITLE_LEN];
 
     memset(codec_title, 0, sizeof(codec_title));
     if (

--- a/src/transcoding/codec/profile.c
+++ b/src/transcoding/codec/profile.c
@@ -185,7 +185,7 @@ tvh_codec_profile_get_name(TVHCodecProfile *self)
 const char *
 tvh_codec_profile_get_title(TVHCodecProfile *self)
 {
-    static char __thread profile_title[TVH_TITLE_LEN];
+    static __thread char profile_title[TVH_TITLE_LEN];
 
     memset(profile_title, 0, sizeof(profile_title));
     if (str_snprintf(profile_title, sizeof(profile_title),

--- a/src/tvhpoll.c
+++ b/src/tvhpoll.c
@@ -193,7 +193,7 @@ static int tvhpoll_add0
   struct kevent *ev = alloca(EV_SIZE * num * 2);
   for (i = j = 0; i < num; i++) {
     const int fd = evs[i].fd;
-    const void *ptr = evs[i].ptr;
+    void *ptr = evs[i].ptr;
     const uint32_t events = evs[i].events;
     const uint32_t oevents = tvhpoll_get_events(tp, fd);
     if (events == oevents) continue;

--- a/src/wrappers.c
+++ b/src/wrappers.c
@@ -656,7 +656,8 @@ int regex_match_substring_length(tvh_regex_t *regex, unsigned number)
 void *blacklisted_memcpy(void *dest, const void *src, size_t n)
   __attribute__((no_sanitize("thread")))
 {
-  uint8_t *d = dest, *s = src;
+  uint8_t *d = dest;
+  const uint8_t *s = src;
   while (n-- > 0) *d++ = *s++;
   return dest;
 }


### PR DESCRIPTION
Remove the option "no-incompatible-pointer-types" for clang since gcc does warn for such types and the official build is done with gcc, making clang builds sometimes not compile with gcc.

Fixed up the couple of locations with such incompatible pointers (mainly const). Also fixed up a few places that gcc can warn about out style declaration (mainly "static" not being first and "__thread" not being before type).