### PR TITLE
dvr: Add minyear/maxyear to autorec.

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -401,6 +401,8 @@ typedef struct dvr_autorec_entry {
 
   int dae_minduration;
   int dae_maxduration;
+  int dae_minyear;
+  int dae_maxyear;
   uint32_t dae_retention;
   uint32_t dae_removal;
   uint32_t dae_btype;

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -891,7 +891,7 @@ tvheadend.dvr_settings = function(panel, index) {
 tvheadend.autorec_editor = function(panel, index) {
 
     var list = 'name,title,fulltext,channel,start,start_window,weekdays,' +
-               'record,tag,btype,content_type,cat1,cat2,cat3,minduration,maxduration,' +
+               'record,tag,btype,content_type,cat1,cat2,cat3,minduration,maxduration,minyear,maxyear,' +
                'star_rating,dedup,directory,config_name,comment,pri';
     var elist = 'enabled,start_extra,stop_extra,' +
                 (tvheadend.accessUpdate.admin ?


### PR DESCRIPTION
My listings provider thinks every old film is worth 5/5, so we add
minyear to allow an autorec of "good films" to filter out old
films. Also add corresponding maxyear for people who think the
opposite and only want old programmes recorded.