### PR TITLE
ui: Add grouping format specifier for dates.

### DIFF
--- a/src/webui/static/app/idnode.js
+++ b/src/webui/static/app/idnode.js
@@ -339,6 +339,21 @@ tvheadend.IdNodeField = function(conf)
             props.renderer = Ext.ux.grid.CheckColumn.prototype.renderer;
         }
 
+        // Special handling for date/time fields.
+        if (ftype == 'date')
+        {
+            // When grouping, only use date and do not include
+            // timestamp, otherwise when grouping recordings, you can
+            // get hundreds of groups, each containing one recording.
+            // This format is for group section titles only, and not
+            // for normal display of dates nor for the display of
+            // dates inside of a group.
+            props.groupRenderer = function(v, m, r) {
+                var date = new Date(v*1000);
+                return date.toLocaleString(tvheadend.toLocaleFormat(), {weekday: 'short', day: 'numeric', month: 'long', year: 'numeric'});
+            }
+        };
+
         return props;
     };
 


### PR DESCRIPTION
When grouping recordings by datetime, each group tends to only
have one recording since time field is unique.

So, when grouping, we only use the date-portion and not the time
portion in order to create the group.

This only affects the title of the group, not the display of the field
in the column. It means most groups then get more than one item
in the group and can be  useful when grouping upcoming recordings.

