### PR TITLE
FreeBSD makefile fixups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -479,6 +479,11 @@ SRCS-INOTIFY = \
 	src/dvr/dvr_inotify.c
 SRCS-${CONFIG_INOTIFY} += $(SRCS-INOTIFY)
 I18N-C += $(SRCS-INOTIFY)
+ifeq ($(CONFIG_INOTIFY), yes)
+ifeq ($(PLATFORM), freebsd)
+LDFLAGS += -linotify
+endif
+endif
 
 # Avahi
 SRCS-AVAHI = \

--- a/Makefile.webui
+++ b/Makefile.webui
@@ -45,6 +45,12 @@ else
 DEBUG = -debug
 endif
 
+ifeq ($(PLATFORM), freebsd)
+STAT_ARG=-f "%-35N %7z"
+else
+STAT_ARG=--printf="%-35n %7s\n"
+endif
+
 JAVASCRIPT =
 JAVASCRIPT2 =
 JAVASCRIPT_TV =
@@ -194,22 +200,22 @@ define GO_JS
 	$(VV)$(CSS_PY) --in="$^" utf-check
 	$(VV)cat $^ > $@.tmp
 	$(VV)$(RUN_JS) < $@.tmp > $@.tmp2
-	@stat --printf="%-35n %7s\n" $@.tmp $@.tmp2
+	@stat $(STAT_ARG) $@.tmp $@.tmp2
 	$(VV)$(GZIPCMD) -c $@.tmp2 > $@.tmp
 	@rm $@.tmp2
 	@mv $@.tmp $@
-	@stat --printf="%-35n %7s\n" $@
+	@stat $(STAT_ARG) $@
 endef
 
 define GO_CSS
 	$(VV)$(CSS_PY) --in="$^" utf-check
 	$(VV)$(CSS_PY) --in="$^" > $@.tmp
 	$(VV)$(RUN_CSS) < $@.tmp > $@.tmp2
-	@stat --printf="%-35n %7s\n" $@.tmp $@.tmp2
+	@stat $(STAT_ARG) $@.tmp $@.tmp2
 	$(VV)$(GZIPCMD) -c $@.tmp2 > $@.tmp
 	@rm $@.tmp2
 	@mv $@.tmp $@
-	@stat --printf="%-35n %7s\n" $@
+	@stat $(STAT_ARG) $@
 endef
 
 define merge-po


### PR DESCRIPTION
Couple of minor fixups for FreeBSD. The "stat(1)" command on FreeBSD takes different arguments. It also requires libinotify for inotify support, otherwise the compile works but the link fails.

