### PR TITLE
dvr: Add minseason and maxseason to autorec (#5176)

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -404,6 +404,8 @@ typedef struct dvr_autorec_entry {
   int dae_maxduration;
   int dae_minyear;
   int dae_maxyear;
+  int dae_minseason;
+  int dae_maxseason;
   uint32_t dae_retention;
   uint32_t dae_removal;
   uint32_t dae_btype;

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -166,6 +166,8 @@ autorec_cmp(dvr_autorec_entry_t *dae, epg_broadcast_t *e)
      (dae->dae_maxduration <= 0 || dae->dae_maxduration > 24 * 3600) &&
      dae->dae_minyear <= 0 &&
      dae->dae_maxyear <= 0 &&
+     dae->dae_minseason <= 0 &&
+     dae->dae_maxseason <= 0 &&
      dae->dae_serieslink_uri == NULL)
     return 0; // Avoid super wildcard match
 
@@ -268,6 +270,14 @@ autorec_cmp(dvr_autorec_entry_t *dae, epg_broadcast_t *e)
 
   if(dae->dae_maxyear > 0) {
     if(e->copyright_year > dae->dae_maxyear) return 0;
+  }
+
+  if(dae->dae_minseason > 0) {
+    if(e->epnum.s_num < dae->dae_minseason) return 0;
+  }
+
+  if(dae->dae_maxseason > 0) {
+    if(e->epnum.s_num > dae->dae_maxseason) return 0;
   }
 
   if(dae->dae_weekdays != 0x7f) {
@@ -1257,6 +1267,22 @@ const idclass_t dvr_autorec_entry_class = {
       .desc     = N_("The latest year for the programme. Programmes must be equal to or earlier than this year."),
       .list     = dvr_autorec_entry_class_year_list,
       .off      = offsetof(dvr_autorec_entry_t, dae_maxyear),
+      .opts     = PO_EXPERT | PO_DOC_NLIST,
+    },
+    {
+      .type     = PT_U16,
+      .id       = "minseason",
+      .name     = N_("Minimum season"),
+      .desc     = N_("The earliest season for the programme. Programmes must be equal to or later than this season."),
+      .off      = offsetof(dvr_autorec_entry_t, dae_minseason),
+      .opts     = PO_EXPERT | PO_DOC_NLIST,
+    },
+    {
+      .type     = PT_U16,
+      .id       = "maxseason",
+      .name     = N_("Maximum season"),
+      .desc     = N_("The latest season for the programme. Programmes must be equal to or earlier than this season."),
+      .off      = offsetof(dvr_autorec_entry_t, dae_maxseason),
       .opts     = PO_EXPERT | PO_DOC_NLIST,
     },
     {

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -972,7 +972,7 @@ tvheadend.dvr_settings = function(panel, index) {
 tvheadend.autorec_editor = function(panel, index) {
 
     var list = 'name,title,fulltext,channel,start,start_window,weekdays,' +
-               'record,tag,btype,content_type,cat1,cat2,cat3,minduration,maxduration,minyear,maxyear,' +
+               'record,tag,btype,content_type,cat1,cat2,cat3,minduration,maxduration,minyear,maxyear,minseason,maxseason,' +
                'star_rating,dedup,directory,config_name,comment,pri';
     var elist = 'enabled,start_extra,stop_extra,' +
                 (tvheadend.accessUpdate.admin ?


### PR DESCRIPTION
This allows users to specify specific seasons to record, season has to be >= min and <= max.

This isn't quite what was requested in bug: it wanted a concat of title,subtitle,summary,description to allow users to regex seasons to record. But that method I think would be slow and a bit error prone with the OTA scrapers. So, instead I added another min/max field to autorec.

For example min=5,max=5 will record only season 5.

Setting min=5,max=0 will record everything on season 5 or
later, which is useful if you've already seen seasons 1--4.

This can then be combined with the normal fulltext regex
such as "Simpsons"+minseason=12.

Fixes: #5176
