### PR TITLE
dvr: Fix async autorec reschedule info message logging/looping

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -207,7 +207,7 @@ typedef struct dvr_entry {
   LIST_ENTRY(dvr_entry) de_config_link;
 
   int de_enabled;
-
+  time_t de_create;             ///< Time entry was created
   time_t de_start;
   time_t de_stop;
 

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -949,7 +949,7 @@ dvr_entry_create(const char *uuid, htsmsg_t *conf, int clone)
   dvr_entry_t *de, *de2;
   int64_t start, stop;
   htsmsg_t *m;
-  char ubuf[UUID_HEX_SIZE];
+  char ubuf[UUID_HEX_SIZE], ubuf2[UUID_HEX_SIZE];
   const char *s;
 
   if (conf) {
@@ -1032,7 +1032,7 @@ dvr_entry_create(const char *uuid, htsmsg_t *conf, int clone)
           idnode_uuid_as_str(&de->de_id, ubuf),
           lang_str_get(de->de_title, NULL), DVR_CH_NAME(de),
           (int64_t)de2->de_start, de->de_creator ?: "",
-          idnode_uuid_as_str(&de2->de_id, ubuf));
+          idnode_uuid_as_str(&de2->de_id, ubuf2));
         dvr_entry_destroy(de, 1);
         return NULL;
       }

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -990,7 +990,7 @@ dvr_entry_create(const char *uuid, htsmsg_t *conf, int clone)
        * and get something reasonable. For all new records however, we
        * use now since they will be written to disk.
        */
-      now = time(NULL);
+      now = gclk();
       if (now > start && start < now - 86400)
           create = start;
       else
@@ -1803,9 +1803,9 @@ dvr_is_better_recording_timeslot(const epg_broadcast_t *new_bcast, const dvr_ent
    * get 50 minutes.
    */
   if (new_bcast->start != old_bcast->start) {
-    if (new_bcast->start > old_bcast->start && time(NULL) >  old_bcast->start) {
+    if (new_bcast->start > old_bcast->start && gclk() >  old_bcast->start) {
       return 1;
-    } else if (new_bcast->start < old_bcast->start && time(NULL) > new_bcast->start) {
+    } else if (new_bcast->start < old_bcast->start && gclk() > new_bcast->start) {
       return 0;
     }
 
@@ -2055,7 +2055,7 @@ dvr_entry_destroy(dvr_entry_t *de, int delconf)
    * created and then immediately destroyed, giving a few seconds
    * lee-way in case of slow hardware.
    */
-  if (!de->de_create || time(NULL) - de->de_create > 10)
+  if (!de->de_create || gclk() - de->de_create > 10)
       dvr_autorec_async_reschedule();
   dvr_entry_dec_ref(de);
 }

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1702,6 +1702,12 @@ static dvr_entry_t *_dvr_duplicate_event(dvr_entry_t *de)
 static int
 dvr_is_better_recording_timeslot(const epg_broadcast_t *new_bcast, const dvr_entry_t *old_de)
 {
+  /* If programme is recording (or completed) then it is the "best",
+   * even if a better schedule is found after recording starts.
+   */
+  if (old_de->de_sched_state != DVR_SCHEDULED)
+    return 0;
+
   if (!old_de || !old_de->de_bcast) return 1;            /* Old broadcast should always exist */
   int old_services = 0;
   int new_services = 0;
@@ -1714,12 +1720,6 @@ dvr_is_better_recording_timeslot(const epg_broadcast_t *new_bcast, const dvr_ent
   /* Sanity check. */
   if (!new_channel) return 0;
   if (!old_channel) return 1;
-
-  /* If programme is recording then it is the "best", even if a better
-   * schedule is found after recording starts.
-   */
-  if (old_de->de_sched_state != DVR_SCHEDULED)
-    return 0;
 
   /* Always prefer a recording that has the correct service profile
    * (UHD, HD, SD).  Someone mentioned (#1846) that some channels can


### PR DESCRIPTION
I've been running variants of this patch and I believe this fixes the issue.

With yesterday's async autorec reschedule we can enter the scenario where we have a recording on disk, the user updates an autorec which matches that entry on disk and which is broadcasting now. The dvr_entry ends up being created, scheduled to start immediately and an info logged. The recording timer callback then realizes it is a "semantic dup" so destroys the dvr_entry. This then causes the async logic to wait for its 60s quiescent timeout and re-check the autorecs one final time to ensure nothing new needs scheduling. However it then finds that the same programme is still being broadcast but has not been scheduled, so does it all again.

So, the logfile ends up with an entry every minute saying a recording is scheduled.

To avoid this, we dup check before the info log, and avoid rechecking autorecs if the entry has just been created and then immediately destroyed.

So I added a persisted "create time" to dvr_entry. So if an entry is created and immediately destroyed, we assume no further scheduling is required. In the future, perhaps it will be visible in UI to allow sorting by it.

We now call dup checker before deciding on starting timer/do logging. Unfortunately you have to create a dvr_entry on disk in order to call the dup checker. Doing the de-dup early means we avoid the "scheduling" info log, allows us to immediately delete the entry, and also means we no longer have a dvr_entry in the global link that we know will never record, so reduces memory usage. This has the side effect that dvr ui will no longer have duplicates, but I've left the ui buttons there for the moment since existing autorecs will have duplicates in the dvr/log until those start time elapse.

I also fixed up an incorrect dup logging where uuid was reusing same buffer for printing.
