### PR TITLE
dvr: Persist dvr entry filename upon creation.

### DIFF
--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -1472,6 +1472,11 @@ dvr_thread_rec_start(dvr_entry_t **_de, streaming_start_t *ss,
       return 0;
     dvr_rec_set_state(de, DVR_RS_WAIT_PROGRAM_START, 0);
     int code = dvr_rec_start(de, ss);
+    /* Persist entry so we save the filename details to avoid orphan
+     * files if we crash before the programme completes recording.
+     */
+    dvr_entry_changed(de);
+    htsp_dvr_entry_update(de);
     if(code == 0) {
       ret = 1;
       *started = 1;


### PR DESCRIPTION
Previously we added the filename to the dvr_entry at the start of the
recording, but did not persist it. This meant that if tvheadend
crashed before the programme completed then we would leave a file on
disk which is not referenced by any recording, hence will never be
deleted.

So we persist after the file is created/stream opened. This entry then
has filename, stream info, and (actual) start time, but no (actual)
stop time. The entry is then updated with full details at completion.

I don't believe persisting early causes any knock-on issues since we've
already informed htsp that the recording exists, and Kodi (at least modern
version I have) seem to know it's a live recording and keep updating the
end time.

AFAICT, playback in Kodi (and from Tvheadend finished recordings) only
plays back the last filename segment and ignores the earlier filename entries. 

Tested by recording the news (since it has a clock), kill -9 tvheadend,
wait a couple of minutes, then restart tvheadend.
