### PR TITLE
Python3: Update to start supporting python3 (but remain compatible with python2)

### DIFF
--- a/lib/py/tvh/htsmsg.py
+++ b/lib/py/tvh/htsmsg.py
@@ -19,21 +19,17 @@ Support for processing HTSMSG binary format
 """
 
 import sys
-
+import struct
 
 # ###########################################################################
 # Utilities
 # ###########################################################################
 
 def int2bin(i):
-    return chr(i >> 24 & 0xFF) + chr(i >> 16 & 0xFF) \
-           + chr(i >> 8 & 0xFF) + chr(i & 0xFF)
-
+    return struct.pack(">i", i)
 
 def bin2int(d):
-    return (ord(d[0]) << 24) + (ord(d[1]) << 16) \
-           + (ord(d[2]) << 8) + ord(d[3])
-
+    return struct.unpack(">i", d)[0]
 
 def uuid2int(uuid):
     if sys.byteorder == 'little':
@@ -78,20 +74,20 @@ class HMFBin(str):
 # Convert python to HTSMSG type
 def hmf_type(f):
     if type(f) == list:
-        return HMF_LIST
+        ret = HMF_LIST
     elif type(f) == dict:
-        return HMF_MAP
+        ret = HMF_MAP
     elif type(f) == str:
-        return HMF_STR
+        ret = HMF_STR
     elif type(f) == int:
-        return HMF_S64
+        ret = HMF_S64
     elif type(f) == HMFBin:
-        return HMF_BIN
+        ret = HMF_BIN
     elif type(f) == bool:
-        return HMF_BOOL
+        ret = HMF_BOOL
     else:
         raise Exception('invalid type')
-
+    return struct.pack("B", ret)
 
 # Size for field
 def _binary_count(f):
@@ -124,26 +120,26 @@ def binary_count(msg):
 
 # Write out field in binary form
 def binary_write(msg):
-    ret = ''
+    ret = b''
     lst = type(msg) == list
     for f in msg:
         na = ''
         if not lst:
             na = f
             f = msg[f]
-        ret = ret + chr(hmf_type(f))
-        ret = ret + chr(len(na) & 0xFF)
+        ret = ret + hmf_type(f)
+        ret = ret + struct.pack("B", (len(na) & 0xFF))
         l = _binary_count(f)
         ret = ret + int2bin(l)
-        ret = ret + na
+        ret = ret + na.encode('utf-8')
 
         if type(f) in [list, dict]:
             ret = ret + binary_write(f)
         elif type(f) in [str, HMFBin]:
-            ret = ret + f
+            ret = ret + f.encode()
         elif type(f) == int:
             while f:
-                ret = ret + chr(f & 0xFF)
+                ret = ret + struct.pack("B", (f & 0xFF))
                 f = f >> 8
         else:
             raise Exception('invalid type')
@@ -164,8 +160,8 @@ def deserialize0(data, typ=HMF_MAP):
         islist = True
         msg = []
     while len(data) > 5:
-        typ = ord(data[0])
-        nlen = ord(data[1])
+        typ = data[0]
+        nlen = data[1]
         dlen = bin2int(data[2:6])
         data = data[6:]
 
@@ -190,7 +186,7 @@ def deserialize0(data, typ=HMF_MAP):
             item = 0
             i = dlen - 1
             while i >= 0:
-                item = (item << 8) | ord(data[i])
+                item = (item << 8) | data[i]
                 i = i - 1
         elif typ in [HMF_LIST, HMF_MAP]:
             item = deserialize0(data[:dlen], typ)
@@ -205,7 +201,7 @@ def deserialize0(data, typ=HMF_MAP):
         if islist:
             msg.append(item)
         else:
-            msg[name] = item
+            msg[name.decode()] = item
         data = data[dlen:]
     return msg
 
@@ -218,7 +214,7 @@ def deserialize(fp, rec=False):
             self._rec = rec
 
         def __iter__(self):
-            print '__iter__()'
+            print ('__iter__()')
             return self
 
         def _read(self, num):
@@ -241,13 +237,17 @@ def deserialize(fp, rec=False):
                 self._fp = None
                 raise StopIteration()
             num = bin2int(tmp)
-            data = ''
+            data = b''
             while len(data) < num:
                 tmp = self._read(num - len(data))
                 if not tmp:
                     raise Exception('failed to read from fp')
                 data = data + tmp
             if not self._rec: self._fp = None
+            # Python2 compatibility: data is a str in python2,
+            # and bytes in python3, so ensure we have consistency
+            # here.
+            data = bytearray(data)
             return deserialize0(data)
 
     ret = _Deserialize(fp, rec)

--- a/lib/py/tvh/htsmsg.py
+++ b/lib/py/tvh/htsmsg.py
@@ -179,7 +179,7 @@ def deserialize0(data, typ=HMF_MAP):
             try:
                 item = data[:dlen].decode('utf-8')
             except:
-                item = data[:dlen]
+                item = data[:dlen].decode(errors='replace')
         elif typ == HMF_BIN:
             item = HMFBin(data[:dlen])
         elif typ == HMF_S64:
@@ -201,7 +201,11 @@ def deserialize0(data, typ=HMF_MAP):
         if islist:
             msg.append(item)
         else:
-            msg[name.decode()] = item
+            try:
+                n = name.decode(errors="replace")
+            except:
+                n = name
+            msg[n] = item
         data = data[dlen:]
     return msg
 

--- a/lib/py/tvh/htsmsg.py
+++ b/lib/py/tvh/htsmsg.py
@@ -174,7 +174,16 @@ def deserialize0(data, typ=HMF_MAP):
         name = data[:nlen]
         data = data[nlen:]
         if typ == HMF_STR:
-            item = data[:dlen]
+            # All of our strings _should_ be utf-8
+            # so need to decode them, otherwise
+            # everything looks fine until you
+            # substr the string elsewhere and
+            # get truncated characters and len is
+            # wrong.
+            try:
+                item = data[:dlen].decode('utf-8')
+            except:
+                item = data[:dlen]
         elif typ == HMF_BIN:
             item = HMFBin(data[:dlen])
         elif typ == HMF_S64:

--- a/lib/py/tvh/htsp.py
+++ b/lib/py/tvh/htsp.py
@@ -29,7 +29,7 @@ import tvh.htsmsg as htsmsg
 # HTSP Client
 # ###########################################################################
 
-HTSP_PROTO_VERSION = 25
+HTSP_PROTO_VERSION = 33
 
 
 # Create passwd digest

--- a/lib/py/tvh/htsp.py
+++ b/lib/py/tvh/htsp.py
@@ -22,8 +22,8 @@ Much of the code is pretty rough, but might help people get started
 with communicating with HTSP server
 """
 
-import log
-import htsmsg
+import tvh.log as log
+import tvh.htsmsg as htsmsg
 
 # ###########################################################################
 # HTSP Client

--- a/support/eitscrape_test.py
+++ b/support/eitscrape_test.py
@@ -123,18 +123,18 @@ class EITScrapeTest(object):
           text = result
           continue
         if result == expect:
-          print 'OK: Got correct result of "{result}" testing "{testing}" for "{text}" using "{pattern}"'.format(result=result, testing=testing, text=text, pattern=regex.text())
+          print ('OK: Got correct result of "{result}" testing "{testing}" for "{text}" using "{pattern}"'.format(result=result, testing=testing, text=text, pattern=regex.text()))
           self.num_ok = self.num_ok + 1
         else:
-          print 'FAIL: Got incorrect result of "{result}" expecting "{expect}" testing "{testing}" for "{text}" using "{pattern}"'.format(result=result, expect=expect, testing=testing, text=text, pattern=regex.text())
+          print ('FAIL: Got incorrect result of "{result}" expecting "{expect}" testing "{testing}" for "{text}" using "{pattern}"'.format(result=result, expect=expect, testing=testing, text=text, pattern=regex.text()))
           self.num_failed = self.num_failed + 1
         return
 
     if expect is None:
-      print 'OK: Got correct result of "<none>" testing "{testing}" for "{text}"'.format(testing=testing, text=text)
+      print ('OK: Got correct result of "<none>" testing "{testing}" for "{text}"'.format(testing=testing, text=text))
       self.num_ok = self.num_ok + 1
     else:
-      print 'FAIL: No match in "{text}" while testing "{testing}" and expecting "{expect}"'.format(text=text, testing=testing, expect=expect)
+      print ('FAIL: No match in "{text}" while testing "{testing}" and expecting "{expect}"'.format(text=text, testing=testing, expect=expect))
       self.num_failed = self.num_failed + 1
 
   def run_test_case(self, engine, test, regexes):
@@ -154,10 +154,10 @@ class EITScrapeTest(object):
       if canonical in ('comment', 'summary', 'title', 'language'):
         continue
       if canonical in ('age', 'genre'):
-        print 'Test case contains key "{key}" which is not currently tested for "{test}"'.format(key=key, test=test)
+        print ('Test case contains key "{key}" which is not currently tested for "{test}"'.format(key=key, test=test))
         continue
       if canonical not in regexes:
-        print 'Test case contains invalid key "{key}" (possible typo) for "{test}"'.format(key=key, test=test)
+        print ('Test case contains invalid key "{key}" (possible typo) for "{test}"'.format(key=key, test=test))
         raise SyntaxWarning('Test case contains invalid/unknown key {}'.format(key))
       if for_engine:
         keys_to_test.discard(canonical)
@@ -178,7 +178,7 @@ class EITScrapeTest(object):
       if regexes[canonical]:
         self.run_test_case_i(text, lang, regexes[canonical], test[key], key)
       else:
-        print 'FAIL: no regex defined for key "{key}"'.format(key=canonical)
+        print ('FAIL: no regex defined for key "{key}"'.format(key=canonical))
         self.num_failed = self.num_failed + 1
 
 
@@ -231,12 +231,12 @@ def main(argv):
   tester = EITScrapeTest()
 
   for test in tests['tests']:
-    print "Running test" + str(test)
+    print ("Running test" + str(test))
     pprint.pprint(test)
     tester.run_test_case(args.engine, test, regexes)
 
   # And show the results
-  print "\n\nSummary:\tNumOK: %s\tNumFailed: %s" %(tester.num_ok, tester.num_failed)
+  print ("\n\nSummary:\tNumOK: %s\tNumFailed: %s" %(tester.num_ok, tester.num_failed))
   return tester.num_failed
 
 if __name__ == "__main__":
@@ -248,5 +248,5 @@ if __name__ == "__main__":
       sys.exit(0)
 
   except SyntaxWarning as e:
-    print 'Failed with invalid input: "%s"' % (e)
+    print ('Failed with invalid input: "%s"' % (e))
     sys.exit(1)

--- a/support/htspmon
+++ b/support/htspmon
@@ -79,7 +79,7 @@ try:
     log.info(msg, pretty=True)
 
 except KeyboardInterrupt: pass
-except Exception, e:
+except Exception as e:
   log.error(e)
   sys.exit(1) 
 


### PR DESCRIPTION
Python2 expires January 2020 (PEP373), so start update to support Python3, while maintaining support for Python2.

Main differences:
    - print requires brackets
    - string is bytes in python2 and unicode in python3 and can't be mixed with bytes
    - need to use struct to more easily pack/unpack binary data
    - need to convert socket data to bytearray to allow data extraction since ord not allowed
    - import and exception lines needed changing

Tested via "htspmon -e" on python2 and python3 on the assumption that it sends data and unpacks lots of messages so should give good coverage of the python htsp changes.

I had an issue where some OTA stations send non-utf-8 data (probably iso-8859-1): previously we'd just pass it through whereas now we have to decode the bytes in to a charset for a string and it would raise an exception, so I convert with the "replace bad character" option

Also bumped our python htsp proto version.