### PR TITLE
Fix building with gcc 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ endif
 CFLAGS  += -Wall -Wwrite-strings -Wno-deprecated-declarations
 CFLAGS  += -Wmissing-prototypes
 CFLAGS  += -fms-extensions -funsigned-char -fno-strict-aliasing
+CFLAGS  += -Wno-stringop-truncation -Wno-stringop-overflow
 CFLAGS  += -D_FILE_OFFSET_BITS=64
 CFLAGS  += -I${BUILDDIR} -I${ROOTDIR}/src -I${ROOTDIR}
 ifeq ($(CONFIG_ANDROID),yes)

--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -49,6 +49,7 @@ NASM           = nasm-$(NASM_VER)
 NASM_TB        = $(NASM).tar.gz
 NASM_URL       = https://www.nasm.us/pub/nasm/releasebuilds/$(NASM_VER)/$(NASM_TB)
 NASM_SHA1      = fa15c35b6003518d8165ab507f31af5d3938e91f
+NASM_DIFFS     = remove-invalid-pure_func-qualifiers.diff
 
 LIBX264        = x264-snapshot-20180906-2245
 LIBX264_TB     = $(LIBX264).tar.bz2
@@ -174,6 +175,7 @@ CONFIGURE_PI := CC="$(COMPILER) $(CFLAGS_PI)" $(CONFIGURE)
 $(LIB_ROOT)/$(NASM)/.tvh_download:
 	$(call DOWNLOAD,$(NASM_URL),$(LIB_ROOT)/$(NASM_TB),$(NASM_SHA1))
 	$(call UNTAR,$(NASM_TB),z)
+	$(call PATCH,$(NASM),$(NASM_DIFFS))
 	@touch $@
 
 $(LIB_ROOT)/$(NASM)/.tvh_build: \
@@ -488,7 +490,7 @@ $(LIB_ROOT)/$(LIBFDKAAC)/.tvh_download:
 
 $(LIB_ROOT)/$(LIBFDKAAC)/.tvh_build: \
 		$(LIB_ROOT)/$(LIBFDKAAC)/.tvh_download
-	cd $(LIB_ROOT)/$(LIBFDKAAC) && CXXFLAGS="-std=c++98" $(CONFIGURE_PI) \
+	cd $(LIB_ROOT)/$(LIBFDKAAC) && CXXFLAGS="-std=c++98 -fPIC" $(CONFIGURE_PI) \
 		--libdir=/$(EPREFIX0)/lib
 	DESTDIR=$(EBUILDIR) \
 		$(MAKE) -C $(LIB_ROOT)/$(LIBFDKAAC) install

--- a/support/patches/remove-invalid-pure_func-qualifiers.diff
+++ b/support/patches/remove-invalid-pure_func-qualifiers.diff
@@ -1,0 +1,27 @@
+From d0dabb46a821b2506681f882af0d5696d2c2bade Mon Sep 17 00:00:00 2001
+From: Michael Simacek <msimacek@redhat.com>
+Date: Thu, 8 Feb 2018 14:47:08 +0100
+Subject: [PATCH] Remove invalid pure_func qualifiers
+
+---
+ include/nasmlib.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git include/nasmlib.h include/nasmlib.h
+index 79e866b..c93cef0 100644
+--- include/nasmlib.h
++++ include/nasmlib.h
+@@ -191,8 +191,8 @@ int64_t readstrnum(char *str, int length, bool *warn);
+  * seg_init: Initialise the segment-number allocator.
+  * seg_alloc: allocate a hitherto unused segment number.
+  */
+-void pure_func seg_init(void);
+-int32_t pure_func seg_alloc(void);
++void seg_init(void);
++int32_t seg_alloc(void);
+ 
+ /*
+  * many output formats will be able to make use of this: a standard
+-- 
+2.14.3
+


### PR DESCRIPTION
- Patch for nasm taken from Fedora 28
- Added CFLAGS -Wno-stringop-truncation -Wno-stringop-overflow
- fdk-aac requires -fPIC to link properly