### PR TITLE
dvr: add infrastructure for fanart support, bump htsp version

### DIFF
--- a/docs/property/postprocessor.md
+++ b/docs/property/postprocessor.md
@@ -26,6 +26,7 @@ Format | Description                               | Example value
 `%r`   | Number of errors during recording         |  0
 `%R`   | Number of data errors during recording    |  6
 `%i`   | Streams (comma separated)                 |  H264,AC3,TELETEXT
+`%U`   | Unique ID of recording                    |  3cf44328eda87a428ba9a8b14876ab80
 `%Z`   | Comment                                   |  A string
 
 *Example usage*

--- a/docs/property/preprocessor.md
+++ b/docs/property/preprocessor.md
@@ -19,6 +19,7 @@ Format | Description                               | Example value
 `%d`   | Program description                       |  News and stories…
 `%S`   | Start time stamp of recording, UNIX epoch |  1224421200
 `%E`   | Stop time stamp of recording, UNIX epoch  |  1224426600
+`%U`   | Unique ID of recording                    |  3cf44328eda87a428ba9a8b14876ab80
 `%Z`   | Comment                                   |  A string
 
 *Example usage*

--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -225,6 +225,7 @@ typedef struct dvr_entry {
   char *de_comment;
   char *de_uri;                 /* Programme unique ID */
   char *de_image;               /* Programme Image */
+  char *de_fanart_image;        /* Programme fanart image */
   htsmsg_t *de_files; /* List of all used files */
   char *de_directory; /* Can be set for autorec entries, will override any 
                          directory setting from the configuration */

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1966,6 +1966,7 @@ dvr_entry_dec_ref(dvr_entry_t *de)
   free(de->de_channel_name);
   free(de->de_epnum.text);
   free(de->de_image);
+  free(de->de_fanart_image);
   free(de->de_uri);
 
   free(de);
@@ -3874,6 +3875,14 @@ const idclass_t dvr_entry_class = {
       .desc     = N_("Episode image."),
       .get      = dvr_entry_class_image_url_get_as_property,
       .off      = offsetof(dvr_entry_t, de_image),
+      .opts     = PO_HIDDEN | PO_RDONLY,
+    },
+    {
+      .type     = PT_STR,
+      .id       = "fanart_image",
+      .name     = N_("Fanart image"),
+      .desc     = N_("Fanart image."),
+      .off      = offsetof(dvr_entry_t, de_fanart_image),
       .opts     = PO_HIDDEN | PO_RDONLY,
     },
     {

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -3875,7 +3875,7 @@ const idclass_t dvr_entry_class = {
       .desc     = N_("Episode image."),
       .get      = dvr_entry_class_image_url_get_as_property,
       .off      = offsetof(dvr_entry_t, de_image),
-      .opts     = PO_HIDDEN | PO_RDONLY,
+      .opts     = PO_HIDDEN,
     },
     {
       .type     = PT_STR,
@@ -3883,7 +3883,7 @@ const idclass_t dvr_entry_class = {
       .name     = N_("Fanart image"),
       .desc     = N_("Fanart image."),
       .off      = offsetof(dvr_entry_t, de_fanart_image),
-      .opts     = PO_HIDDEN | PO_RDONLY,
+      .opts     = PO_HIDDEN,
     },
     {
       .type     = PT_LANGSTR,

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -363,6 +363,16 @@ dvr_sub_description(const char *id, const char *fmt, const void *aux, char *tmp,
 }
 
 static const char *
+dvr_sub_uuid(const char *id, const char *fmt, const void *aux, char *tmp, size_t tmplen)
+{
+  const dvr_entry_t *de = aux;
+  char ubuf[UUID_HEX_SIZE];
+  idnode_uuid_as_str(&de->de_id, ubuf);
+  strlcpy(tmp, ubuf, tmplen);
+  return tmp;
+}
+
+static const char *
 dvr_sub_episode(const char *id, const char *fmt, const void *aux, char *tmp, size_t tmplen)
 {
   const dvr_entry_t *de = aux;
@@ -831,6 +841,7 @@ static htsstr_substitute_t dvr_subs_postproc_entry[] = {
   { .id = "t",  .getval = dvr_sub_title },
   { .id = "s",  .getval = dvr_sub_subtitle_or_summary },
   { .id = "u",  .getval = dvr_sub_subtitle },
+  { .id = "U",  .getval = dvr_sub_uuid },
   { .id = "m",  .getval = dvr_sub_summary },
   { .id = "p",  .getval = dvr_sub_episode },
   { .id = "d",  .getval = dvr_sub_description },

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -65,7 +65,7 @@
 
 static void *htsp_server, *htsp_server_2;
 
-#define HTSP_PROTO_VERSION 33
+#define HTSP_PROTO_VERSION 34
 
 #define HTSP_ASYNC_OFF  0x00
 #define HTSP_ASYNC_ON   0x01
@@ -1045,6 +1045,10 @@ htsp_build_dvrentry(htsp_connection_t *htsp, dvr_entry_t *de, const char *method
     const char *image = dvr_entry_class_image_url_get(de);
     if(image && *image)
       htsmsg_add_str(out, "image", image);
+    /* htsmsg camelcase to be compatible with other names */
+    image = de->de_fanart_image;
+    if(image && *image)
+      htsmsg_add_str(out, "fanartImage", image);
     if (de->de_copyright_year)
       htsmsg_add_u32(out, "copyrightYear", de->de_copyright_year);
 

--- a/support/tvhmeta
+++ b/support/tvhmeta
@@ -1,0 +1,113 @@
+#! /usr/bin/env python
+
+# Update Tvheadend dvr record with additional external metadata
+# such as artwork.
+#
+# Sample usage:
+# ./tvhmeta --artwork-url http://art/img1.jpg --fanart-url http://art/img2.jpg --uuid 8fefddddaa8a57ae4335323222f8e83a1
+#
+# This program is a proof of concept in order to do end-to-end testing
+# between Tvheadend and frontend clients, and to allow developers to
+# produce wrapper scripts that do Internet lookups for fanart.
+#
+# Interface Stability:
+# Unstable: This program is undergoing frequent interface changes.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from optparse import OptionParser
+import urllib
+# Python3 decided to rename things and break compatibility...
+try:
+  import urllib.parse
+  import urllib.request
+except:
+  pass
+try:
+  urlencode = urllib.parse.urlencode
+  urlopen = urllib.request.urlopen
+except:
+  urlencode = urllib.urlencode
+  urlopen = urllib.urlopen
+
+import base64
+import json
+import sys
+
+
+def request(user, password, host, port, url, data):
+  if user is not None and password is not None:
+    full_url = "http://{}:{}@{}:{}/{}".format(user,password,host,port,url)
+  else:
+    full_url = "http://{}:{}/{}".format(host,port,url)
+  print("Sending ", data, "to", full_url)
+  req = urlopen(full_url, data=bytearray(data, 'utf-8'))
+  return req.read().decode()
+
+def request_from_opt(opts, url, data):
+  return request(opts.user, opts.password, opts.host, opts.port, url, data)
+
+def do_artwork(opts):
+#user, password, host, port, url, data)
+  data = urlencode(
+    {"uuid" : opts.uuid,
+     "list" : "uuid,image,fanart_image",
+     "grid" : 1
+    })
+  exist = request_from_opt(opts, "api/idnode/load", data)
+  print(exist)
+
+  new_data_dict = {"uuid" : opts.uuid}
+  if opts.artwork_url is not None: new_data_dict['image'] = opts.artwork_url
+  if opts.fanart_url is not None: new_data_dict['fanart_image'] = opts.fanart_url
+
+  new_data = 'node=[' + json.dumps(new_data_dict) + ']';
+  replace = request_from_opt(opts, "api/idnode/save", new_data)
+  print(replace)
+
+  exist = request_from_opt(opts, "api/idnode/load", data)
+  print(exist)
+
+
+def process(argv):
+  optp = OptionParser()
+  optp.add_option('-a', '--host', default='localhost',
+                  help='Specify HTSP server hostname')
+  optp.add_option('-o', '--port', default=9981, type='int',
+                  help='Specify HTTP server port')
+  optp.add_option('-u', '--user', default=None,
+                  help='Specify HTTP authentication username')
+  optp.add_option('-p', '--password', default=None,
+                  help='Specify HTTP authentication password')
+  optp.add_option('--artwork-url', default=None,
+                  help='Specify artwork URL')
+  optp.add_option('--fanart-url', default=None,
+                  help='Specify fanart URL')
+  optp.add_option('--uuid', default=None,
+                  help='Specify UUID on which to operate')
+
+  (opts, args) = optp.parse_args(argv)
+  if (opts.artwork_url is None and opts.fanart_url is None):
+    print("Need --artwork-url and/or --fanart-url")
+    return 1
+  if (opts.uuid is None):
+    print("Need --uuid")
+    return 1
+  do_artwork(opts)
+
+
+if __name__ == '__main__':
+  try:
+    process(sys.argv)
+  except KeyboardInterrupt: pass


### PR DESCRIPTION
Add fanart_image to dvr entry and send it via htsp. I've a patch (for pvr.hts) that will then pass it to Kodi where it is displayed as the background image when browsing recordings. Kodi doesn't support fanart in EPG so we don't add support for that.

Added new format specifier (for post-proc) of "%U" for passing the UUID of the recording.

Added basic test program of support/tvhmeta for setting fanart/image artwork for a particular UUID using api/idnode/{save,load}. This is mostly a demo program to show how fanart could be set by the user so people could write scripts to do it. In the future, it could set other metadata from some data lookup (such as broadcast year, or full description from a tmdb lookup for people with poor OTA data).

I have not added any tmdb/tvdb/imdb lookups for fetching URLs.

The main reason to get the support in now is to try and get the Kodi patch in before the Kodi 18 release.

Tested via the support/tvhmeta program.
