### PR TITLE
gcc8: Only disable warning options for gcc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,9 @@ endif
 CFLAGS  += -Wall -Wwrite-strings -Wno-deprecated-declarations
 CFLAGS  += -Wmissing-prototypes
 CFLAGS  += -fms-extensions -funsigned-char -fno-strict-aliasing
+ifeq ($(COMPILER), gcc)
 CFLAGS  += -Wno-stringop-truncation -Wno-stringop-overflow
+endif
 CFLAGS  += -D_FILE_OFFSET_BITS=64
 CFLAGS  += -I${BUILDDIR} -I${ROOTDIR}/src -I${ROOTDIR}
 ifeq ($(CONFIG_ANDROID),yes)


### PR DESCRIPTION
The clang compiler (v4, 2017) does not have the gcc8 options "-Wno-stringop-truncation -Wno-stringop-overflow", so enable them only for gcc.

I originally tried to make it a check in the configure script, but clang (annoyingly) seems to only flag unknown options as a warning saying it does not understand the option but carries on to compile the program, and so the configure thinks it _does_ support the flag.

```
echo 'int main(){}' > /tmp/hw.c && clang -c  -Wno-stringop-overflow  /tmp/hw.c  && echo $? && ls hw.o
warning: unknown warning option '-Wno-stringop-overflow'; did you mean '-Wno-shift-overflow'? [-Wunknown-warning-option]
1 warning generated.
0  <--exit status ok, despite unknown compile options
hw.o <--file generated
```
