### PR TITLE
ui: Add fanart background to dvr details dialog.

### DIFF
--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -24,6 +24,7 @@ tvheadend.labelFormattingParser = function(description) {
 tvheadend.dvrDetails = function(grid, index) {
     var current_index = index;
     var win;
+    var updateTimer;
     // We need a unique DOM id in case user opens two dialogs.
     var nextButtonId = Ext.id();
     var previousButtonId = Ext.id();
@@ -70,7 +71,12 @@ tvheadend.dvrDetails = function(grid, index) {
         var category = params[19].value;
         var first_aired = params[20].value;
         var genre = params[21].value;
-        var content = '';
+        /* channelname is unused param 22 */
+        var fanart_image = params[23].value;
+        var content = '<div class="dvr-details-dialog">' +
+        '<div class="dvr-details-dialog-background-image"></div>' +
+        '<div class="dvr-details-dialog-content">';
+
         var but;
 
         if (chicon != null && chicon.length > 0) {
@@ -110,9 +116,14 @@ tvheadend.dvrDetails = function(grid, index) {
             content += '</div>'; /* x-epg-left */
             content += '<div class="x-epg-bottom">';
         }
+        // If we have no image then use fanart image instead.
+        content += '<div class="x-epg-image-container">';
         if (image != null && image.length > 0) {
           content += '<img class="x-epg-image" src="' + image + '">';
+        } else if (fanart_image != null && fanart_image.length > 0) {
+          content += '<img class="x-epg-image" src="' + fanart_image + '">';
         }
+        content += '</div>';
 
         content += '<hr class="x-epg-hr"/>';
         if (summary && (!subtitle || subtitle != summary))
@@ -138,6 +149,7 @@ tvheadend.dvrDetails = function(grid, index) {
             content += '<div class="x-epg-meta"><span class="x-epg-prefix">' + _('Time Scheduler') + ':</span><span class="x-epg-body">' + timerec_caption + '</span></div>';
         if (chicon)
             content += '</div>'; /* x-epg-bottom */
+      content += '</div>';        //dialog content
       return content
     }
 
@@ -191,6 +203,55 @@ tvheadend.dvrDetails = function(grid, index) {
     return buttons;
   }                             // getDialogButtons
 
+  function updateDialogFanart(d) {
+      var params = d[0].params;
+      var image=params[15].value;
+      var fanart = params[23].value;
+
+      if (updateTimer)
+          clearInterval(updateTimer);
+
+      fanart_div = win.el.child(".dvr-details-dialog-background-image");
+      if (fanart != null && fanart.length > 0 && fanart_div) {
+          // Set the fanart image. The rest of the css _should_ by in the tv.css,
+          // but it seemed to ignore it when we applyStyles.
+          // We have to explicitly set width/height otherwise the box was 0px tall.
+          fanart_div.applyStyles({
+              'background' : 'url(' + fanart + ') center center no-repeat',
+              'opacity': 0.15,
+              'position': 'relative',
+              'width' : '100%',
+              'height': '100%',
+          });
+      }                        // Have fanart div
+
+      if (image != null && image.length > 0 &&
+          fanart != null && fanart.length > 0) {
+          // We have image and fanart, so alternate the images every x milliseconds.
+          var index = 0;
+          updateTimer = setInterval(function() {
+              if (win.isDestroyed) {
+                  clearInterval(updateTimer);
+                  return;
+              }
+              var img_div = win.el.child(".x-epg-image");
+              if (img_div && img_div.dom) {
+                  var img= img_div.dom;
+                  // The img.src can be changed by browser so it does
+                  // not match either fanart or image! So we use a
+                  // counter to determine which image should be displayed.
+                  if (++index % 2) {
+                      img.src = fanart;
+                  } else {
+                      img.src = image;
+                  }
+              } else {
+                  clearInterval(updateTimer);
+              }
+          }, 10 * 1000);
+      }
+  }                             //updateDialogFanart
+
   function showit(d) {
        var dialogTitle = getDialogTitle(d);
        var content = getDialogContent(d);
@@ -209,6 +270,7 @@ tvheadend.dvrDetails = function(grid, index) {
             html: content
         });
        win.show();
+       updateDialogFanart(d);
        checkButtonAvailability(win.fbar)
   }
 
@@ -222,7 +284,7 @@ tvheadend.dvrDetails = function(grid, index) {
             list: 'channel_icon,disp_title,disp_subtitle,disp_summary,episode_disp,start_real,stop_real,' +
                   'duration,disp_description,status,filesize,comment,duplicate,' +
                   'autorec_caption,timerec_caption,image,copyright_year,credits,keyword,category,' +
-                  'first_aired,genre,channelname',
+                  'first_aired,genre,channelname,fanart_image',
         },
         success: function(d) {
             d = json_decode(d);
@@ -267,6 +329,7 @@ tvheadend.dvrDetails = function(grid, index) {
         Ext.each(buttons, function(btn) {
             tbar.addButton(btn);
         });
+        updateDialogFanart(d);
         checkButtonAvailability(tbar);
         // Finally, relayout.
         win.doLayout();

--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -166,7 +166,9 @@ tvheadend.epgDetails = function(grid, index) {
         content += '<div class="x-epg-bottom">';
       }
       if (event.image != null && event.image.length > 0) {
+        content += '<div class="x-epg-image-container">';
         content += '<img class="x-epg-image" src="' + event.image + '">';
+        content += '</div>';
       }
       content += '<hr class="x-epg-hr"/>';
       if (event.summary)

--- a/src/webui/static/app/ext.css
+++ b/src/webui/static/app/ext.css
@@ -791,12 +791,27 @@
     margin: 5px 5px 5px 10px;
 }
 
-.x-epg-image{
+/* Our image has to be inside an image container
+ * since when the image changes we don't want text
+ * to reflow. This image is not scaled to this size,
+ * it is simply the size of the container to avoid text
+ * flowing around it.
+ */
+.x-epg-image-container {
     float: right;
     margin-left: 5px;
     margin-right: 5px;
     margin-bottom: 5px;
     width: 20%;
+    height: 200px;
+    position: relative;
+}
+
+.x-epg-image{
+    width: 100%;                /*100% of the container*/
+    max-height: 100%;
+    z-index: 10;                /*Need higher z-index since we are inside a div*/
+    position: relative;         /*z-index only works with position of non-static (the default)*/
 }
 
 .x-epg-image:hover{
@@ -810,6 +825,18 @@
 
 .x-epg-duplicate {
     text-decoration: line-through;
+}
+
+.dvr-details-dialog {
+    postition: relative;
+}
+.dvr-details-dialog-background-image {
+    /* Details in here are overridden by  code */
+}
+.dvr-details-dialog-content {
+    position: absolute;
+    top: 0;
+    left: 0;
 }
 
 .tv-video-player {


### PR DESCRIPTION
We now display fanart (if available) on the background of the dvr
dialog. This fanart image is also displayed every ten seconds where
the existing image is displayed.

Tested with safari/firefox and it seems ok, but not great.  I could not get the images scaled nicely based on the center, but hopefully a bit more css will fix that and how to scale/zoom images will become more obvious once we have a proper fanart grabber and more fanart images to play with.

The main complication is that css does not directly support making images less visible, so I had to create three div elements, and make the image in its own layer, and then make that layer transparent.

I also have to fiddle with the z-index on the (existing) image otherwise hover stops working (for enlarging the image), presumably because it's now inside a layer. And has to put the image inside a fixed-width box in case the fanart and image are different dimensions, otherwise the text would reflow.
![ss](https://user-images.githubusercontent.com/31170571/46126660-0a2bf980-c226-11e8-912e-425f90d257dc.jpg)
![ss-st](https://user-images.githubusercontent.com/31170571/46126663-0bf5bd00-c226-11e8-8941-85bd061bc532.jpg)
