### PR TITLE
xmltv export: Use format "X" instead of "X/" for season/episode export.

### DIFF
--- a/src/webui/xmltv.c
+++ b/src/webui/xmltv.c
@@ -105,8 +105,13 @@ _http_xmltv_add_episode_num(htsbuf_queue_t *hq, uint16_t num, uint16_t cnt)
    * counts are one-based.
    */
   if (num) htsbuf_qprintf(hq, "%d", num - 1);
-  htsbuf_append_str(hq, "/");
-  if (cnt) htsbuf_qprintf(hq, "%d", cnt);
+  /* Some clients can not handle "X", only "X/Y" or "/Y",
+   * so only output "/" if needed.
+   */
+  if (cnt) {
+    htsbuf_append_str(hq, "/");
+    htsbuf_qprintf(hq, "%d", cnt);
+  }
 }
 
 /*


### PR DESCRIPTION
Previously we'd output "4/ . 3/. /", but it was raised
on the forum that some clients can not handle
the omitted "total" number.

So we now output the simpler "4 . 3 ." instead.
Examples:
```
  <episode-num system="xmltv-ns">2 . 24/25 .   </episode-num>
  <episode-num system="xmltv-ns"> . 233 .   </episode-num>
  <episode-num system="xmltv-ns">2/2 . 25 .   </episode-num>
  <episode-num system="xmltv-ns">22/30 . 9/22 .   </episode-num>
```