### PR TITLE
Makefile + Debian build hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ LANGUAGES ?= $(LANGUAGES_ALL)
 # Common compiler flags
 #
 
-CFLAGS  += -g
+# https://wiki.debian.org/Hardening
+CFLAGS  += -g -D_FORTIFY_SOURCE=2
 ifeq ($(CONFIG_CCDEBUG),yes)
 CFLAGS  += -O0
 else

--- a/configure
+++ b/configure
@@ -148,6 +148,12 @@ check_cc_header execinfo
 check_cc_option mmx
 check_cc_option sse2
 check_cc_optionW unused-result
+# Some options from https://wiki.debian.org/Hardening
+check_cc_optionf stack-protector
+check_cc_optionf stack-protector-strong
+# Useful for multi-threaded programs
+check_cc_optionf stack-check
+check_cc_optionf PIE
 
 if check_cc '
 #if !defined(__clang__)

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,6 @@
 #!/usr/bin/make -f
 export DH_VERBOSE=1
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 %:
 	dh $@ --with-systemd

--- a/support/configure.inc
+++ b/support/configure.inc
@@ -325,6 +325,27 @@ check_cc_optionW ()
   fi
 }
 
+# Check compiler option
+check_cc_optionf ()
+{
+  local opt=$1
+  local nam=$2
+  [ -z "$nam" ] && nam=$opt
+  nam=$(echo "f_$nam" | sed -e 's/[-=]/_/g')
+
+  printf "$TAB" "checking for cc -f$opt ..."
+
+  # Enable if supported
+  if check_cc "" -f${opt}; then
+    echo "ok"
+    enable $nam
+  else
+    echo "fail"
+    return 1
+  fi
+}
+
+
 # Check compiler library
 check_cc_lib ()
 {


### PR DESCRIPTION
Add options to Debian build rules and configure/Makefile to enable hardening.

I have had occasional crashes where the debug locals variables are bad, so I've added the compile options to do stack checking, and general hardening based on [https://wiki.debian.org/Hardening ](https://wiki.debian.org/Hardening). These options are enabled if the compiler supports the flags.
