### PR TITLE
FreeBSD: allow core dump, plus minor epg assert fix

### DIFF
--- a/src/epg.c
+++ b/src/epg.c
@@ -1468,13 +1468,13 @@ epg_broadcast_t *epg_broadcast_get_next ( epg_broadcast_t *b )
 
 const char *epg_broadcast_get_title ( epg_broadcast_t *b, const char *lang )
 {
-  if (!b && !b->title) return NULL;
+  if (!b || !b->title) return NULL;
   return lang_str_get(b->title, lang);
 }
 
 const char *epg_broadcast_get_subtitle ( epg_broadcast_t *b, const char *lang )
 {
-  if (!b && !b->subtitle) return NULL;
+  if (!b || !b->subtitle) return NULL;
   return lang_str_get(b->subtitle, lang);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -1118,9 +1118,9 @@ main(int argc, char **argv)
 
     /* Make dumpable */
     if (opt_dump) {
-#ifdef PLATFORM_LINUX
       if (chdir("/tmp"))
         tvhwarn(LS_START, "failed to change cwd to /tmp");
+#ifdef PLATFORM_LINUX
       prctl(PR_SET_DUMPABLE, 1);
 #else
       tvhwarn(LS_START, "Coredumps not implemented on your platform");


### PR DESCRIPTION
The "--dump" option (to enable core dumps in /tmp) only worked on Linux due to the Linux-specific prctl. However, FreeBSD (and others) can core dump in the cwd if it is writable, so allow the "cd /tmp", but still log the warning that it's not supported since other system settings can prevent core dumps.

Also minor fix up of an && that should be || in epg.
