### PR TITLE
xmltv: Add option to save epgdb after xmltv import.

### DIFF
--- a/src/epggrab.c
+++ b/src/epggrab.c
@@ -401,6 +401,17 @@ const idclass_t epggrab_class = {
       .group  = 1,
     },
     {
+      .type   = PT_BOOL,
+      .id     = "epgdb_saveafterimport",
+      .name   = N_("Save EPG to disk after xmltv import"),
+      .desc   = N_("Writes the current in-memory EPG database to disk "
+                   "shortly after an xmltv import has completed, so should a crash/unexpected "
+                   "shutdown occur EPG data is saved "
+                   "(re-read on next startup)."),
+      .off    = offsetof(epggrab_conf_t, epgdb_saveafterimport),
+      .group  = 1,
+    },
+    {
       .type   = PT_STR,
       .id     = "cron",
       .name   = N_("Cron multi-line"),
@@ -484,6 +495,7 @@ void epggrab_init ( void )
   epggrab_conf.channel_renumber   = 0;
   epggrab_conf.channel_reicon     = 0;
   epggrab_conf.epgdb_periodicsave = 0;
+  epggrab_conf.epgdb_saveafterimport = 0;
 
   epggrab_cron_multi              = NULL;
 

--- a/src/epggrab.h
+++ b/src/epggrab.h
@@ -320,6 +320,7 @@ typedef struct epggrab_conf {
   uint32_t              channel_renumber;
   uint32_t              channel_reicon;
   uint32_t              epgdb_periodicsave;
+  uint32_t              epgdb_saveafterimport;
   char                 *ota_cron;
   uint32_t              ota_timeout;
   uint32_t              ota_initial;


### PR DESCRIPTION
The "periodic save database" means that for xmltv you can
import your daily listings, crash, restart, and not have xmltv
data since the periodic epgdb timer has not elapsed.

So, add an option so the user can save the database after the
import has completed, assuming changes occurred.

This save is delayed by a couple of minutes in case the user
is importing from several different xmltv guides, in which case
the save occurs after the last import.