### PR TITLE
ui: Use background-size to scale background fanart to fit dvr dialog box.

### DIFF
--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -222,6 +222,10 @@ tvheadend.dvrDetails = function(grid, index) {
               'position': 'relative',
               'width' : '100%',
               'height': '100%',
+              // This causes background image to scale on css3 with aspect ratio, image
+              // can overflow, vs. 'contain' which will leave blank space top+bottom to
+              // ensure image is fully displayed in the window
+              'background-size': 'cover',
           });
       }                        // Have fanart div
 


### PR DESCRIPTION
Previously the background fanart could be too big for the dialog so we'd just get the middle bit of the image.

Now we use css to scale it using 'background-size: cover'.

This can make the image slightly exceed the dialog dimensions (and be cropped), compared to 'contain' which would leave space at the top/bottom to maintain aspect.

Using 'cover' seems better with the fanart I've seen so far.

Tested in FF and Safari.
