### PR TITLE
htsp: Allow updateDvrEntry to set previously recorded flag. (htsp 34).

### DIFF
--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -65,7 +65,7 @@
 
 static void *htsp_server, *htsp_server_2;
 
-#define HTSP_PROTO_VERSION 33
+#define HTSP_PROTO_VERSION 34
 
 #define HTSP_ASYNC_OFF  0x00
 #define HTSP_ASYNC_ON   0x01
@@ -2042,7 +2042,7 @@ htsp_method_updateDvrEntry(htsp_connection_t *htsp, htsmsg_t *in)
   time_t start, stop, start_extra, stop_extra, priority;
   const char *dvr_config_name, *title, *subtitle, *summary, *desc, *lang;
   channel_t *channel = NULL;
-  int enabled, retention, removal, playcount = -1, playposition = -1;
+  int enabled, retention, removal, playcount = -1, playposition = -1, prevrec;
 
   de = htsp_findDvrEntry(htsp, in, &out, 0);
   if (de == NULL)
@@ -2100,6 +2100,9 @@ htsp_method_updateDvrEntry(htsp_connection_t *htsp, htsmsg_t *in)
                         summary, desc, lang, start, stop, start_extra, stop_extra,
                         priority, retention, removal, playcount, playposition);
 
+  if (!htsmsg_get_s32(in, "prevrec", &prevrec)) {
+    dvr_entry_set_prevrec(de, prevrec);
+  }
   return htsp_success();
 }
 


### PR DESCRIPTION
This will allow Kodi to offer a client actions menu to mark timers as "previously recorded."

We add an additional check for a new "prevrec" field in the htsp updateDvrEntry. It takes a single integer similar to UI API of 1=>previously recorded, 0=>not, -1=>toggle, and just passes it to the existing handler used by the UI API.

My current proposed pvr.hts changes would just send [id, prevrec=1] to updateDvrEntry, so Tvheadend does an update with no changes to start/stop, etc., then updates the prevrec field.

I have the pvr.hts code working locally, but I'm not 100% sure if this change to the htsp message is the right one to use for this, or if we should add a new message such as a prevrecDvrEntry, similar to the api/dvr/entry/prerec/{toggle,set,unset}.

So, reject if you think we should do it differently.

Setting a flag in the message that then alters multiple flags internally seems slightly inconsistent with the existing API; but it is an "update" so makes sense and keeps the api small.
