### PR TITLE
[WIP] Seca EMM fix

### DIFF
--- a/src/descrambler/descrambler.h
+++ b/src/descrambler/descrambler.h
@@ -165,12 +165,15 @@ typedef struct caid {
  * List of EMM subscribers
  */
 #define EMM_PID_UNKNOWN ((uint16_t)-1)
+#define EMM_MAX_PIDS 128
 
 typedef struct descrambler_emm {
   TAILQ_ENTRY(descrambler_emm) link;
 
   uint16_t caid;
-  uint16_t pid;
+  uint16_t pid[EMM_MAX_PIDS];
+  uint8_t pidcount;
+
   unsigned int to_be_removed:1;
 
   descrambler_section_callback_t callback;

--- a/src/descrambler/emm_reass.c
+++ b/src/descrambler/emm_reass.c
@@ -150,11 +150,12 @@ emm_seca
   } else if (data[0] == 0x84) {  // shared emm
     if (len >= 8) {
       /* XXX this part is untested but should do no harm */
-      PROVIDERS_FOREACH(ra, i, ep)
-        if (memcmp(&data[5], &ep->sa[5], 3) == 0) {
+      PROVIDERS_FOREACH(ra, i, ep) {
+        if (memcmp(&data[5], &ep->sa[4], 3) == 0) {
           match = 1;
           break;
         }
+      }
     }
   } else if (data[0] == 0x83) {  // global emm -> seca3
     match = 1;


### PR DESCRIPTION
This fixes a longstanding issue with seca EMM's. To be honest don't know much from encryption/CSA stuff, the commit was actually cherry picked from https://github.com/ViGill/tvheadend/commit/b507c9e96b37eb87bb3fcefa058558826de1f289#diff-780ca6138ebe99c4808cd22e952c22bb @thetroll 

WIP state because I still have a problem when enabling multiple CWC clients, at the moment I have no idea whats going on.
- When 1 CWC client is enabled the added pids are:
```
2018-10-09 23:48:18.640 descrambler: attach emm caid 0100 (256) pid 00B7 (183) dlen=20
2018-10-09 23:48:18.640 descrambler: attach emm caid 0100 (256) pid 00B8 (184) dlen=16
2018-10-09 23:48:18.641 descrambler: attach emm caid 0100 (256) pid 00B9 (185) dlen=12
2018-10-09 23:48:18.641 descrambler: attach emm caid 0100 (256) pid 00BA (186) dlen=8
2018-10-09 23:48:18.641 descrambler: attach emm caid 0100 (256) pid 00BB (187) dlen=4
```
- When 2 CWC clients are enabled:
```
2018-10-09 23:49:03.122 descrambler: attach emm caid 0100 (256) pid 00B7 (183) dlen=20
2018-10-09 23:49:03.122 descrambler: attach emm caid 0100 (256) pid 00B8 (184) dlen=16
2018-10-09 23:49:03.122 descrambler: attach emm caid 0100 (256) pid 00B9 (185) dlen=12
2018-10-09 23:49:03.122 descrambler: attach emm caid 0100 (256) pid 00BA (186) dlen=8
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 00BB (187) dlen=4
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1013 (4115) dlen=251
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1403 (5123) dlen=247
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 0009 (9) dlen=243
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 00E0 (224) dlen=239
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 0120 (288) dlen=235
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 0519 (1305) dlen=231
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 0305 (773) dlen=227
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 0907 (2311) dlen=223
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 00B6 (182) dlen=219
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 0209 (521) dlen=215
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 18E0 (6368) dlen=211
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1E22 (7714) dlen=207
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1819 (6169) dlen=203
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 02FE (766) dlen=199
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 0718 (1816) dlen=195
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1C02 (7170) dlen=191
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 0907 (2311) dlen=187
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 00BC (188) dlen=183
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 0C09 (3081) dlen=179
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 19E0 (6624) dlen=175
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 006D (109) dlen=171
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1817 (6167) dlen=167
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 0201 (513) dlen=163
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 0718 (1816) dlen=159
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1B02 (6914) dlen=155
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 0907 (2311) dlen=151
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 00BB (187) dlen=147
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 0009 (9) dlen=143
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 17E0 (6112) dlen=139
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 006A (106) dlen=135
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1818 (6168) dlen=131
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 0200 (512) dlen=127
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 0718 (1816) dlen=123
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1A02 (6658) dlen=119
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 0904 (2308) dlen=115
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 00BD (189) dlen=111
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 0624 (1572) dlen=107
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 0904 (2308) dlen=103
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1F40 (8000) dlen=99
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 10D4 (4308) dlen=95
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=91
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=87
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=83
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=79
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=75
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=71
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=67
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=63
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=59
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=55
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=51
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=47
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=43
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=39
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=35
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=31
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=27
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=23
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=19
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=15
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=11
2018-10-09 23:49:03.123 descrambler: attach emm caid 0100 (256) pid 1FFF (8191) dlen=7
```
In the second case, the opened channel does not have audio (globalheaders stream disabled). 
The 4 first pids are probably correct the rest seems to be rubbish.
Do EMM pids also count for the adapter pid limit? If so, 4 is already much then too.