### PR TITLE
support/version: use --tags with git describe otherwise new tags are ignored

### DIFF
--- a/support/version
+++ b/support/version
@@ -8,7 +8,7 @@ FILE=$1
 
 # Calculate version
 if [ -d ".git" ]; then
-  VER=$(cd "$(dirname "$0")"/..; git describe --dirty --match "v*" 2> /dev/null)
+  VER=$(cd "$(dirname "$0")"/..; git describe --dirty --tags --match "v*" 2> /dev/null)
   if [ $? -ne 0 ]; then
     # Git describe failed, maybe "--dirty" option is not available
     # Adding "-unknown" postfix to mark this situation


### PR DESCRIPTION
I could not for the life of me figure out why release-4.2 version numbers weren't updating correctly on my bintray repo - it has gotten stuck on 4.2.6 instead of using 4.2.7, even after a full clone of tvheadend/tvheadend!

Turns out ```git describe``` doesn't always correctly describe without --tags, this hopefully fixes it.

Please could this be backported to 4.2 as well? 

Cheers!
