### PR TITLE
FreeBSD: fix read write kevent

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -458,7 +458,7 @@ tcp_socket_dead(int fd)
   if (err < 0)
     return -errno;
   else if (err == 0)
-      return -EIO;
+      return 0;
 #else
   if (recv(fd, NULL, 0, MSG_PEEK | MSG_DONTWAIT) == 0)
     return -EIO;

--- a/src/tvhpoll.c
+++ b/src/tvhpoll.c
@@ -198,11 +198,11 @@ static int tvhpoll_add0
     const uint32_t oevents = tvhpoll_get_events(tp, fd);
     if (events == oevents) continue;
     tvhpoll_set_events(tp, fd, events);
-    if ((events & (TVHPOLL_OUT|TVHPOLL_IN)) == (TVHPOLL_OUT|TVHPOLL_IN)) {
-      EV_SET(ev+j, fd, EVFILT_READ|EVFILT_WRITE, EV_ADD, 0, 0, ptr);
-      j++;
-      continue;
-    }
+    /* Unlike poll, the kevent is not a bitmask (on FreeBSD,
+     * EVILT_READ=-1, EVFILT_WRITE=-2). That means if you OR them
+     * together then you only actually register READ, not WRITE. So,
+     * register them separately here.
+     */
     if (events & TVHPOLL_OUT) {
       EV_SET(ev+j, fd, EVFILT_WRITE, EV_ADD, 0, 0, ptr);
       j++;


### PR DESCRIPTION
On FreeBSD, the kevent EVFILT_READ=-1 and EVFILT_WRITE=-2 (rather than 1 and 2), so when they are ORed together you get -1, so we only end up registering READ in tvhpoll.

This means that on an async tcp connect we eventually timeout since we are not registered for WRITE.

So we now delete the special logic and use the existing separate read/write registration logic.

Also no longer return EIO for FreeBSD on tcp_socket_dead for zero bytes available to read, otherwise streaming fails to my tablet since we get no bytes to read so immediately disconnect the client, but no bytes on async socket is not same as eof.
