### PR TITLE
htsp: Tidy serialization of category and keyword.

### DIFF
--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -1282,15 +1282,12 @@ htsp_build_event
       htsmsg_add_str(out, "description", str);
   }
 
-  if (e->credits) {
+  if (e->credits)
     htsmsg_add_msg(out, "credits", htsmsg_copy(e->credits));
-  }
-  if (e->category) {
-    htsmsg_add_msg(out, "category", string_list_to_htsmsg(e->category));
-  }
-  if (e->keyword) {
-    htsmsg_add_msg(out, "keyword", string_list_to_htsmsg(e->keyword));
-  }
+  if (e->category)
+    string_list_serialize(e->category, out, "category");
+  if (e->keyword)
+    string_list_serialize(e->keyword, out, "keyword");
 
   if (e->serieslink)
     htsmsg_add_str(out, "serieslinkUri", e->serieslink->uri);


### PR DESCRIPTION
In pvr.hts, there's a bug raised that Tvheadend's credits/cast/keywords might be causing problems when doing a deserialize of the binary message (before the actual parsing of the message contents):
[https://github.com/kodi-pvr/pvr.hts/issues/378](https://github.com/kodi-pvr/pvr.hts/issues/378)

I've _not_ managed to reproduce the problem (and the code has been in since Sep 2017 in tvh and November for pvr.hts).

However, I noticed we could tidy the code to use the string_list_serialize function which does an additional check that the converted string list message is created before adding it to the out msg.

I don't think this is the cause of their problem since we should core dump if msg was somehow null after the conversion, but the additional check might be worthwhile.

Also removed extra braces.
