### PR TITLE
doozer: [4.2] add raspbian and cosmic

### DIFF
--- a/.doozer.json
+++ b/.doozer.json
@@ -1,6 +1,96 @@
 {
   "concurrent": false,
   "targets": {
+    "fedora27-x86_64": {
+      "buildenv": "docker:fedora:27",
+      "builddeps": [
+        ["https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-27.noarch.rpm"],
+        "gcc-c++",
+        "which",
+        "rpm-build",
+        "rpmdevtools",
+        "git",
+        "make",
+        "cmake",
+        "gettext-devel",
+        "dbus-devel",
+        "avahi-devel",
+        "openssl-devel",
+        "zlib-devel",
+        "libdvbcsa-devel",
+        "wget",
+        "bzip2",
+        "uriparser-devel",
+        "pcre2-devel",
+        "python",
+        "python-requests",
+        "ccache"
+      ],
+      "buildcmd": [
+        "./configure --disable-dvbscan && make -C rpm build-doozer",
+        "support/bintray.py publish filelist.txt"
+      ]
+    },
+    "fedora28-x86_64": {
+      "buildenv": "docker:fedora:28",
+      "builddeps": [
+        ["https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-28.noarch.rpm"],
+        "gcc-c++",
+        "which",
+        "rpm-build",
+        "rpmdevtools",
+        "git",
+        "make",
+        "cmake",
+        "gettext-devel",
+        "dbus-devel",
+        "avahi-devel",
+        "openssl-devel",
+        "zlib-devel",
+        "libdvbcsa-devel",
+        "wget",
+        "bzip2",
+        "uriparser-devel",
+        "pcre2-devel",
+        "python",
+        "python-requests",
+        "ccache"
+      ],
+      "buildcmd": [
+        "./configure --disable-dvbscan && make -C rpm build-doozer",
+        "support/bintray.py publish filelist.txt"
+      ]
+    },
+    "centos7-x86_64": {
+      "buildenv": "docker:centos:7",
+      "builddeps": [
+        ["https://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm"],
+        "gcc-c++",
+        "which",
+        "rpm-build",
+        "rpmdevtools",
+        "git",
+        "make",
+        "cmake",
+        "gettext-devel",
+        "dbus-devel",
+        "avahi-devel",
+        "openssl-devel",
+        "zlib-devel",
+        "libdvbcsa-devel",
+        "wget",
+        "bzip2",
+        "uriparser-devel",
+        "pcre2-devel",
+        "python",
+        "python-requests",
+        "ccache"
+      ],
+      "buildcmd": [
+        "./configure --disable-dvbscan && make -C rpm build-doozer",
+        "BINTRAY_REPO=centos support/bintray.py publish filelist.txt",
+      ]
+    },
     "trusty-amd64": {
       "buildenv": "trusty-amd64",
       "builddeps": [
@@ -327,94 +417,61 @@
         "support/bintray.py publish filelist.txt"
       ]
     },
-    "fedora27-x86_64": {
-      "buildenv": "docker:fedora:27",
+    "raspbian-jessie": {
+      "buildenv": "raspbian-jessie",
       "builddeps": [
-        ["https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-27.noarch.rpm"],
-        "gcc-c++",
-        "which",
-        "rpm-build",
-        "rpmdevtools",
-        "git",
-        "make",
         "cmake",
-        "gettext-devel",
-        "dbus-devel",
-        "avahi-devel",
-        "openssl-devel",
-        "zlib-devel",
-        "libdvbcsa-devel",
+        "git",
+        "build-essential",
+        "pkg-config",
+        "gettext",
+        "libavahi-client-dev",
+        "libssl-dev",
+        "zlib1g-dev",
         "wget",
         "bzip2",
-        "uriparser-devel",
-        "pcre2-devel",
+        "git-core",
+        "liburiparser-dev",
+        "libpcre3-dev",
+        "libdvbcsa-dev",
         "python",
         "python-requests",
-        "ccache"
+        "debhelper",
+        "ccache",
+        "sudo",
+        "dvb-apps"
       ],
       "buildcmd": [
-        "./configure --disable-dvbscan && make -C rpm build-doozer",
+        "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-hdhomerun_static\\ --disable-ffmpeg_static ./Autobuild.sh -t raspbianjessie-armhf -j ${PARALLEL} -w ${WORKDIR}",
         "support/bintray.py publish filelist.txt"
       ]
     },
-    "fedora28-x86_64": {
-      "buildenv": "docker:fedora:28",
+    "raspbian-stretch": {
+      "buildenv": "raspbian-stretch",
       "builddeps": [
-        ["https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-28.noarch.rpm"],
-        "gcc-c++",
-        "which",
-        "rpm-build",
-        "rpmdevtools",
-        "git",
-        "make",
         "cmake",
-        "gettext-devel",
-        "dbus-devel",
-        "avahi-devel",
-        "openssl-devel",
-        "zlib-devel",
-        "libdvbcsa-devel",
+        "git",
+        "build-essential",
+        "pkg-config",
+        "gettext",
+        "libavahi-client-dev",
+        "libssl-dev",
+        "zlib1g-dev",
         "wget",
         "bzip2",
-        "uriparser-devel",
-        "pcre2-devel",
+        "git-core",
+        "liburiparser-dev",
+        "libpcre2-dev",
+        "libdvbcsa-dev",
         "python",
         "python-requests",
-        "ccache"
+        "debhelper",
+        "ccache",
+        "dvb-apps"
       ],
       "buildcmd": [
-        "./configure --disable-dvbscan && make -C rpm build-doozer",
+        "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-hdhomerun_static\\ --disable-ffmpeg_static ./Autobuild.sh -t raspbianstretch-armhf -j ${PARALLEL} -w ${WORKDIR}",
         "support/bintray.py publish filelist.txt"
-      ]
-    },
-    "centos7-x86_64": {
-      "buildenv": "docker:centos:7",
-      "builddeps": [
-        ["https://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm"],
-        "gcc-c++",
-        "which",
-        "rpm-build",
-        "rpmdevtools",
-        "git",
-        "make",
-        "cmake",
-        "gettext-devel",
-        "dbus-devel",
-        "avahi-devel",
-        "openssl-devel",
-        "zlib-devel",
-        "libdvbcsa-devel",
-        "wget",
-        "bzip2",
-        "uriparser-devel",
-        "pcre2-devel",
-        "python",
-        "python-requests",
-        "ccache"
-      ],
-      "buildcmd": [
-        "./configure --disable-dvbscan && make -C rpm build-doozer",
-        "BINTRAY_REPO=centos support/bintray.py publish filelist.txt",
       ]
     },
     "bionic-amd64": {
@@ -478,6 +535,68 @@
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-ffmpeg_static\\ --enable-hdhomerun_static ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
         "support/bintray.py publish filelist.txt"
       ]
-    }
+    },
+    "cosmic-amd64": {
+      "buildenv": "docker:ubuntu:cosmic",
+      "builddeps": [
+        "cmake",
+        "git",
+        "build-essential",
+        "pkg-config",
+        "gettext",
+        "libavahi-client-dev",
+        "libssl-dev",
+        "zlib1g-dev",
+        "wget",
+        "bzip2",
+        "git-core",
+        "liburiparser-dev",
+        "libpcre2-dev",
+        "libdvbcsa-dev",
+        "python",
+        "python-requests",
+        "debhelper",
+        "ccache",
+        "sudo"
+      ],
+      "buildcmd": [
+        "sudo apt-get -y purge makedev; sudo apt-get -y install makedev || true",
+        "sudo rm /var/lib/dpkg/info/makedev.postinst; sudo apt-get install -f",
+        "sudo ./Autobuild.sh -o deps -t ${TARGET}",
+        "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-ffmpeg_static\\ --enable-hdhomerun_static ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
+        "support/bintray.py publish filelist.txt",
+      ]
+    },
+    "cosmic-i386": {
+      "buildenv": "docker:i386/ubuntu:cosmic",
+      "builddeps": [
+        "cmake",
+        "git",
+        "build-essential",
+        "pkg-config",
+        "gettext",
+        "libavahi-client-dev",
+        "libssl-dev",
+        "zlib1g-dev",
+        "wget",
+        "bzip2",
+        "git-core",
+        "liburiparser-dev",
+        "libpcre2-dev",
+        "libdvbcsa-dev",
+        "python",
+        "python-requests",
+        "debhelper",
+        "ccache",
+        "sudo"
+      ],
+      "buildcmd": [
+        "sudo apt-get -y purge makedev; sudo apt-get -y install makedev || true",
+        "sudo rm /var/lib/dpkg/info/makedev.postinst; sudo apt-get install -f",
+        "sudo ./Autobuild.sh -o deps -t ${TARGET}",
+        "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-ffmpeg_static\\ --enable-hdhomerun_static ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
+        "support/bintray.py publish filelist.txt",
+      ]
+    },
   }
 }

--- a/Autobuild/cosmic-amd64.sh
+++ b/Autobuild/cosmic-amd64.sh
@@ -1,0 +1,3 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --arch=x86_64"
+DEBDIST=cosmic
+source Autobuild/debian.sh

--- a/Autobuild/cosmic-i386.sh
+++ b/Autobuild/cosmic-i386.sh
@@ -1,0 +1,3 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --arch=i686"
+DEBDIST=cosmic
+source Autobuild/debian.sh


### PR DESCRIPTION
This is so that 4.2 stable is built for Raspbian and Cosmic, and is available from apt.tvheadend.org. Cosmic is currently failing, however @andoma is looking into that for us :)