### PR TITLE
tags: fix exclude (from all channels)

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -98,7 +98,7 @@ access_ticket_find(const char *id)
     /* assume that newer tickets are hit more probably */
     TAILQ_FOREACH_REVERSE(at, &access_tickets, access_ticket_queue, at_link)
       if(!strcmp(at->at_id, id))
-	return at;
+        return at;
   }
   
   return NULL;
@@ -299,7 +299,9 @@ access_copy(access_t *src)
       memcpy(dst->aa_chrange, src->aa_chrange, l);
   }
   if (src->aa_chtags)
-    dst->aa_chtags  = htsmsg_copy(src->aa_chtags);
+    dst->aa_chtags = htsmsg_copy(src->aa_chtags);
+  if (src->aa_chtags_exclude)
+    dst->aa_chtags_exclude = htsmsg_copy(src->aa_chtags_exclude);
   if (src->aa_auth)
     dst->aa_auth = strdup(src->aa_auth);
   return dst;
@@ -354,6 +356,7 @@ access_destroy(access_t *a)
   htsmsg_destroy(a->aa_profiles);
   htsmsg_destroy(a->aa_dvrcfgs);
   htsmsg_destroy(a->aa_chtags);
+  htsmsg_destroy(a->aa_chtags_exclude);
   free(a);
 }
 
@@ -510,6 +513,20 @@ access_dump_a(access_t *a)
                    (long long)a->aa_chrange[first+1]);
   }
 
+  if (a->aa_chtags_exclude) {
+    first = 1;
+    HTSMSG_FOREACH(f, a->aa_chtags_exclude) {
+      channel_tag_t *ct = channel_tag_find_by_uuid(htsmsg_field_get_str(f) ?: "");
+      if (ct) {
+        tvh_strlcatf(buf, sizeof(buf), l, "%s'%s'",
+                 first ? ", exclude tags=" : ",", ct->ct_name ?: "");
+        first = 0;
+      }
+    }
+  } else {
+    tvh_strlcatf(buf, sizeof(buf), l, ", exclude tag=ANY");
+  }
+
   if (a->aa_chtags) {
     first = 1;
     HTSMSG_FOREACH(f, a->aa_chtags) {
@@ -622,32 +639,24 @@ access_update(access_t *a, access_entry_t *ae)
   }
 
   if (ae->ae_change_chtags) {
-    if (ae->ae_chtags_exclude && !LIST_EMPTY(&ae->ae_chtags)) {
-      channel_tag_t *ct;
-      TAILQ_FOREACH(ct, &channel_tags, ct_link) {
-        if(ct && ct->ct_name[0] != '\0') {
-          LIST_FOREACH(ilm, &ae->ae_chtags, ilm_in1_link) {
-            channel_tag_t *ct2 = (channel_tag_t *)ilm->ilm_in2;
-            if (ct == ct2) break;
-          }
-          if (ilm == NULL) {
-            if (a->aa_chtags == NULL)
-              a->aa_chtags = htsmsg_create_list();
-            htsmsg_add_str_exclusive(a->aa_chtags, idnode_uuid_as_str(&ct->ct_id, ubuf));
-          }
-        }
-      }
+    if (LIST_EMPTY(&ae->ae_chtags)) {
+      idnode_list_destroy(&ae->ae_chtags, ae);
     } else {
-      if (LIST_EMPTY(&ae->ae_chtags)) {
-        idnode_list_destroy(&ae->ae_chtags, ae);
-      } else {
-        LIST_FOREACH(ilm, &ae->ae_chtags, ilm_in1_link) {
-          channel_tag_t *ct = (channel_tag_t *)ilm->ilm_in2;
-          if(ct && ct->ct_name[0] != '\0') {
-            if (a->aa_chtags == NULL)
-              a->aa_chtags = htsmsg_create_list();
-            htsmsg_add_str_exclusive(a->aa_chtags, idnode_uuid_as_str(&ct->ct_id, ubuf));
+      htsmsg_t **lst;
+      LIST_FOREACH(ilm, &ae->ae_chtags, ilm_in1_link) {
+        channel_tag_t *ct = (channel_tag_t *)ilm->ilm_in2;
+        if(ct && ct->ct_name[0] != '\0') {
+          const char *ct_uuid = idnode_uuid_as_str(&ct->ct_id, ubuf);
+          if (ae->ae_chtags_exclude) {
+            lst = &a->aa_chtags_exclude;
+          } else {
+            lst = &a->aa_chtags;
+            /* adding a tag down the chain removes it from exclude list */
+            htsmsg_remove_string_from_list(a->aa_chtags_exclude, ct_uuid);
           }
+          if (*lst == NULL)
+            *lst = htsmsg_create_list();
+          htsmsg_add_str_exclusive(*lst, ct_uuid);
         }
       }
     }
@@ -747,7 +756,7 @@ access_get(struct sockaddr_storage *src, const char *username, verify_callback_t
     if(ae->ae_username[0] != '*') {
       /* acl entry requires username to match */
       if(username == NULL || strcmp(username, ae->ae_username))
-	continue; /* Didn't get one */
+        continue; /* Didn't get one */
     }
 
     if(!netmask_verify(&ae->ae_ipmasks, src))

--- a/src/access.h
+++ b/src/access.h
@@ -167,6 +167,7 @@ typedef struct access {
   htsmsg_t *aa_dvrcfgs;
   uint64_t *aa_chrange;
   int       aa_chrange_count;
+  htsmsg_t *aa_chtags_exclude;
   htsmsg_t *aa_chtags;
   int       aa_match;
   uint32_t  aa_conn_limit;

--- a/src/channels.c
+++ b/src/channels.c
@@ -719,13 +719,16 @@ int
 channel_access(channel_t *ch, access_t *a, int disabled)
 {
   char ubuf[UUID_HEX_SIZE];
+  idnode_list_mapping_t *ilm;
+  htsmsg_field_t *f;
 
   if (!a)
     return 0;
 
   if (!ch) {
     /* If user has full rights, allow access to removed chanels */
-    if (a->aa_chrange == NULL && a->aa_chtags == NULL)
+    if (a->aa_chrange == NULL && a->aa_chtags == NULL &&
+        a->aa_chtags_exclude == NULL)
       return 1;
     return 0;
   }
@@ -743,20 +746,21 @@ channel_access(channel_t *ch, access_t *a, int disabled)
   }
 
   /* Channel tag check */
-  if (a->aa_chtags) {
-    idnode_list_mapping_t *ilm;
-    htsmsg_field_t *f;
-    HTSMSG_FOREACH(f, a->aa_chtags) {
-      LIST_FOREACH(ilm, &ch->ch_ctms, ilm_in2_link) {
+  if (a->aa_chtags_exclude) {
+    HTSMSG_FOREACH(f, a->aa_chtags_exclude)
+      LIST_FOREACH(ilm, &ch->ch_ctms, ilm_in2_link)
         if (!strcmp(htsmsg_field_get_str(f) ?: "",
                     idnode_uuid_as_str(ilm->ilm_in1, ubuf)))
-          goto chtags_ok;
-      }
-    }
+          return 0;
+  }
+  if (a->aa_chtags) {
+    HTSMSG_FOREACH(f, a->aa_chtags)
+      LIST_FOREACH(ilm, &ch->ch_ctms, ilm_in2_link)
+        if (!strcmp(htsmsg_field_get_str(f) ?: "",
+                    idnode_uuid_as_str(ilm->ilm_in1, ubuf)))
+          return 1;
     return 0;
   }
-chtags_ok:
-
   return 1;
 }
 
@@ -1658,6 +1662,10 @@ channel_tag_get_icon(channel_tag_t *ct)
 int
 channel_tag_access(channel_tag_t *ct, access_t *a, int disabled)
 {
+  htsmsg_field_t *f;
+  char ubuf[UUID_HEX_SIZE];
+  const char *uuid = idnode_uuid_as_str(&ct->ct_id, ubuf);
+
   if (!ct)
     return 0;
 
@@ -1668,17 +1676,17 @@ channel_tag_access(channel_tag_t *ct, access_t *a, int disabled)
     return 1;
 
   /* Channel tag check */
+  if (a->aa_chtags_exclude) {
+    HTSMSG_FOREACH(f, a->aa_chtags_exclude)
+      if (!strcmp(htsmsg_field_get_str(f) ?: "", uuid))
+        return 0;
+  }
   if (a->aa_chtags) {
-    htsmsg_field_t *f;
-    char ubuf[UUID_HEX_SIZE];
-    const char *uuid = idnode_uuid_as_str(&ct->ct_id, ubuf);
     HTSMSG_FOREACH(f, a->aa_chtags)
       if (!strcmp(htsmsg_field_get_str(f) ?: "", uuid))
-        goto chtags_ok;
+        return 1;
     return 0;
   }
-chtags_ok:
-
   return 1;
 }
 


### PR DESCRIPTION
Currently the exclude flag gives the user access to all channels that ARE TAGGED except the ones that match the selected tag(s).
This fix will give the user access to ALL channels (tagged or not) except the ones that match the selected tag(s).

Fixes #5288