### PR TITLE
 webui: access theme - color correction for EPG count info

### DIFF
--- a/src/webui/static/app/ext-access.css
+++ b/src/webui/static/app/ext-access.css
@@ -54,3 +54,7 @@ a {
 .x-progress-text-back {
     color: #fff;
 }
+
+.x-paging-info {
+    color: #fff;
+}


### PR DESCRIPTION
EPG events count is dark-gray so we can't see it with access theme.


![](https://i.gyazo.com/bd944ac162649a4bff675b4943ec4d8d.png)

![](https://user-images.githubusercontent.com/7295293/47744913-ba0be100-dc82-11e8-8880-095babee5e3b.png)

![](https://i.gyazo.com/b7e5f5c9167f89f3cd3d828e576bac88.png)