### PR TITLE
dvr: Add option to automatically delete recording after playback.

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -80,6 +80,7 @@ typedef struct dvr_config {
   uint32_t dvr_rerecord_errors;
   uint32_t dvr_retention_days;
   uint32_t dvr_removal_days;
+  uint32_t dvr_removal_after_playback;
   uint32_t dvr_autorec_max_count;
   uint32_t dvr_autorec_max_sched_count;
   char *dvr_charset;
@@ -200,6 +201,7 @@ typedef struct dvr_entry {
   char *de_channel_name;
 
   gtimer_t de_timer;
+  gtimer_t de_watched_timer;
   mtimer_t de_deferred_timer;
 
   /**
@@ -211,6 +213,7 @@ typedef struct dvr_entry {
 
   int de_enabled;
   time_t de_create;             ///< Time entry was created
+  time_t de_watched;            ///< Time entry was last watched
   time_t de_start;
   time_t de_stop;
 
@@ -557,6 +560,9 @@ void dvr_entry_destroy_by_config(dvr_config_t *cfg, int delconf);
 
 int dvr_entry_set_state(dvr_entry_t *de, dvr_entry_sched_state_t state,
                         dvr_rs_state_t rec_state, int error_code);
+
+int dvr_entry_set_playcount(dvr_entry_t *de, uint32_t playcount);
+int dvr_entry_incr_playcount(dvr_entry_t *de);
 
 const char *dvr_entry_status(dvr_entry_t *de);
 

--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -747,6 +747,47 @@ dvr_config_class_removal_list ( void *o, const char *lang )
 }
 
 static htsmsg_t *
+dvr_config_class_remove_after_playback_list ( void *o, const char *lang )
+{
+  enum {
+    ONE_MINUTE = 60,
+    ONE_HOUR = ONE_MINUTE * 60,
+    ONE_DAY = ONE_HOUR * 24
+  };
+
+  /* We want a few "soon" options (other than immediately) since that
+   * gives the user time to restart the playback if they accidentally
+   * skipped to the end and marked it as watched, whereas immediately
+   * would immediately delete that recording (and we don't yet support
+   * undelete).
+   */
+  static const struct strtab_u32 tab[] = {
+    { N_("Never"),              0 },
+    { N_("Immediately"),        1 },
+    { N_("1 minute"),           ONE_MINUTE },
+    { N_("10 minutes"),         ONE_MINUTE * 10 },
+    { N_("30 minutes"),         ONE_MINUTE * 30 },
+    { N_("1 hour"),             ONE_HOUR },
+    { N_("2 hours"),            ONE_HOUR * 2 },
+    { N_("4 hour"),             ONE_HOUR * 4 },
+    { N_("8 hour"),             ONE_HOUR * 8 },
+    { N_("12 hours"),           ONE_HOUR * 12 },
+    { N_("1 day"),              ONE_DAY },
+    { N_("2 days"),             ONE_DAY * 2 },
+    { N_("3 days"),             ONE_DAY * 3 },
+    { N_("5 days"),             ONE_DAY * 5 },
+    { N_("1 week"),             ONE_DAY * 7 },
+    { N_("2 weeks"),            ONE_DAY * 14 },
+    { N_("3 weeks"),            ONE_DAY * 21 },
+    { N_("1 month"),            ONE_DAY * 31 }, /* Approximations based on RET_REM */
+    { N_("2 months"),           ONE_DAY * 62 },
+    { N_("3 months"),           ONE_DAY * 92 },
+  };
+  return strtab2htsmsg_u32(tab, 1, lang);
+}
+
+
+static htsmsg_t *
 dvr_config_class_retention_list ( void *o, const char *lang )
 {
   static const struct strtab_u32 tab[] = {
@@ -928,6 +969,25 @@ const idclass_t dvr_config_class = {
       .def.u32  = DVR_RET_REM_FOREVER,
       .list     = dvr_config_class_removal_list,
       .opts     = PO_DOC_NLIST,
+      .group    = 1,
+    },
+    {
+      .type     = PT_U32,
+      .id       = "remove-after-playback",
+      .name     = N_("Automatically delete played recordings"),
+      .desc     = N_("Number of minutes after playback has finished "
+                     "before file should be automatically removed "
+                     "(unless its retention is 'forever'). "
+                     "Note that some clients may pre-cache playback "
+                     "which means the recording will be marked as "
+                     "played when the client has cached the data, "
+                     "which may be before the end of the programme is "
+                     "actually watched."
+                    ),
+      .off      = offsetof(dvr_config_t, dvr_removal_after_playback),
+      .def.u32  = 0,
+      .list     = dvr_config_class_remove_after_playback_list,
+      .opts     = PO_ADVANCED,
       .group    = 1,
     },
     {

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -2913,7 +2913,7 @@ htsp_method_file_close(htsp_connection_t *htsp, htsmsg_t *in)
     int save = 0;
     /* Only allow incrementing playcount on file close, the rest can be done with "updateDvrEntry" */
     if (htsp->htsp_version < 27 || htsmsg_get_u32_or_default(in, "playcount", HTSP_DVR_PLAYCOUNT_INCR) == HTSP_DVR_PLAYCOUNT_INCR) {
-      de->de_playcount++;
+      dvr_entry_incr_playcount(de);
       save = 1;
     }
     if(htsp->htsp_version >= 27 && !htsmsg_get_u32(in, "playposition", &u32)) {

--- a/src/satip/server.c
+++ b/src/satip/server.c
@@ -257,7 +257,7 @@ satip_server_satip_m3u(http_connection_t *hc)
   if (hts_settings_buildpath(path, sizeof(path), "satip.m3u"))
     return HTTP_STATUS_SERVICE;
 
-  return http_serve_file(hc, path, 0, MIME_M3U, NULL, NULL, NULL);
+  return http_serve_file(hc, path, 0, MIME_M3U, NULL, NULL, NULL, NULL);
 }
 
 int

--- a/src/webui/webui.h
+++ b/src/webui/webui.h
@@ -42,6 +42,8 @@ http_serve_file(http_connection_t *hc, const char *fname,
                 int fconv, const char *content,
                 int (*preop)(http_connection_t *hc, off_t file_start,
                              size_t content_len, void *opaque),
+                int (*postop)(http_connection_t *hc, off_t file_start,
+                              size_t content_len, off_t file_size, void *opaque),
                 void (*stats)(http_connection_t *hc, size_t len, void *opaque),
                 void *opaque);
 


### PR DESCRIPTION
Previously when watching a programme, the user usually has to then
manually delete the programme to recover disk space, or wait for its
retention to expire.

So we now add an option to Config->Recording->DVR Profile. This allows
the user to select time after watching to automatically delete the
recording (unless it is marked as "keep forever"). Default is disabled
(do not delete after playback).

For example, if the user specifies "2 days" then we'd delete the
recording two days after playback, even if the retention period is "3
months".

"Playback" can vary based on client. Some clients read and cache the
entire file before starting playback, so the file would be marked as
watched immediately. Other clients only buffer a small amount, so the
file will be marked as watched near the end of the show.

For htsp, this is done via a new postop cb and we move the existing
"set playcount" logic in to this postop, and once the playcount is incremented
then we arm the timer.
