### PR TITLE
dvr: delete partial files when replacing schedule after crash

### DIFF
--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -2015,6 +2015,7 @@ dvr_entry_create_by_autorec(int enabled, epg_broadcast_t *e, dvr_autorec_entry_t
             gmtime2local(replace->de_bcast->start, t1buf, sizeof t1buf),
             e->channel ? channel_get_name(e->channel, channel_blank_name) : channel_blank_name,
             gmtime2local(e->start, t2buf, sizeof t2buf));
+    dvr_entry_delete(replace);
     dvr_entry_destroy(replace, 1);
   }
 


### PR DESCRIPTION
Scenario: Complex scheduling enabled. Recording ok, then crash and restart. Partially recorded files are left on disk but dvr/log entry pointing to files can sometimes be destroyed.

So on restart the recording is not currently running, so we can find a
better recording (via complex scheduling option).

If there is a better recording later in the week,
that show will get preference (since complex recording states we don't
want a partial recording so prefer a later date for a full recording).

But, we used to destroy the dvr_entry, but this does not delete its
associated files so they would be left on disk as orphans/unreferenced
from any dvr/log file.

So now we also call delete to delete the files.
