### PR TITLE
descrambler: reset 'changed' flag on cc_remove_card

### DIFF
--- a/src/descrambler/cclient.c
+++ b/src/descrambler/cclient.c
@@ -251,6 +251,7 @@ cc_remove_card(cclient_t *cc, cc_card_data_t *pcard)
     if (changed) {
       ct->cs_capid = 0xffff;
       ct->ecm_state = ECM_INIT;
+      changed = 0;
     }
   }
 


### PR DESCRIPTION
I believe this is missing on the previous commit!