### PR TITLE
Fix IPTV glitches

### DIFF
--- a/src/descrambler/cclient.c
+++ b/src/descrambler/cclient.c
@@ -251,6 +251,7 @@ cc_remove_card(cclient_t *cc, cc_card_data_t *pcard)
     if (changed) {
       ct->cs_capid = 0xffff;
       ct->ecm_state = ECM_INIT;
+      changed = 0;
     }
   }
 

--- a/src/input/mpegts/iptv/iptv_private.h
+++ b/src/input/mpegts/iptv/iptv_private.h
@@ -26,8 +26,8 @@
 #include "udp.h"
 #include "tvhpoll.h"
 
-#define IPTV_BUF_SIZE    (300*188)
-#define IPTV_PKTS        32
+#define IPTV_BUF_SIZE    (9000*188)
+#define IPTV_PKTS        128
 #define IPTV_PKT_PAYLOAD 1472
 
 typedef struct iptv_input   iptv_input_t;


### PR DESCRIPTION
Some channels used to glitch quite badly on TVH but play/recover fine on vlc(directly).. this patch makes TVH behave like vlc