### PR TITLE
dvr: Fix unique season episode recording rule test

### DIFF
--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1606,8 +1606,9 @@ static int _dvr_duplicate_unique_match(dvr_entry_t *de1, dvr_entry_t *de2, void 
    * AND episode are present since OTA often have just "Ep 1" without
    * giving the season.
    */
-  if (de1->de_epnum.e_num && de2->de_epnum.e_num)
-    return de1->de_epnum.e_num == de2->de_epnum.e_num ? DUP : NOT_DUP;
+  if (de1->de_epnum.s_num && de1->de_epnum.e_num &&
+      de2->de_epnum.s_num && de2->de_epnum.e_num)
+    return de1->de_epnum.s_num == de2->de_epnum.s_num && de1->de_epnum.e_num == de2->de_epnum.e_num ? DUP : NOT_DUP;
 
   /* Only one has season and episode? Then can't be a dup with the
    * other one that doesn't have season+episode


### PR DESCRIPTION
The test for season/episode uniqueness no longer worked after the types were changed from string to int.

So it only checked episode numbers (ignoring season). This meant that S02E01 would not record if S01E01 was available. So, fix that to check both Season+Episode if both are available.

If only season or episode is available (which can happen on OTA where we just have "Ep3" and no season details), then we can only compare the one we have and if they differ, we know its definitely not a dup, but if they are the same then we have to continue to do the remaining checks.
