### PR TITLE
webui: epg: fix compatibility issue for FreeBSD

### DIFF
--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -1166,10 +1166,11 @@ tvheadend.epg = function() {
     epgFilterTitle.on('valid', function(c) {
         var value = c.getValue();
 
-        if (value.length < 1)
-            value = null;
-
-        if (epgStore.baseParams.title !== value) {
+        if (value.length < 1) {
+            delete epgStore.baseParams.title;
+            epgView.reset();
+        }
+        else if (epgStore.baseParams.title !== value) {
             epgStore.baseParams.title = value;
             epgView.reset();
         }


### PR DESCRIPTION
The EPG screen serviced by FreeBSD port of tvheadend has two abnormal control
behaviors:

    Reset All button makes the list empty
    Typing and then deleting any search string also makes the list empty.

This patch fixes the symptoms above.

Patch tested with the latest FreeBSD port of tvheadend-4.2.7.

Changes since v1:
- call reset only if required