### PR TITLE
ui: show similar and alternative broadcasts (#5335, #5336)

### DIFF
--- a/Makefile.webui
+++ b/Makefile.webui
@@ -150,6 +150,7 @@ JAVASCRIPT += $(ROOTPATH)/app/timeshift.js
 endif
 JAVASCRIPT += $(ROOTPATH)/app/chconf.js
 JAVASCRIPT += $(ROOTPATH)/app/epg.js
+JAVASCRIPT += $(ROOTPATH)/app/epgevent.js
 JAVASCRIPT += $(ROOTPATH)/app/dvr.js
 JAVASCRIPT += $(ROOTPATH)/app/epggrab.js
 JAVASCRIPT += $(ROOTPATH)/app/config.js

--- a/src/access.h
+++ b/src/access.h
@@ -261,7 +261,7 @@ access_get_theme(access_t *a);
  *
  * Return 0 if access is granted, -1 otherwise
  */
-static inline int access_verify2(access_t *a, uint32_t mask)
+static inline int access_verify2(const access_t *a, uint32_t mask)
   { return (mask & ACCESS_OR) ?
       ((a->aa_rights & mask) ? 0 : -1) :
       ((a->aa_rights & mask) == mask ? 0 : -1); }

--- a/src/api/api_epg.c
+++ b/src/api/api_epg.c
@@ -74,7 +74,7 @@ api_epg_add_channel ( htsmsg_t *m, channel_t *ch, const char *blank )
 static htsmsg_t *
 api_epg_entry ( epg_broadcast_t *eb, const char *lang, access_t *perm, const char **blank )
 {
-  const char *s;
+  const char *s, *blank2 = NULL;
   char buf[64];
   channel_t     *ch = eb->channel;
   htsmsg_t *m, *m2;
@@ -85,6 +85,8 @@ api_epg_entry ( epg_broadcast_t *eb, const char *lang, access_t *perm, const cha
 
   if (!ch) return NULL;
 
+  if (blank == NULL)
+    blank = &blank2;
   if (*blank == NULL)
     *blank = tvh_gettext_lang(lang, channel_blank_name);
 

--- a/src/api/api_epg.c
+++ b/src/api/api_epg.c
@@ -72,7 +72,7 @@ api_epg_add_channel ( htsmsg_t *m, channel_t *ch, const char *blank )
 }
 
 static htsmsg_t *
-api_epg_entry ( epg_broadcast_t *eb, const char *lang, access_t *perm, const char **blank )
+api_epg_entry ( epg_broadcast_t *eb, const char *lang, const access_t *perm, const char **blank )
 {
   const char *s, *blank2 = NULL;
   char buf[64];
@@ -508,27 +508,80 @@ api_epg_grid
   return 0;
 }
 
+static int
+api_epg_sort_by_time_t(const void *a, const void *b, void *arg)
+{
+  const time_t *at= (const time_t*)a;
+  const time_t *bt= (const time_t*)b;
+  return *at - *bt;
+}
+
+/// Generate a sorted list of episodes that
+/// do NOT match ebc_skip in to message l.
+/// @return number of entries allocated.
+static uint32_t
+api_epg_episode_sorted(const struct epg_set *set,
+                       const access_t *perm,
+                       htsmsg_t *l,
+                       const char *lang,
+                       const epg_broadcast_t *ebc_skip)
+{
+  typedef struct {
+    time_t start;
+    htsmsg_t *m;
+  } bcast_entry_t;
+
+  epg_broadcast_t *ebc;
+  htsmsg_t *m;
+  bcast_entry_t *bcast_entries = NULL;
+  const epg_set_item_t *item;
+  bcast_entry_t new_bcast_entry;
+  size_t num_allocated = 0;
+  size_t num_entries = 0;
+  size_t i;
+
+  LIST_FOREACH(item, &set->broadcasts, item_link) {
+    ebc = item->broadcast;
+    if (ebc != ebc_skip) {
+      m = api_epg_entry(ebc, lang, perm, NULL);
+      if (num_entries == num_allocated) {
+        num_allocated = MAX(100, num_allocated + 100);
+        /* We don't expect any/many reallocs so we store physical struct instead of pointers */
+        bcast_entries = realloc(bcast_entries, num_allocated * sizeof(bcast_entry_t));
+      }
+
+      new_bcast_entry.start = htsmsg_get_u32_or_default(m, "start", 0);
+      new_bcast_entry.m = m;
+      bcast_entries[num_entries++] = new_bcast_entry;
+    }
+  }
+
+  tvh_qsort_r(bcast_entries, num_entries, sizeof(bcast_entry_t), api_epg_sort_by_time_t, 0);
+
+  for (i=0; i<num_entries; ++i) {
+    htsmsg_t *m = bcast_entries[i].m;
+    htsmsg_add_msg(l, NULL, m);
+  }
+  free(bcast_entries);
+
+  return num_entries;
+}
+
+
 static void
 api_epg_episode_broadcasts
   ( access_t *perm, htsmsg_t *l, const char *lang, epg_broadcast_t *ep,
     uint32_t *entries, epg_broadcast_t *ebc_skip )
 {
-  epg_broadcast_t *ebc;
-  htsmsg_t *m;
   epg_set_t *episodelink = ep->episodelink;
-  epg_set_item_t *item;
 
   if (episodelink == NULL)
     return;
 
-  LIST_FOREACH(item, &episodelink->broadcasts, item_link) {
-    ebc = item->broadcast;
-    if (ebc != ebc_skip) {
-      m = api_epg_entry(ebc, lang, perm, NULL);
-      htsmsg_add_msg(l, NULL, m);
-      (*entries)++;
-    }
-  }
+  /* Need to sort these ourselves since they are used as a livegrid
+   * which requires remote sort.
+   */
+  *entries = api_epg_episode_sorted(episodelink, perm, l, lang, ebc_skip);
 }
 
 static int
@@ -565,11 +618,10 @@ api_epg_related
   ( access_t *perm, void *opaque, const char *op, htsmsg_t *args, htsmsg_t **resp )
 {
   uint32_t id, entries = 0;
-  htsmsg_t *l = htsmsg_create_list(), *m;
-  epg_broadcast_t *e, *ebc;
+  htsmsg_t *l = htsmsg_create_list();
+  epg_broadcast_t *e;
   char *lang;
   epg_set_t *serieslink;
-  epg_set_item_t *item;
   
   if (htsmsg_get_u32(args, "eventId", &id))
     return -EINVAL;
@@ -579,16 +631,9 @@ api_epg_related
   pthread_mutex_lock(&global_lock);
   e = epg_broadcast_find_by_id(id);
   serieslink = e->serieslink;
-  if (serieslink) {
-    LIST_FOREACH(item, &serieslink->broadcasts, item_link) {
-      ebc = item->broadcast;
-      if (ebc != e) {
-        m = api_epg_entry(ebc, lang, perm, NULL);
-        htsmsg_add_msg(l, NULL, m);
-        entries++;
-      }
-    }
-  }
+  if (serieslink)
+    entries = api_epg_episode_sorted(serieslink, perm, l, lang, e);
+
   pthread_mutex_unlock(&global_lock);
   free(lang);
 

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -4480,7 +4480,8 @@ const idclass_t dvr_entry_class = {
       .desc     = N_("Broadcast."),
       .set      = dvr_entry_class_broadcast_set,
       .get      = dvr_entry_class_broadcast_get,
-      .opts     = PO_RDONLY | PO_NOUI,
+      /* Has to be available to UI for "show duplicate" from dvr upcoming */
+      .opts     = PO_RDONLY | PO_HIDDEN,
     },
     {
       .type     = PT_STR,

--- a/src/webui/static/app/epgevent.js
+++ b/src/webui/static/app/epgevent.js
@@ -1,0 +1,214 @@
+/*
+ * epgevent.js
+ * EPG dialogs for broadcast events.
+ * Copyright (C) 2018 Tvheadend Foundation CIC
+ */
+
+/// Display dialog showing alternative showings for a broadcast event.
+/// @param alternative - If true then display "alternatives", otherwise display "related" broadcasts
+function epgAlternativeShowingsDialog(eventId, alternative) {
+    // Default params only exist in ECMA2015+, so do it old way.
+    alternative = (typeof alternative !== 'undefined') ?  alternative : true;
+
+    function getAlternativeShowingsStore(eventId) {
+        var base = alternative ? "alternative" : "related";
+        return new Ext.ux.grid.livegrid.Store({
+            autoLoad: true,
+            // Passing params doesn't seem to work, so force eventId in to url.
+            url: 'api/epg/events/' + base + '?eventId='+eventId,
+            baseParams: {
+                eventId: eventId,
+            },
+            bufferSize: 300,
+            selModel: new Ext.ux.grid.livegrid.RowSelectionModel(),
+            reader: new Ext.ux.grid.livegrid.JsonReader({
+                root: 'entries',
+                totalProperty: 'totalCount',
+                id: 'eventId'
+            }, [
+                // We need a complete set of fields since user can request
+                // dialog that retrieves its data from our store.
+                { name: 'eventId' },
+                { name: 'channelName' },
+                { name: 'channelUuid' },
+                { name: 'channelNumber' },
+                { name: 'channelIcon' },
+                { name: 'title' },
+                { name: 'subtitle' },
+                { name: 'summary' },
+                { name: 'description' },
+                { name: 'extratext' },
+                { name: 'episodeOnscreen' },
+                { name: 'image' },
+                {
+                    name: 'start',
+                    type: 'date',
+                    dateFormat: 'U' /* unix time */
+                },
+                {
+                    name: 'stop',
+                    type: 'date',
+                    dateFormat: 'U' /* unix time */
+                },
+                {
+                    name: 'first_aired',
+                    type: 'date',
+                    dateFormat: 'U' /* unix time */
+                },
+                { name: 'duration' },
+                { name: 'starRating' },
+                { name: 'credits' },
+                { name: 'category' },
+                { name: 'keyword' },
+                { name: 'ageRating' },
+                { name: 'copyright_year' },
+                { name: 'new' },
+                { name: 'genre' },
+                { name: 'dvrUuid' },
+                { name: 'dvrState' },
+                { name: 'serieslinkUri' }
+            ])
+        });
+    }                           //getAlternativeShowingsStore
+
+
+    var store = getAlternativeShowingsStore(eventId);
+    var epgView = new Ext.ux.grid.livegrid.GridView({
+        nearLimit: 100,
+        loadMask: {
+            msg: _('Buffering. Please wait…')
+        },
+    });
+
+    var epgEventDetails = getEPGEventDetails();
+
+    var grid = new Ext.ux.grid.livegrid.GridPanel({
+        store: store,
+        plugins: [epgEventDetails],
+        iconCls: 'epg',
+        view: epgView,
+        cm: new Ext.grid.ColumnModel({
+            columns: [
+                epgEventDetails,
+                {
+                    width: 250,
+                    id: 'title',
+                    header: _("Title"),
+                    tooltip: _("Title"),
+                    dataIndex: 'title',
+                },
+                {
+                    width: 250,
+                    id: 'extratext',
+                    header: _("Extra text"),
+                    tooltip: _("Extra text: subtitle or summary or description"),
+                    dataIndex: 'extratext',
+                    renderer: tvheadend.renderExtraText
+                },
+                {
+                    width: 100,
+                    id: 'episodeOnscreen',
+                    header: _("Episode"),
+                    tooltip: _("Episode"),
+                    dataIndex: 'episodeOnscreen',
+                },
+                {
+                    width: 200,
+                    id: 'start',
+                    header: _("Start Time"),
+                    tooltip: _("Start Time"),
+                    dataIndex: 'start',
+                    renderer: tvheadend.renderCustomDate
+                },
+                {
+                    width: 200,
+                    id: 'stop',
+                    header: _("End Time"),
+                    tooltip: _("End Time"),
+                    dataIndex: 'stop',
+                    renderer: tvheadend.renderCustomDate
+                },
+                {
+                    width: 250,
+                    id: 'channelName',
+                    header: _("Channel"),
+                    tooltip: _("Channel"),
+                    dataIndex: 'channelName',
+                },
+            ],
+        }),
+    });                      // grid
+
+
+    var windowHeight = Ext.getBody().getViewSize().height - 150;
+
+    var win = new Ext.Window({
+        title: alternative ? _('Alternative Showings') : _('Related Showings'),
+        iconCls: 'info',
+        layout: 'fit',
+        width: 1317,
+        height: windowHeight,
+        constrainHeader: true,
+        buttonAlign: 'center',
+        autoScroll: false,  // Internal grid has its own scrollbars so no need for us to have them
+        items: grid,
+        bbar: new Ext.ux.grid.livegrid.Toolbar(
+        tvheadend.PagingToolbarConf({view: epgView},_('Events'),0,0)
+        ),
+
+    });
+
+    // Handle comet updates until user closes dialog.
+    var update = function(m) {
+        tvheadend.epgCometUpdate(m, store);
+    };
+    tvheadend.comet.on('epg', update);
+    win.on('close', function(panel, opts) {
+         tvheadend.comet.un('epg', update);
+     });
+
+    win.show();
+}
+
+
+var epgAlternativeShowingsDialogForSelection = function(conf, e, store, select, alternative) {
+    var r = select.getSelections();
+    if (r && r.length > 0) {
+        for (var i = 0; i < r.length; i++) {
+            var rec = r[i];
+            var eventId = rec.data['broadcast'];
+            if (eventId)
+                epgAlternativeShowingsDialog(eventId, alternative);
+        }
+    }
+};
+
+var epgShowRelatedButtonConf = {
+    name: 'epgrelated',
+    builder: function() {
+        return new Ext.Toolbar.Button({
+            tooltip: _('Display dialog of related broadcasts'),
+            iconCls: 'epgrelated',
+            text: _('Related broadcasts'),
+            disabled: true
+        });
+    },
+    callback: function(conf, e, store, select) {
+        epgAlternativeShowingsDialogForSelection(conf, e, store, select, false);
+    }
+}
+
+var epgShowAlternativesButtonConf = {
+    name: 'epgalt',
+    builder: function() {
+        return new Ext.Toolbar.Button({
+            tooltip: _('Display dialog showing alternative broadcasts'),
+            iconCls: 'duprec',
+            text: _('Alternative showings'),
+            disabled: true
+        });
+    },
+    callback: function(conf, e, store, select) {
+        epgAlternativeShowingsDialogForSelection(conf, e, store, select, true);
+    }
+};

--- a/src/webui/static/app/ext.css
+++ b/src/webui/static/app/ext.css
@@ -228,6 +228,10 @@
     background-image: url(../icons/accept.png) !important;
 }
 
+.epgrelated {
+    background-image: url(../icons/clock.png) !important;
+}
+
 .duprec {
     background-image: url(../icons/control_repeat_blue.png) !important;
 }

--- a/src/webui/static/app/tvheadend.js
+++ b/src/webui/static/app/tvheadend.js
@@ -277,6 +277,24 @@ tvheadend.getContentTypeIcons = function(rec, style) {
     tvheadend.applyHighResIconPath(tvheadend.uniqueArray(ret_minor)).join("") + '</span>';
 }
 
+tvheadend.renderCustomDate = function(value, meta, record) {
+    if (value) {
+        var dt = new Date(value);
+        return tvheadend.toCustomDate(dt,tvheadend.date_mask);
+    }
+    return "";
+}
+
+tvheadend.renderExtraText = function(value, meta, record) {
+    value = record.data.subtitle;
+    if (!value) {
+        value = record.data.summary;
+        if (!value)
+            value = record.data.description;
+    }
+  return value;
+}
+
 tvheadend.displayCategoryIcon = function(value, meta, record, ri, ci, store) {
   if (value == null)
     return '';


### PR DESCRIPTION
This add a similar/alternative button to DVR and EPG info dialog boxes.

Repurposed the "show duplicated" button from DVR to display this "show alternatives" dialog box. This then allows the user to select episodes to record.

Main internal changes was splitting some logic in epg.js so it could be shared with the new dialog, create new file epgevents.js to display the dialog box.

In tvh, we return the sorted lists using shared code since the dialog uses a livegrid that needs remote sorting. Also some minor const fixups and fixup core dump where NULL ptr passed through.
