### PR TITLE
freebsd: Fixup header files for socket definitions. 

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -19,11 +19,11 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <signal.h>
+#include <sys/types.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
-#include <sys/types.h>
 #include <sys/socket.h>
 #include <ifaddrs.h>
 #include <netdb.h>

--- a/src/tvh_thread.c
+++ b/src/tvh_thread.c
@@ -384,7 +384,11 @@ static void tvh_thread_mutex_deadlock(tvh_mutex_t *mutex)
 {
   int fd = hts_settings_open_file(HTS_SETTINGS_OPEN_WRITE | HTS_SETTINGS_OPEN_DIRECT, "mutex-deadlock.txt");
   if (fd < 0) fd = fileno(stderr);
+#ifdef PLATFORM_LINUX
   int sid = mutex->mutex.__data.__owner; /* unportable */
+#else
+  int sid = -1;
+#endif
   char name[256], *s;
   htsbuf_queue_t q;
   size_t l;

--- a/src/wrappers.c
+++ b/src/wrappers.c
@@ -1,5 +1,7 @@
 #define _GNU_SOURCE
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/socket.h>
 #include <fcntl.h>
 #include "tvheadend.h"
 #include "tvhregex.h"


### PR DESCRIPTION
Header files needed reordering for typedef ordering, and add missing socket headers to fix compilation on FreeBSD.

Also make thread owner debug conditional on Linux since not supported on FreeBSD/OSX.