### PR TITLE
ui: make related showings use api_epg_grid if no series link, fixes #5402

### DIFF
--- a/src/api/api_epg.c
+++ b/src/api/api_epg.c
@@ -620,8 +620,9 @@ api_epg_related
   uint32_t id, entries = 0;
   htsmsg_t *l = htsmsg_create_list();
   epg_broadcast_t *e;
-  char *lang;
-  epg_set_t *serieslink;
+  char *lang, *title_esc, *title_anchor;
+  epg_set_t *serieslink = NULL;
+  const char *title = NULL;
   
   if (htsmsg_get_u32(args, "eventId", &id))
     return -EINVAL;
@@ -630,9 +631,34 @@ api_epg_related
   lang = access_get_lang(perm, htsmsg_get_str(args, "lang"));
   tvh_mutex_lock(&global_lock);
   e = epg_broadcast_find_by_id(id);
-  serieslink = e->serieslink;
-  if (serieslink)
+  /* e might not exist if it is a dvr entry that does not exist in the epg */
+  if (e)
+    serieslink = e->serieslink;
+  if (serieslink) {
     entries = api_epg_episode_sorted(serieslink, perm, l, lang, e);
+  } else {
+    /* Ensure we have a title in the query we are generating.  If no
+     * title, then we return a dummy message.
+     */
+    title = epg_broadcast_get_title(e, lang);
+    if (title) {
+      /* Need to escape/anchor the search, otherwise the film "elf"
+       *  matches titles containing "self".
+       */
+      title_esc = regexp_escape(title);
+      title_anchor = alloca(strlen(title_esc) + 3);
+      sprintf(title_anchor, "^%s$", title_esc);
+      htsmsg_add_str(args, "title", title_anchor);
+      free(title_esc);
+
+      /* Have to unlock here since grid will re-lock */
+      tvh_mutex_unlock(&global_lock);
+      free(lang);
+      /* And let the grid do the query for us */
+      return api_epg_grid(perm, opaque, op, args, resp);
+    }
+    /*FALLTHRU*/
+  }
 
   tvh_mutex_unlock(&global_lock);
   free(lang);

--- a/src/epg.c
+++ b/src/epg.c
@@ -1466,7 +1466,7 @@ epg_broadcast_t *epg_broadcast_get_next ( epg_broadcast_t *b )
   return RB_NEXT(b, sched_link);
 }
 
-const char *epg_broadcast_get_title ( epg_broadcast_t *b, const char *lang )
+const char *epg_broadcast_get_title ( const epg_broadcast_t *b, const char *lang )
 {
   if (!b || !b->title) return NULL;
   return lang_str_get(b->title, lang);

--- a/src/epg.h
+++ b/src/epg.h
@@ -420,7 +420,7 @@ int epg_broadcast_set_age_rating
 epg_broadcast_t *epg_broadcast_get_prev( epg_broadcast_t *b );
 epg_broadcast_t *epg_broadcast_get_next( epg_broadcast_t *b );
 const char *epg_broadcast_get_title 
-  ( epg_broadcast_t *b, const char *lang );
+  ( const epg_broadcast_t *b, const char *lang );
 const char *epg_broadcast_get_subtitle
   ( epg_broadcast_t *b, const char *lang );
 const char *epg_broadcast_get_summary

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -280,7 +280,7 @@ tvheadend.dvrDetails = function(grid, index) {
             title: dialogTitle,
             iconCls: 'info',
             layout: 'fit',
-            width: 760,
+            width: 790,
             height: windowHeight,
             constrainHeader: true,
             buttonAlign: 'center',

--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -472,7 +472,7 @@ tvheadend.epgDetails = function(grid, index) {
         title: title,
         iconCls: 'broadcast_details',
         layout: 'fit',
-        width: 760,
+        width: 790,
         height: windowHeight,
         constrainHeader: true,
         buttons: buttons,


### PR DESCRIPTION
Some broadcasts do not have series link, so the related showings dialog returned an empty list.

Now, if we have no series link then we do a query to find entries that match by title and return that list as related showings.

Also make epg/dvr info dialogs slightly larger to mitigate problems where translated strings were pushing the related showings buttons off the screen.

Fixes: #5402
