### PR TITLE
ui: Enable scrollbar for dialog info, fixes #5405

### DIFF
--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -240,6 +240,8 @@ tvheadend.dvrDetails = function(grid, index) {
               // can overflow, vs. 'contain' which will leave blank space top+bottom to
               // ensure image is fully displayed in the window
               'background-size': 'cover',
+              // Image can not be clicked on (so events propagate to buttons).
+              'pointer-events': 'none',
           });
       }                        // Have fanart div
 

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -233,7 +233,7 @@ tvheadend.dvrDetails = function(grid, index) {
           fanart_div.applyStyles({
               'background' : 'url(' + fanart + ') center center no-repeat',
               'opacity': 0.15,
-              'position': 'relative',
+              'position': 'absolute',
               'width' : '100%',
               'height': '100%',
               // This causes background image to scale on css3 with aspect ratio, image

--- a/src/webui/static/app/ext.css
+++ b/src/webui/static/app/ext.css
@@ -842,7 +842,7 @@
     /* Details in here are overridden by  code */
 }
 .dvr-details-dialog-content {
-    position: absolute;
+    position: relative;
     top: 0;
     left: 0;
 }


### PR DESCRIPTION
When the dvr info dialog has a lot of text it was overflowing on to the buttons in the bbar.
By changing the css, the text now generates a scrollbar so no longer overflows in to the bbar. The image does still overflow, but its opacity makes it less of an issue.

Image below shows the scrollbar on the right when the window was resized to make the text flow.

![scrollbar](https://user-images.githubusercontent.com/31170571/49700567-4097d480-fbd8-11e8-9b55-76838fe396f2.png)
