### PR TITLE
added linudvb_rotor_external to control an actuator by spawning...

### DIFF
--- a/src/input/mpegts/linuxdvb/linuxdvb_private.h
+++ b/src/input/mpegts/linuxdvb/linuxdvb_private.h
@@ -282,6 +282,7 @@ struct linuxdvb_satconf
   int                    ls_last_tone_off;
   int                    ls_last_orbital_pos;
   int                    ls_last_queued_pos;
+  char                   *ls_external_cmd;
 };
 
 /*

--- a/src/input/mpegts/linuxdvb/linuxdvb_satconf.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_satconf.c
@@ -757,6 +757,15 @@ const idclass_t linuxdvb_satconf_advanced_class =
       .def.i    = 0
     },
     {
+      .type     = PT_STR,
+      .id       = "external_cmd",
+      .name     = N_("External command"),
+      .desc     = N_("Command to move the dish with rotor external."),
+      .off      = offsetof(linuxdvb_satconf_t, ls_external_cmd),
+      .opts     = PO_ADVANCED,
+      .def.i    = 0
+    },
+    {
       .type     = PT_U32,
       .id       = "motor_rate",
       .name     = N_("Motor rate (milliseconds/deg)"),


### PR DESCRIPTION
...an external command.

I have an old style actuator jack that I''m controlling with a parallel port, a couple of relays and an ad-hoc device driver, I'm planning to eventually control it with an arduino
(see https://linuxtv.org/vdrwiki/index.php/Actuator-plugin and https://tvheadend.org/boards/5/topics/35438)

This patch adds a new kind of rotor that spawns an external command to move the dish.
In turn the command will talk to the device (or the arduino) and will print on stdout an estimated time to move the dish. The command is used both in linuxdvb_rotor_tune and linux_dvb and linuxdvb_rotor_grace (the latter because the device knows where it is and it can give a better estimate than simply calculating the time the usual way).

A better option (instead of the grace time) would be to have a method to check if the dish is positioned, but I couldn't find where to add it in the tvheadend's tuning logic.

Another thing I miss is some kind of notification in the user interface (specifically the htsp client for kodi)  that the dish is moving, but that's another issue.