### PR TITLE
webui, htsbuf: Content-Disposition escape chars are not correct.

### DIFF
--- a/src/htsbuf.h
+++ b/src/htsbuf.h
@@ -79,6 +79,8 @@ void htsbuf_append_and_escape_xml(htsbuf_queue_t *hq, const char *str);
 
 void htsbuf_append_and_escape_url(htsbuf_queue_t *hq, const char *s);
 
+void htsbuf_append_and_escape_rfc8187(htsbuf_queue_t *hq, const char *s);
+
 void htsbuf_append_and_escape_jsonstr(htsbuf_queue_t *hq, const char *s);
 
 void htsbuf_dump_raw_stderr(htsbuf_queue_t *hq);

--- a/src/webui/webui.c
+++ b/src/webui/webui.c
@@ -1705,7 +1705,7 @@ http_serve_file(http_connection_t *hc, const char *fname,
         return HTTP_STATUS_INTERNAL;
       }
       htsbuf_queue_init(&q, 0);
-      htsbuf_append_and_escape_url(&q, basename);
+      htsbuf_append_and_escape_rfc8187(&q, basename);
       str = htsbuf_to_string(&q);
       r = 50 + strlen(str0) + strlen(str);
       disposition = alloca(r);


### PR DESCRIPTION
When attempting to download a recording with a comma Google Chrome will
fail with ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION. This is
because the comma ',' in the filename*=UTF-8'' field was not escaped.

This commit implements the defined list of non-escape characters from
RFC8187 based on htsbuf_append_and_escape_url.

The same problem occurs in issue #2086. Fixed in 2fdfe4836 "webui: fix the
attachment; filename encoding, fixes #2086" and broken again in ab9fc249a
"fix htsbuf_append_and_escape_url() - don't escape more allowed characters,
fixes #3721".

Only tested in release/4.2.

https://bugs.chromium.org/p/chromium/issues/detail?id=454165