### PR TITLE
hdhomerun: auto detect DVB_T devices

### DIFF
--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
@@ -331,6 +331,8 @@ static void tvhdhomerun_device_create(struct hdhomerun_discover_device_t *dInfo)
       type = DVB_TYPE_ATSC_T;
     if (strstr(hd->hd_info.deviceModel, "_cablecard"))
       type = DVB_TYPE_CABLECARD;
+    if (strstr(hd->hd_info.deviceModel, "_dvbt"))
+      type = DVB_TYPE_T;
   }
 
   hd->hd_override_type = strdup(dvb_type2str(type));


### PR DESCRIPTION
I have a DVB-T hdhomerun which reports itself as model hdhomerun5_dvbt. When installing with the wizard it incorrectly assumes it is DVB-C. This fixes it.