### PR TITLE
Changes to make tvheadend work in a container while talking to HDHomerun

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1707,6 +1707,9 @@ config_boot
   config.iptv_tpool_count = 2;
   config.date_mask = strdup("");
   config.label_formatting = 0;
+  config.hdhomerun_ip = strdup("");
+  config.local_ip = strdup("");
+  config.local_port = 0;
 
   idclass_register(&config_class);
 
@@ -1843,6 +1846,8 @@ void config_done ( void )
   free(config.picon_path);
   free(config.cors_origin);
   free(config.date_mask);
+  free(config.hdhomerun_ip);
+  free(config.local_ip);
   file_unlock(config_lock, config_lock_fd);
 }
 
@@ -2133,6 +2138,43 @@ const idclass_t config_class = {
                    "config."),
       .off    = offsetof(config_t, full_version),
       .opts   = PO_RDONLY | PO_HIDDEN | PO_EXPERT,
+      .group  = 1
+    },
+    {
+      .type   = PT_STR,
+      .id     = "hdhomerun_ip",
+      .name   = N_("HDHomerun IP Address"),
+      .desc   = N_("IP address of the HDHomerun device. This is needed if you "
+                   "plan to run TVheadend in a container and you want to stream "
+                   "from an HDHomerun without enabling host networking for "
+                   "the container."),
+      .off    = offsetof(config_t, hdhomerun_ip),
+      .opts   = PO_HIDDEN | PO_EXPERT,
+      .group  = 1
+    },
+    {
+      .type   = PT_STR,
+      .id     = "local_ip",
+      .name   = N_("Local IP Address"),
+      .desc   = N_("IP address of the HDHomerun device. This is needed if you "
+                   "plan to run TVheadend in a container and you want to stream "
+                   "from an HDHomerun without enabling host networking for "
+                   "the container."),
+      .off    = offsetof(config_t, local_ip),
+      .opts   = PO_HIDDEN | PO_EXPERT,
+      .group  = 1
+    },
+    {
+      .type   = PT_INT,
+      .id     = "local_port",
+      .name   = N_("Local Socket Port Number"),
+      .desc   = N_("Port number of the UDP listener. This listener listens "
+                   "for traffic from the HDHomerun device. This is needed if "
+                   "you plan to run TVheadend in a container and you want to "
+                   "stream from an HDHomerun without enabling host networking "
+                   "for the container."),
+      .off    = offsetof(config_t, local_port),
+      .opts   = PO_HIDDEN | PO_EXPERT,
       .group  = 1
     },
     {

--- a/src/config.c
+++ b/src/config.c
@@ -2457,10 +2457,11 @@ const idclass_t config_class = {
       .type   = PT_STR,
       .id     = "local_ip",
       .name   = N_("Local IP Address"),
-      .desc   = N_("IP address of the HDHomerun device. This is needed if you "
-                   "plan to run TVheadend in a container and you want to stream "
-                   "from an HDHomerun without enabling host networking for "
-                   "the container."),
+      .desc   = N_("IP of the Docker host. Each HDHomeRun tuner sends data "
+                   "to TVheadend through a socket. This lets you define the "
+                   "IP address that HDHomeRun needs to send to. Leave this "
+                   "blank if you want TVheadend to automatically pick an "
+                   "address."),
       .off    = offsetof(config_t, local_ip),
       .opts   = PO_HIDDEN | PO_EXPERT,
       .group  = 6

--- a/src/config.c
+++ b/src/config.c
@@ -2168,11 +2168,17 @@ const idclass_t config_class = {
       .type   = PT_INT,
       .id     = "local_port",
       .name   = N_("Local Socket Port Number"),
-      .desc   = N_("Port number of the UDP listener. This listener listens "
-                   "for traffic from the HDHomerun device. This is needed if "
-                   "you plan to run TVheadend in a container and you want to "
-                   "stream from an HDHomerun without enabling host networking "
-                   "for the container."),
+      .desc   = N_("Starting port number of the UDP listeners. The listeners "
+                   "listen for traffic from the HDHomerun tuners. This is "
+                   "needed if you plan to run TVheadend in a container and "
+                   "you want to stream from an HDHomerun without enabling "
+                   "host networking for the container. Set this to 0 if you "
+                   "want the port numbers to be assigned dynamically. If you "
+                   "have multiple tuners, this will be the start of the port "
+                   "range. For example, if you have 4 tuners and you set this "
+                   "to 9983, then tuner 0 will talk to port 9983, tuner 1 "
+                   "will talk to port 9984, tuner 2 will talk to port 9985, "
+                   "and tuner 3 will talk to port 9986."),
       .off    = offsetof(config_t, local_port),
       .opts   = PO_HIDDEN | PO_EXPERT,
       .group  = 1

--- a/src/config.c
+++ b/src/config.c
@@ -2106,8 +2106,12 @@ const idclass_t config_class = {
          .number = 5,
       },
       {
-         .name   = N_("Miscellaneous Settings"),
+         .name   = N_("HDHomeRun"),
          .number = 6,
+      },
+      {
+         .name   = N_("Miscellaneous Settings"),
+         .number = 7,
       },
       {}
   },
@@ -2138,49 +2142,6 @@ const idclass_t config_class = {
                    "config."),
       .off    = offsetof(config_t, full_version),
       .opts   = PO_RDONLY | PO_HIDDEN | PO_EXPERT,
-      .group  = 1
-    },
-    {
-      .type   = PT_STR,
-      .id     = "hdhomerun_ip",
-      .name   = N_("HDHomerun IP Address"),
-      .desc   = N_("IP address of the HDHomerun device. This is needed if you "
-                   "plan to run TVheadend in a container and you want to stream "
-                   "from an HDHomerun without enabling host networking for "
-                   "the container."),
-      .off    = offsetof(config_t, hdhomerun_ip),
-      .opts   = PO_HIDDEN | PO_EXPERT,
-      .group  = 1
-    },
-    {
-      .type   = PT_STR,
-      .id     = "local_ip",
-      .name   = N_("Local IP Address"),
-      .desc   = N_("IP address of the HDHomerun device. This is needed if you "
-                   "plan to run TVheadend in a container and you want to stream "
-                   "from an HDHomerun without enabling host networking for "
-                   "the container."),
-      .off    = offsetof(config_t, local_ip),
-      .opts   = PO_HIDDEN | PO_EXPERT,
-      .group  = 1
-    },
-    {
-      .type   = PT_INT,
-      .id     = "local_port",
-      .name   = N_("Local Socket Port Number"),
-      .desc   = N_("Starting port number of the UDP listeners. The listeners "
-                   "listen for traffic from the HDHomerun tuners. This is "
-                   "needed if you plan to run TVheadend in a container and "
-                   "you want to stream from an HDHomerun without enabling "
-                   "host networking for the container. Set this to 0 if you "
-                   "want the port numbers to be assigned dynamically. If you "
-                   "have multiple tuners, this will be the start of the port "
-                   "range. For example, if you have 4 tuners and you set this "
-                   "to 9983, then tuner 0 will talk to port 9983, tuner 1 "
-                   "will talk to port 9984, tuner 2 will talk to port 9985, "
-                   "and tuner 3 will talk to port 9986."),
-      .off    = offsetof(config_t, local_port),
-      .opts   = PO_HIDDEN | PO_EXPERT,
       .group  = 1
     },
     {
@@ -2482,12 +2443,55 @@ const idclass_t config_class = {
     },
     {
       .type   = PT_STR,
+      .id     = "hdhomerun_ip",
+      .name   = N_("HDHomerun IP Address"),
+      .desc   = N_("IP address of the HDHomerun device. This is needed if you "
+                   "plan to run TVheadend in a container and you want to stream "
+                   "from an HDHomerun without enabling host networking for "
+                   "the container."),
+      .off    = offsetof(config_t, hdhomerun_ip),
+      .opts   = PO_HIDDEN | PO_EXPERT,
+      .group  = 6
+    },
+    {
+      .type   = PT_STR,
+      .id     = "local_ip",
+      .name   = N_("Local IP Address"),
+      .desc   = N_("IP address of the HDHomerun device. This is needed if you "
+                   "plan to run TVheadend in a container and you want to stream "
+                   "from an HDHomerun without enabling host networking for "
+                   "the container."),
+      .off    = offsetof(config_t, local_ip),
+      .opts   = PO_HIDDEN | PO_EXPERT,
+      .group  = 6
+    },
+    {
+      .type   = PT_INT,
+      .id     = "local_port",
+      .name   = N_("Local Socket Port Number"),
+      .desc   = N_("Starting port number of the UDP listeners. The listeners "
+                   "listen for traffic from the HDHomerun tuners. This is "
+                   "needed if you plan to run TVheadend in a container and "
+                   "you want to stream from an HDHomerun without enabling "
+                   "host networking for the container. Set this to 0 if you "
+                   "want the port numbers to be assigned dynamically. If you "
+                   "have multiple tuners, this will be the start of the port "
+                   "range. For example, if you have 4 tuners and you set this "
+                   "to 9983, then tuner 0 will talk to port 9983, tuner 1 "
+                   "will talk to port 9984, tuner 2 will talk to port 9985, "
+                   "and tuner 3 will talk to port 9986."),
+      .off    = offsetof(config_t, local_port),
+      .opts   = PO_HIDDEN | PO_EXPERT,
+      .group  = 6
+    },
+    {
+      .type   = PT_STR,
       .id     = "http_user_agent",
       .name   = N_("HTTP User Agent"),
       .desc   = N_("The user agent string for the build-in HTTP client."),
       .off    = offsetof(config_t, http_user_agent),
       .opts   = PO_HIDDEN | PO_EXPERT,
-      .group  = 6,
+      .group  = 7,
     },
     {
       .type   = PT_INT,
@@ -2496,7 +2500,7 @@ const idclass_t config_class = {
       .desc   = N_("Set the number of threads for IPTV to split load "
                    "across more CPUs."),
       .off    = offsetof(config_t, iptv_tpool_count),
-      .group  = 6,
+      .group  = 7,
     },
     {
       .type   = PT_INT,
@@ -2513,7 +2517,7 @@ const idclass_t config_class = {
       .off    = offsetof(config_t, dscp),
       .list   = config_class_dscp_list,
       .opts   = PO_EXPERT | PO_DOC_NLIST,
-      .group  = 6,
+      .group  = 7,
     },
     {
       .type   = PT_U32,
@@ -2523,7 +2527,7 @@ const idclass_t config_class = {
                    "there is a delay receiving CA keys. "),
       .off    = offsetof(config_t, descrambler_buffer),
       .opts   = PO_EXPERT,
-      .group  = 6,
+      .group  = 7,
     },
     {
       .type   = PT_BOOL,
@@ -2534,7 +2538,7 @@ const idclass_t config_class = {
                    "It may cause issues with some clients / players."),
       .off    = offsetof(config_t, parser_backlog),
       .opts   = PO_EXPERT,
-      .group  = 6,
+      .group  = 7,
     },
     {
       .type   = PT_STR,
@@ -2547,7 +2551,7 @@ const idclass_t config_class = {
       .off    = offsetof(config_t, muxconf_path),
       .notify = config_muxconfpath_notify,
       .opts   = PO_ADVANCED,
-      .group  = 6,
+      .group  = 7,
     },
     {
       .type   = PT_BOOL,
@@ -2555,7 +2559,7 @@ const idclass_t config_class = {
       .name   = N_("Parse HbbTV info"),
       .desc   = N_("Parse HbbTV information from services."),
       .off    = offsetof(config_t, hbbtv),
-      .group  = 6,
+      .group  = 7,
     },
     {
       .type   = PT_BOOL,
@@ -2566,7 +2570,7 @@ const idclass_t config_class = {
                    "the system clock (normally only root)."),
       .off    = offsetof(config_t, tvhtime_update_enabled),
       .opts   = PO_EXPERT,
-      .group  = 6,
+      .group  = 7,
     },
     {
       .type   = PT_BOOL,
@@ -2578,7 +2582,7 @@ const idclass_t config_class = {
                    "performance is not that great."),
       .off    = offsetof(config_t, tvhtime_ntp_enabled),
       .opts   = PO_EXPERT,
-      .group  = 6,
+      .group  = 7,
     },
     {
       .type   = PT_U32,
@@ -2590,7 +2594,7 @@ const idclass_t config_class = {
                    "excessive oscillations on the system clock."),
       .off    = offsetof(config_t, tvhtime_tolerance),
       .opts   = PO_EXPERT,
-      .group  = 6,
+      .group  = 7,
     },
     {
       .type   = PT_STR,

--- a/src/config.h
+++ b/src/config.h
@@ -70,6 +70,9 @@ typedef struct config {
   char *date_mask;
   int label_formatting;
   uint32_t ticket_expires;
+  char *hdhomerun_ip;
+  char *local_ip;
+  int local_port;
 } config_t;
 
 extern const idclass_t config_class;

--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
@@ -387,18 +387,14 @@ static void tvhdhomerun_device_create(struct hdhomerun_discover_device_t *dInfo)
 static uint32_t
 tvhdhomerun_ip( void )
 {
-  static int homerun_ip_initialized = 0;
-  static uint32_t ip = 0;
+  if (*config.hdhomerun_ip == 0) return 0;
 
-  if (!homerun_ip_initialized)
-  {
-    if ((*config.hdhomerun_ip != 0) && inet_pton(AF_INET, config.hdhomerun_ip, &ip))
-    {
-      tvhinfo(LS_TVHDHOMERUN, "HDHomerun IP set to %s", config.hdhomerun_ip);
-      ip = ntohl(ip);
-    }
-    homerun_ip_initialized = 1;
-  }
+  uint32_t ip = 0;
+  if (inet_pton(AF_INET, config.hdhomerun_ip, &ip))
+    ip = ntohl(ip);
+  else
+    tvhwarn(LS_TVHDHOMERUN, "Could not parse IP address %s", config.hdhomerun_ip);
+
   return ip;
 }
 

--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
@@ -30,6 +30,8 @@
 #include <arpa/inet.h>
 #include <openssl/sha.h>
 
+#include "config.h"
+
 #ifdef HDHOMERUN_TAG_DEVICE_AUTH_BIN
 #define hdhomerun_discover_find_devices_custom \
            hdhomerun_discover_find_devices_custom_v2
@@ -382,6 +384,24 @@ static void tvhdhomerun_device_create(struct hdhomerun_discover_device_t *dInfo)
   htsmsg_destroy(conf);
 }
 
+static uint32_t
+tvhdhomerun_ip( void )
+{
+  static int homerun_ip_initialized = 0;
+  static uint32_t ip = 0;
+
+  if (!homerun_ip_initialized)
+  {
+    if ((*config.hdhomerun_ip != 0) && inet_pton(AF_INET, config.hdhomerun_ip, &ip))
+    {
+      tvhinfo(LS_TVHDHOMERUN, "HDHomerun IP set to %s", config.hdhomerun_ip);
+      ip = ntohl(ip);
+    }
+    homerun_ip_initialized = 1;
+  }
+  return ip;
+}
+
 static void *
 tvhdhomerun_device_discovery_thread( void *aux )
 {
@@ -391,7 +411,7 @@ tvhdhomerun_device_discovery_thread( void *aux )
   while (tvheadend_is_running()) {
 
     numDevices =
-      hdhomerun_discover_find_devices_custom(0,
+      hdhomerun_discover_find_devices_custom(tvhdhomerun_ip(),
                                              HDHOMERUN_DEVICE_TYPE_TUNER,
                                              HDHOMERUN_DEVICE_ID_WILDCARD,
                                              result_list,

--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
@@ -393,7 +393,7 @@ tvhdhomerun_ip( void )
   if (inet_pton(AF_INET, config.hdhomerun_ip, &ip))
     ip = ntohl(ip);
   else
-    tvhwarn(LS_TVHDHOMERUN, "Could not parse IP address %s", config.hdhomerun_ip);
+    tvherror(LS_TVHDHOMERUN, "Could not parse IP address %s", config.hdhomerun_ip);
 
   return ip;
 }

--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c
@@ -133,7 +133,7 @@ tvhdhomerun_frontend_input_thread ( void *aux )
   memset(&sock_addr, 0, sizeof(sock_addr));
   sock_addr.sin_family = AF_INET;
   sock_addr.sin_addr.s_addr = htonl(INADDR_ANY);
-  sock_addr.sin_port = config.local_port==0?0:htons(config.local_port);
+  sock_addr.sin_port = config.local_port==0?0:htons(config.local_port + hfe->hf_tunerNumber);
   if(bind(sockfd, (struct sockaddr *) &sock_addr, sizeof(sock_addr)) != 0) {
     tvherror(LS_TVHDHOMERUN, "failed bind socket: %d", errno);
     close(sockfd);

--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c
@@ -93,11 +93,12 @@ tvhdhomerun_frontend_input_thread ( void *aux )
 
   /* local IP */
   /* TODO: this is nasty */
-  local_ip = hdhomerun_device_get_local_machine_addr(hfe->hf_hdhomerun_tuner);
-  if ((*config.local_ip != 0) && inet_pton(AF_INET, config.local_ip, &local_ip))
-  {
+  if (*config.local_ip == 0)
+    local_ip = hdhomerun_device_get_local_machine_addr(hfe->hf_hdhomerun_tuner);
+  else if (inet_pton(AF_INET, config.local_ip, &local_ip))
     local_ip = ntohl(local_ip);
-  }
+  else
+    tvherror(LS_TVHDHOMERUN, "failed to parse local IP (%s)", config.local_ip);
 
   /* first setup a local socket for the device to stream to */
   sockfd = tvh_socket(AF_INET, SOCK_DGRAM, 0);


### PR DESCRIPTION
tvheadend relies on multicasting to communicate with the HDHomerun.

This presents problems when running tvheadend in a Docker container without enabling host networking in the container.

To solve this, I added 3 fields to the config -
1. hdhomerun_ip
2. local_ip
3. local_port

hdhomerun_ip is used during the discovery process. The IP of the HDHomerun device is passed to libhdhomerun, bypassing the multicast process.

local_ip and local_port are used for communications with the HDHomerun device. This lets you forward traffic from the Docker host to the container.