### PR TITLE
dvr: autorec should only compare min season/year if it exists in EPG (fixes #5479)

### DIFF
--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -309,19 +309,24 @@ dvr_autorec_cmp(dvr_autorec_entry_t *dae, epg_broadcast_t *e)
     if(duration > dae->dae_maxduration) return 0;
   }
 
-  if(dae->dae_minyear > 0) {
+  /* Only do year/season checks when programme guide has these values available.
+   * This is because you might have "minseason=5" but Christmas specials have no
+   * no season (or season=0) and many people still want them to be picked up by
+   * default.
+   */
+  if(e->copyright_year && dae->dae_minyear > 0) {
     if(e->copyright_year < dae->dae_minyear) return 0;
   }
 
-  if(dae->dae_maxyear > 0) {
+  if(e->copyright_year && dae->dae_maxyear > 0) {
     if(e->copyright_year > dae->dae_maxyear) return 0;
   }
 
-  if(dae->dae_minseason > 0) {
+  if(e->epnum.s_num && dae->dae_minseason > 0) {
     if(e->epnum.s_num < dae->dae_minseason) return 0;
   }
 
-  if(dae->dae_maxseason > 0) {
+  if(e->epnum.s_num && dae->dae_maxseason > 0) {
     if(e->epnum.s_num > dae->dae_maxseason) return 0;
   }
 

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -1250,6 +1250,10 @@ tvheadend.autorec_editor = function(panel, index) {
             maxsched:     { width: 80 },
             star_rating:  { width: 80 },
             config_name:  { width: 120 },
+            minyear:      { width: 100 },
+            maxyear:      { width: 100 },
+            minseason:    { width: 100 },
+            maxseason:    { width: 100 },
             owner:        { width: 100 },
             creator:      { width: 200 },
             comment:      { width: 200 }
@@ -1269,7 +1273,7 @@ tvheadend.autorec_editor = function(panel, index) {
         del: true,
         list: 'enabled,name,title,fulltext,channel,tag,start,start_window,' +
               'weekdays,minduration,maxduration,record,btype,content_type,cat1,cat2,cat3' +
-              'star_rating,pri,dedup,directory,config_name,owner,creator,comment',
+              'star_rating,pri,dedup,directory,config_name,minseason,maxseason,minyear,maxyear,owner,creator,comment',
         sort: {
           field: 'name',
           direction: 'ASC'


### PR DESCRIPTION
Autorec rule can have minseason/maxseason and minyear/maxyear. However, specials (such as Christmas specials) frequently don't have season/episode details.  But users could expect all "s5 or greater" to include the "s5 Christmas special".

So, we now only compare min/max season if it is available in the EPG. Similar for min/max year. If the EPG is missing the info then we allow the entry to be recorded.

Also added these four fields to the autorec grid as requested.
