### PR TITLE
dvr: New format specifier for per-dir seasons and one movie per dir. (#4667)

### DIFF
--- a/docs/property/pathname.md
+++ b/docs/property/pathname.md
@@ -56,7 +56,8 @@ Examples are below based on different information in the EPG:
 - Countdown/Countdown (episode without guide season/episode information)
 
 The `$Q` and `$q` formats also have two numeric modifiers to select
-variant formats and can be used as `$1Q`, `$2Q`, `$1q`, and `$2q`.
+variant formats and can be used as `$1Q`, `$2Q`, `3Q`, `$1q`,  `$2q`,
+and `$3q`.
 
 The number 1 variant forces the recording to be formatted as a movie,
 ignoring the genre from the schedule.
@@ -66,6 +67,19 @@ tv series.
 
 These variants can be useful to work-around bad schedule data that gives
 incorrect genres for programmes.
+
+The number 3 variants (`$3Q` and `$3q`) is an alternative directory
+layout that can be used if your guide data has accurate programme
+information. It will put movies in separate directories for each movie
+and tvshows in separate per-season directories.
+
+Examples for `$3q` are:
+- tvmovies/Gladiator (2000)/Gladiator (2000)
+- tvshows/Bones/Season 5/Bones - S05E11
+
+Examples for `$3Q` are:
+- Gladiator (2000)/Gladiator (2000)
+- Bones/Season 5/Bones - S05E11
 
 Typically the `$q` and `$Q` formats would be combined with other
 modifiers to generate a complete filename such as `$q$n.$x`.


### PR DESCRIPTION
Previously the $q format specifier would only output movies as:
	tvmovies/title (yyyy).ts

However, a common alternative is to store each movie in its own sub-directory:
	tvmovies/title1 (yyyy)/title1 (yyyy).ts
	tvmovies/title2 (yyyy)/title2 (yyyy).ts

Similarly for episodes we output:
	tvshows/title/title - SxxEyy.ts

But a common alternative is to have one directory per season:
	tvshows/title/Season 1/title - S01Eyy.ts
	tvshows/title/Season 2/title - S02Eyy.ts

So we now add a "$3q" to output these common alternatives, as requested in the forums.
[https://tvheadend.org/boards/5/topics/35778](https://tvheadend.org/boards/5/topics/35778)

Also add equivalent "$3Q" to output without the "genre" prefix i.e., without "tvshows/" or "tvmovies/".

I've put change against the original issue 4667 which implemented the original $q format specifier. I'm not too happy with it being called "$3q" since these modifiers are hard to remember, but I am hoping the small number of variants makes it acceptable.

The word "Season" for directories is deliberately not localized based on advice from the Plex wiki to always use the English word. [https://support.plex.tv/articles/200220687-naming-series-season-based-tv-shows/](https://support.plex.tv/articles/200220687-naming-series-season-based-tv-shows/).

Issue: #4667

