### PR TITLE
Include a possible status update link for hosting outages

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,8 @@ For more information about building, including generating packages, please visit
 * https://tvheadend.org/projects/tvheadend/wiki/Packaging
 * https://tvheadend.org/projects/tvheadend/wiki/Git
 * https://tvheadend.org/projects/tvheadend/wiki/Internationalization
+
+Site status Updates
+--------------
+
+https://twitter.com/tvheadend


### PR DESCRIPTION
Hello,

I've been trying to access https://tvheadend.org for the last 40'ish hours and it's not accessing with the browser nor `apt-get update` in Ubunutu/Kubuntu.

Cloudflare returns a 522 status code page saying the server host has an error.

``` console

Error 522 Ray ID: 4ac8e3c56d68c7df • 2019-02-21 11:32:29 UTC
Connection timed out
```

I realize [the twitter feed](https://twitter.com/tvheadend) hasn't been used in a very long time *(2016)* but thought perhaps someone could add this PR and utilize twitter for site status notices/updates of some sort. 

If this is not wanted please give a gentle close perhaps with another recommendation for knowing how to report an outage or PR change... however it's literally the only way that I know of to mention that the FQDN of tvheadend.org is "down" atm and the forums are located there as well. So a little difficult to mention it there.

Thank you for the consideration.

Keep up the great work everyone and a super big THANK YOU! for all of your dedication and support to this project.

P.S. Irc with name registration won't happen due to security restraints since I am a site administrator e.g. network and site policy prevents me from exposing confidential information.

Refs:
* <a href="https://user-images.githubusercontent.com/114709/53167232-9bfd2000-3594-11e9-86a5-f609cd2b4fcd.png"><img src="https://user-images.githubusercontent.com/114709/53167232-9bfd2000-3594-11e9-86a5-f609cd2b4fcd.png" alt="Browser 522" title="Click to enlarge... Browser 522 status code" width="167" height="87"/></a> *(What I see for about 2 days now)*
* https://www.cloudflarestatus.com/ *(particularly in the U.S. ... there was an incident yesterday but they claim it's fixed)*

and also:
``` console
$ sudo apt-get update
...
Err:20 https://apt.tvheadend.org/unstable bionic Release
  522  Origin Connection Time-out [IP: 104.31.94.73 443]
Reading package lists... Done
E: The repository 'https://apt.tvheadend.org/unstable bionic Release' no longer has a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
...
$ ping -c 1 tvheadend.org
PING tvheadend.org (104.31.95.73) 56(84) bytes of data.
64 bytes from 104.31.95.73: icmp_seq=1 ttl=57 time=10.6 ms

--- tvheadend.org ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 10.698/10.698/10.698/0.000 ms
```
... I tagged onto a forum issue discussion at https://www.tvheadend.org/issues/5541 for the inability to install the stable version probably due to a compilation issue which is why I'm currently using the unstable.