### PR TITLE
Change expected result type from export

### DIFF
--- a/lib/api/python/tvh-json.py
+++ b/lib/api/python/tvh-json.py
@@ -124,7 +124,7 @@ def do_get(*args):
 def do_export(*args):
     if len(args) < 1: error(1, 'get [uuid]')
     body = do_get0('raw/export', {'uuid':args[0]})
-    if type(body) != type({}):
+    if type(body) != type([]):
         error(11, 'Unknown data')
     if 'entries' in body:
         body = body['entries']


### PR DESCRIPTION
It appears that now the result type for "export" is a list and not a dictionary