### PR TITLE
systemd: service/unit should not be started until after file-systems …

### DIFF
--- a/debian/tvheadend.service
+++ b/debian/tvheadend.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Tvheadend - a TV streaming server and DVR
-After=syslog.target network.target auditd.service
+After=auditd.service syslog.target network.target local-fs.target *.mount
 
 [Service]
 EnvironmentFile=/etc/default/tvheadend

--- a/rpm/tvheadend.service
+++ b/rpm/tvheadend.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Tvheadend - a TV streaming server and DVR
-After=syslog.target network.target auditd.service
+After=auditd.service syslog.target network.target local-fs.target *.mount
 
 [Service]
 EnvironmentFile=/etc/sysconfig/tvheadend


### PR DESCRIPTION
…are mounted - this avoids "file missing" errors