### PR TITLE
Added patch to HDHomerun library to allow cross-compilation

### DIFF
--- a/Makefile.hdhomerun
+++ b/Makefile.hdhomerun
@@ -48,6 +48,7 @@ LIB_FILES      := \
 			$(LIB_ROOT)/$(LIBHDHR)/.tvh_build \
 			$(LIB_ROOT)/libhdhomerun/libhdhomerun.a \
 			$(LIB_ROOT)/libhdhomerun/*.h
+LIB_DIFFS      := hdhomerun.diff
 
 include $(DIR)/Makefile.static
 
@@ -79,6 +80,7 @@ $(LIB_ROOT)/$(LIBHDHR)/.tvh_download:
 	$(call DOWNLOAD,$(LIBHDHR_URL),$(LIB_ROOT)/$(LIBHDHR_TB),$(LIBHDHR_SHA1))
 	$(call UNTAR,$(LIBHDHR_TB),z)
 	ln -sf libhdhomerun $(LIB_ROOT)/$(LIBHDHR)
+	$(call PATCH,$(LIBHDHR),$(LIB_DIFFS))
 	@touch $@
 
 $(LIB_ROOT)/$(LIBHDHR)/.tvh_build: \

--- a/support/patches/hdhomerun.diff
+++ b/support/patches/hdhomerun.diff
@@ -1,0 +1,14 @@
+diff -urN ./Makefile.original ./Makefile
+--- ./Makefile.original	2019-03-09 12:11:36.506168804 +0100
++++ ./Makefile	2019-03-09 12:11:44.490392155 +0100
+@@ -11,8 +11,8 @@
+ LIBSRCS += hdhomerun_sock_posix.c
+ LIBSRCS += hdhomerun_video.c
+ 
++#CC    := $(CROSS_COMPILE)gcc
++#STRIP := $(CROSS_COMPILE)strip
+-CC    := $(CROSS_COMPILE)gcc
+-STRIP := $(CROSS_COMPILE)strip
+ 
+ CFLAGS += -O2 -Wall -Wextra -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wpointer-arith -Wno-unused-parameter
+ LDFLAGS += -lpthread


### PR DESCRIPTION
Allows to static build HDHomerun library when cross-compiling for other platforms (such as armel), see feature #5130.

The HDHomerun [Makefile ignores the `CC` variable](https://github.com/Silicondust/libhdhomerun/blob/9719cbc7a562dfc3ae638ba1f3769f9451db5389/Makefile#L14-L15) set by the TVHeadend makefile after configuration and this builds the `libhdhomerun.a` library with the host gcc (x86_64 for example). This gives errors when linking at the end:
```
Markdown: docs/wizard/network.md
Markdown: docs/wizard/status.md
CC              src/docs.o
CC              build.o
CC              timestamp.o
CC              tvheadend
/root/tvheadend/tvheadend/build.linux/hdhomerun/libhdhomerun/libhdhomerun.a: error adding symbols: File format not recognized
collect2: error: ld returned 1 exit status
Makefile:699: recipe for target '/root/tvheadend/tvheadend/build.linux/tvheadend' failed
make: *** [/root/tvheadend/tvheadend/build.linux/tvheadend] Error 1
```