### PR TITLE
[4.2 release] Fix compilation with OpenSSL 1.1.1

### DIFF
--- a/src/httpc.c
+++ b/src/httpc.c
@@ -56,7 +56,7 @@ struct http_client_ssl {
   char    *rbio_buf;
   size_t   rbio_size;
   size_t   rbio_pos;
-  
+
   BIO     *wbio;
   char    *wbio_buf;
   size_t   wbio_size;
@@ -890,7 +890,7 @@ http_client_data_received( http_client_t *hc, char *buf, ssize_t len, int hdr )
     if (!hdr && hc->hc_rpos >= hc->hc_csize)
       return 1;
     return 0;
-  }  
+  }
 
   csize = hc->hc_csize == (size_t)-1 ? 0 : hc->hc_csize;
   l = len;
@@ -1505,7 +1505,11 @@ http_client_reconnect
   if (strcasecmp(scheme, "https") == 0 || strcasecmp(scheme, "rtsps") == 0) {
     ssl = calloc(1, sizeof(*ssl));
     hc->hc_ssl = ssl;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     ssl->ctx   = SSL_CTX_new(SSLv23_client_method());
+#else
+    ssl->ctx   = SSL_CTX_new(TLS_client_method());
+#endif
     if (ssl->ctx == NULL) {
       tvherror(LS_HTTPC, "%04X: Unable to get SSL_CTX", shortid(hc));
       goto err1;
@@ -1552,7 +1556,7 @@ errnval:
 }
 
 http_client_t *
-http_client_connect 
+http_client_connect
   ( void *aux, http_ver_t ver, const char *scheme,
     const char *host, int port, const char *bindaddr )
 {
@@ -1593,7 +1597,7 @@ http_client_register( http_client_t *hc )
 {
   assert(hc->hc_data_received || hc->hc_conn_closed || hc->hc_data_complete);
   assert(hc->hc_efd == NULL);
-  
+
   pthread_mutex_lock(&http_lock);
 
   TAILQ_INSERT_TAIL(&http_clients, hc, hc_link);

--- a/src/main.c
+++ b/src/main.c
@@ -83,7 +83,9 @@
 #include <openssl/conf.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
+#ifndef OPENSSL_NO_ENGINE
 #include <openssl/engine.h>
+#endif
 
 pthread_t main_tid;
 
@@ -1155,10 +1157,12 @@ main(int argc, char **argv)
   sigprocmask(SIG_BLOCK, &set, NULL);
   trap_init(argv[0]);
 
-  /* SSL library init */
-  OPENSSL_config(NULL);
-  SSL_load_error_strings();
-  SSL_library_init();
+  #if OPENSSL_VERSION_NUMBER < 0x10100000L
+    /* SSL library init */
+    OPENSSL_config(NULL);
+    SSL_load_error_strings();
+    SSL_library_init();
+  #endif
 
   #ifndef OPENSSL_NO_ENGINE
     /* ENGINE init */
@@ -1352,8 +1356,11 @@ main(int argc, char **argv)
   if(opt_fork)
     unlink(opt_pidpath);
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
   /* OpenSSL - welcome to the "cleanup" hell */
+  #ifndef OPENSSL_NO_ENGINE
   ENGINE_cleanup();
+  #endif
   RAND_cleanup();
   CRYPTO_cleanup_all_ex_data();
   EVP_cleanup();
@@ -1367,6 +1374,7 @@ main(int argc, char **argv)
   sk_SSL_COMP_free(SSL_COMP_get_compression_methods());
 #endif
   /* end of OpenSSL cleanup code */
+#endif
 
 #if ENABLE_DBUS_1
   extern void dbus_shutdown(void);

--- a/src/main.c
+++ b/src/main.c
@@ -98,7 +98,7 @@ typedef struct {
   enum {
     OPT_STR,
     OPT_INT,
-    OPT_BOOL, 
+    OPT_BOOL,
     OPT_STR_LIST,
   }          type;
   void       *param;
@@ -526,7 +526,7 @@ show_usage
       free(desc);
     }
   }
-  printf("%s", 
+  printf("%s",
          _("\n"
            "For more information please visit the Tvheadend website:\n"
            "https://tvheadend.org\n"));
@@ -615,7 +615,7 @@ mtimer_thread(void *aux)
     next = now + sec2mono(3600);
 
     while((mti = LIST_FIRST(&mtimers)) != NULL) {
-      
+
       if (mti->mti_expire > now) {
         next = mti->mti_expire;
         break;
@@ -648,7 +648,7 @@ mtimer_thread(void *aux)
     tvh_cond_timedwait(&mtimer_cond, &global_lock, next);
     pthread_mutex_unlock(&global_lock);
   }
-  
+
   return NULL;
 }
 
@@ -678,7 +678,7 @@ mainloop(void)
 
     // TODO: there is a risk that if timers re-insert themselves to
     //       the top of the list with a 0 offset we could loop indefinitely
-    
+
 #if 0
     tvhdebug(LS_GTIMER, "now %"PRItime_t, ts.tv_sec);
     LIST_FOREACH(gti, &gtimers, gti_link)
@@ -686,7 +686,7 @@ mainloop(void)
 #endif
 
     while((gti = LIST_FIRST(&gtimers)) != NULL) {
-      
+
       if (gti->gti_expire > now) {
         ts.tv_sec = gti->gti_expire;
         break;
@@ -1033,12 +1033,12 @@ main(int argc, char **argv)
   }
   if (opt_log_debug)
     log_debug  = opt_log_debug;
-    
+
   tvhlog_init(log_level, log_options, opt_logpath);
   tvhlog_set_debug(log_debug);
   tvhlog_set_trace(log_trace);
   tvhinfo(LS_MAIN, "Log started");
- 
+
   signal(SIGPIPE, handle_sigpipe); // will be redundant later
   signal(SIGILL, handle_sigill);   // see handler..
 
@@ -1144,7 +1144,7 @@ main(int argc, char **argv)
     tvhlog_options &= ~TVHLOG_OPT_STDERR;
   if (!isatty(2))
     tvhlog_options &= ~TVHLOG_OPT_DECORATE;
-  
+
   /* Initialise clock */
   pthread_mutex_lock(&global_lock);
   __mdispatch_clock = getmonoclock();
@@ -1159,6 +1159,12 @@ main(int argc, char **argv)
   OPENSSL_config(NULL);
   SSL_load_error_strings();
   SSL_library_init();
+
+  #ifndef OPENSSL_NO_ENGINE
+    /* ENGINE init */
+    ENGINE_load_builtin_engines();
+  #endif
+
   /* Rand seed */
   randseed.thread_id = (void *)main_tid;
   gettimeofday(&randseed.tv, NULL);
@@ -1345,7 +1351,7 @@ main(int argc, char **argv)
 
   if(opt_fork)
     unlink(opt_pidpath);
-    
+
   /* OpenSSL - welcome to the "cleanup" hell */
   ENGINE_cleanup();
   RAND_cleanup();


### PR DESCRIPTION
I'm cross-compiling release/4.2 for OpenWrt (and in their master, they're using OpenSSL 1.1.1b) and even tvheadend version 4.2.8 was tagged on 12th January 2019, there wasn't included PR https://github.com/tvheadend/tvheadend/pull/1217 , which was merged on 21st November 2018. Would be nice to have it included in the next stable version.

When I have included all the commits from @neheb, I have been able to successfully compile it. I will test it later on my router.

Otherwise release/4.2 (together with tagged version 4.2.8) ends up with output:

```
cc1: note: someone does not honour COPTS correctly, passed 2 times
src/main.c: In function 'main':
src/main.c:1356:3: error: implicit declaration of function 'ENGINE_cleanup'; did you mean 'EVP_PBE_cleanup'? [-Werror=implicit-function-declaration]
   ENGINE_cleanup();
   ^~~~~~~~~~~~~~
   EVP_PBE_cleanup
cc1: all warnings being treated as errors
make[3]: *** [Makefile:643: /home/pepe/work/turrisos40/omnia-hbd/build/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/tvheadend-release-4.2/build.linux/src/main.o] Error 1
make[3]: Leaving directory '/home/pepe/work/turrisos40/omnia-hbd/build/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/tvheadend-release-4.2'
make[2]: *** [Makefile:105: /home/pepe/work/turrisos40/omnia-hbd/build/build_dir/target-arm_cortex-a9+vfpv3_musl_eabi/tvheadend-release-4.2/.built] Error 2
```
