### PR TITLE
Update to newest ffmpeg to fix libX11 compile issue when vaapi is enabled.

### DIFF
--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -103,10 +103,10 @@ FFNVCODEC_TB   = $(FFNVCODEC).tar.gz
 FFNVCODEC_URL  = https://github.com/FFmpeg/nv-codec-headers/releases/download/n$(FFNVCODEC_VER)/nv-codec-headers-$(FFNVCODEC_VER).tar.gz
 FFNVCODEC_SHA1 = 57eb91aab785b1adeb2d17c95fd1bba32e6f53d9
 
-FFMPEG         = ffmpeg-4.1
+FFMPEG         = ffmpeg-4.1.1
 FFMPEG_TB      = $(FFMPEG).tar.bz2
 FFMPEG_URL     = http://ffmpeg.org/releases/$(FFMPEG_TB)
-FFMPEG_SHA1    = dbbecc574c0a57687271165a618353d4ddbd8cfa
+FFMPEG_SHA1    = 9076734d98fb8d6ad1cff8f8f68228afa0bb2204
 
 # ##############################################################################
 # Library Config


### PR DESCRIPTION
Compiling master on Ubuntu 18.04 and 18.10 with vaapi enabled causes an error (as described in https://tvheadend.org/issues/5504).

```
/usr/bin/ld: /root/tvheadend/build.linux/ffmpeg/build/ffmpeg/lib/libavutil.a(hwcontext_vaapi.o): undefined reference to symbol 'XDisplayName'
//usr/lib/x86_64-linux-gnu/libX11.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
Makefile:709: recipe for target '/root/tvheadend/build.linux/tvheadend' failed
make2: * [/root/tvheadend/build.linux/tvheadend] Error 1
make2: Leaving directory '/root/tvheadend'
debian/rules:15: recipe for target 'override_dh_auto_build' failed
make1: [override_dh_auto_build] Error 2
make1: Leaving directory '/root/tvheadend'
debian/rules:6: recipe for target 'build' failed
make: ** [build] Error 2
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
```

Updating to ffmpeg 4.1.1 resolved the issue for me.

This fixes #5504