### PR TITLE
Freesat_huffman: Suppress characters < 0x20 except \n.

### DIFF
--- a/src/epggrab/support/freesat_huffman.c
+++ b/src/epggrab/support/freesat_huffman.c
@@ -5800,9 +5800,9 @@ size_t freesat_huffman_decode
 				nextCh = (value >> 24) & 0xff;
 				bitShift = 8;
 				if ((nextCh & 0x80) == 0) {
-					if (nextCh < ' ')
-						nextCh = STOP;
 					lastch = nextCh;
+					if ((nextCh < 0x20) && (nextCh != '\n'))
+						nextCh = ESCAPE;
 				}
 			} else {
 				indx = (unsigned int) lastch;


### PR DESCRIPTION
Bug #5366 reported control codes appearing in EPG data on UK Freeview; this was fixed in commit 3ae6d947a4d074b3498e59f82d5a860273b0ae7f. However the same issue affects DVB-T2 channels where the EPG is Huffman coded.
freesat_huffman.c already has code to suppress these control codes, however the decoding is stopped when one is encountered and so the text is truncated. This patch drops the control codes but continues to decode the remaining text.