### PR TITLE
 Mux scan: Log correction

### DIFF
--- a/src/input/mpegts/mpegts_mux.c
+++ b/src/input/mpegts/mpegts_mux.c
@@ -1132,10 +1132,10 @@ mpegts_mux_scan_done ( mpegts_mux_t *mm, const char *buf, int res )
   if (res < 0) {
     /* is threshold 3 missing tables enough? */
     if (incomplete > 0 && total > incomplete && incomplete <= 3) {
-      tvhinfo(LS_MPEGTS, "%s - scan complete (partial - %d/%d tables)", buf, total, incomplete);
+      tvhinfo(LS_MPEGTS, "%s - scan complete (partial - %d/%d tables)", buf, incomplete, total);
       mpegts_network_scan_mux_partial(mm);
     } else {
-      tvhwarn(LS_MPEGTS, "%s - scan timed out (%d/%d tables)", buf, total, incomplete);
+      tvhwarn(LS_MPEGTS, "%s - scan timed out (%d/%d tables)", buf, incomplete, total);
       mpegts_network_scan_mux_fail(mm);
     }
   } else if (res) {


### PR DESCRIPTION
Should not it be the opposite?

`2019-03-28 00:28:53.648 mpegts: 498MHz in A - scan timed out (9/6 tables)`