### PR TITLE
Fix en50221 menu text handling

### DIFF
--- a/src/input/mpegts/en50221/en50221_apps.c
+++ b/src/input/mpegts/en50221/en50221_apps.c
@@ -501,7 +501,7 @@ getmenutext
         c = htsmsg_get_list(app->cia_menu, key);
         if (c == NULL) {
           c = htsmsg_create_list();
-          htsmsg_add_msg(app->cia_menu, key, c);
+          c = htsmsg_add_msg(app->cia_menu, key, c);
         }
         tvhtrace(LS_EN50221, "%s:  add to %s '%s'", app->cia_name, key, txt);
         htsmsg_add_str(c, NULL, txt);

--- a/src/input/mpegts/en50221/en50221_apps.c
+++ b/src/input/mpegts/en50221/en50221_apps.c
@@ -496,7 +496,7 @@ getmenutext
     return r;
   if (l2 > 0) {
     txt = alloca(l2 * 2 + 1);
-    if (dvb_get_string(txt, l2 * 2 + 1, p2, l2, NULL, NULL) > 0 && txt[0]) {
+    if (dvb_get_string(txt, l2 * 2 + 1, p2, l2, NULL, NULL) == 0 && txt[0]) {
       if (list) {
         c = htsmsg_get_list(app->cia_menu, key);
         if (c == NULL) {


### PR DESCRIPTION
Fix several issues in the en50221 menu text handling code that prevented the CAM messages from being passed on and then logged by linuxdvb_ca.c.