### PR TITLE
Makefile: fix -pie linking according to --disable-pie

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,10 @@ LDFLAGS += -ldl -lm
 else
 LDFLAGS += -ldl -lpthread -lm
 endif
-LDFLAGS += -pie -Wl,-z,now
+ifeq ($(CONFIG_PIE),yes)
+LDFLAGS += -pie
+endif
+LDFLAGS += -Wl,-z,now
 ifeq ($(CONFIG_LIBICONV),yes)
 LDFLAGS += -liconv
 endif


### PR DESCRIPTION
Only compilation follows './configure --disable-pie', linking instead
doesn't, because '-pie' flag is passed to LDFLAGS uncoditionally.

So add '-pie' flag only if CONFIG_PIE=yes.

Signed-off-by: Giulio Benetti <giulio.benetti@micronovasrl.com>