### PR TITLE
Fix compilation with libhdhomerun 20190621

### DIFF
--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
@@ -32,7 +32,8 @@
 
 #include "config.h"
 
-#ifdef HDHOMERUN_TAG_DEVICE_AUTH_BIN
+#if defined(HDHOMERUN_TAG_DEVICE_AUTH_BIN) \
+           || defined(HDHOMERUN_TAG_DEVICE_AUTH_BIN_DEPRECATED)
 #define hdhomerun_discover_find_devices_custom \
            hdhomerun_discover_find_devices_custom_v2
 #endif


### PR DESCRIPTION
They renamed the symbol that was used to determine whether the
"hdhomerun_discover_find_devices_custom" needed to be aliased,
causing an FTBFS.  Instead, recognize both the old and new symbols.