### PR TITLE
linuxdvb: fix signal status monitor

### DIFF
--- a/src/input/mpegts/linuxdvb/linuxdvb_frontend.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_frontend.c
@@ -2023,8 +2023,7 @@ linuxdvb_frontend_tune1
 
   /* Start monitor */
   if (!r) {
-    time(&lfe->lfe_monitor);
-    lfe->lfe_monitor += 4;
+    lfe->lfe_monitor = mclk() + sec2mono(4);
     mtimer_arm_rel(&lfe->lfe_monitor_timer, linuxdvb_frontend_monitor, lfe, ms2mono(50));
     lfe->lfe_ready = 1;
   }


### PR DESCRIPTION
Fix unknown signal and device status (HTSP Client) in the first 26 minutes after power on.

Incompatible values were compared:
time() = now = 1561843153 [s]
mclk() = uptime [μs]

https://github.com/tvheadend/tvheadend/blob/453ee8dfd80b240e1005502c002bdc6de3f121c8/src/input/mpegts/linuxdvb/linuxdvb_frontend.c#L2024-L2030

https://github.com/tvheadend/tvheadend/blob/453ee8dfd80b240e1005502c002bdc6de3f121c8/src/input/mpegts/linuxdvb/linuxdvb_frontend.c#L998-L1007

Patch tested with CoreELEC 9.0.x (devel) + Kodi 18.3 + Tvheadend HTSP Client 4.4.18.1 + Tvheadend Server 4.2.7.