### PR TITLE
Include stdio.h before tvheadend headers

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -16,10 +16,10 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdio.h>
 #include <tvh_thread.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/tvh_locale.c
+++ b/src/tvh_locale.c
@@ -16,6 +16,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdio.h>
 #include "tvh_thread.h"
 #include "tvh_locale.h"
 #include "tvh_string.h"

--- a/src/tvhlog.c
+++ b/src/tvhlog.c
@@ -16,9 +16,9 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdio.h>
 #include "tvhlog.h"
 #include <string.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <sys/time.h>
 #include <sys/types.h>


### PR DESCRIPTION
Fixes build error with uClibc: https://www.tvheadend.org/issues/5667