### PR TITLE
autobuild: add build target for raspbian-buster

### DIFF
--- a/.doozer.json
+++ b/.doozer.json
@@ -497,6 +497,33 @@
         "support/bintray.py publish filelist.txt"
       ]
     },
+    "raspbian-buster": {
+      "buildenv": "raspbian-buster",
+      "builddeps": [
+        "cmake",
+        "git",
+        "build-essential",
+        "pkg-config",
+        "gettext",
+        "libavahi-client-dev",
+        "libssl-dev",
+        "zlib1g-dev",
+        "wget",
+        "bzip2",
+        "git-core",
+        "liburiparser-dev",
+        "libpcre2-dev",
+        "libdvbcsa-dev",
+        "python",
+        "python-requests",
+        "debhelper",
+        "ccache"
+      ],
+      "buildcmd": [
+        "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-hdhomerun_static\\ --disable-ffmpeg_static ./Autobuild.sh -t raspbianbuster-armhf -j ${PARALLEL} -w ${WORKDIR}",
+        "support/bintray.py publish filelist.txt"
+      ]
+    },
     "fedora28-x86_64": {
       "buildenv": "docker:fedora:28",
       "builddeps": [

--- a/Autobuild/raspbianbuster-armhf.sh
+++ b/Autobuild/raspbianbuster-armhf.sh
@@ -1,0 +1,3 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --arch=armhf"
+DEBDIST=raspbianbuster
+source Autobuild/debian.sh


### PR DESCRIPTION
Please also cherry pick 2d020e8f214c6817f6b36271d82039c95a7d1447 for release/4.2, note these builds will fail until @andoma has a chance to add the required buildenv to doozer.io

