### PR TITLE
tvhcsa.c: include stdio.h

### DIFF
--- a/src/descrambler/tvhcsa.c
+++ b/src/descrambler/tvhcsa.c
@@ -16,6 +16,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdio.h>
 #include "tvhcsa.h"
 #include "input.h"
 #include "input/mpegts/tsdemux.h"


### PR DESCRIPTION
Fixes uclibc build error:

CC              src/descrambler/tvhcsa.o
In file included from /home/buildroot/autobuild/instance-0/output/build/tvheadend-8f1de1621d78c91431238176bf4f6290870a031a/src/tvhlog.h:30:0,
                 from src/descrambler/tvhcsa.h:30,
                 from src/descrambler/tvhcsa.c:19:
/home/buildroot/autobuild/instance-0/output/build/tvheadend-8f1de1621d78c91431238176bf4f6290870a031a/src/tvh_thread.h:163:25:
 error: unknown type name '__do_not_use_pthread_mutex_t'
 #define pthread_mutex_t __do_not_use_pthread_mutex_t

detected by buildroot autobuilder:
http://autobuild.buildroot.net/results/627/627e7080e655005d6724b9977670cc73059d6281/