### PR TITLE
mpegts: linuxdvb/iptv: fix integer overflow on 32-bit platforms

### DIFF
--- a/src/input/mpegts/iptv/iptv_private.h
+++ b/src/input/mpegts/iptv/iptv_private.h
@@ -131,7 +131,7 @@ struct iptv_mux
   char                 *mm_iptv_epgid;
 
   int                   mm_iptv_respawn;
-  time_t                mm_iptv_respawn_last;
+  int64_t               mm_iptv_respawn_last;
   int                   mm_iptv_kill;
   int                   mm_iptv_kill_timeout;
   char                 *mm_iptv_env;

--- a/src/input/mpegts/linuxdvb/linuxdvb_private.h
+++ b/src/input/mpegts/linuxdvb/linuxdvb_private.h
@@ -133,7 +133,7 @@ struct linuxdvb_frontend
   int                       lfe_ioctls;
   int                       lfe_nodata;
   int                       lfe_freq;
-  time_t                    lfe_monitor;
+  int64_t                   lfe_monitor;
   mtimer_t                  lfe_monitor_timer;
   tvhlog_limit_t            lfe_status_log;
 


### PR DESCRIPTION
The time_t items are used in expressions with int64_t mclk().
https://github.com/tvheadend/tvheadend/blob/6be300c430ab614aa527ef34e34f007f34a68ee0/src/input/mpegts/linuxdvb/linuxdvb_frontend.c#L998-L1007

https://github.com/tvheadend/tvheadend/blob/2c35dca60d373f685fad040b993450ed5505a546/src/input/mpegts/iptv/iptv_pipe.c#L112-L115