### PR TITLE
SATIP Kathrein & Triax: Force rolloff on DVB-S2, fixes #5517

### DIFF
--- a/src/input/mpegts/satip/satip.c
+++ b/src/input/mpegts/satip/satip.c
@@ -342,6 +342,16 @@ const idclass_t satip_device_class =
     },
     {
       .type     = PT_BOOL,
+      .id       = "rolloffon",
+      .name     = N_("Force rolloff for DVB-S2"),
+      .desc     = N_("Enable if the SAT>IP box requests ro=0.35 "
+                     "parameter in the SETUP RTSP command for DVB-S2 "
+                     "muxes."),
+      .opts     = PO_ADVANCED,
+      .off      = offsetof(satip_device_t, sd_rolloff_on),
+    },
+    {
+      .type     = PT_BOOL,
       .id       = "pids21",
       .name     = N_("PIDs 21 in setup"),
       .desc     = N_("Enable if the SAT>IP box requires pids=21 "
@@ -579,20 +589,20 @@ satip_device_hack( satip_device_t *sd )
     /* OctopusNet requires pids in the SETUP RTSP command */
   } else if (strstr(sd->sd_info.manufacturer, "Triax") &&
              strstr(sd->sd_info.modelname, "TSS400")) {
-    /* Rolloff is required to tune into DVB-S2 muxes */
     sd->sd_fullmux_ok  = 0;
     sd->sd_pids_max    = 64;
     sd->sd_pids_len    = 255;
     sd->sd_pilot_on    = 1;
+    sd->sd_rolloff_on  = 1;
   } else if (strstr(sd->sd_info.manufacturer, "KATHREIN") &&
             (strstr(sd->sd_info.modelname, "EXIP-4124") ||
              strstr(sd->sd_info.modelname, "EXIP-418") ||
              strstr(sd->sd_info.modelname, "EXIP-414"))) {
-    /* Rolloff is required to tune into DVB-S2 muxes */
     sd->sd_fullmux_ok  = 0;
     sd->sd_pids_max    = 64;
     sd->sd_pids_len    = 255;
     sd->sd_pilot_on    = 1;
+    sd->sd_rolloff_on  = 1;
   } else if (strcmp(sd->sd_info.modelname, "TVHeadend SAT>IP") == 0)  {
     sd->sd_pids_max    = 128;
     sd->sd_pids_len    = 2048;

--- a/src/input/mpegts/satip/satip_frontend.c
+++ b/src/input/mpegts/satip/satip_frontend.c
@@ -1859,6 +1859,8 @@ new_tune:
   position = lfe_master->sf_position;
   if (lfe->sf_device->sd_pilot_on)
     rtsp_flags |= SATIP_SETUP_PILOT_ON;
+  if (lfe->sf_device->sd_rolloff_on)
+    rtsp_flags |= SATIP_SETUP_ROLLOFF_ON;
   if (lfe->sf_device->sd_pids21)
     rtsp_flags |= SATIP_SETUP_PIDS21;
   if (lfe->sf_specinv == 0)

--- a/src/input/mpegts/satip/satip_private.h
+++ b/src/input/mpegts/satip/satip_private.h
@@ -92,6 +92,7 @@ struct satip_device
   char                      *sd_tunercfg;
   int                        sd_pids21;
   int                        sd_pilot_on;
+  int                        sd_rolloff_on;
   int                        sd_no_univ_lnb;
   int                        sd_can_weight;
   int                        sd_dbus_allow;
@@ -283,13 +284,14 @@ satip_satconf_t *satip_satconf_get_position
  * RTSP part
  */
 
-#define SATIP_SETUP_TCP      (1<<0)
-#define SATIP_SETUP_PLAY     (1<<1)
-#define SATIP_SETUP_PILOT_ON (1<<2)
-#define SATIP_SETUP_PIDS21   (1<<3)
-#define SATIP_SETUP_FE       (1<<4)
-#define SATIP_SETUP_SPECINV0 (1<<5)
-#define SATIP_SETUP_SPECINV1 (1<<6)
+#define SATIP_SETUP_TCP        (1<<0)
+#define SATIP_SETUP_PLAY       (1<<1)
+#define SATIP_SETUP_PILOT_ON   (1<<2)
+#define SATIP_SETUP_ROLLOFF_ON (1<<3)
+#define SATIP_SETUP_PIDS21     (1<<4)
+#define SATIP_SETUP_FE         (1<<5)
+#define SATIP_SETUP_SPECINV0   (1<<6)
+#define SATIP_SETUP_SPECINV1   (1<<7)
 
 int
 satip_rtsp_setup( http_client_t *hc,

--- a/src/input/mpegts/satip/satip_rtsp.c
+++ b/src/input/mpegts/satip/satip_rtsp.c
@@ -185,8 +185,10 @@ satip_rtsp_setup( http_client_t *hc, int src, int fe,
     if (dmc->u.dmc_fe_qpsk.fec_inner != DVB_FEC_NONE &&
         dmc->u.dmc_fe_qpsk.fec_inner != DVB_FEC_AUTO)
       ADD(u.dmc_fe_qpsk.fec_inner, fec, "auto");
-    if (dmc->dmc_fe_rolloff != DVB_ROLLOFF_NONE &&
-        dmc->dmc_fe_rolloff != DVB_ROLLOFF_AUTO)
+    if ((dmc->dmc_fe_rolloff != DVB_ROLLOFF_NONE &&
+         dmc->dmc_fe_rolloff != DVB_ROLLOFF_AUTO) ||
+        ((flags & SATIP_SETUP_ROLLOFF_ON) != 0 &&
+         dmc->dmc_fe_delsys == DVB_SYS_DVBS2))
       ADD(dmc_fe_rolloff, ro, "0.35");
     if (dmc->dmc_fe_pilot != DVB_PILOT_NONE &&
         dmc->dmc_fe_pilot != DVB_PILOT_AUTO) {


### PR DESCRIPTION
Set permanent 0.35 rolloff for Kathrein and Triax devices, to avoid failed tunning on DVB-S2 frequencies.