### PR TITLE
Corrected logic related to limit connections and connection types

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -570,6 +570,7 @@ access_update(access_t *a, access_entry_t *ae)
     switch (ae->ae_conn_limit_type) {
     case ACCESS_CONN_LIMIT_TYPE_ALL:
       a->aa_conn_limit = ae->ae_conn_limit;
+      break;
     case ACCESS_CONN_LIMIT_TYPE_STREAMING:
       a->aa_conn_limit_streaming = ae->ae_conn_limit;
       break;

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -111,8 +111,8 @@ dvr_rec_subscribe(dvr_entry_t *de)
     rec_count = dvr_usage_count(aa);
     net_count = aa->aa_conn_limit ? tcp_connection_count(aa) : 0;
     /* the rule is: allow if one condition is OK */
-    c1 = aa->aa_conn_limit ? rec_count + net_count >= aa->aa_conn_limit : -1;
-    c2 = aa->aa_conn_limit_dvr ? rec_count >= aa->aa_conn_limit_dvr : -1;
+    c1 = aa->aa_conn_limit ? rec_count + net_count > aa->aa_conn_limit : -1;
+    c2 = aa->aa_conn_limit_dvr ? rec_count > aa->aa_conn_limit_dvr : -1;
     if (c1 && c2) {
       tvherror(LS_DVR, "multiple connections are not allowed for user '%s' from '%s' "
                       "(limit %u, dvr limit %u, active DVR %u, streaming %u)",


### PR DESCRIPTION
Sort issues related to user limits and dvr. 
Before fix user with "connection limit type" set to ALL and "limmit connections" set to 1, was not able to record. 
With fixes in place, limits are working for dvr and streaming as it's supposed to

This fixes Bug #5692
https://tvheadend.org/issues/5692