### PR TITLE
packaging: add missing DEBHELPER placeholder to postrm script

### DIFF
--- a/debian/tvheadend.postrm
+++ b/debian/tvheadend.postrm
@@ -15,4 +15,6 @@ purge)
    ;;
 esac
 
+#DEBHELPER#
+
 exit 0


### PR DESCRIPTION
Partial fix for https://tvheadend.org/issues/5705

`dh` replaces this placeholder with things it needs to add. Currently, postinst has this and is what installs, enables and starts the service, but postrm is missing it so files get left behind.

I haven't done anything about the home directory getting left behind because I'm not 100% sure that's safe to remove.

Please also add this to the 4.2 release branch