### PR TITLE
FHD quality support

### DIFF
--- a/intl/js/tvheadend.js.ach.po
+++ b/intl/js/tvheadend.js.ach.po
@@ -1835,6 +1835,10 @@ msgstr ""
 msgid "UHDTV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr ""

--- a/intl/js/tvheadend.js.ady.po
+++ b/intl/js/tvheadend.js.ady.po
@@ -1835,6 +1835,10 @@ msgstr ""
 msgid "UHDTV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr ""

--- a/intl/js/tvheadend.js.ar.po
+++ b/intl/js/tvheadend.js.ar.po
@@ -1835,6 +1835,10 @@ msgstr ""
 msgid "UHDTV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr ""

--- a/intl/js/tvheadend.js.bg.po
+++ b/intl/js/tvheadend.js.bg.po
@@ -1839,6 +1839,10 @@ msgstr "Вид"
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "Невъзможен достъп до помощника!"

--- a/intl/js/tvheadend.js.cs.po
+++ b/intl/js/tvheadend.js.cs.po
@@ -1837,6 +1837,10 @@ msgstr "Typ"
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "Namohu načíst stránku pomocníka!"

--- a/intl/js/tvheadend.js.da.po
+++ b/intl/js/tvheadend.js.da.po
@@ -1839,6 +1839,10 @@ msgstr "Type"
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "Ikke i stand til at få fat i guiden!"

--- a/intl/js/tvheadend.js.de.po
+++ b/intl/js/tvheadend.js.de.po
@@ -1845,6 +1845,10 @@ msgstr "Typ"
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "Assistentseite ist nicht erreichbar!"

--- a/intl/js/tvheadend.js.en_GB.po
+++ b/intl/js/tvheadend.js.en_GB.po
@@ -1839,6 +1839,10 @@ msgstr "Type"
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "Unable to obtain wizard page!"

--- a/intl/js/tvheadend.js.en_US.po
+++ b/intl/js/tvheadend.js.en_US.po
@@ -1838,6 +1838,10 @@ msgstr "Type"
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "Unable to obtain wizard page!"

--- a/intl/js/tvheadend.js.es.po
+++ b/intl/js/tvheadend.js.es.po
@@ -1840,6 +1840,10 @@ msgstr "Tipo"
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "¡Incapaz de obtener la página del asistente!"

--- a/intl/js/tvheadend.js.et.po
+++ b/intl/js/tvheadend.js.et.po
@@ -1836,6 +1836,10 @@ msgstr "Tüüp"
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "Ei saa juhendava abiprogrammi lehele!"

--- a/intl/js/tvheadend.js.fa.po
+++ b/intl/js/tvheadend.js.fa.po
@@ -1835,6 +1835,10 @@ msgstr ""
 msgid "UHDTV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr ""

--- a/intl/js/tvheadend.js.fi.po
+++ b/intl/js/tvheadend.js.fi.po
@@ -1838,6 +1838,10 @@ msgstr ""
 msgid "UHDTV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr ""

--- a/intl/js/tvheadend.js.fr.po
+++ b/intl/js/tvheadend.js.fr.po
@@ -1845,6 +1845,10 @@ msgstr "Type"
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "Impossible de lancer l'assistant de configuration !"

--- a/intl/js/tvheadend.js.he.po
+++ b/intl/js/tvheadend.js.he.po
@@ -1838,6 +1838,10 @@ msgstr "סוג"
 msgid "UHDTV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr ""

--- a/intl/js/tvheadend.js.hr.po
+++ b/intl/js/tvheadend.js.hr.po
@@ -1837,6 +1837,10 @@ msgstr "Vrsta"
 msgid "UHDTV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "Nemoguće upotrijebiti stranicu čarobnjaka!"

--- a/intl/js/tvheadend.js.hu.po
+++ b/intl/js/tvheadend.js.hu.po
@@ -1839,6 +1839,10 @@ msgstr "Típus"
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "Nem tölthető be a varázsló oldal!"

--- a/intl/js/tvheadend.js.it.po
+++ b/intl/js/tvheadend.js.it.po
@@ -1840,6 +1840,10 @@ msgstr "Tipo"
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "Incapace di ottenere la pagina della configurazione guidata"

--- a/intl/js/tvheadend.js.ko.po
+++ b/intl/js/tvheadend.js.ko.po
@@ -1836,6 +1836,10 @@ msgstr "종류"
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "마법사 페이지를 가져올 수 없습니다!"

--- a/intl/js/tvheadend.js.lt.po
+++ b/intl/js/tvheadend.js.lt.po
@@ -1836,6 +1836,10 @@ msgstr "Tipas"
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "Nepavyksta išgauti vedlio puslapio!"

--- a/intl/js/tvheadend.js.lv.po
+++ b/intl/js/tvheadend.js.lv.po
@@ -1836,6 +1836,10 @@ msgstr "Tips"
 msgid "UHDTV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr ""

--- a/intl/js/tvheadend.js.nl.po
+++ b/intl/js/tvheadend.js.nl.po
@@ -1840,6 +1840,10 @@ msgstr "Type"
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "Begeleidings pagina kan niet worden verkregen!"

--- a/intl/js/tvheadend.js.no.po
+++ b/intl/js/tvheadend.js.no.po
@@ -1836,6 +1836,10 @@ msgstr "Type"
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "Kan ikke hente veiviser side!"

--- a/intl/js/tvheadend.js.pl.po
+++ b/intl/js/tvheadend.js.pl.po
@@ -1838,6 +1838,10 @@ msgstr "Typ"
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "Nie można uzyskać strony kreatora!"

--- a/intl/js/tvheadend.js.pot
+++ b/intl/js/tvheadend.js.pot
@@ -1836,6 +1836,10 @@ msgstr ""
 msgid "UHDTV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr ""

--- a/intl/js/tvheadend.js.pt.po
+++ b/intl/js/tvheadend.js.pt.po
@@ -1837,6 +1837,10 @@ msgstr "Tipo"
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "Incapaz de obter a página de wizard!"

--- a/intl/js/tvheadend.js.ro.po
+++ b/intl/js/tvheadend.js.ro.po
@@ -1835,6 +1835,10 @@ msgstr ""
 msgid "UHDTV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr ""

--- a/intl/js/tvheadend.js.ru.po
+++ b/intl/js/tvheadend.js.ru.po
@@ -1837,6 +1837,10 @@ msgstr "Тип"
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "Невозможно получить страницу мастера!"

--- a/intl/js/tvheadend.js.sk.po
+++ b/intl/js/tvheadend.js.sk.po
@@ -1835,6 +1835,10 @@ msgstr ""
 msgid "UHDTV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr ""

--- a/intl/js/tvheadend.js.sl.po
+++ b/intl/js/tvheadend.js.sl.po
@@ -1836,6 +1836,10 @@ msgstr ""
 msgid "UHDTV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr ""

--- a/intl/js/tvheadend.js.sq.po
+++ b/intl/js/tvheadend.js.sq.po
@@ -1835,6 +1835,10 @@ msgstr ""
 msgid "UHDTV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr ""

--- a/intl/js/tvheadend.js.sr.po
+++ b/intl/js/tvheadend.js.sr.po
@@ -1835,6 +1835,10 @@ msgstr ""
 msgid "UHDTV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr ""

--- a/intl/js/tvheadend.js.sv.po
+++ b/intl/js/tvheadend.js.sv.po
@@ -1836,6 +1836,10 @@ msgstr ""
 msgid "UHDTV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr ""

--- a/intl/js/tvheadend.js.tr.po
+++ b/intl/js/tvheadend.js.tr.po
@@ -1836,6 +1836,10 @@ msgstr ""
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr "Sihirbaz sayfası alınamadı!"

--- a/intl/js/tvheadend.js.uk.po
+++ b/intl/js/tvheadend.js.uk.po
@@ -1836,6 +1836,10 @@ msgstr "Тип"
 msgid "UHDTV"
 msgstr "UHDTV"
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr "FHDTV"
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr ""

--- a/intl/js/tvheadend.js.zh-Hans.po
+++ b/intl/js/tvheadend.js.zh-Hans.po
@@ -1835,6 +1835,10 @@ msgstr ""
 msgid "UHDTV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr ""

--- a/intl/js/tvheadend.js.zh.po
+++ b/intl/js/tvheadend.js.zh.po
@@ -1835,6 +1835,10 @@ msgstr ""
 msgid "UHDTV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/webui/static/app/wizard.js:188
 msgid "Unable to obtain wizard page!"
 msgstr ""

--- a/intl/tvheadend.ach.po
+++ b/intl/tvheadend.ach.po
@@ -7565,8 +7565,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:270
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.ady.po
+++ b/intl/tvheadend.ady.po
@@ -7565,8 +7565,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.ar.po
+++ b/intl/tvheadend.ar.po
@@ -7567,9 +7567,18 @@ msgstr ""
 msgid "UHD TV"
 msgstr ""
 
+#: src/webui/static/app/epg.js:150
+msgid "FHDTV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
 msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
+msgstr ""
+
 
 #: src/tvhlog.c:93
 msgid "UPnP Protocol"

--- a/intl/tvheadend.bg.po
+++ b/intl/tvheadend.bg.po
@@ -7569,8 +7569,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.cs.po
+++ b/intl/tvheadend.cs.po
@@ -7567,8 +7567,16 @@ msgstr "UDP RTP číslo portu (2 porty)"
 msgid "UHD TV"
 msgstr "UHD TV"
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr "FHD TV"
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.da.po
+++ b/intl/tvheadend.da.po
@@ -7569,8 +7569,16 @@ msgstr "UDP RTP portnumre (2 porte)"
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.de.po
+++ b/intl/tvheadend.de.po
@@ -7585,9 +7585,17 @@ msgstr "UDP RTP Port Nummer (2 ports)"
 msgid "UHD TV"
 msgstr "UHD TV"
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr "FHD TV"
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
 msgstr "UHD: Ultra-High-Definition"
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
+msgstr "FHD: Full-High-Definition"
 
 #: src/tvhlog.c:93
 msgid "UPnP Protocol"

--- a/intl/tvheadend.en_GB.po
+++ b/intl/tvheadend.en_GB.po
@@ -7569,9 +7569,17 @@ msgstr "UDP RTP port number (2 ports)"
 msgid "UHD TV"
 msgstr "UHD TV"
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr "FHD TV"
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
 msgstr "UHD: ultra high definition"
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
+msgstr "FHD: full high definition"
 
 #: src/tvhlog.c:93
 msgid "UPnP Protocol"

--- a/intl/tvheadend.en_US.po
+++ b/intl/tvheadend.en_US.po
@@ -7568,8 +7568,16 @@ msgstr "UDP RTP port number (2 ports)"
 msgid "UHD TV"
 msgstr "UHD TV"
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr "FHD TV"
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.es.po
+++ b/intl/tvheadend.es.po
@@ -7574,9 +7574,17 @@ msgstr "Nombre de puerto UDP RTP (2 puertos)"
 msgid "UHD TV"
 msgstr "UHD TV"
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr "FHD TV"
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
 msgstr "UHD: ultra alta definición"
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
+msgstr "FHD: full high definition"
 
 #: src/tvhlog.c:93
 msgid "UPnP Protocol"

--- a/intl/tvheadend.et.po
+++ b/intl/tvheadend.et.po
@@ -7566,8 +7566,16 @@ msgstr "UDP RTP pordi number (2 porti)"
 msgid "UHD TV"
 msgstr "UHD TV"
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr "FHD TV"
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.fa.po
+++ b/intl/tvheadend.fa.po
@@ -7566,8 +7566,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.fi.po
+++ b/intl/tvheadend.fi.po
@@ -7568,8 +7568,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.fr.po
+++ b/intl/tvheadend.fr.po
@@ -7580,8 +7580,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.he.po
+++ b/intl/tvheadend.he.po
@@ -7568,8 +7568,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.hr.po
+++ b/intl/tvheadend.hr.po
@@ -7567,8 +7567,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr "UHD TV"
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr "FHD TV"
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.hu.po
+++ b/intl/tvheadend.hu.po
@@ -7571,8 +7571,16 @@ msgstr "UDP RTP port száma (2 port)"
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.it.po
+++ b/intl/tvheadend.it.po
@@ -7567,8 +7567,16 @@ msgstr "Numero di porta UDP RTP (2 porte)"
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.ko.po
+++ b/intl/tvheadend.ko.po
@@ -7566,8 +7566,16 @@ msgstr "UDP RTP 포트 번호 (2포트)"
 msgid "UHD TV"
 msgstr "UHD TV"
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr "FHD TV"
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.lt.po
+++ b/intl/tvheadend.lt.po
@@ -7566,9 +7566,17 @@ msgstr "UDP RTP porto numeris (2 portai)"
 msgid "UHD TV"
 msgstr "UHD TV"
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr "FHD TV"
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
 msgstr "UHD: ultra aukšta raiška"
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
+msgstr ""
 
 #: src/tvhlog.c:93
 msgid "UPnP Protocol"

--- a/intl/tvheadend.lv.po
+++ b/intl/tvheadend.lv.po
@@ -7566,8 +7566,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.nl.po
+++ b/intl/tvheadend.nl.po
@@ -7571,8 +7571,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr "UHD TV"
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr "FHD TV"
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.no.po
+++ b/intl/tvheadend.no.po
@@ -7566,8 +7566,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr "UHD TV"
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr "FHD TV"
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.pl.po
+++ b/intl/tvheadend.pl.po
@@ -7570,8 +7570,16 @@ msgstr "UDP RTP numer portu (2 porty)"
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.pot
+++ b/intl/tvheadend.pot
@@ -7617,8 +7617,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.pt.po
+++ b/intl/tvheadend.pt.po
@@ -7567,8 +7567,16 @@ msgstr "UDP RTP Número das Portas (2 portas)"
 msgid "UHD TV"
 msgstr "UHD TV"
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr "FHD TV"
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.ro.po
+++ b/intl/tvheadend.ro.po
@@ -7566,8 +7566,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.ru.po
+++ b/intl/tvheadend.ru.po
@@ -7568,8 +7568,16 @@ msgstr "UDP RTP Номер порта (2 порта)"
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.sk.po
+++ b/intl/tvheadend.sk.po
@@ -7565,8 +7565,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.sl.po
+++ b/intl/tvheadend.sl.po
@@ -7567,8 +7567,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.sq.po
+++ b/intl/tvheadend.sq.po
@@ -7565,8 +7565,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.sr.po
+++ b/intl/tvheadend.sr.po
@@ -7565,8 +7565,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.sv.po
+++ b/intl/tvheadend.sv.po
@@ -7569,8 +7569,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.tr.po
+++ b/intl/tvheadend.tr.po
@@ -7566,8 +7566,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.uk.po
+++ b/intl/tvheadend.uk.po
@@ -7566,8 +7566,16 @@ msgstr "Номер порту UDP RTP (2 порти)"
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.zh-Hans.po
+++ b/intl/tvheadend.zh-Hans.po
@@ -7565,8 +7565,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/intl/tvheadend.zh.po
+++ b/intl/tvheadend.zh.po
@@ -7566,8 +7566,16 @@ msgstr ""
 msgid "UHD TV"
 msgstr ""
 
+#: src/service.c:160
+msgid "FHD TV"
+msgstr ""
+
 #: src/profile.c:269
 msgid "UHD: ultra high definition"
+msgstr ""
+
+#: src/profile.c:269
+msgid "FHD: full high definition"
 msgstr ""
 
 #: src/tvhlog.c:93

--- a/src/channels.c
+++ b/src/channels.c
@@ -638,6 +638,9 @@ channel_make_fuzzy_name(const char *name)
     /* Strip trailing 'UHD'. */
     if (*ch == 'U' && *(ch+1) == 'H' && *(ch+2) == 'D' && *(ch+3) == 0)
       break;
+    /* Strip trailing 'FHD'. */
+    if (*ch == 'F' && *(ch+1) == 'H' && *(ch+2) == 'D' && *(ch+3) == 0)
+      break;
 
     if (!isspace(*ch)) {
       *ch_fuzzy++ = tolower(*ch);
@@ -1996,6 +1999,7 @@ channel_has_correct_service_filter(const channel_t *ch, int svf)
     service = (const service_t*)ilm->ilm_in1;
     if ((svf == PROFILE_SVF_SD && service_is_sdtv(service)) ||
         (svf == PROFILE_SVF_HD && service_is_hdtv(service)) ||
+        (svf == PROFILE_SVF_FHD && service_is_fhdtv(service)) ||
         (svf == PROFILE_SVF_UHD && service_is_uhdtv(service))) {
       return 1;
     }

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1875,7 +1875,7 @@ dvr_is_better_recording_timeslot(const epg_broadcast_t *new_bcast, const dvr_ent
   if (!old_channel) return 1;
 
   /* Always prefer a recording that has the correct service profile
-   * (UHD, HD, SD).  Someone mentioned (#1846) that some channels can
+   * (UHD, FHD, HD, SD).  Someone mentioned (#1846) that some channels can
    * show a recording earlier in the week in SD then later in the week
    * in HD so this would prefer the later HD recording if the user so
    * desired.
@@ -1890,10 +1890,29 @@ dvr_is_better_recording_timeslot(const epg_broadcast_t *new_bcast, const dvr_ent
       return 0;
     if (!old_has_svf && new_has_svf)
       return 1;
-    /* Also try "downgrading", where user asks for UHD, which we don't
+    /* Also try "downgrading", where user asks for FHD, which we don't
      * have, but we could give them HD.
      */
+    if (svf == PROFILE_SVF_FHD && !old_has_svf) {
+      old_has_svf = channel_has_correct_service_filter(old_channel, PROFILE_SVF_HD);
+      new_has_svf = channel_has_correct_service_filter(new_channel, PROFILE_SVF_HD);
+
+      if (old_has_svf && !new_has_svf)
+        return 0;
+      if (!old_has_svf && new_has_svf)
+        return 1;
+    }
+
+    /* Also try "downgrading", where user asks for UHD, which we don't
+     * have, but we could give them FHD, then HD.
+     */
     if (svf == PROFILE_SVF_UHD && !old_has_svf) {
+      old_has_svf = channel_has_correct_service_filter(old_channel, PROFILE_SVF_FHD);
+      new_has_svf = channel_has_correct_service_filter(new_channel, PROFILE_SVF_FHD);
+      
+      if (!old_has_svf && new_has_svf)
+        return 1;
+
       old_has_svf = channel_has_correct_service_filter(old_channel, PROFILE_SVF_HD);
       new_has_svf = channel_has_correct_service_filter(new_channel, PROFILE_SVF_HD);
 

--- a/src/epggrab/module/xmltv.c
+++ b/src/epggrab/module/xmltv.c
@@ -270,8 +270,10 @@ xmltv_parse_vid_quality
   if ((str = htsmsg_xml_get_cdata_str(m, "quality"))) {
     if (strstr(str, "HD")) {
       hd    = 1;
-    } else if (strstr(str, "UHD")) {
+    } else if (strstr(str, "FHD")) {
       hd    = 2;
+    } else if (strstr(str, "UHD")) {
+      hd    = 3;
     } else if (strstr(str, "480")) {
       lines  = 480;
       aspect = 150;
@@ -284,15 +286,15 @@ xmltv_parse_vid_quality
       aspect = 178;
     } else if (strstr(str, "1080")) {
       lines  = 1080;
-      hd     = 1;
+      hd     = 2;
       aspect = 178;
     } else if (strstr(str, "1716")) {
       lines  = 1716;
-      hd     = 2;
+      hd     = 3;
       aspect = 239;
     } else if (strstr(str, "2160")) {
       lines  = 2160;
-      hd     = 2;
+      hd     = 3;
       aspect = 178;
     }
   }

--- a/src/profile.c
+++ b/src/profile.c
@@ -272,6 +272,7 @@ profile_class_svfilter_list ( void *o, const char *lang )
     { N_("None"),                       PROFILE_SVF_NONE },
     { N_("SD: standard definition"),    PROFILE_SVF_SD },
     { N_("HD: high definition"),        PROFILE_SVF_HD },
+    { N_("FHD: full high definition"), PROFILE_SVF_FHD },
     { N_("UHD: ultra high definition"), PROFILE_SVF_UHD },
   };
   return strtab2htsmsg(tab, 1, lang);

--- a/src/profile.h
+++ b/src/profile.h
@@ -41,6 +41,7 @@ typedef enum {
   PROFILE_SVF_NONE = 0,
   PROFILE_SVF_SD,
   PROFILE_SVF_HD,
+  PROFILE_SVF_FHD,
   PROFILE_SVF_UHD
 } profile_svfilter_t;
 

--- a/src/service.c
+++ b/src/service.c
@@ -148,6 +148,7 @@ service_type_auto_list ( void *o, const char *lang )
     { N_("Radio"),             ST_RADIO },
     { N_("SD TV"),             ST_SDTV  },
     { N_("HD TV"),             ST_HDTV  },
+    { N_("FHD TV"),            ST_FHDTV },
     { N_("UHD TV"),            ST_UHDTV }
   };
   return strtab2htsmsg(tab, 1, lang);
@@ -406,6 +407,7 @@ service_find_instance
             pro->pro_svfilter == PROFILE_SVF_NONE ||
             (pro->pro_svfilter == PROFILE_SVF_SD && service_is_sdtv(s)) ||
             (pro->pro_svfilter == PROFILE_SVF_HD && service_is_hdtv(s)) ||
+            (pro->pro_svfilter == PROFILE_SVF_FHD && service_is_fhdtv(s)) ||
             (pro->pro_svfilter == PROFILE_SVF_UHD && service_is_uhdtv(s))) {
           r1 = s->s_enlist(s, ti, sil, flags, weight);
           if (r1 && r == 0)
@@ -416,13 +418,59 @@ service_find_instance
     /* find a valid instance, no error and "user" idle */
     TAILQ_FOREACH(si, sil, si_link)
       if (si->si_weight < SUBSCRIPTION_PRIO_MIN && si->si_error == 0) break;
-    /* UHD->HD fallback and SD->HD fallback */
+    /* SD->HD->FHD->UHD fallback */
     if (si == NULL && pro &&
-        (pro->pro_svfilter == PROFILE_SVF_UHD ||
-         pro->pro_svfilter == PROFILE_SVF_SD)) {
+        pro->pro_svfilter == PROFILE_SVF_SD) {
       LIST_FOREACH(ilm, &ch->ch_services, ilm_in2_link) {
         s = (service_t *)ilm->ilm_in1;
         if (s->s_is_enabled(s, flags) && service_is_hdtv(s)) {
+          r1 = s->s_enlist(s, ti, sil, flags, weight);
+          if (r1 && r == 0)
+            r = r1;
+        }
+      }
+      LIST_FOREACH(ilm, &ch->ch_services, ilm_in2_link) {
+        s = (service_t *)ilm->ilm_in1;
+        if (s->s_is_enabled(s, flags) && service_is_fhdtv(s)) {
+          r1 = s->s_enlist(s, ti, sil, flags, weight);
+          if (r1 && r == 0)
+            r = r1;
+        }
+      }
+      LIST_FOREACH(ilm, &ch->ch_services, ilm_in2_link) {
+        s = (service_t *)ilm->ilm_in1;
+        if (s->s_is_enabled(s, flags) && service_is_uhdtv(s)) {
+          r1 = s->s_enlist(s, ti, sil, flags, weight);
+          if (r1 && r == 0)
+            r = r1;
+        }
+      }
+      /* find a valid instance, no error and "user" idle */
+      TAILQ_FOREACH(si, sil, si_link)
+        if (si->si_weight < SUBSCRIPTION_PRIO_MIN && si->si_error == 0) break;
+    }
+    /* UHD->FHD->HD->SD fallback */
+    if (si == NULL && pro &&
+        pro->pro_svfilter == PROFILE_SVF_UHD) {
+      LIST_FOREACH(ilm, &ch->ch_services, ilm_in2_link) {
+        s = (service_t *)ilm->ilm_in1;
+        if (s->s_is_enabled(s, flags) && service_is_fhdtv(s)) {
+          r1 = s->s_enlist(s, ti, sil, flags, weight);
+          if (r1 && r == 0)
+            r = r1;
+        }
+      }
+      LIST_FOREACH(ilm, &ch->ch_services, ilm_in2_link) {
+        s = (service_t *)ilm->ilm_in1;
+        if (s->s_is_enabled(s, flags) && service_is_hdtv(s)) {
+          r1 = s->s_enlist(s, ti, sil, flags, weight);
+          if (r1 && r == 0)
+            r = r1;
+        }
+      }
+      LIST_FOREACH(ilm, &ch->ch_services, ilm_in2_link) {
+        s = (service_t *)ilm->ilm_in1;
+        if (s->s_is_enabled(s, flags) && service_is_sdtv(s)) {
           r1 = s->s_enlist(s, ti, sil, flags, weight);
           if (r1 && r == 0)
             r = r1;
@@ -840,7 +888,26 @@ service_is_hdtv(const service_t *t)
     elementary_stream_t *st;
     TAILQ_FOREACH(st, &t->s_components.set_all, es_link)
       if (SCT_ISVIDEO(st->es_type) &&
-          st->es_height >= 720 && st->es_height <= 1080)
+          st->es_height >= 720 && st->es_height < 1080)
+        return 1;
+  }
+  return 0;
+}
+
+int
+service_is_fhdtv(const service_t *t)
+{
+  char s_type;
+  if(t->s_type_user == ST_UNSET)
+    s_type = t->s_servicetype;
+  else
+    s_type = t->s_type_user;
+  if (s_type == ST_FHDTV)
+    return 1;
+  else if (s_type == ST_NONE) {
+    elementary_stream_t *st;
+    TAILQ_FOREACH(st, &t->s_components.set_all, es_link)
+      if (SCT_ISVIDEO(st->es_type) && st->es_height == 1080)
         return 1;
   }
   return 0;
@@ -915,13 +982,14 @@ const char *
 service_servicetype_txt ( service_t *s )
 {
   static const char *types[] = {
-    "HDTV", "SDTV", "Radio", "UHDTV", "Other"
+    "HDTV", "SDTV", "Radio", "FHDTV", "UHDTV", "Other"
   };
   if (service_is_hdtv(s))  return types[0];
   if (service_is_sdtv(s))  return types[1];
   if (service_is_radio(s)) return types[2];
-  if (service_is_uhdtv(s)) return types[3];
-  return types[4];
+  if (service_is_fhdtv(s)) return types[3];
+  if (service_is_uhdtv(s)) return types[4];
+  return types[5];
 }
 
 

--- a/src/service.h
+++ b/src/service.h
@@ -183,6 +183,7 @@ typedef struct service {
     ST_OTHER,
     ST_SDTV,
     ST_HDTV,
+    ST_FHDTV,
     ST_UHDTV,
     ST_RADIO
   } s_servicetype;
@@ -433,10 +434,11 @@ static inline uint16_t service_id16(void *t)
 
 int service_is_sdtv(const service_t *t);
 int service_is_uhdtv(const service_t *t);
+int service_is_fhdtv(const service_t *t);
 int service_is_hdtv(const service_t *t);
 int service_is_radio(const service_t *t);
 static inline int service_is_tv( const service_t *s)
-  { return service_is_hdtv(s) || service_is_sdtv(s) || service_is_uhdtv(s); }
+  { return service_is_hdtv(s) || service_is_sdtv(s) || service_is_uhdtv(s) || service_is_fhdtv(s); }
 static inline int service_is_other(const service_t *t)
   { return !service_is_tv(t) && !service_is_radio(t); }
 

--- a/src/service_mapper.c
+++ b/src/service_mapper.c
@@ -230,9 +230,9 @@ service_mapper_process
       // 4HD\0   len=3,  HD at pos 1 (3-2)
       // 4\0     len=1
       if (name[len-2] == 'H' && name[len-1] == 'D') {
-        /* Ends in HD but does it end in UHD? */
+        /* Ends in HD but does it end in UHD/FHD? */
         tidy_name = tvh_strdupa(name);
-        if (len > 3 && name[len-3] == 'U')
+        if (len > 3 && (name[len-3] == 'U' || name[len-3] == 'F'))
           tidy_name[len-3] = 0;
         else
           tidy_name[len-2] = 0;
@@ -300,6 +300,9 @@ service_mapper_process
       if (service_is_uhdtv(s)) {
         channel_tag_map(channel_tag_find_by_name("TV channels", 1), chn, chn);
         channel_tag_map(channel_tag_find_by_name("UHDTV", 1), chn, chn);
+      } else if (service_is_fhdtv(s)) {
+        channel_tag_map(channel_tag_find_by_name("TV channels", 1), chn, chn);
+        channel_tag_map(channel_tag_find_by_name("FHDTV", 1), chn, chn);
       } else if (service_is_hdtv(s)) {
         channel_tag_map(channel_tag_find_by_name("TV channels", 1), chn, chn);
         channel_tag_map(channel_tag_find_by_name("HDTV", 1), chn, chn);

--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -282,8 +282,10 @@ tvheadend.epgDetails = function(grid, index) {
         content += '<div class="x-epg-meta"><span class="x-epg-prefix">' + _('Content Type') + ':</span><span class="x-epg-genre">' + genre.join(', ') + '</span></div>';
       }
       var tags = [];
-      if (event.hd > 1)
+      if (event.hd > 2)
         tags.push(_('UHDTV'));
+      else if (event.hd > 1)
+        tags.push(_('FHDTV'));
       else if (event.hd > 0)
         tags.push(_('HDTV'));
       if ('new' in event && event.new)


### PR DESCRIPTION
Had the need for FHD support in my tvheadend setup, thought I could make a pull request if there is need for this in the main repo as well.

The code is more or less a blind hack since I haven't contributed to tvheadend before and pretty much does not know what I am doing ^^. It probably needs testing and a few changes before being in a good shape for merging. I have not found any functional bugs yet in my tests.

Oh, also added UHD->FHD->HD->SD and SD->HD->FHD->UHD fallback instead of just UHD->HD and SD->HD.  (Not tested)