### PR TITLE
man page: Correct default values for http and htsp port

### DIFF
--- a/man/tvheadend.1
+++ b/man/tvheadend.1
@@ -82,13 +82,13 @@ Specify an interface IP address on which incoming HTTP and HTSP connections
 will be accepted. By default, connections are accepted on all interfaces.
 .TP
 \fB\-\-http_port
-Specify alternative http port (default 9881).
+Specify alternative http port (default 9981).
 .TP
 \fB\-\-http_root
 Specify alternative http webroot.
 .TP
 \fB\-\-htsp_port
-Specify alternative HTSP port (default 9882).
+Specify alternative HTSP port (default 9982).
 .TP
 \fB\-\-htsp_port2
 Specify extra HTSP port.


### PR DESCRIPTION
The man page incorrectly states the default values for the `--http_port` and `--htsp_port` options are 9**8**81 and 9**8**82, when in fact they are [9**9**81](https://github.com/tvheadend/tvheadend/blob/8f1de1621d78c91431238176bf4f6290870a031a/src/main.c#L822) and [9**9**82](https://github.com/tvheadend/tvheadend/blob/8f1de1621d78c91431238176bf4f6290870a031a/src/main.c#L824).