### PR TITLE
Cosmetic: Tooltip description not shown on webui (truncated)

### DIFF
--- a/src/input/mpegts/mpegts_network.c
+++ b/src/input/mpegts/mpegts_network.c
@@ -243,7 +243,7 @@ const idclass_t mpegts_network_class =
       .id       = "skipinitscan",
       .name     = N_("Skip startup scan"),
       .desc     = N_("Skip scanning known muxes when Tvheadend starts. "
-                     "If \"startup scan\" is allowed and new muxes are "
+                     "If 'startup scan' is allowed and new muxes are "
                      "found then they will still be scanned. See Help for "
                      "more details."),
       .off      = offsetof(mpegts_network_t, mn_skipinitscan),


### PR DESCRIPTION
" are not shown while ' yes. Actually text is truncated.

![image](https://user-images.githubusercontent.com/7295293/65140270-7642d700-da0e-11e9-81ad-8db1dd8bb638.png)