### PR TITLE
mux grid: enable 'hide: parent disabled'

### DIFF
--- a/src/api/api_mpegts.c
+++ b/src/api/api_mpegts.c
@@ -244,7 +244,7 @@ api_mpegts_mux_grid
   }
 
   LIST_FOREACH(mn, &mpegts_network_all, mn_global_link) {
-    //if (hide && !mn->mn_enabled) continue;
+    if (hide && !mn->mn_enabled) continue;
     LIST_FOREACH(mm, &mn->mn_muxes, mm_network_link) {
       if (hide == 2 && !mm->mm_is_enabled(mm)) continue;
       idnode_set_add(ins, (idnode_t*)mm, &conf->filter, perm->aa_lang_ui);
@@ -272,7 +272,7 @@ api_mpegts_service_grid
   }
 
   LIST_FOREACH(mn, &mpegts_network_all, mn_global_link) {
-    //if (hide && !mn->mn_enabled) continue;
+    if (hide && !mn->mn_enabled) continue;
     LIST_FOREACH(mm, &mn->mn_muxes, mm_network_link) {
       if (hide && !mm->mm_is_enabled(mm)) continue;
       LIST_FOREACH(ms, &mm->mm_services, s_dvb_mux_link) {


### PR DESCRIPTION
Lines were added commented waiting for "network enable/disable" to be implemented.
When it got implemented they were left behind.

PS: Should also make the "Services" tab rendering faster for "hide: parent disabled" since it will exit the loop as soon as it sees that the network is disabled (instead of unnecessary cycling through all the network muxes).