### PR TITLE
#4182: Add 'duplicate handling' - feature in DVR-Profiles

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -83,6 +83,7 @@ typedef struct dvr_config {
   uint32_t dvr_removal_after_playback;
   uint32_t dvr_autorec_max_count;
   uint32_t dvr_autorec_max_sched_count;
+  uint32_t dvr_autorec_record;
   char *dvr_charset;
   char *dvr_charset_id;
   char *dvr_preproc;
@@ -346,7 +347,8 @@ typedef enum {
   DVR_AUTOREC_LRECORD_ONCE_PER_MONTH = 13,
   DVR_AUTOREC_LRECORD_ONCE_PER_WEEK = 10,
   DVR_AUTOREC_LRECORD_ONCE_PER_DAY = 11,
-  /* first free value == 15 */
+  DVR_AUTOREC_RECORD_DVR_PROFILE = 15,
+  /* first free value == 16 */
 } dvr_autorec_dedup_t;
 
 typedef enum {

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -998,6 +998,8 @@ static htsmsg_t *
 dvr_autorec_entry_class_dedup_list ( void *o, const char *lang )
 {
   static const struct strtab tab[] = {
+    { N_("Use DVR configuration"),
+        DVR_AUTOREC_RECORD_DVR_PROFILE },
     { N_("Record all"),
         DVR_AUTOREC_RECORD_ALL },
     { N_("All: Record if EPG/XMLTV indicates it is a unique programme"),
@@ -1353,7 +1355,7 @@ const idclass_t dvr_autorec_entry_class = {
       .id       = "record",
       .name     = N_("Duplicate handling"),
       .desc     = N_("Duplicate recording handling."),
-      .def.i    = DVR_AUTOREC_RECORD_ALL,
+      .def.i    = DVR_AUTOREC_RECORD_DVR_PROFILE,
       .doc      = prop_doc_duplicate_handling,
       .off      = offsetof(dvr_autorec_entry_t, dae_record),
       .list     = dvr_autorec_entry_class_dedup_list,

--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -127,6 +127,43 @@ dvr_config_find_by_list(htsmsg_t *uuids, const char *name)
     res = dvr_config_find_by_name_default(NULL);
   return res;
 }
+static htsmsg_t *
+dvr_autorec_entry_class_record_list ( void *o, const char *lang )
+{
+  static const struct strtab tab[] = {
+    { N_("Record all"),
+        DVR_AUTOREC_RECORD_ALL },
+    { N_("All: Record if EPG/XMLTV indicates it is a unique programme"),
+        DVR_AUTOREC_RECORD_UNIQUE },
+    { N_("All: Record if different episode number"),
+        DVR_AUTOREC_RECORD_DIFFERENT_EPISODE_NUMBER },
+    { N_("All: Record if different subtitle"),
+        DVR_AUTOREC_RECORD_DIFFERENT_SUBTITLE },
+    { N_("All: Record if different description"),
+        DVR_AUTOREC_RECORD_DIFFERENT_DESCRIPTION },
+    { N_("All: Record once per month"),
+        DVR_AUTOREC_RECORD_ONCE_PER_MONTH },
+    { N_("All: Record once per week"),
+        DVR_AUTOREC_RECORD_ONCE_PER_WEEK },
+    { N_("All: Record once per day"),
+        DVR_AUTOREC_RECORD_ONCE_PER_DAY },
+    { N_("Local: Record if different episode number"),
+        DVR_AUTOREC_LRECORD_DIFFERENT_EPISODE_NUMBER },
+    { N_("Local: Record if different title"),
+        DVR_AUTOREC_LRECORD_DIFFERENT_TITLE },
+    { N_("Local: Record if different subtitle"),
+        DVR_AUTOREC_LRECORD_DIFFERENT_SUBTITLE },
+    { N_("Local: Record if different description"),
+        DVR_AUTOREC_LRECORD_DIFFERENT_DESCRIPTION },
+    { N_("Local: Record once per month"),
+        DVR_AUTOREC_LRECORD_ONCE_PER_MONTH },
+    { N_("Local: Record once per week"),
+        DVR_AUTOREC_LRECORD_ONCE_PER_WEEK },
+    { N_("Local: Record once per day"),
+        DVR_AUTOREC_LRECORD_ONCE_PER_DAY },
+  };
+  return strtab2htsmsg(tab, 1, lang);
+}
 
 /**
  *
@@ -185,6 +222,7 @@ dvr_config_create(const char *name, const char *uuid, htsmsg_t *conf)
   cfg->dvr_cleanup_threshold_free = 1000; // keep 1000 MiB of free space on disk by default
   cfg->dvr_cleanup_threshold_used = 0;    // disabled
   cfg->dvr_autorec_max_count = 50;
+  cfg->dvr_autorec_record = DVR_AUTOREC_RECORD_ALL;
   cfg->dvr_format_tvmovies_subdir = strdup("tvmovies");
   cfg->dvr_format_tvshows_subdir = strdup("tvshows");
 
@@ -1402,6 +1440,17 @@ const idclass_t dvr_config_class = {
       .opts     = PO_ADVANCED,
       .group    = 6,
     },
+    {
+      .type     = PT_U32,
+      .id       = "autorec-record",
+      .name     = N_("Autorec duplicate handling"),
+      .desc     = N_("Duplicate recording handling."),
+      .off      = offsetof(dvr_config_t, dvr_autorec_record),
+      .list     = dvr_autorec_entry_class_record_list,
+      .opts     = PO_ADVANCED,
+      .def.i    = DVR_AUTOREC_RECORD_ALL,
+      .group    = 6,
+    },    
     {
       .type     = PT_BOOL,
       .id       = "skip-commercials",

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1737,7 +1737,10 @@ static dvr_entry_t *_dvr_duplicate_event(dvr_entry_t *de)
   if (lang_str_empty(de->de_title))
     return NULL;
 
-  record = de->de_autorec->dae_record;
+  if (de->de_autorec->dae_record == DVR_AUTOREC_RECORD_DVR_PROFILE)
+    record = de->de_config->dvr_autorec_record;
+  else
+    record = de->de_autorec->dae_record;
 
   switch (record) {
     case DVR_AUTOREC_RECORD_ALL:

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -272,6 +272,7 @@ cleanup_filename(dvr_config_t *cfg, char *s, int dosubs)
       *s = '-';
 
     else if (cfg->dvr_clean_title &&
+             strchr("äöüÄÖÜß", *s) == NULL &&
              ((*s < 32) || (*s > 122) ||
              (strchr("/:\\<>|*?\"", *s) != NULL)) &&
              dosubs)


### PR DESCRIPTION
This patch adds drop-down list to "DVR profile "configuration which is then used by default for newly created "autorec" entry. Can be altered in "Autorec" configuration.
Solves issue [#4182](https://tvheadend.org/issues/4182)