### PR TITLE
Webui: visual fixes

### DIFF
--- a/src/webui/static/app/config.js
+++ b/src/webui/static/app/config.js
@@ -146,7 +146,7 @@ tvheadend.satipsrvconf = function(panel, index) {
         iconCls: 'satipsrvconf',
         tabIndex: index,
         comet: 'satip_server',
-        width: 600,
+        width: 610,
         labelWidth: 250,
         tbar: [discoverButton]
     });

--- a/src/webui/static/app/idnode.js
+++ b/src/webui/static/app/idnode.js
@@ -2731,7 +2731,7 @@ tvheadend.idnode_tree = function(panel, conf)
                         uuid = n.attributes.uuid;
                         current = new tvheadend.idnode_editor(uilevel, n.attributes, {
                             title: _('Parameters'),
-                            width: 550,
+                            width: 560,
                             noautoWidth: true,
                             fixedHeight: true,
                             noApply: true,

--- a/vendor/ext-3.4.1/resources/css/xtheme-access.css
+++ b/vendor/ext-3.4.1/resources/css/xtheme-access.css
@@ -1833,6 +1833,10 @@ body.x-body-masked .x-window-plain .x-window-mc {
     background-image:url(../images/access/window/icon-error.gif);
 }
 
+.x-form-spinner-trigger {
+    width:17px!important;
+}
+
 .tmdb {
     content:url(../../../img/tmdb_white.png)!important;
 }


### PR DESCRIPTION
* Sightly increase 'SAT>IP Servers' width (design collision).

* Sightly increase 'TVadapters' width (design collision).

* Fix width for spinner arrows (image was repeated)

**(Attached before/after)**

![image](https://user-images.githubusercontent.com/7295293/67810708-5980d100-fa9b-11e9-88d8-b4f8ac7db446.png)
![image](https://user-images.githubusercontent.com/7295293/67810731-66052980-fa9b-11e9-80eb-2f066b5478d2.png)

![834bbaac897002aabeae6d45d05a71a6](https://user-images.githubusercontent.com/7295293/67810604-2e967d00-fa9b-11e9-9894-b225be25cca8.png)
![547060ed56fdb07c5483139ed4cb4e79](https://user-images.githubusercontent.com/7295293/67810660-440ba700-fa9b-11e9-83f2-ffdc02a5371d.png)

![image](https://user-images.githubusercontent.com/7295293/67810766-7d441700-fa9b-11e9-8607-03dacae5daa1.png)
![image](https://user-images.githubusercontent.com/7295293/67810772-8208cb00-fa9b-11e9-8c85-607a752c77a6.png)
