### PR TITLE
configure: Fix build failure in IPTV-only configuration

### DIFF
--- a/configure
+++ b/configure
@@ -753,8 +753,6 @@ if enabled linuxdvb || enabled iptv || enabled tsfile || enabled satip_client ||
    enabled hdhomerun_client || enabled satip_server;
 then
   enable mpegts
-fi
-if enabled linuxdvb || enabled satip_client || enabled hdhomerun_client || enabled satip_server; then
   enable mpegts_dvb
 fi
 


### PR DESCRIPTION
mpegts_service.c is part of the "mpegts" feature.
Therein, function mpegts_service_source depends on the existence
of dvb_mux_*_class.
These classes are defined in mpegts_mux_dvb.c, which itself is part
of the "mpegts_dvb" feature.

So, all configurations with mpegts=yes and mpegts_dvb=no fail to
build.

Fix this by synchronizing both features.

Signed-off-by: Klaus Kudielka <klaus.kudielka@gmail.com>