### PR TITLE
Don't overwrite custom headers, fixes #5575

### DIFF
--- a/src/input/mpegts/iptv/iptv_auto.c
+++ b/src/input/mpegts/iptv/iptv_auto.c
@@ -249,7 +249,7 @@ skip_url:
         im->mm_iptv_epgid = epgid ? strdup(epgid) : NULL;
         change = 1;
       }
-      if (strcmp(im->mm_iptv_hdr ?: "", custom)) {
+      if (strcmp(im->mm_iptv_hdr ?: "", custom) && strcmp(custom, "")) {
         free(im->mm_iptv_hdr);
         im->mm_iptv_hdr = strdup(custom);
         change = 1;


### PR DESCRIPTION
Don't overwrite custom headers defined in the web interface with the ones set in an m3u file, fixes #5575