### PR TITLE
WebUI: Fix the query URL for IMDB website

### DIFF
--- a/src/webui/static/app/epg.js
+++ b/src/webui/static/app/epg.js
@@ -170,7 +170,7 @@ tvheadend.seachTitleWeb = function(index, title){
     var url = '';
     switch(index){
         case 1:
-            url = 'http://akas.imdb.com/find?q=' + encodeURIComponent(title);
+            url = 'https://www.imdb.com/find?q=' + encodeURIComponent(title);
             break;
         case 2:
             url = 'https://www.thetvdb.com/search?q='+ encodeURIComponent(title)+'&l=en';


### PR DESCRIPTION
When using the WebUI and clicking a program in the EPG to bring up the "Broadcast Details" window, there is a IMDB icon at the bottom left of this window.  I find it very useful to directly query the IMDB website for the title I'm looking at.  Unfortunately, there was probably a change on IMDB side that generates a "Privacy error" message when trying to open the URL: https://akas.imdb.com/find?q=Skyfall 

Note: full URL example is given using the Skyvall movie title.

```
Your connection is not private
Attackers might be trying to steal your information from akas.imdb.com (for example, passwords, messages, or credit cards). Learn more
NET::ERR_CERT_COMMON_NAME_INVALID
```

This PR corrects this issue by providing an updated URL that works without issue to query a title.

The new URL I propose is simply: https://www.imdb.com/find?q=Skyfall   (same example given)