### PR TITLE
Add ENVyfile for easier environment setup.

### DIFF
--- a/.envyfile
+++ b/.envyfile
@@ -22,6 +22,7 @@ environment:
 network:
   ports:
     - '9981:9981'
+    - '9982:9982'
 actions:
   - name: build
     script: './configure && make'

--- a/.envyfile
+++ b/.envyfile
@@ -1,0 +1,31 @@
+environment:
+  system-packages:
+    - recipe: build-essential
+    - recipe: git
+    - recipe: pkg-config
+    - recipe: libssl-dev
+    - recipe: bzip2
+    - recipe: wget
+    - recipe: libavahi-client-dev
+    - recipe: zlib1g-dev
+    - recipe: libavcodec-dev
+    - recipe: libavutil-dev
+    - recipe: libavformat-dev
+    - recipe: libswscale-dev
+    - recipe: libavresample-dev
+    - recipe: gettext
+    - recipe: cmake
+    - recipe: python
+    - recipe: libdvbcsa-dev
+    - recipe: libpcre3-dev
+    - recipe: liburiparser-dev
+network:
+  ports:
+    - '9981:9981'
+actions:
+  - name: build
+    script: './configure && make'
+    help: 'Build tvheadend'
+  - name: run
+    script: './build.linux/tvheadend'
+    help: 'Run tvheadend'

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ intl/js/tvheadend.js.en_CZ.po
 intl/js/*.new
 src/webui/static/intl
 
+envy/
+
 #############
 ###Windows###
 #############

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ Thus, to start it, just type:
 
 Settings are stored in `$HOME/.hts/tvheadend`.
 
+Alternatively, you can use the [ENVy](http://envy-project.github.io/) environment
+manager to get your environment set up quickly. It won't be able to use DVB
+cards, but it's a faster way to get started working on Tvheadend.
+
+You can then (without installing dependencies manually) run:
+
+	$ envy up && envy build && envy run
+
+Note that `envy run` can take arguments like `-C` and they will be passed along
+to Tvheadend.
+
 How to build for OS X
 ---------------------
 


### PR DESCRIPTION
Hello!

We (@magmastonealex, @omstrumpf, @gbateman, @Tim-Willard) have been working on a tool called [ENVy](http://envy-project.github.io/).

ENVy is an environment manager to make working on disparate projects easier. You don't need to worry
about what a system package is called on your Linux distribution, or figure out how to build for Mac
from scratch.

Part of our goal was to make it easier to contribute to open source. We noticed that long contributing
guides dissuades casual involvement - if you have to install a bunch of dependencies (that you won't
necessarily know how or remember to get rid of),
and spend half an hour getting set up, you're not very likely to fix a typo or make a 30 second fix for a personally annoying bug.

Setup with ENVy is as simple as typing `envy up` for any project you want to work on. Running `envy nuke` removes all traces of that environment.
With ENVy, you don't need to hunt down a lint command or how you run the tests. `envy -h` shows you all the commands you can run - or just
jump into a shell with `envy shell`.

You can read more about ENVy [here](http://envy-project.github.io/), but the short version is that we think it'll make it
easier for contributors to help out. 

This PR adds an `ENVyfile`, the file that describes a development environment and contains the commands to run.  

I used tvheadend while developing, in order to test ENVy, and we hoped you'd consider committing this file to help out casual contributors.

If you're not interested, or you think this isn't a good fit, please let me (or any of us) know. We would greatly appreciate your feedback!
