### PR TITLE
Consider to change default PID path to /run/tvheadend.pid

### DIFF
--- a/debian/tvheadend.service
+++ b/debian/tvheadend.service
@@ -9,8 +9,8 @@ After=auditd.service syslog.target network.target local-fs.target
 
 [Service]
 EnvironmentFile=/etc/default/tvheadend
-ExecStart=/usr/bin/tvheadend -f -p /var/run/tvheadend.pid $OPTIONS
-PIDFile=/var/run/tvheadend.pid
+ExecStart=/usr/bin/tvheadend -f -p /run/tvheadend.pid $OPTIONS
+PIDFile=/run/tvheadend.pid
 Type=forking
 Restart=on-failure
 RestartSec=54s

--- a/man/tvheadend.1
+++ b/man/tvheadend.1
@@ -45,7 +45,7 @@ use the uid of 1 ('daemon' on most systems).
 Run as group \fR\fIgroupname\fR. Only applicable if daemonizing. Default is to use the 'video' group. If the 'video' group does not exist, gid 1 ('daemon') will be used.
 .TP
 \fB\-p\fR \fIpidpath\fR, \fB\-\-pid \fR\fIpidpath\fR
-Specify alternative PID path file (default /var/run/tvheadend.pid).
+Specify alternative PID path file (default /run/tvheadend.pid).
 .TP
 \fB\-C\fR, \fB\-\-firstrun\fR
 If no user account exist then create one with no username and no
@@ -196,7 +196,7 @@ is run as a system daemon a dedicated user needs to be created and Tvheadend
 should be launched with the '-u' argument. Also notice that XMLTV will read/
 store cache and configuration from the same user home directory.
 .PP
-If daemonizing, Tvheadend will writes its pid in /var/run/tvheadend.pid
+If daemonizing, Tvheadend will writes its pid in /run/tvheadend.pid
 .SH "AUTHOR"
 .B Tvheadend
 and this man page is maintained by the Tvheadend team. Please see the 

--- a/rpm/tvheadend.service
+++ b/rpm/tvheadend.service
@@ -9,8 +9,8 @@ After=auditd.service syslog.target network.target local-fs.target
 
 [Service]
 EnvironmentFile=/etc/sysconfig/tvheadend
-ExecStart=/usr/bin/tvheadend -f -p /var/run/tvheadend.pid $OPTIONS
-PIDFile=/var/run/tvheadend.pid
+ExecStart=/usr/bin/tvheadend -f -p /run/tvheadend.pid $OPTIONS
+PIDFile=/run/tvheadend.pid
 Type=forking
 Restart=on-failure
 RestartSec=54s

--- a/src/main.c
+++ b/src/main.c
@@ -862,7 +862,7 @@ main(int argc, char **argv)
              *opt_logpath      = NULL,
              *opt_log_debug    = NULL,
              *opt_log_trace    = NULL,
-             *opt_pidpath      = "/var/run/tvheadend.pid",
+             *opt_pidpath      = "/run/tvheadend.pid",
 #if ENABLE_LINUXDVB
              *opt_dvb_adapters = NULL,
 #endif


### PR DESCRIPTION
Hello following [FSH3](http://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s13.html) consider to change default pid path to /run/tvheadend.pid from /var/run/tvheadend.pid.

Some utilities (i.e. systemd-analyze) are now reporting *legacy path* /var/run


`systemd-analyze verify tvheadend.service`
> /usr/lib/systemd/system/tvheadend.service:13: PIDFile= references a path below legacy directory /var/run/, updating /var/run/tvheadend.pid → /run/tvheadend.pid; please update the unit file accordingly.