### PR TITLE
Makefile.ffmpeg: update almost all upstream packages

### DIFF
--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -51,62 +51,62 @@ NASM_URL       = https://www.nasm.us/pub/nasm/releasebuilds/$(NASM_VER)/$(NASM_T
 NASM_SHA1      = bfa67d0d33f0c7b00c50d9f1bd33fd4d5df3c5d5
 NASM_DIFFS     = remove-invalid-pure_func-qualifiers.diff
 
-LIBX264        = x264-snapshot-20190108-2245
+LIBX264        = x264-snapshot-20191216-2245
 LIBX264_TB     = $(LIBX264).tar.bz2
 LIBX264_URL    = http://ftp.videolan.org/x264/snapshots/$(LIBX264_TB)
-LIBX264_SHA1   = 6d216c7892b9c886aa6b18a580698083136e2fdc
+LIBX264_SHA1   = 712f37aeabf3cb42f1ebe55588c33583636a7230
 
-LIBX265        = x265_2.9
+LIBX265        = x265_3.2
 LIBX265_TB     = $(LIBX265).tar.gz
 LIBX265_URL    = http://ftp.videolan.org/videolan/x265/$(LIBX265_TB)
-LIBX265_SHA1   = 3c005b4ab409c6f996b36ad88d780ff85fbc9abf
+LIBX265_SHA1   = 5922f88d0997c47e2c95feee95dc98bcb2e54871
 ifeq ($(CONFIG_PIE),yes)
 LIBX265_DIFFS  = libx265.pie.diff
 else
 LIBX265_DIFFS  = libx265.pic.diff
 endif
 
-LIBVPX_VER     = 1.7.0
+LIBVPX_VER     = 1.8.2
 LIBVPX         = libvpx-$(LIBVPX_VER)
 LIBVPX_TB      = $(LIBVPX).tar.gz
 LIBVPX_URL     = https://github.com/webmproject/libvpx/archive/v$(LIBVPX_VER)/$(LIBVPX_TB)
-LIBVPX_SHA1    = fb3d4b80596d1e3b1a7f53757d63e7d2b3eeb7c9
+LIBVPX_SHA1    = 7fbc7de47f59431fa2c5b76660f115963e83193d
 
-LIBOGG         = libogg-1.3.3
+LIBOGG         = libogg-1.3.4
 LIBOGG_TB      = $(LIBOGG).tar.gz
-LIBOGG_URL     = http://downloads.xiph.org/releases/ogg/$(LIBOGG_TB)
-LIBOGG_SHA1    = 28ba40fd2e2d41988f658a0016fa7b534e509bc0
+LIBOGG_URL     = https://ftp.osuosl.org/pub/xiph/releases/ogg/$(LIBOGG_TB)
+LIBOGG_SHA1    = 851cef020b346d44893e5d1c3dab83c675d479d9
 
 LIBTHEORA      = libtheora-1.1.1
 LIBTHEORA_TB   = $(LIBTHEORA).tar.gz
-LIBTHEORA_URL  = http://downloads.xiph.org/releases/theora/$(LIBTHEORA_TB)
+LIBTHEORA_URL  = https://ftp.osuosl.org/pub/xiph/releases/theora/$(LIBTHEORA_TB)
 LIBTHEORA_SHA1 = 0b91be522746a29351a5ee592fd8160940059303
 
 LIBVORBIS      = libvorbis-1.3.6
 LIBVORBIS_TB   = $(LIBVORBIS).tar.gz
-LIBVORBIS_URL  = http://downloads.xiph.org/releases/vorbis/$(LIBVORBIS_TB)
+LIBVORBIS_URL  = https://ftp.osuosl.org/pub/xiph/releases/vorbis/$(LIBVORBIS_TB)
 LIBVORBIS_SHA1 = 91f140c220d1fe3376d637dc5f3d046263784b1f
 
-LIBFDKAAC      = fdk-aac-0.1.4
+LIBFDKAAC      = fdk-aac-0.1.6
 LIBFDKAAC_TB   = $(LIBFDKAAC).tar.gz
 LIBFDKAAC_URL  = https://freefr.dl.sourceforge.net/project/opencore-amr/fdk-aac/$(LIBFDKAAC_TB)
-LIBFDKAAC_SHA1 = 9215d19bdd911954fd5bc879c707ab571716ba0d
+LIBFDKAAC_SHA1 = 574103e24fe45b3b89a92cc6a7a9d260c483b9e0
 
-LIBOPUS        = opus-1.3-rc
+LIBOPUS        = opus-1.3.1
 LIBOPUS_TB     = $(LIBOPUS).tar.gz
 LIBOPUS_URL    = https://archive.mozilla.org/pub/opus/$(LIBOPUS_TB)
-LIBOPUS_SHA1   = ea74356b762ac466637a40c82cdd3acbc35daa43
+LIBOPUS_SHA1   = ed226536537861c9f0f1ef7ca79dffc225bc181b
 
-FFNVCODEC_VER  = 8.2.15.6
+FFNVCODEC_VER  = 8.2.15.10
 FFNVCODEC      = nv-codec-headers-n$(FFNVCODEC_VER)
 FFNVCODEC_TB   = $(FFNVCODEC).tar.gz
 FFNVCODEC_URL  = https://github.com/FFmpeg/nv-codec-headers/releases/download/n$(FFNVCODEC_VER)/nv-codec-headers-$(FFNVCODEC_VER).tar.gz
-FFNVCODEC_SHA1 = 57eb91aab785b1adeb2d17c95fd1bba32e6f53d9
+FFNVCODEC_SHA1 = 80c3bd878e6b4a7d3a6a643ad6ad07a9f02bfe81
 
-FFMPEG         = ffmpeg-4.1.1
+FFMPEG         = ffmpeg-4.1.5
 FFMPEG_TB      = $(FFMPEG).tar.bz2
-FFMPEG_URL     = http://ffmpeg.org/releases/$(FFMPEG_TB)
-FFMPEG_SHA1    = 9076734d98fb8d6ad1cff8f8f68228afa0bb2204
+FFMPEG_URL     = https://ffmpeg.org/releases/$(FFMPEG_TB)
+FFMPEG_SHA1    = 850ca59493aa6d773a1346257c9fbee80ba6efe0
 
 # ##############################################################################
 # Library Config


### PR DESCRIPTION
- Updated x264 to its the latest snapshot 20191216 as their
snapshotting service was discontinued.

- Updated x265 to version 3.2.

- Updated libvpx to version 1.8.2.

- Updated libogg to version 1.3.4

- Updated fdk-aac to version 0.1.6
There is version 2.0.x, but let's leave it for later.

- Updated opus to version 1.3.1

- Updated nv-codec-headers to version 8.2.15.10

- Updated ffmpeg to version 4.1.5
Fixes CVEs:
CVE-2019-9718
CVE-2019-9721
CVE-2019-11338
CVE-2019-11339
CVE-2019-12730
CVE-2019-17539
CVE-2019-17542

Misc changes:
- Changed url for libogg, libtheora, libvorbis to use HTTPS and previous
  site points to new one
- FFmpeg now uses HTTPS