### PR TITLE
Correct description of Change Parameters flag.

### DIFF
--- a/docs/property/change_parameters.md
+++ b/docs/property/change_parameters.md
@@ -3,15 +3,11 @@
 The *Change parameters* flag allows you to control which parameters
 (permission flags, all types of profiles, channel tags and ranges) are
 combined when multiple entries match a username/login. When the
-change parameter flag is enabled (checked) for a parameter that
-isn't set, the next matching entry (if any) in the sequence can set it.
-
-Username/Entry (matched in sequence)   | "Change parameters" "Rights" checked?     | Admin enabled/set?  | Can access configuration tab?
----------------------------------------|-------------------------------------------|---------------------|------------------------------
-* (Anon entry).                        | Yes.                                      | No.                 | No.
-* (Another anon entry).                | No.                                       | Yes.                | Yes, this is because the above entry "Change parameters" rights **is** checked and this user has admin rights.
-John doe.                              | Yes.                                      | Yes.                | No, this is because the above entry "Change parameters" rights **isn't** checked even though this user has admin rights.
-John doe (Another entry).              | Yes.                                      | No.                 | No, this is because the even though above entry "Change parameters" rights **is** checked this user has no admin rights.
+change parameter flag is enabled (checked) for a parameter, the setting
+for this user overrides any previous entry (though it can in turn be
+overridden by a later entry). The exception is the **Rights** option
+where the permissions for all matching users having the change parameter
+flag set are added together.
 
 Option                     | Description/Properties
 ---------------------------|---------------------------


### PR DESCRIPTION
The Change Parameters flag on the Access Entries screen for a user determines whether that user's settings will override any previously-set parameters (for example from a wildcard user) - it does not affect the ability of subsequent users to override settings in turn. The exception is the 'Rights' settings where all matched users with the Change flag set are ORed together.
