### PR TITLE
dvbpsi: Fix build when DVB is not enabled at all

### DIFF
--- a/src/input/mpegts/dvb_psi.c
+++ b/src/input/mpegts/dvb_psi.c
@@ -2331,9 +2331,11 @@ psi_tables_install ( mpegts_input_t *mi, mpegts_mux_t *mm,
     psi_tables_atsc_t(mm);
     break;
   case DVB_SYS_DVBC_ANNEX_B:
+#if ENABLE_MPEGTS_DVB
     if (idnode_is_instance(&mm->mm_id, &dvb_mux_dvbc_class))
       psi_tables_dvb(mm);
     else
+#endif
       psi_tables_atsc_c(mm);
     break;
   case DVB_SYS_NONE:


### PR DESCRIPTION
Not sure if this is entirely correct but otherwise you get:

```
src/input/mpegts/dvb_psi.c: In function ‘psi_tables_install’:
src/input/mpegts/dvb_psi.c:2334:41: error: ‘dvb_mux_dvbc_class’ undeclared (first use in this function)
 2334 |     if (idnode_is_instance(&mm->mm_id, &dvb_mux_dvbc_class))
      |                                         ^~~~~~~~~~~~~~~~~~
src/input/mpegts/dvb_psi.c:2334:41: note: each undeclared identifier is reported only once for each function it appears in
make: *** [Makefile:716: /var/tmp/portage/media-tv/tvheadend-9999/work/tvheadend-9999/build.linux/src/input/mpegts/dvb_psi.o] Error 1
```