### PR TITLE
Add packet buffer on stream restart, fixes #5722

### DIFF
--- a/src/parsers/parsers.h
+++ b/src/parsers/parsers.h
@@ -98,6 +98,8 @@ struct parser {
   commercial_advice_t prs_tt_commercial_advice;
   time_t prs_tt_clock;   /* Network clock as determined by teletext decoder */
 
+  /* restart_pending log */
+  struct streaming_message_queue prs_rstlog;
 };
 
 static inline int64_t


### PR DESCRIPTION
Seems to works for me in most cases, but i'm not sure if function parser_create is the best place to send pkt from rstlog.

Can someone test and review this patch ?