### PR TITLE
Fix infinite loop when parsing invalid EIT CRID data

### DIFF
--- a/src/epggrab/module/eit.c
+++ b/src/epggrab/module/eit.c
@@ -478,7 +478,12 @@ static int _eit_desc_crid
       /* Next */
       len -= 1 + r;
       ptr += 1 + r;
+    } else {
+      break;
     }
+  }
+  if (len > 3) {
+    return -1;
   }
 
   return 0;


### PR DESCRIPTION
Fixes a logic issue which resulted in an infinite busy loop when TVH encountered certain invalid EIT data.

In case the if condition inside the loop does not evaluate to true the variable in the loop condition (len) doesn't get touched and thus gets stuck inside the loop endlessly evaluating the same if and loop conditions. This patch makes it return an error instead of indefinitely looping.