### PR TITLE
xmltv: add program icon to exported xmltv. Fixes: #5685

### DIFF
--- a/src/webui/xmltv.c
+++ b/src/webui/xmltv.c
@@ -207,6 +207,11 @@ http_xmltv_programme_one_long(const http_connection_t *hc,
       htsbuf_append_and_escape_xml(hq, lse->str);
       htsbuf_append_str(hq, "</desc>\n");
     }
+  if (ebc->image) {
+      htsbuf_append_str(hq, "  <icon src=\"");
+      htsbuf_append_and_escape_xml(hq, ebc->image);
+      htsbuf_append_str(hq, "\"/>\n");
+  }
   if (ebc->credits) {
     htsbuf_append_str(hq, "  <credits>\n");
     htsmsg_field_t *f;


### PR DESCRIPTION
Adds support for exporting program icons. This has been supported when importing xmltv files but is not supported in the exported xmltv.

The fix is very simple, but if needed the pull request can be updated with additional flags to enable/disable this behaviour.