### PR TITLE
Fix compilation error.

### DIFF
--- a/src/misc/json.c
+++ b/src/misc/json.c
@@ -342,7 +342,7 @@ json_parse_value(const char *s, void *parent, const char *name,
   const char *s2;
   char *str;
   double d = 0;
-  long l = 0;
+  int64_t l = 0;
   void *c;
 
   if((c = json_parse_map(s, &s2, jd, opaque, failp, failmsg)) == NULL)


### PR DESCRIPTION
src/misc/json.c: In function ‘json_parse_value’:
src/misc/json.c:372:34: error: passing argument 2 of ‘json_parse_integer’ from incompatible pointer type [-Werror=incompatible-pointer-types]
  372 |   if((s2 = json_parse_integer(s, &l)) != NULL) {
      |                                  ^~
      |                                  |
      |                                  long int *
src/misc/json.c:307:44: note: expected ‘int64_t *’ {aka ‘long long int *’} but argument is of type ‘long int *’
  307 | json_parse_integer(const char *s, int64_t *lp)
      |                                   ~~~~~~~~~^~