### PR TITLE
Fix escape code '&quote;' should be '&quot;'.

### DIFF
--- a/src/webui/html.c
+++ b/src/webui/html.c
@@ -30,7 +30,7 @@ static struct {
   { '<',  "&lt;"    },
   { '&',  "&amp;"   },
   { '\'', "&apos;"  },
-  { '"',  "&quote;" }
+  { '"',  "&quot;" }
 };
 
 static const char *html_escape_char ( const char chr )


### PR DESCRIPTION
It seems the escaping for html is using "`&quote;`" instead of "`&quot;`".

For example S3.2.4:
https://www.w3.org/MarkUp/html-spec/html-spec.txt
or
https://dev.w3.org/html5/html-author/charref

The browsers I tested displayed '&quote;' as double quote marks followed by "e;".
