### PR TITLE
fix vaapi-profiles

### DIFF
--- a/src/transcoding/codec/codecs/libs/vaapi.c
+++ b/src/transcoding/codec/codecs/libs/vaapi.c
@@ -163,7 +163,6 @@ static const codec_profile_class_t codec_profile_vaapi_class = {
 /* h264_vaapi =============================================================== */
 
 static const AVProfile vaapi_h264_profiles[] = {
-    { FF_PROFILE_H264_BASELINE,             "Baseline" },
     { FF_PROFILE_H264_CONSTRAINED_BASELINE, "Constrained Baseline" },
     { FF_PROFILE_H264_MAIN,                 "Main" },
     { FF_PROFILE_H264_HIGH,                 "High" },
@@ -227,6 +226,8 @@ TVHVideoCodec tvh_codec_vaapi_h264 = {
 
 static const AVProfile vaapi_hevc_profiles[] = {
     { FF_PROFILE_HEVC_MAIN, "Main" },
+    { FF_PROFILE_HEVC_MAIN_10, "Main 10" },
+    { FF_PROFILE_HEVC_REXT, "Rext" },
     { FF_PROFILE_UNKNOWN },
 };
 

--- a/src/transcoding/transcode/hwaccels/vaapi.c
+++ b/src/transcoding/transcode/hwaccels/vaapi.c
@@ -170,9 +170,6 @@ tvhva_context_profile(TVHVAContext *self, AVCodecContext *avctx)
                 case FF_PROFILE_H264_HIGH:
                     check = VAProfileH264High;
                     break;
-                case FF_PROFILE_H264_BASELINE:
-                    check = VAProfileH264Baseline;
-                    break;
                 case FF_PROFILE_H264_CONSTRAINED_BASELINE:
                     check = VAProfileH264ConstrainedBaseline;
                     break;
@@ -190,6 +187,7 @@ tvhva_context_profile(TVHVAContext *self, AVCodecContext *avctx)
                     check = VAProfileHEVCMain;
                     break;
                 case FF_PROFILE_HEVC_MAIN_10:
+                case FF_PROFILE_HEVC_REXT:
                     check = VAProfileHEVCMain10;
                     break;
                 default:


### PR DESCRIPTION
- remove "Baseline" h264 Profil (not exist)

- include "Main10" and "Rext" in hevc Profiles