### PR TITLE
Remove libva-x11 dependency

### DIFF
--- a/configure
+++ b/configure
@@ -654,7 +654,6 @@ fi
 if enabled_or_auto vaapi; then
   if enabled libav; then
     if check_pkg libva ">=0.38.0"; then
-      check_pkg libva-x11 ">=0.38.0" || die "libva-x11 not found"
       check_pkg libva-drm ">=0.38.0" || die "libva-drm not found"
       enable vaapi
       enable hwaccels


### PR DESCRIPTION
This change removes the dependency for the libva-x11 from the tvheadend build.

The libva-x11 library can cause issue when running TvHeadend in a headless server and the installation of several unnecessary packages. Running headless is the major use case for TvHeadend.