### PR TITLE
Update STAT_ARG to use -c instead of --printf

### DIFF
--- a/Makefile.webui
+++ b/Makefile.webui
@@ -48,7 +48,7 @@ endif
 ifeq ($(PLATFORM), freebsd)
 STAT_ARG=-f "%-35N %7z"
 else
-STAT_ARG=--printf="%-35n %7s\n"
+STAT_ARG=-c "%-35n %7s\n"
 endif
 
 JAVASCRIPT =


### PR DESCRIPTION
`--printf` only works with the stat provided by coreutils. `-c` is more portable and works with busybox. When running `make` in busybox, stat will fail with the error:

```
/bin/stat: unrecognized option: printf=%-35n %7s\n
BusyBox v1.31.1 () multi-call binary.

Usage: stat [OPTIONS] FILE...
```