### PR TITLE
docs: fix simple typo, seperately -> separately

### DIFF
--- a/src/descrambler/capmt.c
+++ b/src/descrambler/capmt.c
@@ -1311,7 +1311,7 @@ capmt_msg_size(capmt_t *capmt, sbuf_t *sb, int offset)
     return 4 + 12 + adapter_byte;
   else if (oscam_new && cmd == DMX_SET_FILTER)
     /* when using network protocol the dmx_sct_filter_params fields are added */
-    /* seperately to avoid padding problems, so we substract 2 bytes: */
+    /* separately to avoid padding problems, so we substract 2 bytes: */
     return 4 + 2 + 60 + adapter_byte + (capmt_oscam_netproto(capmt) ? -2 : 0);
   else if (oscam_new && cmd == DMX_STOP)
     return 4 + 4 + adapter_byte;


### PR DESCRIPTION
There is a small typo in src/descrambler/capmt.c.

Should read `separately` rather than `seperately`.

