### PR TITLE
Add ISDB-T support to HDHomeRun client

### DIFF
--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
@@ -123,6 +123,7 @@ tvhdhomerun_device_class_override_enum( void * p, const char *lang )
   htsmsg_add_str(m, NULL, "ATSC-T");
   htsmsg_add_str(m, NULL, "ATSC-C");
   htsmsg_add_str(m, NULL, "CableCARD");
+  htsmsg_add_str(m, NULL, "ISDB-T");
   return m;
 }
 
@@ -336,6 +337,8 @@ static void tvhdhomerun_device_create(struct hdhomerun_discover_device_t *dInfo)
       type = DVB_TYPE_CABLECARD;
     if (strstr(hd->hd_info.deviceModel, "_dvbt"))
       type = DVB_TYPE_T;
+    if (strstr(hd->hd_info.deviceModel, "_isdbt"))
+      type = DVB_TYPE_ISDB_T;
   }
 
   hd->hd_override_type = strdup(dvb_type2str(type));
@@ -481,6 +484,7 @@ void tvhdhomerun_init ( void )
   idclass_register(&tvhdhomerun_frontend_atsc_t_class);
   idclass_register(&tvhdhomerun_frontend_atsc_c_class);
   idclass_register(&tvhdhomerun_frontend_cablecard_class);
+  idclass_register(&tvhdhomerun_frontend_isdbt_class);
   TAILQ_INIT(&tvhdhomerun_discoveries);
   tvh_mutex_init(&tvhdhomerun_discovery_lock, NULL);
   tvh_cond_init(&tvhdhomerun_discovery_cond, 1);

--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun.h
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun.h
@@ -26,6 +26,7 @@ extern const idclass_t tvhdhomerun_frontend_dvbc_class;
 extern const idclass_t tvhdhomerun_frontend_atsc_t_class;
 extern const idclass_t tvhdhomerun_frontend_atsc_c_class;
 extern const idclass_t tvhdhomerun_frontend_cablecard_class;
+extern const idclass_t tvhdhomerun_frontend_isdbt_class;
 
 void tvhdhomerun_init( void );
 void tvhdhomerun_done( void );

--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c
@@ -672,6 +672,16 @@ const idclass_t tvhdhomerun_frontend_cablecard_class =
   }
 };
 
+const idclass_t tvhdhomerun_frontend_isdbt_class =
+{
+  .ic_super      = &tvhdhomerun_frontend_class,
+  .ic_class      = "tvhdhomerun_frontend_isdbt",
+  .ic_caption    = N_("HDHomeRun ISDB-T frontend"),
+  .ic_properties = (const property_t[]){
+    {}
+  }
+};
+
 static mpegts_network_t *
 tvhdhomerun_frontend_wizard_network ( tvhdhomerun_frontend_t *hfe )
 {
@@ -762,6 +772,8 @@ tvhdhomerun_frontend_create(tvhdhomerun_device_t *hd, struct hdhomerun_discover_
     idc = &tvhdhomerun_frontend_atsc_c_class;
   else if (type == DVB_TYPE_CABLECARD)
     idc = &tvhdhomerun_frontend_cablecard_class;
+  else if (type == DVB_TYPE_ISDB_T)
+    idc = &tvhdhomerun_frontend_isdbt_class;
   else {
     tvherror(LS_TVHDHOMERUN, "unknown FE type %d", type);
     return NULL;


### PR DESCRIPTION
Adding support to the HDHomeRun client for HDHomeRub device HDHR4-2IS which is compatible with ISDB-T standard used in Brazil and other countries.