### PR TITLE
Fix possible deadlock when using tvh_mutex_trylock()

### DIFF
--- a/src/tvh_thread.h
+++ b/src/tvh_thread.h
@@ -123,7 +123,7 @@ int tvh__mutex_trylock(tvh_mutex_t *mutex, const char *filename, int lineno);
 #define tvh_mutex_trylock(_mutex)				\
  ({								\
     tvh_thread_debug == 0 ?					\
-      pthread_mutex_lock(&(_mutex)->mutex) :			\
+      pthread_mutex_trylock(&(_mutex)->mutex) :			\
       tvh__mutex_trylock((_mutex), __FILE__, __LINE__);		\
  })
 int tvh__mutex_unlock(tvh_mutex_t *mutex);


### PR DESCRIPTION
Fixes possible deadlock when using tvh_mutex_trylock() macro in thread non-debug mode.
The macro expands to call pthread_mutex_lock() instead of pthread_mutex_trylock(),
which most likely is a result of copy/paste.