### PR TITLE
Upgrade to libhdhomerun_20200907

### DIFF
--- a/Makefile.hdhomerun
+++ b/Makefile.hdhomerun
@@ -32,10 +32,10 @@ endif
 # Upstream Packages
 # ###########################################################################
 
-LIBHDHR         = libhdhomerun_20200521
+LIBHDHR         = libhdhomerun_20200907
 LIBHDHR_TB      = $(LIBHDHR).tgz
 LIBHDHR_URL     = https://download.silicondust.com/hdhomerun/$(LIBHDHR_TB)
-LIBHDHR_SHA1    = 8524464d4a005dbe7265dc544c025d63a18b32bd
+LIBHDHR_SHA1    = 38c44befa42b14cf6e3f9772ef9f23a60ad0b89f
 
 # ###########################################################################
 # Library Config


### PR DESCRIPTION
There is a new version of libhdhomerun on the home page (also available under Fedora 32, 33)