### PR TITLE
EMM patch

### DIFF
--- a/src/descrambler/emm_reass.c
+++ b/src/descrambler/emm_reass.c
@@ -149,9 +149,8 @@ emm_seca
       match = memcmp(&data[3], &ra->ua[2], 6) == 0;
   } else if (data[0] == 0x84) {  // shared emm
     if (len >= 8) {
-      /* XXX this part is untested but should do no harm */
       PROVIDERS_FOREACH(ra, i, ep)
-        if (memcmp(&data[5], &ep->sa[4], 3) == 0) {
+        if (memcmp(&data[5], &ep->sa[5], 3) == 0) {
           match = 1;
           break;
         }


### PR DESCRIPTION
EMM patch, TVheadend stopped sending shared EMM's to OScam.

I believe this commit broke it. 6ea7c38

After changing back OScam started to receive shared EMM's again.

Tested on dvb-c provider nl-Delta.