### PR TITLE
Clean transcoding when htsp based transcoding is used

### DIFF
--- a/src/profile.c
+++ b/src/profile.c
@@ -1005,6 +1005,11 @@ profile_sharer_destroy(profile_chain_t *prch)
         prsh->prsh_master = NULL;
       tvh_mutex_unlock(&prsh->prsh_queue_mutex);
     } else {
+#if ENABLE_LIBAV
+      if (prsh->prsh_transcoder)
+        transcoder_destroy(prsh->prsh_transcoder);
+      prsh->prsh_transcoder = NULL;
+#endif
       tvh_mutex_lock(&prsh->prsh_queue_mutex);
       prch->prch_sharer = NULL;
       prch->prch_post_share = NULL;


### PR DESCRIPTION
@perexg There was an issue when HTSP clients like kodi used a transcoding profile (especially nvidia based profiles) so the transcoder was never cleaned up which caused more and more GPU memory to be used. This fixes it for me but I have absolutely no idea if this is a proper fix or if `run` should evaluate to true in this case and the cleanup code from above should be used instead. There is no profile sharer thread started in this case if I saw that correctly, so it should be correct that run evaluates to 0 but it could be that a profile sharer thread should be started in this case. Really not sure about this and I would appreciate if you could look over this and approve this or reject this is this is not a proper fix (and I believe that this is not a proper fix).