### PR TITLE
remote timeshift: fix crash on multiple subscriptions and cleanup

### DIFF
--- a/src/input/mpegts/iptv/iptv_private.h
+++ b/src/input/mpegts/iptv/iptv_private.h
@@ -124,6 +124,7 @@ typedef struct {
   /* Connection to the RTCP remote */
   udp_connection_t *connection;
   int connection_fd;
+  udp_multirecv_t um;
 
   uint32_t source_ssrc;
   uint32_t my_ssrc;
@@ -172,6 +173,7 @@ struct iptv_mux
   uint32_t              mm_iptv_rtp_seq;
 
   sbuf_t                mm_iptv_buffer;
+  sbuf_t                im_temp_buffer;
 
   uint32_t              mm_iptv_buffer_limit;
 
@@ -189,11 +191,11 @@ struct iptv_mux
 
   void                 *im_opaque;
 
-  udp_multirecv_t      im_um1;
-  udp_multirecv_t      im_um2;
+  udp_multirecv_t      im_um;
+
   char                 im_use_retransmission;
-  sbuf_t               im_temp_buffer;
   char                 im_is_ce_detected;
+
   rtcp_t               im_rtcp_info;
 };
 

--- a/src/input/mpegts/iptv/iptv_rtcp.c
+++ b/src/input/mpegts/iptv/iptv_rtcp.c
@@ -371,8 +371,8 @@ rtcp_send_nak(rtcp_t *rtcp_info, uint32_t ssrc, uint16_t seqn, uint16_t len)
           ssrc, n, (uint32_t )sizeof(network_buffer));
     }
 
-  // Cleanup
-  sbuf_free(&network_buffer);
+    // Cleanup
+    sbuf_free(&network_buffer);
   }
   return 0;
 }

--- a/src/profile.c
+++ b/src/profile.c
@@ -641,8 +641,6 @@ profile_deliver(profile_chain_t *prch, streaming_message_t *sm)
     }
     sm2 = streaming_msg_create_data(SMT_START,
                                    streaming_start_copy(prsh->prsh_start_msg));
-    if (sm)
-      sm2->sm_s = sm->sm_s;
     streaming_target_deliver(prch->prch_post_share, sm2);
     prch->prch_start_pending = 0;
   }

--- a/src/streaming.c
+++ b/src/streaming.c
@@ -201,11 +201,12 @@ streaming_target_disconnect(streaming_pad_t *sp, streaming_target_t *st)
 streaming_message_t *
 streaming_msg_create(streaming_message_type_t type)
 {
-  streaming_message_t *sm = calloc(1, sizeof(streaming_message_t));
+  streaming_message_t *sm = malloc(sizeof(streaming_message_t));
   memoryinfo_alloc(&streaming_msg_memoryinfo, sizeof(*sm));
   sm->sm_type = type;
 #if ENABLE_TIMESHIFT
   sm->sm_time = 0;
+  sm->sm_s = NULL;
 #endif
   return sm;
 }
@@ -263,6 +264,7 @@ streaming_msg_clone(streaming_message_t *src)
   dst->sm_type      = src->sm_type;
 #if ENABLE_TIMESHIFT
   dst->sm_time      = src->sm_time;
+  dst->sm_s         = src->sm_s;
 #endif
 
   switch(src->sm_type) {


### PR DESCRIPTION
In case multiple users subscribe to a remote time shift channel the different code path would not initialize the service_t * sm_s properly and caused a segfault due to invalid pointer later in the code. Also I was able to revert the change from malloc to calloc, we need speed!
Furthermore the code was cleaned up slightly.

A limitation still is that all subscribers will look at the same source stream so remote time shifting will apply to all. A solution would be to spawn multiple instances of the same mux / service. Not sure how to handle this in tvheadend, it doesn't seem to be designed for this. Ideas are welcome!