### PR TITLE
Add pid file hint for systemd-sysv-generator

### DIFF
--- a/debian/tvheadend.init
+++ b/debian/tvheadend.init
@@ -1,4 +1,5 @@
 #! /bin/sh
+# pidfile: /var/run/tvheadend.pid
 ### BEGIN INIT INFO
 # Provides:          tvheadend
 # Required-Start:    $local_fs $remote_fs udev


### PR DESCRIPTION
So that for systemd users, systemd-sysv-generator can work out where the pid file is located. And restart on detection that the process has died.