### PR TITLE
Introduce ROTOR access control via subscription priority.

### DIFF
--- a/src/input/mpegts/linuxdvb/linuxdvb_private.h
+++ b/src/input/mpegts/linuxdvb/linuxdvb_private.h
@@ -268,6 +268,7 @@ struct linuxdvb_satconf
   int                    ls_site_lat_south;
   int                    ls_site_lon_west;
   int                    ls_site_altitude;
+  int                    ls_rotor_weight;
   char                  *ls_rotor_extcmd;
   
   /*

--- a/src/input/mpegts/linuxdvb/linuxdvb_rotor.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_rotor.c
@@ -401,7 +401,7 @@ linuxdvb_rotor_grace
   if (idnode_is_instance(&lr->ld_id, &linuxdvb_rotor_external_class))
     return linuxdvb_external_grace(lr, ld->ld_satconf);
 
-  if (!ls->ls_last_orbital_pos || ls->ls_motor_rate == 0)
+  if ((ls->ls_last_orbital_pos == INT_MAX) || ls->ls_motor_rate == 0)
     return ls->ls_max_rotor_move;
 
   newpos = pos_to_integer(lr->lr_sat_lon);
@@ -432,7 +432,7 @@ linuxdvb_rotor_check_orbital_pos
   int pos = lsp->ls_last_orbital_pos;
   char dir;
 
-  if (!pos)
+  if (pos == INT_MAX)
     return 0;
 
   if (abs(pos_to_integer(lr->lr_sat_lon) - pos) > 2)
@@ -523,6 +523,10 @@ linuxdvb_rotor_tune
 
   if (linuxdvb_rotor_check_orbital_pos(lr, lm, ls))
     return 0;
+  else if ( lsp->ls_rotor_weight > lsp->ls_mmi->mmi_start_weight ) {
+    tvherror(LS_DISEQC, "subscription priority is not high enough to control ROTOR");
+    return -1;
+  }
 
   /* Force to 18v (quicker movement) */
   if (linuxdvb_satconf_start(lsp, MINMAX(lr->lr_powerup_time, 15, 200), 1))

--- a/src/input/mpegts/linuxdvb/linuxdvb_satconf.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_satconf.c
@@ -772,6 +772,17 @@ const idclass_t linuxdvb_satconf_advanced_class =
       .desc     = N_("Motor rate (in milliseconds/deg)."),
       .off      = offsetof(linuxdvb_satconf_t, ls_motor_rate),
     },
+    {
+      .type    = PT_INT,
+      .id      = "rotor_priority",
+      .name    = N_("Rotor access priority"),
+      .desc    = N_("Allow rotor to move only for subscriptions with this"
+		    "priority and above. For example, set to 5 to prevent"
+		    "OTA EPG and other periodic scan from moving rotor."),
+      .off     = offsetof(linuxdvb_satconf_t, ls_rotor_weight),
+      .opts    = PO_ADVANCED,
+      .def.i   = 0
+    },
     {}
   }
 };
@@ -1222,6 +1233,7 @@ linuxdvb_satconf_create
   ls->ls_early_tune = 1;
   ls->ls_diseqc_full = 1;
   ls->ls_max_rotor_move = 120;
+  ls->ls_last_orbital_pos = INT_MAX;
 
   /* Create node */
   if (idnode_insert(&ls->ls_id, uuid, lst->idc, 0)) {


### PR DESCRIPTION
Only subscriptions with this priority and above are allowed to control/move ROTOR
For example, set to 5 to prevent OTA EPG and other periodic scan from moving rotor.