### PR TITLE
Allow network scan to modify muxes

### DIFF
--- a/src/input/mpegts/mpegts_network_dvb.c
+++ b/src/input/mpegts/mpegts_network_dvb.c
@@ -703,7 +703,7 @@ dvb_network_create_mux
   }
 
   ln = (dvb_network_t*)mn;
-  mm = dvb_network_find_mux(ln, dmc, onid, tsid, 0, 0);
+  mm = dvb_network_find_mux(ln, dmc, onid, tsid, 0, (ln->mn_autodiscovery == MN_DISCOVERY_CHANGE));
   if (!mm && (ln->mn_autodiscovery != MN_DISCOVERY_DISABLE || force)) {
     save |= dvb_fe_type_by_network_class(ln->mn_id.in_class) == dmc->dmc_fe_type;
     if (save && dmc->dmc_fe_type == DVB_TYPE_S) {


### PR DESCRIPTION
When 'change muxes' option for network discovery is enabled, allow network scan to modify muxes rather than duplicate them on minor changes such as FEC.

Looking at the history of changes around this feature, I believe there was a deliberate choice to create a new mux entry every time a transponder is changed via network scan. I can understand the motivation to keep it safe, but this is cumbersome as some satellite operators actively modify PHY parameters for some of their transponders, typically DVB-S2, to adapt to what I believe are either seasonal weather conditions and/or the number of services they want to use at a point in time.

Without this change, I need to manually scrub muxes in the db, and remove duplicates manually on a regular basis. 
 
The existing code to decide whether a mux change is minor or not seems to be used only when importing dvb scan files, but DVB NIT discovery is always excluded for this logic. This change allow a user to decide whether  a given network can be trusted to provide trustworthy MUX info via Network Information Table. 
