### PR TITLE
resolve conflict of SDT, NIT and EIT rewrite in Korean terrestrial tv streams 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-![TVHeadend Logo](https://github.com/tvheadend/tvheadend/raw/master/src/webui/static/img/satip-icon120.png)
 Tvheadend
 ========================================
 (c) 2006 - 2021 Tvheadend Foundation CIC
@@ -7,18 +6,11 @@ Status
 ------
 
 [![Build Status](https://travis-ci.org/tvheadend/tvheadend.svg?branch=master)](https://travis-ci.org/tvheadend/tvheadend)
+
 [![Coverity Scan](https://scan.coverity.com/projects/2114/badge.svg)](https://scan.coverity.com/projects/2114)
-[![Github last commit](https://img.shields.io/github/last-commit/tvheadend/tvheadend)](https://github.com/tvheadend/tvheadend)
-
-[![Releases](https://img.shields.io/github/tag/tvheadend/tvheadend.svg?style=flat-square)](https://github.com/tvheadend/tvheadend/releases)
-[![License](https://img.shields.io/badge/license-GPLv3-blue)](./LICENSE.md) 
-[![GitHub Activity](https://img.shields.io/github/commit-activity/y/tvheadend/tvheadend.svg?label=commits)](https://github.com/tvheadend/tvheadend/commits)
-
 
 What it is
 ----------
-
-![tvheadend front page](https://github.com/tvheadend/tvheadend/raw/master/src/webui/static/img/epg.png)
 
 Tvheadend is a TV streaming server and digital video recorder.
 

--- a/src/input/mpegts/dvb.h
+++ b/src/input/mpegts/dvb.h
@@ -40,7 +40,7 @@ struct lang_str;
 #define DVB_PAT_PID                   0x00
 #define DVB_CAT_PID                   0x01
 #define DVB_TSDT_PID                  0x02
-#define DVB_NIT_PID                   0x0F
+#define DVB_NIT_PID                   0x10
 #define DVB_SDT_PID                   0x11
 #define DVB_BAT_PID                   0x11
 #define DVB_EIT_PID                   0x12

--- a/src/input/mpegts/dvb.h
+++ b/src/input/mpegts/dvb.h
@@ -40,7 +40,7 @@ struct lang_str;
 #define DVB_PAT_PID                   0x00
 #define DVB_CAT_PID                   0x01
 #define DVB_TSDT_PID                  0x02
-#define DVB_NIT_PID                   0x10
+#define DVB_NIT_PID                   0x0F
 #define DVB_SDT_PID                   0x11
 #define DVB_BAT_PID                   0x11
 #define DVB_EIT_PID                   0x12

--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -452,7 +452,7 @@ pass_muxer_reconfigure(muxer_t* m, const struct streaming_start *ss)
   pm->pm_rewrite_nit = !!pm->m_config.u.pass.m_rewrite_nit;
   pm->pm_rewrite_eit = !!pm->m_config.u.pass.m_rewrite_eit;
 
-  if (pm->pm_pmt_pid == DVB_SDT_PID || pm->pm_pmt_pid == DVB_NIT_PID || pm->pm_pmt_pid == DVB_EIT_PID) && pm->pm_rewrite_pmt) {
+  if ( (pm->pm_pmt_pid == DVB_SDT_PID || pm->pm_pmt_pid == DVB_NIT_PID || pm->pm_pmt_pid == DVB_EIT_PID) && pm->pm_rewrite_pmt) {
     tvhwarn(LS_PASS, "PMT PID shared with SDT/NIT/EIT, rewrite disabled");
     pm->pm_rewrite_pmt = 0;
     if (pm->pm_pmt_pid == DVB_SDT_PID && pm->pm_rewrite_sdt) {

--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -648,6 +648,8 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
       pid = (tsb[1] & 0x1f) << 8 | tsb[2];
       l = mpegts_word_count(tsb, len2, 0x001FFF00);
 
+      tvhwarn(LS_PASS, "PID: %i", pid);
+
       /* Process */
       if ( (pm->m_config.u.pass.m_rewrite_pat && pid == DVB_PAT_PID) ||
            (pm->pm_rewrite_pmt && pid == pm->pm_pmt_pid) ||

--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -648,7 +648,7 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
       pid = (tsb[1] & 0x1f) << 8 | tsb[2];
       l = mpegts_word_count(tsb, len2, 0x001FFF00);
 
-      //tvhwarn(LS_PASS, "PID out of if: %i", pid);
+      tvhwarn(LS_PASS, "PID out of if: %i", pid);
 
       /* Process */
       if ( (pm->m_config.u.pass.m_rewrite_pat && pid == DVB_PAT_PID) ||

--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -648,7 +648,7 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
       pid = (tsb[1] & 0x1f) << 8 | tsb[2];
       l = mpegts_word_count(tsb, len2, 0x001FFF00);
 
-      tvhwarn(LS_PASS, "PID: %i", pid);
+      //tvhwarn(LS_PASS, "PID out of if: %i", pid);
 
       /* Process */
       if ( (pm->m_config.u.pass.m_rewrite_pat && pid == DVB_PAT_PID) ||
@@ -656,6 +656,8 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
            (pm->pm_rewrite_sdt && pid == DVB_SDT_PID) ||
            (pm->pm_rewrite_nit && pid == DVB_NIT_PID) ||
            (pm->pm_rewrite_eit && pid == DVB_EIT_PID) ) {
+
+        tvhwarn(LS_PASS, "  PID in if: %i", pid);
 
         /* Flush */
         if (len)
@@ -672,11 +674,13 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
 
         /* SDT */
         } else if (pid == DVB_SDT_PID) {
-        
+          tvhwarn(LS_PASS, "    DVB_SDT_PID");
+          
           dvb_table_parse(&pm->pm_sdt, "-", tsb, l, 1, 0, pass_muxer_sdt_cb);
 
         /* NIT */
         } else if (pid == DVB_NIT_PID) {
+          tvhwarn(LS_PASS, "    DVB_NIT_PID");
         
           dvb_table_parse(&pm->pm_nit, "-", tsb, l, 1, 0, pass_muxer_nit_cb);
 

--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -452,6 +452,10 @@ pass_muxer_reconfigure(muxer_t* m, const struct streaming_start *ss)
   pm->pm_rewrite_nit = !!pm->m_config.u.pass.m_rewrite_nit;
   pm->pm_rewrite_eit = !!pm->m_config.u.pass.m_rewrite_eit;
 
+  if (pm->pm_pmt_pid == DVB_SDT_PID && pm->pm_rewrite_pmt) {
+    tvhwarn(LS_PASS, "PMT PID shared with A/V, rewrite disabled");
+    pm->pm_rewrite_pmt = 0;
+  }
   if (pm->pm_pmt_pid == DVB_SDT_PID && pm->pm_rewrite_sdt) {
     tvhwarn(LS_PASS, "PMT PID shared with A/V, rewrite disabled");
     pm->pm_rewrite_pmt = 0;

--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -646,16 +646,12 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
       pid = (tsb[1] & 0x1f) << 8 | tsb[2];
       l = mpegts_word_count(tsb, len2, 0x001FFF00);
 
-      tvhwarn(LS_PASS, "PID out of if: %i", pid);
-
       /* Process */
       if ( (pm->m_config.u.pass.m_rewrite_pat && pid == DVB_PAT_PID) ||
            (pm->pm_rewrite_pmt && pid == pm->pm_pmt_pid) ||
            (pm->pm_rewrite_sdt && pid == DVB_SDT_PID) ||
            (pm->pm_rewrite_nit && pid == DVB_NIT_PID) ||
            (pm->pm_rewrite_eit && pid == DVB_EIT_PID) ) {
-
-        tvhwarn(LS_PASS, "  PID in if: %i", pid);
 
         /* Flush */
         if (len)
@@ -672,13 +668,11 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
 
         /* SDT */
         } else if (pid == DVB_SDT_PID) {
-          tvhwarn(LS_PASS, "    DVB_SDT_PID");
           
           dvb_table_parse(&pm->pm_sdt, "-", tsb, l, 1, 0, pass_muxer_sdt_cb);
 
         /* NIT */
         } else if (pid == DVB_NIT_PID) {
-          tvhwarn(LS_PASS, "    DVB_NIT_PID");
         
           dvb_table_parse(&pm->pm_nit, "-", tsb, l, 1, 0, pass_muxer_nit_cb);
 

--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -452,27 +452,21 @@ pass_muxer_reconfigure(muxer_t* m, const struct streaming_start *ss)
   pm->pm_rewrite_nit = !!pm->m_config.u.pass.m_rewrite_nit;
   pm->pm_rewrite_eit = !!pm->m_config.u.pass.m_rewrite_eit;
 
-  if (pm->pm_pmt_pid == DVB_SDT_PID && pm->pm_rewrite_pmt) {
-    tvhwarn(LS_PASS, "PMT PID shared with A/V, rewrite disabled");
+  if (pm->pm_pmt_pid == (DVB_SDT_PID || DVB_NIT_PID || DVB_EIT_PID) && pm->pm_rewrite_pmt) {
+    tvhwarn(LS_PASS, "PMT PID shared with SDT/NIT/EIT, rewrite disabled");
     pm->pm_rewrite_pmt = 0;
-  }
-  if (pm->pm_pmt_pid == DVB_SDT_PID && pm->pm_rewrite_sdt) {
-    tvhwarn(LS_PASS, "PMT PID shared with A/V, rewrite disabled");
-    pm->pm_rewrite_pmt = 0;
-    tvhwarn(LS_PASS, "SDT PID shared with A/V, rewrite disabled");
-    pm->pm_rewrite_sdt = 0;
-  }
-  if (pm->pm_pmt_pid == DVB_NIT_PID && pm->pm_rewrite_nit) {
-    tvhwarn(LS_PASS, "PMT PID shared with A/V, rewrite disabled");
-    pm->pm_rewrite_pmt = 0;
-    tvhwarn(LS_PASS, "NIT PID shared with A/V, rewrite disabled");
-    pm->pm_rewrite_nit = 0;
-  }
-  if (pm->pm_pmt_pid == DVB_EIT_PID && pm->pm_rewrite_eit) {
-    tvhwarn(LS_PASS, "PMT PID shared with A/V, rewrite disabled");
-    pm->pm_rewrite_pmt = 0;
-    tvhwarn(LS_PASS, "EIT PID shared with A/V, rewrite disabled");
-    pm->pm_rewrite_eit = 0;
+    if (pm->pm_pmt_pid == DVB_SDT_PID && pm->pm_rewrite_sdt) {
+      tvhwarn(LS_PASS, "SDT PID shared with PMT, rewrite disabled");
+      pm->pm_rewrite_sdt = 0;
+    }
+    if (pm->pm_pmt_pid == DVB_NIT_PID && pm->pm_rewrite_nit) {
+      tvhwarn(LS_PASS, "NIT PID shared with PMT, rewrite disabled");
+      pm->pm_rewrite_nit = 0;
+    }
+    if (pm->pm_pmt_pid == DVB_EIT_PID && pm->pm_rewrite_eit) {
+      tvhwarn(LS_PASS, "EIT PID shared with PMT, rewrite disabled");
+      pm->pm_rewrite_eit = 0;
+    }
   }
 
   for(i=0; i < ss->ss_num_components; i++) {

--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -48,6 +48,7 @@ typedef struct pass_muxer {
   streaming_start_t *pm_ss;
 
   /* TS muxing */
+  uint8_t  pm_rewrite_pmt;
   uint8_t  pm_rewrite_sdt;
   uint8_t  pm_rewrite_nit;
   uint8_t  pm_rewrite_eit;
@@ -446,9 +447,29 @@ pass_muxer_reconfigure(muxer_t* m, const struct streaming_start *ss)
     pm->pm_dst_onid  = pm->pm_src_onid;
   }
   pm->pm_pmt_pid     = ss->ss_pmt_pid;
+  pm->pm_rewrite_pmt = !!pm->m_config.u.pass.m_rewrite_pmt;
   pm->pm_rewrite_sdt = !!pm->m_config.u.pass.m_rewrite_sdt;
   pm->pm_rewrite_nit = !!pm->m_config.u.pass.m_rewrite_nit;
   pm->pm_rewrite_eit = !!pm->m_config.u.pass.m_rewrite_eit;
+
+  if (pm->pm_pmt_pid == DVB_SDT_PID && pm->pm_rewrite_sdt) {
+    tvhwarn(LS_PASS, "PMT PID shared with A/V, rewrite disabled");
+    pm->pm_rewrite_pmt = 0;
+    tvhwarn(LS_PASS, "SDT PID shared with A/V, rewrite disabled");
+    pm->pm_rewrite_sdt = 0;
+  }
+  if (pm->pm_pmt_pid == DVB_NIT_PID && pm->pm_rewrite_nit) {
+    tvhwarn(LS_PASS, "PMT PID shared with A/V, rewrite disabled");
+    pm->pm_rewrite_pmt = 0;
+    tvhwarn(LS_PASS, "NIT PID shared with A/V, rewrite disabled");
+    pm->pm_rewrite_nit = 0;
+  }
+  if (pm->pm_pmt_pid == DVB_EIT_PID && pm->pm_rewrite_eit) {
+    tvhwarn(LS_PASS, "PMT PID shared with A/V, rewrite disabled");
+    pm->pm_rewrite_pmt = 0;
+    tvhwarn(LS_PASS, "EIT PID shared with A/V, rewrite disabled");
+    pm->pm_rewrite_eit = 0;
+  }
 
   for(i=0; i < ss->ss_num_components; i++) {
     ssc = &ss->ss_components[i];
@@ -468,8 +489,7 @@ pass_muxer_reconfigure(muxer_t* m, const struct streaming_start *ss)
     }
   }
 
-
-  if (pm->m_config.u.pass.m_rewrite_pmt) {
+  if (pm->pm_rewrite_pmt) {
 
     if (pm->pm_ss)
       streaming_start_unref(pm->pm_ss);
@@ -619,7 +639,7 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
   size_t  len = pktbuf_len(pb), len2;
   
   /* Rewrite PAT/PMT in operation */
-  if (pm->m_config.u.pass.m_rewrite_pat || pm->m_config.u.pass.m_rewrite_pmt ||
+  if (pm->m_config.u.pass.m_rewrite_pat || pm->pm_rewrite_pmt ||
       pm->pm_rewrite_sdt || pm->pm_rewrite_nit || pm->pm_rewrite_eit) {
 
     for (tsb = pktbuf_ptr(pb), len2 = pktbuf_len(pb), len = 0;
@@ -630,7 +650,7 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
 
       /* Process */
       if ( (pm->m_config.u.pass.m_rewrite_pat && pid == DVB_PAT_PID) ||
-           (pm->m_config.u.pass.m_rewrite_pmt && pid == pm->pm_pmt_pid) ||
+           (pm->pm_rewrite_pmt && pid == pm->pm_pmt_pid) ||
            (pm->pm_rewrite_sdt && pid == DVB_SDT_PID) ||
            (pm->pm_rewrite_nit && pid == DVB_NIT_PID) ||
            (pm->pm_rewrite_eit && pid == DVB_EIT_PID) ) {

--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -48,7 +48,6 @@ typedef struct pass_muxer {
   streaming_start_t *pm_ss;
 
   /* TS muxing */
-  uint8_t  pm_rewrite_pmt;
   uint8_t  pm_rewrite_sdt;
   uint8_t  pm_rewrite_nit;
   uint8_t  pm_rewrite_eit;
@@ -447,33 +446,9 @@ pass_muxer_reconfigure(muxer_t* m, const struct streaming_start *ss)
     pm->pm_dst_onid  = pm->pm_src_onid;
   }
   pm->pm_pmt_pid     = ss->ss_pmt_pid;
-  pm->pm_rewrite_pmt = !!pm->m_config.u.pass.m_rewrite_pmt;
   pm->pm_rewrite_sdt = !!pm->m_config.u.pass.m_rewrite_sdt;
   pm->pm_rewrite_nit = !!pm->m_config.u.pass.m_rewrite_nit;
   pm->pm_rewrite_eit = !!pm->m_config.u.pass.m_rewrite_eit;
-
-  if (pm->pm_pmt_pid == DVB_SDT_PID && pm->pm_rewrite_pmt) {
-    tvhwarn(LS_PASS, "PMT PID shared with A/V, rewrite disabled");
-    pm->pm_rewrite_pmt = 0;
-  }
-  if (pm->pm_pmt_pid == DVB_SDT_PID && pm->pm_rewrite_sdt) {
-    tvhwarn(LS_PASS, "PMT PID shared with A/V, rewrite disabled");
-    pm->pm_rewrite_pmt = 0;
-    tvhwarn(LS_PASS, "SDT PID shared with A/V, rewrite disabled");
-    pm->pm_rewrite_sdt = 0;
-  }
-  if (pm->pm_pmt_pid == DVB_NIT_PID && pm->pm_rewrite_nit) {
-    tvhwarn(LS_PASS, "PMT PID shared with A/V, rewrite disabled");
-    pm->pm_rewrite_pmt = 0;
-    tvhwarn(LS_PASS, "NIT PID shared with A/V, rewrite disabled");
-    pm->pm_rewrite_nit = 0;
-  }
-  if (pm->pm_pmt_pid == DVB_EIT_PID && pm->pm_rewrite_eit) {
-    tvhwarn(LS_PASS, "PMT PID shared with A/V, rewrite disabled");
-    pm->pm_rewrite_pmt = 0;
-    tvhwarn(LS_PASS, "EIT PID shared with A/V, rewrite disabled");
-    pm->pm_rewrite_eit = 0;
-  }
 
   for(i=0; i < ss->ss_num_components; i++) {
     ssc = &ss->ss_components[i];
@@ -493,7 +468,8 @@ pass_muxer_reconfigure(muxer_t* m, const struct streaming_start *ss)
     }
   }
 
-  if (pm->pm_rewrite_pmt) {
+
+  if (pm->m_config.u.pass.m_rewrite_pmt) {
 
     if (pm->pm_ss)
       streaming_start_unref(pm->pm_ss);
@@ -643,7 +619,7 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
   size_t  len = pktbuf_len(pb), len2;
   
   /* Rewrite PAT/PMT in operation */
-  if (pm->m_config.u.pass.m_rewrite_pat || pm->pm_rewrite_pmt ||
+  if (pm->m_config.u.pass.m_rewrite_pat || pm->m_config.u.pass.m_rewrite_pmt ||
       pm->pm_rewrite_sdt || pm->pm_rewrite_nit || pm->pm_rewrite_eit) {
 
     for (tsb = pktbuf_ptr(pb), len2 = pktbuf_len(pb), len = 0;
@@ -652,16 +628,12 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
       pid = (tsb[1] & 0x1f) << 8 | tsb[2];
       l = mpegts_word_count(tsb, len2, 0x001FFF00);
 
-      tvhwarn(LS_PASS, "PID out of if: %i", pid);
-
       /* Process */
       if ( (pm->m_config.u.pass.m_rewrite_pat && pid == DVB_PAT_PID) ||
-           (pm->pm_rewrite_pmt && pid == pm->pm_pmt_pid) ||
+           (pm->m_config.u.pass.m_rewrite_pmt && pid == pm->pm_pmt_pid) ||
            (pm->pm_rewrite_sdt && pid == DVB_SDT_PID) ||
            (pm->pm_rewrite_nit && pid == DVB_NIT_PID) ||
            (pm->pm_rewrite_eit && pid == DVB_EIT_PID) ) {
-
-        tvhwarn(LS_PASS, "  PID in if: %i", pid);
 
         /* Flush */
         if (len)
@@ -678,13 +650,11 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
 
         /* SDT */
         } else if (pid == DVB_SDT_PID) {
-          tvhwarn(LS_PASS, "    DVB_SDT_PID");
-          
+        
           dvb_table_parse(&pm->pm_sdt, "-", tsb, l, 1, 0, pass_muxer_sdt_cb);
 
         /* NIT */
         } else if (pid == DVB_NIT_PID) {
-          tvhwarn(LS_PASS, "    DVB_NIT_PID");
         
           dvb_table_parse(&pm->pm_nit, "-", tsb, l, 1, 0, pass_muxer_nit_cb);
 

--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -48,6 +48,7 @@ typedef struct pass_muxer {
   streaming_start_t *pm_ss;
 
   /* TS muxing */
+  uint8_t  pm_rewrite_pmt;
   uint8_t  pm_rewrite_sdt;
   uint8_t  pm_rewrite_nit;
   uint8_t  pm_rewrite_eit;
@@ -446,9 +447,33 @@ pass_muxer_reconfigure(muxer_t* m, const struct streaming_start *ss)
     pm->pm_dst_onid  = pm->pm_src_onid;
   }
   pm->pm_pmt_pid     = ss->ss_pmt_pid;
+  pm->pm_rewrite_pmt = !!pm->m_config.u.pass.m_rewrite_pmt;
   pm->pm_rewrite_sdt = !!pm->m_config.u.pass.m_rewrite_sdt;
   pm->pm_rewrite_nit = !!pm->m_config.u.pass.m_rewrite_nit;
   pm->pm_rewrite_eit = !!pm->m_config.u.pass.m_rewrite_eit;
+
+  if (pm->pm_pmt_pid == DVB_SDT_PID && pm->pm_rewrite_pmt) {
+    tvhwarn(LS_PASS, "PMT PID shared with A/V, rewrite disabled");
+    pm->pm_rewrite_pmt = 0;
+  }
+  if (pm->pm_pmt_pid == DVB_SDT_PID && pm->pm_rewrite_sdt) {
+    tvhwarn(LS_PASS, "PMT PID shared with A/V, rewrite disabled");
+    pm->pm_rewrite_pmt = 0;
+    tvhwarn(LS_PASS, "SDT PID shared with A/V, rewrite disabled");
+    pm->pm_rewrite_sdt = 0;
+  }
+  if (pm->pm_pmt_pid == DVB_NIT_PID && pm->pm_rewrite_nit) {
+    tvhwarn(LS_PASS, "PMT PID shared with A/V, rewrite disabled");
+    pm->pm_rewrite_pmt = 0;
+    tvhwarn(LS_PASS, "NIT PID shared with A/V, rewrite disabled");
+    pm->pm_rewrite_nit = 0;
+  }
+  if (pm->pm_pmt_pid == DVB_EIT_PID && pm->pm_rewrite_eit) {
+    tvhwarn(LS_PASS, "PMT PID shared with A/V, rewrite disabled");
+    pm->pm_rewrite_pmt = 0;
+    tvhwarn(LS_PASS, "EIT PID shared with A/V, rewrite disabled");
+    pm->pm_rewrite_eit = 0;
+  }
 
   for(i=0; i < ss->ss_num_components; i++) {
     ssc = &ss->ss_components[i];
@@ -468,8 +493,7 @@ pass_muxer_reconfigure(muxer_t* m, const struct streaming_start *ss)
     }
   }
 
-
-  if (pm->m_config.u.pass.m_rewrite_pmt) {
+  if (pm->pm_rewrite_pmt) {
 
     if (pm->pm_ss)
       streaming_start_unref(pm->pm_ss);
@@ -619,7 +643,7 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
   size_t  len = pktbuf_len(pb), len2;
   
   /* Rewrite PAT/PMT in operation */
-  if (pm->m_config.u.pass.m_rewrite_pat || pm->m_config.u.pass.m_rewrite_pmt ||
+  if (pm->m_config.u.pass.m_rewrite_pat || pm->pm_rewrite_pmt ||
       pm->pm_rewrite_sdt || pm->pm_rewrite_nit || pm->pm_rewrite_eit) {
 
     for (tsb = pktbuf_ptr(pb), len2 = pktbuf_len(pb), len = 0;
@@ -628,12 +652,16 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
       pid = (tsb[1] & 0x1f) << 8 | tsb[2];
       l = mpegts_word_count(tsb, len2, 0x001FFF00);
 
+      tvhwarn(LS_PASS, "PID out of if: %i", pid);
+
       /* Process */
       if ( (pm->m_config.u.pass.m_rewrite_pat && pid == DVB_PAT_PID) ||
-           (pm->m_config.u.pass.m_rewrite_pmt && pid == pm->pm_pmt_pid) ||
+           (pm->pm_rewrite_pmt && pid == pm->pm_pmt_pid) ||
            (pm->pm_rewrite_sdt && pid == DVB_SDT_PID) ||
            (pm->pm_rewrite_nit && pid == DVB_NIT_PID) ||
            (pm->pm_rewrite_eit && pid == DVB_EIT_PID) ) {
+
+        tvhwarn(LS_PASS, "  PID in if: %i", pid);
 
         /* Flush */
         if (len)
@@ -650,11 +678,13 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
 
         /* SDT */
         } else if (pid == DVB_SDT_PID) {
-        
+          tvhwarn(LS_PASS, "    DVB_SDT_PID");
+          
           dvb_table_parse(&pm->pm_sdt, "-", tsb, l, 1, 0, pass_muxer_sdt_cb);
 
         /* NIT */
         } else if (pid == DVB_NIT_PID) {
+          tvhwarn(LS_PASS, "    DVB_NIT_PID");
         
           dvb_table_parse(&pm->pm_nit, "-", tsb, l, 1, 0, pass_muxer_nit_cb);
 

--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -452,7 +452,7 @@ pass_muxer_reconfigure(muxer_t* m, const struct streaming_start *ss)
   pm->pm_rewrite_nit = !!pm->m_config.u.pass.m_rewrite_nit;
   pm->pm_rewrite_eit = !!pm->m_config.u.pass.m_rewrite_eit;
 
-  if (pm->pm_pmt_pid == (DVB_SDT_PID || DVB_NIT_PID || DVB_EIT_PID) && pm->pm_rewrite_pmt) {
+  if (pm->pm_pmt_pid == DVB_SDT_PID || pm->pm_pmt_pid == DVB_NIT_PID || pm->pm_pmt_pid == DVB_EIT_PID) && pm->pm_rewrite_pmt) {
     tvhwarn(LS_PASS, "PMT PID shared with SDT/NIT/EIT, rewrite disabled");
     pm->pm_rewrite_pmt = 0;
     if (pm->pm_pmt_pid == DVB_SDT_PID && pm->pm_rewrite_sdt) {

--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -452,23 +452,6 @@ pass_muxer_reconfigure(muxer_t* m, const struct streaming_start *ss)
   pm->pm_rewrite_nit = !!pm->m_config.u.pass.m_rewrite_nit;
   pm->pm_rewrite_eit = !!pm->m_config.u.pass.m_rewrite_eit;
 
-  if ( (pm->pm_pmt_pid == DVB_SDT_PID || pm->pm_pmt_pid == DVB_NIT_PID || pm->pm_pmt_pid == DVB_EIT_PID) && pm->pm_rewrite_pmt) {
-    tvhwarn(LS_PASS, "PMT PID shared with SDT/NIT/EIT, rewrite disabled");
-    pm->pm_rewrite_pmt = 0;
-    if (pm->pm_pmt_pid == DVB_SDT_PID && pm->pm_rewrite_sdt) {
-      tvhwarn(LS_PASS, "SDT PID shared with PMT, rewrite disabled");
-      pm->pm_rewrite_sdt = 0;
-    }
-    if (pm->pm_pmt_pid == DVB_NIT_PID && pm->pm_rewrite_nit) {
-      tvhwarn(LS_PASS, "NIT PID shared with PMT, rewrite disabled");
-      pm->pm_rewrite_nit = 0;
-    }
-    if (pm->pm_pmt_pid == DVB_EIT_PID && pm->pm_rewrite_eit) {
-      tvhwarn(LS_PASS, "EIT PID shared with PMT, rewrite disabled");
-      pm->pm_rewrite_eit = 0;
-    }
-  }
-
   for(i=0; i < ss->ss_num_components; i++) {
     ssc = &ss->ss_components[i];
     if (!SCT_ISVIDEO(ssc->es_type) && !SCT_ISAUDIO(ssc->es_type))
@@ -681,8 +664,10 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
         
           dvb_table_parse(&pm->pm_eit, "-", tsb, l, 1, 0, pass_muxer_eit_cb);
 
+        }
+        
         /* PMT */
-        } else {
+        if (pid == pm->pm_pmt_pid) {
 
           dvb_table_parse(&pm->pm_pmt, "-", tsb, l, 1, 0, pass_muxer_pmt_cb);
 


### PR DESCRIPTION
Some Korean terrestrial TV streams are broadcasting the Program Map Table (PMT) and the video and the audio streams on PIDs where usually SDT, NIT or EIT should be. For the video and audio stream, muxer_pass.c did already take provisions and turns of SDT, NIT and EIT rewriting. For the PMT, up to now, no provisions were taken.
This patch checks if the PMT PID conflicts with the PIDs usually used for SDT, NIT or EIT. If that is the case, it disables PMT rewriting as well as the SDT, NIT or EIT rewriting.
The pull request also includes the changes from #1400.