### PR TITLE
Remove unnecessary conversion

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -525,8 +525,8 @@ access_dump_a(access_t *a)
   if (a->aa_chrange) {
     for (first = 0; first < a->aa_chrange_count; first += 2)
       tvh_strlcatf(buf, sizeof(buf), l, ", [chmin=%llu, chmax=%llu]",
-                   (long long)a->aa_chrange[first],
-                   (long long)a->aa_chrange[first+1]);
+                   a->aa_chrange[first],
+                   a->aa_chrange[first+1]);
   }
 
 


### PR DESCRIPTION
The conversion from unsigned long long to long long is not necessary. The print statement uses the correct format code %llu.