### PR TITLE
Check the return value of malloc, calloc and realloc

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -26,6 +26,7 @@
 #include "dvr/dvr.h"
 #include "tcp.h"
 #include "lang_codes.h"
+#include "tvhlog.h"
 
 struct access_entry_queue access_entries;
 struct access_ticket_queue access_tickets;
@@ -129,6 +130,9 @@ access_ticket_create(const char *resource, access_t *a)
   }
 
   at = calloc(1, sizeof(access_ticket_t));
+  if (at == NULL) {
+    tvhabort(LS_ACCESS, "calloc is NULL");
+  }
 
   uuid_random(buf, sizeof(buf));
   bin2hex(id, sizeof(id), buf, sizeof(buf));
@@ -263,6 +267,10 @@ access_t *
 access_copy(access_t *src)
 {
   access_t *dst = malloc(sizeof(*dst));
+  if (dst == NULL) {
+    tvhabort(LS_ACCESS, "malloc is NULL");
+  }
+
   *dst = *src;
   if (src->aa_username)
     dst->aa_username = strdup(src->aa_username);
@@ -542,6 +550,9 @@ access_dump_a(access_t *a)
 static access_t *access_alloc(void)
 {
   access_t *a = calloc(1, sizeof(access_t));
+  if (a == NULL) {
+    tvhabort(LS_ACCESS, "calloc is NULL");
+  }
   a->aa_uilevel = -1;
   a->aa_uilevel_nochange = -1;
   return a;
@@ -724,7 +735,6 @@ access_get(struct sockaddr_storage *src, const char *username, verify_callback_t
   access_t *a = access_alloc();
   access_entry_t *ae;
   int nouser = tvh_str_default(username, NULL) == NULL;
-  char *s;
 
   if (!access_noacl && access_ip_blocked(src))
     return a;
@@ -736,7 +746,7 @@ access_get(struct sockaddr_storage *src, const char *username, verify_callback_t
                        superuser_username, superuser_password))
       return access_full(a);
   } else {
-    s = alloca(50);
+    char s[50];
     tcp_get_str_from_ip(src, s, 50);
     a->aa_representative = strdup(s);
     if(!passwd_verify2(username, verify, aux,
@@ -891,10 +901,16 @@ access_set_prefix_default(struct access_ipmask_queue *ais)
   access_ipmask_t *ai;
 
   ai = calloc(1, sizeof(access_ipmask_t));
+  if (ai == NULL) {
+      tvhabort(LS_ACCESS, "calloc is NULL");
+  }
   ai->ai_family = AF_INET6;
   TAILQ_INSERT_HEAD(ais, ai, ai_link);
 
   ai = calloc(1, sizeof(access_ipmask_t));
+  if (ai == NULL) {
+      tvhabort(LS_ACCESS, "calloc is NULL");
+  }
   ai->ai_family = AF_INET;
   TAILQ_INSERT_HEAD(ais, ai, ai_link);
 }
@@ -964,8 +980,12 @@ access_set_prefix(struct access_ipmask_queue *ais, const char *prefix, int dflt)
   tok = strtok_r(tokbuf, delim, &saveptr);
 
   while (tok != NULL) {
-    if (ai == NULL)
+    if (ai == NULL) {
       ai = calloc(1, sizeof(access_ipmask_t));
+      if (ai == NULL) {
+        tvhabort(LS_ACCESS, "calloc is NULL");
+      }
+    }
 
     if (strlen(tok) > sizeof(buf) - 1 || *tok == '\0')
       goto fnext;
@@ -1099,6 +1119,9 @@ access_entry_create(const char *uuid, htsmsg_t *conf)
   lock_assert(&global_lock);
 
   ae = calloc(1, sizeof(access_entry_t));
+  if (ae == NULL) {
+      tvhabort(LS_ACCESS, "calloc is NULL");
+  }
 
   if (idnode_insert(&ae->ae_id, uuid, &access_entry_class, 0)) {
     if (uuid)
@@ -2065,6 +2088,9 @@ passwd_entry_create(const char *uuid, htsmsg_t *conf)
   lock_assert(&global_lock);
 
   pw = calloc(1, sizeof(passwd_entry_t));
+  if (pw == NULL) {
+      tvhabort(LS_ACCESS, "calloc is NULL");
+  }
 
   if (idnode_insert(&pw->pw_id, uuid, &passwd_entry_class, 0)) {
     if (uuid)
@@ -2344,6 +2370,9 @@ ipblock_entry_create(const char *uuid, htsmsg_t *conf)
   lock_assert(&global_lock);
 
   ib = calloc(1, sizeof(ipblock_entry_t));
+  if (ib == NULL) {
+      tvhabort(LS_ACCESS, "calloc is NULL");
+  }
 
   TAILQ_INIT(&ib->ib_ipmasks);
 

--- a/src/api/api_epg.c
+++ b/src/api/api_epg.c
@@ -26,6 +26,7 @@
 #include "dvr/dvr.h"
 #include "lang_codes.h"
 #include "string_list.h"
+#include "tvhlog.h"
 
 static htsmsg_t *
 api_epg_get_list ( const char *s )
@@ -433,9 +434,12 @@ api_epg_grid
                 uint32_t count = 0;
                 HTSMSG_FOREACH(f3, z)
                   count++;
-                if (ARRAY_SIZE(eq.genre_static) > count)
+                if (ARRAY_SIZE(eq.genre_static) > count) {
                   eq.genre = malloc(sizeof(eq.genre[0]) * count);
-                else
+                  if (eq.genre == NULL) {
+                    tvhabort(LS_API, "malloc is NULL");
+                  }
+                } else
                   eq.genre = eq.genre_static;
                 HTSMSG_FOREACH(f3, z)
                   if (!htsmsg_field_get_s64(f3, &v))
@@ -557,6 +561,10 @@ api_epg_episode_sorted(const struct epg_set *set,
         num_allocated = MAX(100, num_allocated + 100);
         /* We don't expect any/many reallocs so we store physical struct instead of pointers */
         bcast_entries = realloc(bcast_entries, num_allocated * sizeof(bcast_entry_t));
+        // if return value realloc is NULL then the old pointer is valid
+        if (bcast_entries == NULL) {
+          tvhabort(LS_API, "realloc is NULL");
+        }
       }
 
       new_bcast_entry.start = htsmsg_get_u32_or_default(m, "start", 0);

--- a/src/avahi.c
+++ b/src/avahi.c
@@ -162,6 +162,9 @@ create_services(AvahiClient *c)
     if (tvheadend_webui_port > 0) {
       if (tvheadend_webroot) {
         path = malloc(strlen(tvheadend_webroot) + 6);
+        if (path == NULL) {
+          tvhabort(LS_AVAHI, "malloc is NULL");
+        }
         sprintf(path, "path=%s", tvheadend_webroot);
       } else {
         path = strdup("path=/");

--- a/src/bouquet.c
+++ b/src/bouquet.c
@@ -91,6 +91,9 @@ bouquet_create(const char *uuid, htsmsg_t *conf,
   lock_assert(&global_lock);
 
   bq = calloc(1, sizeof(bouquet_t));
+  if (bq == NULL) {
+    tvhabort(LS_BOUQUET, "calloc is NULL");
+  }
   bq->bq_services = idnode_set_create(1);
   bq->bq_active_services = idnode_set_create(1);
   bq->bq_ext_url_period = 60;
@@ -133,6 +136,9 @@ bouquet_create(const char *uuid, htsmsg_t *conf,
       snprintf(buf, sizeof(buf), "exturl://%s", idnode_uuid_as_str(&bq->bq_id, ubuf));
       bq->bq_src = strdup(buf);
       bq->bq_download = bqd = calloc(1, sizeof(*bqd));
+      if (bqd == NULL) {
+        tvhabort(LS_BOUQUET, "calloc is NULL");
+      }
       bqd->bq = bq;
       download_init(&bqd->download, LS_BOUQUET);
       bqd->download.process = bouquet_download_process;
@@ -356,6 +362,9 @@ bouquet_add_service(bouquet_t *bq, service_t *s, uint64_t lcn, const char *tag)
 
   if (!tl) {
     tl = calloc(1, sizeof(*tl));
+    if (tl == NULL) {
+      tvhabort(LS_BOUQUET, "calloc is NULL");
+    }
     tl->sl_bouquet = bq;
     LIST_INSERT_HEAD(&s->s_lcns, tl, sl_link);
     bq->bq_saveflag = 1;

--- a/src/channels.c
+++ b/src/channels.c
@@ -641,6 +641,10 @@ channel_make_fuzzy_name(const char *name)
   char *ch_fuzzy = fuzzy_name;
   const char *ch = name;
 
+  if (fuzzy_name == NULL) {
+    tvhabort(LS_CHANNEL, "malloc is NULL");
+  }
+
   for (; *ch ; ++ch) {
     /* Strip trailing 'HD'. */
     if (*ch == 'H' && *(ch+1) == 'D' && *(ch+2) == 0)
@@ -1020,6 +1024,10 @@ svcnamepicons(const char *svcname)
       count++;
   }
   r = d = malloc(count * 4 + (s - svcname) + 1);
+  if (r == NULL) {
+    tvhabort(LS_CHANNEL, "malloc is NULL");
+  }
+
   for (s = svcname; *s; s++) {
     c = *s;
     if (c == '&') {
@@ -1396,6 +1404,9 @@ channel_get_sorted_list(const char *sort_type, int all, int *_count)
 {
   int count = 0;
   channel_t *ch, **chlist = malloc(channels_count * sizeof(channel_t *));
+  if (chlist == NULL) {
+    tvhabort(LS_CHANNEL, "malloc is NULL");
+  }
 
   CHANNEL_FOREACH(ch)
     if (all || ch->ch_enabled)
@@ -1415,6 +1426,10 @@ channel_get_sorted_list_for_tag
   int count = 0;
   channel_t *ch, **chlist = malloc(channels_count * sizeof(channel_t *));
   idnode_list_mapping_t *ilm;
+ 
+  if (chlist == NULL) {
+    tvhabort(LS_CHANNEL, "malloc is NULL");
+  } 
 
   LIST_FOREACH(ilm, &tag->ct_ctms, ilm_in1_link) {
     ch = (channel_t *)ilm->ilm_in2;
@@ -1586,6 +1601,11 @@ channel_tag_create(const char *uuid, htsmsg_t *conf)
   channel_tag_t *ct;
 
   ct = calloc(1, sizeof(channel_tag_t));
+
+  if (ct == NULL) {
+    tvhabort(LS_CHANNEL, "calloc is NULL");
+  }
+
   LIST_INIT(&ct->ct_ctms);
   LIST_INIT(&ct->ct_autorecs);
   LIST_INIT(&ct->ct_accesses);
@@ -1929,6 +1949,10 @@ channel_tag_get_sorted_list(const char *sort_type, int *_count)
   channel_tag_t *ct, **ctlist;
 
   ctlist = malloc(channel_tags_count * sizeof(channel_tag_t *));
+
+  if (ctlist == NULL) {
+    tvhabort(LS_CHANNEL, "malloc is NULL");
+  }
 
   TAILQ_FOREACH(ct, &channel_tags, ct_link)
     if(ct->ct_enabled && !ct->ct_internal)

--- a/src/cron.c
+++ b/src/cron.c
@@ -164,14 +164,16 @@ cron_set ( cron_t *c, const char *str )
 cron_multi_t *
 cron_multi_set ( const char *str )
 {
-  char *s = str ? alloca(strlen(str) + 1) : NULL;
   char *line, *sptr = NULL;
   cron_t cron;
   cron_multi_t *cm = NULL, *cm2;
   int count = 0;
 
-  if (s == NULL)
+  if (str == NULL)
     return NULL;
+
+  char s[strlen(str) + 1];
+
   strcpy(s, str);
   line = strtok_r(s, "\n", &sptr);
   while (line) {

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -70,8 +70,16 @@ dbus_emit_signal(const char *obj_name, const char *sig_name, htsmsg_t *msg)
     return;
   }
   ds = calloc(1, sizeof(dbus_sig_t));
+  if (ds == NULL) {
+    tvhabort(LS_DBUS, "calloc is NULL");
+  }
+
   l = strlen(obj_name);
   ds->obj_name = malloc(l + 15);
+  if (ds->obj_name == NULL) {
+    tvhabort(LS_DBUS, "malloc is NULL");
+  }
+
   strcpy(ds->obj_name, "/org/tvheadend");
   strcpy(ds->obj_name + 14, obj_name);
   ds->sig_name = strdup(sig_name);
@@ -270,6 +278,10 @@ dbus_register_rpc_s64(const char *call_name, void *opaque,
                       int64_t (*fcn)(void *, const char *, int64_t))
 {
   dbus_rpc_t *rpc = calloc(1, sizeof(*rpc));
+  if (rpc == NULL) {
+    tvhabort(LS_DBUS, "calloc is NULL");
+  }
+
   rpc->call_name = strdup(call_name);
   rpc->rpc_s64 = fcn;
   rpc->opaque = opaque;
@@ -286,6 +298,10 @@ dbus_register_rpc_str(const char *call_name, void *opaque,
                       char *(*fcn)(void *, const char *, char *))
 {
   dbus_rpc_t *rpc = calloc(1, sizeof(*rpc));
+  if (rpc == NULL) {
+    tvhabort(LS_DBUS, "calloc is NULL");
+  }
+
   rpc->call_name = strdup(call_name);
   rpc->rpc_str = fcn;
   rpc->opaque = opaque;

--- a/src/download.c
+++ b/src/download.c
@@ -20,6 +20,7 @@
 #include "tvheadend.h"
 #include "download.h"
 #include "spawn.h"
+#include "tvhlog.h"
 
 #include <signal.h>
 #include <fcntl.h>
@@ -50,6 +51,9 @@ download_file(download_t *dn, const char *filename)
     return -1;
   }
   data = malloc(st.st_size+1);
+  if (data == NULL) {
+    tvhabort(LS_DOWNLOAD, "malloc is NULL");
+  }
   off = 0;
   do {
     r = read(fd, data + off, st.st_size - off);

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -391,6 +391,9 @@ dvr_autorec_create(const char *uuid, htsmsg_t *conf)
   dvr_autorec_entry_t *dae;
 
   dae = calloc(1, sizeof(*dae));
+  if (dae == NULL) {
+    tvhabort(LS_DVR, "calloc is NULL");
+  }
 
   if (idnode_insert(&dae->dae_id, uuid, &dvr_autorec_entry_class, 0)) {
     if (uuid)

--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -159,6 +159,9 @@ dvr_config_create(const char *name, const char *uuid, htsmsg_t *conf)
     name = "";
 
   cfg = calloc(1, sizeof(dvr_config_t));
+  if (cfg == NULL) {
+    tvhabort(LS_DVR, "calloc is NULL");
+  }
   LIST_INIT(&cfg->dvr_entries);
   LIST_INIT(&cfg->dvr_autorec_entries);
   LIST_INIT(&cfg->dvr_timerec_entries);
@@ -363,6 +366,11 @@ dvr_insert_fmtstr(dvr_config_t *cfg, int idx, const char *str)
   size_t t = strlen(cfg->dvr_pathname);
   size_t l = strlen(str);
   char *n = malloc(t + l + 1);
+
+  if (n == NULL) {
+    tvhabort(LS_DVR, "malloc is NULL");
+  }
+
   memcpy(n, cfg->dvr_pathname, idx);
   memcpy(n + idx, str, l);
   memcpy(n + idx + l, cfg->dvr_pathname + idx, t - idx);

--- a/src/dvr/dvr_cutpoints.c
+++ b/src/dvr/dvr_cutpoints.c
@@ -159,8 +159,11 @@ dvr_parse_file
     line_count++;
 
     /* Alloc cut point */
-    if (!(cp = calloc(1, sizeof(dvr_cutpoint_t))))
+    cp = calloc(1, sizeof(dvr_cutpoint_t));
+    if (cp == NULL) {
+      tvhinfo(LS_DVR, "calloc is NULL");
       goto done;
+    }
 
     /* Parse */
     if (!parse(line, cp, &frate)) {
@@ -209,7 +212,7 @@ dvr_cutpoint_list_t *
 dvr_get_cutpoint_list (dvr_entry_t *de)
 {
   int i;
-  char *path, *sptr;
+  char *sptr;
   const char *filename;
   dvr_cutpoint_list_t *cuts;
 
@@ -221,13 +224,15 @@ dvr_get_cutpoint_list (dvr_entry_t *de)
 
   /* Allocate list space */
   cuts = calloc(1, sizeof(dvr_cutpoint_list_t));
-  if (cuts == NULL)
+  if (cuts == NULL) {
+    tvhinfo(LS_DVR, "calloc is NULL");
     return NULL;
+  }
   TAILQ_INIT(cuts);
 
   /* Get base filename */
   // TODO: harcoded 3 for max extension plus 1 for termination
-  path = alloca(strlen(filename) + 4);
+  char path[strlen(filename) + 4];
   strcpy(path, filename);
   sptr = strrchr(path, '.');
   if (!sptr) {
@@ -281,11 +286,11 @@ dvr_cutpoint_list_destroy (dvr_cutpoint_list_t *list)
 void
 dvr_cutpoint_delete_files (const char *s)
 {
-  char *path, *dot;
+  char *dot;
   int i;
 
   // TODO: harcoded 3 for max extension, plus 1 for . and one for termination
-  path = alloca(strlen(s) + 5);
+  char path[strlen(s) + 5];
 
   /* Check each cutlist extension */
   for (i = 0; i < ARRAY_SIZE(dvr_cutpoint_parsers); i++) {

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1050,6 +1050,9 @@ dvr_entry_create(const char *uuid, htsmsg_t *conf, int clone)
   }
 
   de = calloc(1, sizeof(*de));
+  if (de == NULL) {
+    tvhabort(LS_DVR, "calloc is NULL");
+  }
 
   if (idnode_insert(&de->de_id, uuid, &dvr_entry_class, IDNODE_SHORT_UUID)) {
     if (uuid)
@@ -1507,6 +1510,9 @@ static int _dvr_duplicate_per_month(dvr_entry_t *de, dvr_entry_t *de2, void **au
   struct tm *de1_start = *aux, de2_start;
   if (de1_start == NULL) {
     de1_start = calloc(1, sizeof(*de1_start));
+    if (de1_start == NULL) {
+      tvhabort(LS_DVR, "calloc is NULL");
+    }
     localtime_r(&de->de_start, de1_start);
     *aux = de1_start;
   }
@@ -1520,6 +1526,9 @@ static int _dvr_duplicate_per_week(dvr_entry_t *de, dvr_entry_t *de2, void **aux
   struct tm *de1_start = *aux, de2_start;
   if (de1_start == NULL) {
     de1_start = calloc(1, sizeof(*de1_start));
+    if (de1_start == NULL) {
+      tvhabort(LS_DVR, "calloc is NULL");
+    }
     localtime_r(&de->de_start, de1_start);
     de1_start->tm_mday -= (de1_start->tm_wday + 6) % 7; // week = mon-sun
     mktime(de1_start); // adjusts de_start
@@ -1537,6 +1546,9 @@ static int _dvr_duplicate_per_day(dvr_entry_t *de, dvr_entry_t *de2, void **aux)
   struct tm *de1_start = *aux, de2_start;
   if (de1_start == NULL) {
     de1_start = calloc(1, sizeof(*de1_start));
+    if (de1_start == NULL) {
+      tvhabort(LS_DVR, "calloc is NULL");
+    }
     localtime_r(&de->de_start, de1_start);
     *aux = de1_start;
   }

--- a/src/dvr/dvr_inotify.c
+++ b/src/dvr/dvr_inotify.c
@@ -136,6 +136,9 @@ static void dvr_inotify_add_one ( dvr_entry_t *de, htsmsg_t *m )
   if (!dvr_inotify_exists(e, de)) {
 
     dif = malloc(sizeof(*dif));
+    if (dif == NULL) {
+      tvhabort(LS_DVR, "malloc is NULL");
+    }
     dif->de = de;
 
     LIST_INSERT_HEAD(&e->entries, dif, link);

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -132,6 +132,9 @@ dvr_rec_subscribe(dvr_entry_t *de)
 
   pro = de->de_config->dvr_profile;
   prch = malloc(sizeof(*prch));
+  if (prch == NULL) {
+    tvhabort(LS_DVR, "malloc is NULL");
+  }
   profile_chain_init(prch, pro, de->de_channel, 1);
   if (profile_chain_open(prch, &de->de_config->dvr_muxcnf, NULL, 0, 0)) {
     profile_chain_close(prch);

--- a/src/dvr/dvr_timerec.c
+++ b/src/dvr/dvr_timerec.c
@@ -174,7 +174,9 @@ dvr_timerec_create(const char *uuid, htsmsg_t *conf)
   dvr_timerec_entry_t *dte;
 
   dte = calloc(1, sizeof(*dte));
-
+  if (dte == NULL) {
+    tvhabort(LS_DVR, "calloc is NULL");
+  }    
   if (idnode_insert(&dte->dte_id, uuid, &dvr_timerec_entry_class, 0)) {
     if (uuid)
       tvhwarn(LS_DVR, "invalid timerec entry uuid '%s'", uuid);

--- a/src/dvr/dvr_vfsmgr.c
+++ b/src/dvr/dvr_vfsmgr.c
@@ -54,6 +54,9 @@ dvr_vfs_find(dvr_vfs_t *old, tvh_fsid_t *id)
     if (tvh_vfs_fsid_match(&dv->fsid, id))
       return dv;
   dv = calloc(1, sizeof(*dv));
+  if (dv == NULL) {
+    tvhabort(LS_DVR, "calloc is NULL");
+  }
   dv->fsid = *id;
   LIST_INSERT_HEAD(&dvrvfs_list, dv, link);
   return dv;

--- a/src/epgdb.c
+++ b/src/epgdb.c
@@ -34,6 +34,7 @@
 #include "epggrab.h"
 #include "config.h"
 #include "memoryinfo.h"
+#include "tvhlog.h"
 
 #define EPG_DB_VERSION 3
 #define EPG_DB_ALLOC_STEP (1024*1024)
@@ -344,8 +345,10 @@ void epg_save ( void )
   epggrab_stats_t stats;
   extern gtimer_t epggrab_save_timer;
 
-  if (!sb)
+  if (sb == NULL){
+    tvhinfo(LS_EPGDB, "malloc is NULL; don't save epg");
     return;
+  }
 
   tvhinfo(LS_EPGDB, "snapshot start");
 

--- a/src/epggrab.c
+++ b/src/epggrab.c
@@ -207,8 +207,10 @@ void epggrab_queue_data(epggrab_module_t *mod,
     return;
   len = sizeof(*eq) + len1 + len2;
   eq = malloc(len);
-  if (eq == NULL)
+  if (eq == NULL){
+    tvhinfo(LS_EPGGRAB, "malloc is NULL; can't queue epggrab data");
     return;
+  }
   eq->eq_len = len1 + len2;
   if (len1)
     memcpy(eq->eq_data, data1, len1);

--- a/src/epggrab/module.c
+++ b/src/epggrab/module.c
@@ -475,7 +475,9 @@ epggrab_module_int_t *epggrab_module_int_create
 {
   /* Allocate data */
   if (!skel) skel = calloc(1, sizeof(epggrab_module_int_t));
-
+  if (skel == NULL) {
+      tvhabort(LS_EPGGRAB, "calloc is NULL");
+  }
   /* Pass through */
   epggrab_module_create((epggrab_module_t*)skel,
                         cls ?: &epggrab_mod_int_class,
@@ -705,6 +707,10 @@ epggrab_module_ext_t *epggrab_module_ext_create
 
   /* Allocate data */
   if (!skel) skel = calloc(1, sizeof(epggrab_module_ext_t));
+  if (skel == NULL) {
+      tvhabort(LS_EPGGRAB, "calloc is NULL");
+  }
+
   atomic_set(&skel->sock, -1);
 
   /* Pass through */
@@ -733,7 +739,9 @@ epggrab_module_ota_t *epggrab_module_ota_create
     const epggrab_ota_module_ops_t *ops )
 {
   if (!skel) skel = calloc(1, sizeof(epggrab_module_ota_t));
-
+  if (skel == NULL) {
+      tvhabort(LS_EPGGRAB, "calloc is NULL");
+  }
   /* Pass through */
   epggrab_module_create((epggrab_module_t*)skel,
                         idclass ?: &epggrab_mod_ota_class,

--- a/src/epggrab/module/eit.c
+++ b/src/epggrab/module/eit.c
@@ -395,7 +395,12 @@ static int _eit_desc_content
     if (*ptr == 0xb1)
       ev->bw = 1;
     else if (*ptr < 0xb0) {
-      if (!ev->genre) ev->genre = calloc(1, sizeof(epg_genre_list_t));
+      if (!ev->genre) {
+        ev->genre = calloc(1, sizeof(epg_genre_list_t));
+        if (ev->genre == NULL) {
+          tvhabort(LS_EPGGRAB, "calloc is NULL");
+        }
+      }
       epg_genre_list_add_by_eit(ev->genre, *ptr);
     }
     len -= 2;
@@ -1285,6 +1290,9 @@ static void eit_queue_priv
 
   tvhtrace(LS_TBL_EIT, "%s - detected module '%s'", src, priv->module->id);
   plist = calloc(1, sizeof(*plist));
+  if (plist == NULL) {
+      tvhabort(LS_EPGGRAB, "calloc is NULL");
+  }
   plist->src = src;
   plist->priv = priv;
   LIST_INSERT_HEAD(&om->om_eit_plist, plist, link);
@@ -1521,8 +1529,12 @@ static eit_module_t *eit_module_ota_create
     const char *name, int priority,
     epggrab_ota_module_ops_t *ops )
 {
+  void * epg_mem = calloc(1, sizeof(eit_module_t));
+  if (epg_mem == NULL) {
+    tvhabort(LS_EPGGRAB, "calloc is NULL");
+  }
   eit_module_t * mod = (eit_module_t *)
-    epggrab_module_ota_create(calloc(1, sizeof(eit_module_t)),
+  epggrab_module_ota_create( epg_mem,
                               id, subsys, saveid, name, priority,
                               &epggrab_mod_eit_class, ops);
   return mod;
@@ -1567,7 +1579,13 @@ static void eit_init_one ( const char *id, htsmsg_t *conf )
   lang_str_t *name_str = lang_str_deserialize(conf, "name");
 
   ops = calloc(1, sizeof(*ops));
+  if (ops == NULL) {
+      tvhabort(LS_EPGGRAB, "calloc is NULL");
+  }
   priv = calloc(1, sizeof(*priv));
+  if (priv == NULL) {
+      tvhabort(LS_EPGGRAB, "calloc is NULL");
+  }
   ops->start = _eit_start;
   ops->handlers = _eit_install_handlers;
   ops->done = _eit_done;
@@ -1585,6 +1603,9 @@ static void eit_init_one ( const char *id, htsmsg_t *conf )
   if (map) {
     HTSMSG_FOREACH(f, map) {
       nit = calloc(1, sizeof(*nit));
+      if (nit == NULL) {
+          tvhabort(LS_EPGGRAB, "calloc is NULL");
+      }
       nit->name = htsmsg_field_name(f)[0] ? strdup(htsmsg_field_name(f)) : NULL;
       if ((e = htsmsg_field_get_map(f)) != NULL) {
         eit_parse_list(e, "onid", nit->onid, ARRAY_SIZE(nit->onid), &nit->onid_count);
@@ -1599,6 +1620,9 @@ static void eit_init_one ( const char *id, htsmsg_t *conf )
   if (map) {
     HTSMSG_FOREACH(f, map) {
       sdt = calloc(1, sizeof(*sdt));
+      if (sdt == NULL) {
+          tvhabort(LS_EPGGRAB, "calloc is NULL");
+      }
       if ((e = htsmsg_field_get_map(f)) != NULL) {
         eit_parse_list(e, "onid", sdt->onid, ARRAY_SIZE(sdt->onid), &sdt->onid_count);
         eit_parse_list(e, "tsid", sdt->tsid, ARRAY_SIZE(sdt->tsid), &sdt->tsid_count);

--- a/src/epggrab/module/eitpatternlist.c
+++ b/src/epggrab/module/eitpatternlist.c
@@ -77,6 +77,9 @@ void eit_pattern_compile_list ( eit_pattern_list_t *list, htsmsg_t *l, int flags
       langs = get_languages_string(htsmsg_field_find(m, "lang"));
     }
     pattern = calloc(1, sizeof(eit_pattern_t));
+    if (pattern == NULL) {
+        tvhabort(LS_EPGGRAB, "calloc is NULL");
+    }
     pattern->text = strdup(text);
     pattern->filter = filter;
     pattern->langs = langs;

--- a/src/epggrab/module/opentv.c
+++ b/src/epggrab/module/opentv.c
@@ -235,7 +235,11 @@ static void opentv_add_entry(opentv_status_t *sta, opentv_event_t *ev)
 {
   if (sta == NULL) return;
 
-  opentv_entry_t *entry, *nentry = calloc(1, sizeof(*nentry));
+  opentv_entry_t *entry;
+  opentv_entry_t *nentry = calloc(1, sizeof(*nentry));
+  if (nentry == NULL) {
+      tvhabort(LS_OPENTV, "calloc is NULL");
+  }
 
   nentry->event = *ev;
   entry = RB_INSERT_SORTED(&sta->os_entries, nentry, link, _entry_cmp);
@@ -258,6 +262,9 @@ static char *_opentv_parse_string
 
   // Note: unlikely decoded string will be longer (though its possible)
   ret = tmp = malloc(2*len);
+  if (tmp == NULL) {
+      tvhabort(LS_OPENTV, "malloc is NULL");
+  }
   *ret = 0;
   if (huffman_decode(prov->dict->codes, buf, len, 0x20, tmp, 2*len)) {
 
@@ -408,6 +415,9 @@ opentv_do_event
   }
   if (ev->cat) {
     epg_genre_list_t *egl = calloc(1, sizeof(epg_genre_list_t));
+    if (egl == NULL) {
+        tvhabort(LS_OPENTV, "calloc is NULL");
+    }
     epg_genre_list_add_by_eit(egl, ev->cat);
     save |= epg_broadcast_set_genre(ebc, egl, changes);
     epg_genre_list_destroy(egl);
@@ -824,6 +834,9 @@ static int _opentv_start
   while (*t) {
     if (!sta) {
       sta = calloc(1, sizeof(opentv_status_t));
+      if (sta == NULL) {
+          tvhabort(LS_OPENTV, "calloc is NULL");
+      }
       sta->os_mod = mod;
       sta->os_map = map;
     }
@@ -862,6 +875,9 @@ static int* _pid_list_to_array ( htsmsg_t *m )
   HTSMSG_FOREACH(f, m) 
     if (f->hmf_s64) i++;
   ret = calloc(i, sizeof(int));
+  if (ret == NULL) {
+      tvhabort(LS_OPENTV, "calloc is NULL");
+  }
   i   = 0;
   HTSMSG_FOREACH(f, m) 
     if (f->hmf_s64) {
@@ -875,6 +891,9 @@ static int _opentv_genre_load_one ( const char *id, htsmsg_t *m )
 {
   htsmsg_field_t *f;
   opentv_genre_t *genre = calloc(1, sizeof(opentv_genre_t));
+  if (genre == NULL) {
+      tvhabort(LS_OPENTV, "calloc is NULL");
+  }
   genre->id = (char*)id;
   if (RB_INSERT_SORTED(&_opentv_genres, genre, h_link, _genre_cmp)) {
     tvhdebug(LS_OPENTV, "ignore duplicate genre map %s", id);
@@ -912,6 +931,9 @@ static void _opentv_genre_load ( htsmsg_t *m )
 static int _opentv_dict_load_one ( const char *id, htsmsg_t *m )
 {
   opentv_dict_t *dict = calloc(1, sizeof(opentv_dict_t));
+  if (dict == NULL) {
+      tvhabort(LS_OPENTV, "calloc is NULL");
+  }
   dict->id = (char*)id;
   if (RB_INSERT_SORTED(&_opentv_dicts, dict, h_link, _dict_cmp)) {
     tvhdebug(LS_OPENTV, "ignore duplicate dictionary %s", id);
@@ -1020,8 +1042,11 @@ static int _opentv_prov_load_one ( const char *id, htsmsg_t *m )
 
   /* Create */
   sprintf(nbuf, "OpenTV: %s", name);
-  mod = (opentv_module_t *)
-    epggrab_module_ota_create(calloc(1, sizeof(opentv_module_t)),
+  void * epg_mem = calloc(1, sizeof(opentv_module_t));
+  if (epg_mem == NULL) {
+      tvhabort(LS_OPENTV, "calloc is NULL");
+  }
+  mod = (opentv_module_t *) epggrab_module_ota_create(epg_mem,
                               ibuf, LS_OPENTV, NULL, nbuf, 2, NULL, &ops);
 
   /* Add provider details */

--- a/src/epggrab/module/psip.c
+++ b/src/epggrab/module/psip.c
@@ -132,6 +132,9 @@ psip_update_table(psip_status_t *ps, uint16_t pid, int type)
     return pt;
   }
   pt = calloc(1, sizeof(*pt));
+  if (pt == NULL) {
+      tvhabort(LS_PSIP, "calloc is NULL");
+  }
   TAILQ_INSERT_TAIL(&ps->ps_tables, pt, pt_link);
   pt->pt_pid = pid;
 assign:
@@ -209,6 +212,9 @@ psip_reschedule_tables(psip_status_t *ps)
     }
   }
   tables = malloc(total * sizeof(psip_table_t *));
+  if (tables == NULL) {
+      tvhabort(LS_PSIP, "malloc is NULL");
+  }
 
   tvhtrace(LS_PSIP, "reschedule tables, total %d", total);
 
@@ -315,6 +321,9 @@ static void psip_add_desc
 {
   psip_desc_t *pc, *pd = calloc(1, sizeof(*pd));
 
+  if (pd == NULL) {
+      tvhabort(LS_PSIP, "calloc is NULL");
+  }
   pd->pd_eventid = eventid;
   pc = RB_INSERT_SORTED(&ps->ps_descs, pd, pd_link, _desc_cmp);
   if (pc) {
@@ -325,6 +334,9 @@ static void psip_add_desc
     free(pd->pd_data);
   }
   pd->pd_data = malloc(datalen);
+  if (pd->pd_data == NULL) {
+      tvhabort(LS_PSIP, "malloc is NULL");
+  }
   memcpy(pd->pd_data, data, datalen);
   pd->pd_datalen = datalen;
 }
@@ -701,6 +713,9 @@ static int _psip_start
   psip_status_t *ps;
 
   ps = calloc(1, sizeof(*ps));
+  if (ps == NULL) {
+      tvhabort(LS_PSIP, "calloc is NULL");
+  }
   TAILQ_INIT(&ps->ps_tables);
   ps->ps_mod      = map->om_module;
   ps->ps_map      = map;

--- a/src/epggrab/module/xmltv.c
+++ b/src/epggrab/module/xmltv.c
@@ -202,6 +202,9 @@ static void parse_xmltv_dd_progid
 
   const int buf_size = s_len + strlen(mod->id) + 13;
   char * buf = (char *) malloc( buf_size);
+  if (buf == NULL) {
+      tvhabort(LS_XMLTV, "malloc is NULL");
+  }
   /* Raw URI */
   int e = snprintf( buf, buf_size, "ddprogid://%s/%s", mod->id, s);
 
@@ -496,7 +499,12 @@ static epg_genre_list_t
   epg_genre_list_t *egl = NULL;
   HTSMSG_FOREACH(f, tags) {
     if (!strcmp(htsmsg_field_name(f), "category") && (e = htsmsg_get_map_by_field(f))) {
-      if (!egl) egl = calloc(1, sizeof(epg_genre_list_t));
+      if (!egl) {
+        egl = calloc(1, sizeof(epg_genre_list_t));
+        if (egl == NULL) {
+            tvhabort(LS_XMLTV, "calloc is NULL");
+        }
+      }
       epg_genre_list_add_by_str(egl, htsmsg_get_str(e, "cdata"), NULL);
     }
   }

--- a/src/epggrab/otamux.c
+++ b/src/epggrab/otamux.c
@@ -422,6 +422,9 @@ epggrab_ota_register
   map = epggrab_ota_find_map(ota, mod);
   if (!map) {
     map = calloc(1, sizeof(epggrab_ota_map_t));
+    if (map == NULL) {
+      tvhabort(LS_EPGGRAB, "calloc is NULL");
+    }
     RB_INIT(&map->om_svcs);
     map->om_module   = mod;
     LIST_INSERT_HEAD(&ota->om_modules, map, om_link);
@@ -872,6 +875,9 @@ epggrab_ota_load_one
   tvhtrace(LS_EPGGRAB, "loading config for %s", mm->mm_nicename);
 
   ota = calloc(1, sizeof(epggrab_ota_mux_t));
+  if (ota == NULL) {
+    tvhabort(LS_EPGGRAB, "calloc is NULL");
+  }
   LIST_INIT(&ota->om_eit_plist);
   ota->om_mux_uuid = mm->mm_id.in_uuid;
   if (RB_INSERT_SORTED(&epggrab_ota_all, ota, om_global_link, om_id_cmp)) {
@@ -888,6 +894,9 @@ epggrab_ota_load_one
       continue;
     
     map = calloc(1, sizeof(epggrab_ota_map_t));
+    if (map == NULL) {
+      tvhabort(LS_EPGGRAB, "calloc is NULL");
+    }
     RB_INIT(&map->om_svcs);
     map->om_module   = mod;
     if ((l2 = htsmsg_get_list(e, "services")) != NULL) {

--- a/src/esfilter.c
+++ b/src/esfilter.c
@@ -144,6 +144,10 @@ esfilter_create
   const idclass_t *c = NULL;
   uint32_t ct;
 
+  if (esf == NULL) {
+    tvhabort(LS_CHANNEL, "calloc is NULL");
+  } 
+
   lock_assert(&global_lock);
 
   esf->esf_caid = -1;
@@ -432,7 +436,7 @@ static htsmsg_t *
 esfilter_build_ca_enum(int provider)
 {
   htsmsg_t *l;
-  uint32_t *a = alloca(sizeof(uint32_t) * MAX_ITEMS);
+  uint32_t a[sizeof(uint32_t) * MAX_ITEMS];
   char buf[16], buf2[128];
   service_t *s;
   elementary_stream_t *es;

--- a/src/esstream.c
+++ b/src/esstream.c
@@ -227,7 +227,7 @@ void
 elementary_set_filter_build(elementary_set_t *set)
 {
   service_t *t;
-  elementary_stream_t *st, *st2, **sta;
+  elementary_stream_t *st, *st2;
   esfilter_t *esf;
   caid_t *ca, *ca2;
   int i, n, p, o, exclusive, sindex;
@@ -265,7 +265,7 @@ filter:
     n++;
   }
 
-  sta = alloca(sizeof(elementary_stream_t *) * n);
+  elementary_stream_t *sta[sizeof(elementary_stream_t *) * n];
 
   for (i = ESF_CLASS_VIDEO, p = 0; i <= ESF_CLASS_LAST; i++) {
     o = p;
@@ -467,6 +467,9 @@ elementary_stream_create_parent
 
 create:
   st = calloc(1, sizeof(elementary_stream_t));
+  if (st == NULL) {
+      tvhabort(LS_ESSTREAM, "calloc is NULL");
+  }
   st->es_index = idx + 1;
 
   st->es_type = type;
@@ -604,13 +607,13 @@ escmp(const void *A, const void *B)
 void
 elementary_set_sort_streams(elementary_set_t *set)
 {
-  elementary_stream_t *st, **v;
+  elementary_stream_t *st;
   int num = 0, i = 0;
 
   TAILQ_FOREACH(st, &set->set_all, es_link)
     num++;
 
-  v = alloca(num * sizeof(elementary_stream_t *));
+  elementary_stream_t *v[num * sizeof(elementary_stream_t *)];
   TAILQ_FOREACH(st, &set->set_all, es_link)
     v[i++] = st;
 
@@ -636,6 +639,9 @@ elementary_stream_build_start(elementary_set_t *set)
 
   ss = calloc(1, sizeof(streaming_start_t) +
 	      sizeof(streaming_start_component_t) * n);
+  if (ss == NULL) {
+      tvhabort(LS_ESSTREAM, "calloc is NULL");
+  }
 
   ss->ss_num_components = n;
 
@@ -670,6 +676,9 @@ elementary_stream_create_from_start
   for (n = 0; n < ss->ss_num_components; n++) {
     streaming_start_component_t *ssc = &ss->ss_components[n];
     st = calloc(1, es_size ?: sizeof(*st));
+    if (st == NULL) {
+        tvhabort(LS_ESSTREAM, "calloc is NULL");
+    }
     *(elementary_info_t *)st = *(elementary_info_t *)ssc;
     st->es_service = set->set_service;
     elementary_stream_make_nicename(st, set->set_nicename);

--- a/src/filebundle.c
+++ b/src/filebundle.c
@@ -122,6 +122,9 @@ static fb_dir *_fb_opendir ( const char *root, const char *path )
   /* Open */
   if ((dir = opendir(path))) {
     ret         = calloc(1, sizeof(fb_dir));
+    if (ret == NULL) {
+      tvhabort(LS_FILEBUNDLE, "calloc is NULL");
+    }
     ret->type   = FB_DIRECT;
     ret->d.root = strdup(path);
     ret->d.cur  = dir;
@@ -156,6 +159,9 @@ fb_dir *fb_opendir ( const char *path )
     /* Found */
     if (fb) {
       ret = calloc(1, sizeof(fb_dir));
+      if (ret == NULL) {
+        tvhabort(LS_FILEBUNDLE, "calloc is NULL");
+      }
       ret->type   = FB_BUNDLE;
       ret->b.root = fb;
       ret->b.cur  = fb->d.child;
@@ -227,8 +233,14 @@ int fb_scandir ( const char *path, fb_dirent ***list )
   if (dir->type == FB_DIRECT) {
     if ((ret = scandir(dir->d.root, &de, NULL, NULL)) > 0) {
       *list = malloc(sizeof(fb_dirent*)*ret);
+      if (list == NULL) {
+        tvhabort(LS_FILEBUNDLE, "malloc is NULL");
+      }
       for (i = 0; i < ret; i++) {
         (*list)[i] = calloc(1, sizeof(fb_dirent));
+        if ((*list)[i] == NULL) {
+          tvhabort(LS_FILEBUNDLE, "calloc is NULL");
+        }
         strcpy((*list)[i]->name, de[i]->d_name);
         switch(de[i]->d_type) {
           case DT_DIR: 
@@ -257,9 +269,15 @@ int fb_scandir ( const char *path, fb_dirent ***list )
     ret = dir->b.root->d.count;
     fb  = dir->b.root->d.child;
     *list = malloc(ret * sizeof(fb_dirent*));
+    if (list == NULL) {
+      tvhabort(LS_FILEBUNDLE, "malloc is NULL");
+    }
     i = 0;
     while (fb) {
       (*list)[i] = calloc(1, sizeof(fb_dirent));
+      if ((*list)[i] == NULL) {
+        tvhabort(LS_FILEBUNDLE, "calloc is NULL");
+      }
       strlcpy((*list)[i]->name, fb->name, sizeof((*list)[i]->name));
       fb = fb->next;
       i++;
@@ -297,6 +315,9 @@ fb_file *fb_open2
     }
     if (fb) {
       ret               = calloc(1, sizeof(fb_file));
+      if (ret == NULL) {
+          tvhabort(LS_FILEBUNDLE, "calloc is NULL");
+      }
       ret->type         = FB_BUNDLE;
       ret->size         = fb->f.size;
       ret->gzip         = fb->f.orig != -1;
@@ -328,6 +349,9 @@ fb_file *fb_open2
       struct stat st;
       if (!stat(path, &st)) {
         ret         = calloc(1, sizeof(fb_file));
+        if (ret == NULL) {
+          tvhabort(LS_FILEBUNDLE, "calloc is NULL");
+        }
         ret->type   = FB_DIRECT;
         ret->size   = st.st_size;
         ret->gzip   = 0;
@@ -350,6 +374,9 @@ fb_file *fb_open2
       ret->buf = tvh_gzip_deflate(data, ret->size, &ret->size);
     } else {
       uint8_t *data = malloc(ret->size);
+      if (data == NULL) {
+          tvhabort(LS_FILEBUNDLE, "malloc is NULL");
+      }
       ssize_t c = fread(data, 1, ret->size, ret->d.cur);
       if (c == ret->size)
         ret->buf = tvh_gzip_deflate(data, ret->size, &ret->size);

--- a/src/fsmonitor.c
+++ b/src/fsmonitor.c
@@ -139,6 +139,9 @@ fsmonitor_add ( const char *path, fsmonitor_t *fsm )
   lock_assert(&global_lock);
 
   skel = calloc(1, sizeof(fsmonitor_path_t));
+  if (skel == NULL) {
+    tvhabort(LS_FSMONITOR, "calloc is NULL");
+  }
   skel->fmp_path = (char*)path;
 
   /* Build mask */
@@ -178,6 +181,9 @@ fsmonitor_add ( const char *path, fsmonitor_t *fsm )
 
   /* Add */
   fml = calloc(1, sizeof(fsmonitor_link_t));
+  if (fml == NULL) {
+    tvhabort(LS_FSMONITOR, "calloc is NULL");
+  }
   fml->fml_path    = fmp;
   fml->fml_monitor = fsm;
   LIST_INSERT_HEAD(&fmp->fmp_monitors, fml, fml_plink);

--- a/src/htsbuf.c
+++ b/src/htsbuf.c
@@ -25,6 +25,7 @@
 
 #include "tvheadend.h"
 #include "htsbuf.h"
+#include "tvhlog.h"
 
 /**
  *
@@ -47,6 +48,9 @@ htsbuf_queue_t *
 htsbuf_queue_alloc(unsigned int maxsize)
 {
   htsbuf_queue_t *hq = malloc(sizeof(htsbuf_queue_t));
+  if (hq == NULL) {
+    tvhabort(LS_HTSBUF, "malloc is NULL");
+  }
   htsbuf_queue_init(hq, maxsize);
   return hq;
 }
@@ -110,11 +114,17 @@ htsbuf_append(htsbuf_queue_t *hq, const void *buf, size_t len)
     return;
   
   hd = malloc(sizeof(htsbuf_data_t));
+  if (hd == NULL) {
+    tvhabort(LS_HTSBUF, "malloc is NULL");
+  }
   TAILQ_INSERT_TAIL(&hq->hq_q, hd, hd_link);
   
   c = MAX(len, 1000); /* Allocate 1000 bytes to support lots of small writes */
 
   hd->hd_data = malloc(c);
+  if (hd->hd_data == NULL) {
+    tvhabort(LS_HTSBUF, "malloc is NULL");
+  }
   hd->hd_data_size = c;
   hd->hd_data_len = len;
   hd->hd_data_off = 0;
@@ -133,6 +143,9 @@ htsbuf_append_prealloc(htsbuf_queue_t *hq, const void *buf, size_t len)
   hq->hq_size += len;
 
   hd = malloc(sizeof(htsbuf_data_t));
+  if (hd == NULL) {
+    tvhabort(LS_HTSBUF, "malloc is NULL");
+  }
   TAILQ_INSERT_TAIL(&hq->hq_q, hd, hd_link);
   
   hd->hd_data = (void *)buf;
@@ -266,6 +279,9 @@ htsbuf_vqprintf(htsbuf_queue_t *hq, const char *fmt, va_list ap0)
   size = sizeof(buf) * 2;
 
   p = malloc(size);
+  if (p == NULL) {
+    tvhabort(LS_HTSBUF, "malloc is NULL");
+  }
   while (1) {
     /* Try to print in the allocated space. */
     va_copy(ap, ap0);
@@ -339,6 +355,9 @@ void
 htsbuf_hexdump(htsbuf_queue_t *hq, const char *prefix)
 {
   void *r = malloc(hq->hq_size);
+  if (r == NULL) {
+    tvhabort(LS_HTSBUF, "malloc is NULL");
+  }
   htsbuf_peek(hq, r, hq->hq_size);
   hexdump(prefix, r, hq->hq_size);
   free(r);
@@ -581,6 +600,9 @@ char *
 htsbuf_to_string(htsbuf_queue_t *hq)
 {
   char *r = malloc(hq->hq_size + 1);
+  if (r == NULL) {
+    tvhabort(LS_HTSBUF, "malloc is NULL");
+  }
   r[hq->hq_size] = 0;
   htsbuf_read(hq, r, hq->hq_size);
   return r;

--- a/src/htsmsg_binary.c
+++ b/src/htsmsg_binary.c
@@ -66,8 +66,10 @@ htsmsg_binary_des0(htsmsg_t *msg, const uint8_t *buf, size_t len)
         return -1;
     }
     f = malloc(tlen);
-    if (f == NULL)
+    if (f == NULL) {
+      tvhinfo(LS_HTSMSG, "malloc is NULL; continuing");
       return -1;
+    }
 #if ENABLE_SLOW_MEMORYINFO
     f->hmf_edata_size = tlen - sizeof(htsmsg_field_t);
     memoryinfo_alloc(&htsmsg_field_memoryinfo, tlen);
@@ -359,7 +361,9 @@ htsmsg_binary_serialize0(htsmsg_t *msg, void **datap, size_t *lenp, int maxlen)
     return -1;
 
   data = malloc(len);
-
+  if (data == NULL) {
+      tvhabort(LS_HTSMSG, "malloc is NULL");
+  }
   htsmsg_binary_write(msg, data);
   *datap = data;
   *lenp  = len;
@@ -380,6 +384,9 @@ htsmsg_binary_serialize(htsmsg_t *msg, void **datap, size_t *lenp, int maxlen)
     return -1;
 
   data = malloc(len + 4);
+  if (data == NULL) {
+      tvhabort(LS_HTSMSG, "malloc is NULL");
+  }
 
   data[0] = len >> 24;
   data[1] = len >> 16;

--- a/src/htsmsg_binary2.c
+++ b/src/htsmsg_binary2.c
@@ -25,6 +25,7 @@
 
 #include "htsmsg_binary2.h"
 #include "memoryinfo.h"
+#include "tvhlog.h"
 
 static uint32_t htsmsg_binary2_count(htsmsg_t *msg);
 
@@ -125,8 +126,10 @@ htsmsg_binary2_des0(htsmsg_t *msg, const uint8_t *buf, uint32_t len)
         return -1;
     }
     f = malloc(tlen);
-    if (f == NULL)
+    if (f == NULL) {
+      tvhinfo(LS_HTSMSG, "malloc is NULL");
       return -1;
+    }
 #if ENABLE_SLOW_MEMORYINFO
     f->hmf_edata_size = tlen - sizeof(htsmsg_field_t);
     memoryinfo_alloc(&htsmsg_field_memoryinfo, tlen);
@@ -409,6 +412,9 @@ htsmsg_binary2_serialize0
     return -1;
 
   data = malloc(len);
+  if (data == NULL) {
+    tvhabort(LS_HTSMSG, "malloc is NULL");
+  }
 
   htsmsg_binary2_write(msg, data);
 
@@ -433,6 +439,9 @@ htsmsg_binary2_serialize
     return -1;
 
   data = malloc(len + llen);
+  if (data == NULL) {
+    tvhabort(LS_HTSMSG, "malloc is NULL");
+  }
 
   p = htsmsg_binary2_set_length(data, len);
   htsmsg_binary2_write(msg, p);

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -416,6 +416,9 @@ htsp_send(htsp_connection_t *htsp, htsmsg_t *m, pktbuf_t *pb,
 	  htsp_msg_q_t *hmq, int payloadsize)
 {
   htsp_msg_t *hm = malloc(sizeof(htsp_msg_t));
+  if (hm == NULL) {
+    tvhabort(LS_HTSP, "malloc is NULL");
+  }
 
   hm->hm_msg = m;
   hm->hm_pb = pb;
@@ -770,6 +773,9 @@ htsp_file_open(htsp_connection_t *htsp, const char *path, int fd, dvr_entry_t *d
   }
 
   htsp_file_t *hf = calloc(1, sizeof(htsp_file_t));
+  if (hf == NULL) {
+    tvhabort(LS_HTSP, "calloc is NULL");
+  }
   hf->hf_fd = fd;
   hf->hf_id = ++htsp->htsp_file_id;
   hf->hf_path = strdup(path);
@@ -2534,6 +2540,9 @@ htsp_method_subscribe(htsp_connection_t *htsp, htsmsg_t *in)
   /* Initialize the HTSP subscription structure */
 
   hs = calloc(1, sizeof(htsp_subscription_t));
+  if (hs == NULL) {
+    tvhabort(LS_HTSP, "calloc is NULL");
+  }
 
   hs->hs_htsp = htsp;
   hs->hs_90khz = req90khz;
@@ -3196,8 +3205,12 @@ htsp_read_message(htsp_connection_t *htsp, htsmsg_t **mp, int timeout)
   len = (data[0] << 24) | (data[1] << 16) | (data[2] << 8) | data[3];
   if(len > 1024 * 1024)
     return EMSGSIZE;
-  if((buf = malloc(len)) == NULL)
+
+  buf = malloc(len);
+  if(buf == NULL) {
+    tvhinfo (LS_HTSP, "malloc is NULL");
     return ENOMEM;
+  }
 
   v = timeout ? tcp_read_timeout(htsp->htsp_fd, buf, len, timeout) : 
                 tcp_read(htsp->htsp_fd, buf, len);

--- a/src/htsstr.c
+++ b/src/htsstr.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "tvh_string.h"
+#include "tvhlog.h"
 
 #define MIN(a,b) ((a) < (b) ? (a) : (b))
 
@@ -28,6 +29,9 @@ char *
 hts_strndup(const char *src, size_t len)
 {
   char *r = malloc(len + 1);
+  if (r == NULL) {
+    tvhabort(LS_HTSSTR, "malloc is NULL");
+  }
   r[len] = 0;
   return memcpy(r, src, len);
 }
@@ -127,6 +131,10 @@ htsstr_argsplit_add
   if (start)
     s = htsstr_unescape(hts_strndup(start, stop - start));
   *argv = realloc(*argv, sizeof((*argv)[0]) * (*argc + 1));
+  // if realloc return NULL, the old pointer is still valid.
+  if (argv == NULL) {
+    tvhabort(LS_HTSSTR, "realloc is NULL");
+  }
   (*argv)[(*argc)++] = s;
 }
 

--- a/src/huffman.c
+++ b/src/huffman.c
@@ -22,6 +22,7 @@
 #include "huffman.h"
 #include "htsmsg.h"
 #include "settings.h"
+#include "tvhlog.h"
 
 void huffman_tree_destroy ( huffman_node_t *n )
 {
@@ -48,6 +49,9 @@ huffman_node_t *huffman_tree_build ( htsmsg_t *m )
   htsmsg_t *e;
   htsmsg_field_t *f;
   huffman_node_t *root = calloc(1, sizeof(huffman_node_t));
+  if (root == NULL) {
+    tvhabort(LS_HUFFMAN, "calloc is NULL");
+  }
   HTSMSG_FOREACH(f, m) {
     e = htsmsg_get_map_by_field(f);
     c = code = htsmsg_get_str(e, "code");
@@ -56,10 +60,20 @@ huffman_node_t *huffman_tree_build ( htsmsg_t *m )
       huffman_node_t *node = root;
       while (*c) {
         if ( *c == '0' ) {
-          if (!node->b0) node->b0 = calloc(1, sizeof(huffman_node_t));
+          if (!node->b0) {
+            node->b0 = calloc(1, sizeof(huffman_node_t));
+            if (node->b0 == NULL) {
+              tvhabort(LS_HUFFMAN, "calloc is NULL");
+            }
+          }
           node = node->b0;
         } else if ( *c == '1' ) {
-          if (!node->b1) node->b1 = calloc(1, sizeof(huffman_node_t));
+          if (!node->b1) {
+            node->b1 = calloc(1, sizeof(huffman_node_t));
+            if (node->b1 == NULL) {
+              tvhabort(LS_HUFFMAN, "calloc is NULL");
+            }
+          }
           node = node->b1;
         } else {
           huffman_tree_destroy(root);

--- a/src/idnode.c
+++ b/src/idnode.c
@@ -674,6 +674,9 @@ idnode_find_all ( const idclass_t *idc, const idnodes_rb_t *domain )
   char ubuf[UUID_HEX_SIZE];
   tvhtrace(LS_IDNODE, "find class %s", idc->ic_class);
   idnode_set_t *is = calloc(1, sizeof(idnode_set_t));
+  if (is == NULL) {
+    tvhabort(LS_IDNODE, "calloc is NULL");
+  }
   if (domain == NULL)
     domain = idnode_domain(idc);
   if (domain == NULL) {
@@ -945,6 +948,9 @@ idnode_filter_add_str
   ( idnode_filter_t *filt, const char *key, const char *val, int comp )
 {
   idnode_filter_ele_t *ele = calloc(1, sizeof(idnode_filter_ele_t));
+  if (ele == NULL) {
+    tvhabort(LS_IDNODE, "calloc is NULL");
+  }
   ele->key  = strdup(key);
   ele->type = IF_STR;
   ele->comp = comp;
@@ -963,6 +969,9 @@ idnode_filter_add_num
   ( idnode_filter_t *filt, const char *key, int64_t val, int comp, int64_t intsplit )
 {
   idnode_filter_ele_t *ele = calloc(1, sizeof(idnode_filter_ele_t));
+  if (ele == NULL) {
+    tvhabort(LS_IDNODE, "calloc is NULL");
+  }
   ele->key  = strdup(key);
   ele->type = IF_NUM;
   ele->comp = comp;
@@ -976,6 +985,9 @@ idnode_filter_add_dbl
   ( idnode_filter_t *filt, const char *key, double dbl, int comp )
 {
   idnode_filter_ele_t *ele = calloc(1, sizeof(idnode_filter_ele_t));
+  if (ele == NULL) {
+    tvhabort(LS_IDNODE, "calloc is NULL");
+  }
   ele->key   = strdup(key);
   ele->type  = IF_DBL;
   ele->comp  = comp;
@@ -988,6 +1000,9 @@ idnode_filter_add_bool
   ( idnode_filter_t *filt, const char *key, int val, int comp )
 {
   idnode_filter_ele_t *ele = calloc(1, sizeof(idnode_filter_ele_t));
+  if (ele == NULL) {
+    tvhabort(LS_IDNODE, "calloc is NULL");
+  }
   ele->key  = strdup(key);
   ele->type = IF_BOOL;
   ele->comp = comp;
@@ -1020,6 +1035,10 @@ idnode_set_alloc
   if (is->is_alloc < alloc) {
     is->is_alloc = alloc;
     is->is_array = realloc(is->is_array, alloc * sizeof(idnode_t*));
+    // if return value of realloc is NULL then the old pointer is still valid
+    if (is->is_array == NULL) {
+      tvhabort(LS_IDNODE, "realloc is NULL");
+    }
   }
 }
 
@@ -1194,6 +1213,9 @@ idnode_save_queue ( idnode_t *self )
   if (self->in_save)
     return;
   ise = malloc(sizeof(*ise));
+  if (ise == NULL) {
+    tvhabort(LS_IDNODE, "malloc is NULL");
+  }
   ise->ise_node = self;
   ise->ise_reqtime = mclk();
   if (TAILQ_EMPTY(&idnodes_save) && atomic_get(&save_running))
@@ -1458,6 +1480,9 @@ idclass_find_all(void)
   if (count == 0)
     return NULL;
   ret = calloc(count + 1, sizeof(idclass_t *));
+  if (ret == NULL) {
+    tvhabort(LS_IDNODE, "calloc is NULL");
+  }
   RB_FOREACH(l, &idclasses, link)
     ret[i++] = l->idc;
   ret[i] = NULL;
@@ -1484,12 +1509,21 @@ idclass_find_children(const char *clazz)
       if (i <= count) {
         count += 50;
         ret = realloc(ret, count * sizeof(const idclass_t *));
+        // if realloc return NULL then the old pointer is still valid
+        if (ret == NULL) {
+          tvhabort(LS_IDNODE, "realloc is NULL");
+        }
       }
       ret[i++] = ic;
     }
   }
-  if (i <= count)
+  if (i <= count) {
     ret = realloc(ret, (count + 1) * sizeof(const idclass_t *));
+    // if realloc return NULL then the old pointer is still valid
+    if (ret == NULL) {
+      tvhabort(LS_IDNODE, "realloc is NULL");
+    }
+  }
   ret[i] = NULL;
   return ret;
 }
@@ -1684,6 +1718,9 @@ idnode_list_link ( idnode_t *in1, idnode_list_head_t *in1_list,
 
   /* Link */
   ilm = calloc(1, sizeof(idnode_list_mapping_t));
+  if (ilm == NULL) {
+    tvhabort(LS_IDNODE, "calloc is NULL");
+  }
   ilm->ilm_in1 = in1;
   ilm->ilm_in2 = in2;
   LIST_INSERT_HEAD(in1_list, ilm, ilm_in1_link);

--- a/src/imagecache.c
+++ b/src/imagecache.c
@@ -502,6 +502,9 @@ imagecache_init ( void )
       if (!(id  = atoi(htsmsg_field_name(f)))) continue;
       if (!(url = htsmsg_get_str(e, "url"))) continue;
       img           = calloc(1, sizeof(imagecache_image_t));
+      if (img == NULL) {
+        tvhabort(LS_IMAGECACHE, "calloc is NULL");
+      }
       img->id       = id;
       img->ref      = 1;
       img->url      = strdup(url);

--- a/src/input/mpegts/dvb_charset.c
+++ b/src/input/mpegts/dvb_charset.c
@@ -60,6 +60,8 @@ static void _charset_load_file()
           enc->charset = strdup(charset);
           LIST_INSERT_HEAD(&dvb_charset_list, enc, link);
           i++;
+        } else {
+          tvhinfo(LS_CHARSET, "calloc is NULL");
         }
       }
     };

--- a/src/input/mpegts/dvb_psi.c
+++ b/src/input/mpegts/dvb_psi.c
@@ -229,8 +229,12 @@ dvb_fs_mux_add ( mpegts_table_t *mt, mpegts_mux_t *mm, mpegts_mux_t *mux )
   int i;
 
   uuid = idnode_uuid_as_str(&mux->mm_id, ubuf);
-  if (mm->mm_fastscan_muxes == NULL)
+  if (mm->mm_fastscan_muxes == NULL) {
     mm->mm_fastscan_muxes = calloc(DVB_FASTSCAN_MUXES, UUID_HEX_SIZE);
+    if (mm->mm_fastscan_muxes == NULL) {
+        tvhabort(LS_DVB, "calloc is NULL");
+    }
+  }
   for (i = 0; i < DVB_FASTSCAN_MUXES * UUID_HEX_SIZE; i += UUID_HEX_SIZE) {
     s = mm->mm_fastscan_muxes + i;
     if (s[0] == '\0')
@@ -553,6 +557,9 @@ dvb_bat_find_service( dvb_bat_id_t *bi, mpegts_service_t *s,
       break;
   if (!bs) {
     bs = calloc(1, sizeof(*bs));
+    if (bs == NULL) {
+        tvhabort(LS_DVB, "calloc is NULL");
+    }
     bs->svc = s;
     service_ref((service_t *)s);
     TAILQ_INSERT_TAIL(&bi->services, bs, link);
@@ -661,6 +668,9 @@ dvb_freesat_local_channels
           break;
       if (!fs) {
         fs = calloc(1, sizeof(*fs));
+        if (fs == NULL) {
+            tvhabort(LS_DVB, "calloc is NULL");
+        }
         fs->sid = sid;
         fs->regionid = regionid;
         fs->lcn = lcn;
@@ -698,6 +708,9 @@ dvb_freesat_regions
         break;
     if (!fr) {
       fr = calloc(1, sizeof(*fr));
+      if (fr == NULL) {
+          tvhabort(LS_DVB, "calloc is NULL");
+      }
       fr->regionid = id;
       strlcpy(fr->name, name, sizeof(fr->name));
       TAILQ_INIT(&fr->services);
@@ -925,6 +938,9 @@ dvb_bskyb_local_channels
         break;
     if (!fs) {
       fs = calloc(1, sizeof(*fs));
+      if (fs == NULL) {
+          tvhabort(LS_DVB, "calloc is NULL");
+      }
       fs->sid = sid;
       fs->regionid = regionid;
       fs->lcn = lcn != 0xffff ? lcn : 0;
@@ -938,6 +954,9 @@ dvb_bskyb_local_channels
       s = mpegts_service_find(mm, sid, 0, 0, NULL);
       if (s) {
         bs = calloc(1, sizeof(*bs));
+        if (bs == NULL) {
+          tvhabort(LS_DVB, "calloc is NULL");
+        }
         bs->svc = s;
         service_ref((service_t *)s);
         TAILQ_INSERT_TAIL(&bi->services, bs, link);
@@ -950,6 +969,9 @@ dvb_bskyb_local_channels
           break;
       if (!fr) {
         fr = calloc(1, sizeof(*fr));
+        if (fr == NULL) {
+          tvhabort(LS_DVB, "calloc is NULL");
+        }
         fr->regionid = regionid;
         /* Note: Poland provider on 13E uses also this bouquet format */
         if (bi->nbid < 0x1000 || bi->nbid > 0x1010 ||
@@ -1472,6 +1494,9 @@ dvb_nit_callback
       (tableid == 0x4A || tableid == DVB_FASTSCAN_NIT_BASE)) {
     if ((b = mt->mt_bat) == NULL) {
       b = calloc(1, sizeof(*b));
+      if (b == NULL) {
+          tvhabort(LS_DVB, "calloc is NULL");
+      }
       mt->mt_bat = b;
     }
     LIST_FOREACH(bi, &b->bats, link)
@@ -1479,6 +1504,9 @@ dvb_nit_callback
         break;
     if (!bi) {
       bi = calloc(1, sizeof(*bi));
+      if (bi == NULL) {
+          tvhabort(LS_DVB, "calloc is NULL");
+      }
       bi->nbid = nbid;
       TAILQ_INIT(&bi->services);
       TAILQ_INIT(&bi->fservices);

--- a/src/input/mpegts/dvb_psi_hbbtv.c
+++ b/src/input/mpegts/dvb_psi_hbbtv.c
@@ -139,6 +139,9 @@ dvb_psi_parse_hbbtv
       htsmsg_add_msg(map, "title", titles);
       titles = NULL;
       str = malloc(strlen(name) + strlen(location) + 1);
+      if (str == NULL) {
+          tvhabort(LS_DVB, "malloc is NULL");
+      }
       strcpy(str, name);
       strcat(str, location);
       htsmsg_add_str(map, "url", str);

--- a/src/intlconv.c
+++ b/src/intlconv.c
@@ -142,6 +142,7 @@ intlconv_utf8( char *dst, size_t dst_size,
     }
     ic = malloc(sizeof(*ic));
     if (ic == NULL) {
+      tvhinfo(LS_INTLCONV, "malloc is NULL");
       tvh_mutex_unlock(&intlconv_lock);
       iconv_close(c);
       return -ENOMEM;
@@ -176,14 +177,14 @@ intlconv_utf8safestr( const char *dst_charset_id,
                       const char *src_utf8,
                       size_t max_size )
 {
-  char *str, *res;
+  char *res;
   ssize_t r;
   size_t i;
 
   if (max_size == 0 || *src_utf8 == '\0')
     return strdup("");
 
-  str = alloca(max_size);
+  char str[max_size];
   r = intlconv_utf8(str, max_size, dst_charset_id, src_utf8);
   if (r <= 0)
     return NULL;
@@ -230,6 +231,7 @@ intlconv_to_utf8( char *dst, size_t dst_size,
     }
     ic = malloc(sizeof(*ic));
     if (ic == NULL) {
+      tvhinfo(LS_INTLCONV, "malloc is NULL");
       tvh_mutex_unlock(&intlconv_lock_src);
       iconv_close(c);
       return -ENOMEM;
@@ -264,13 +266,12 @@ intlconv_to_utf8safestr( const char *src_charset_id,
                          const char *src_str,
                          size_t max_size )
 {
-  char *str;
   ssize_t r;
 
   if (max_size == 0 || *src_str == '\0')
     return strdup("");
 
-  str = alloca(max_size);
+  char str[max_size];
   r = intlconv_to_utf8(str, max_size, src_charset_id, src_str, strlen(src_str));
   if (r <= 0)
     return NULL;

--- a/src/lang_codes.c
+++ b/src/lang_codes.c
@@ -532,6 +532,9 @@ static int _lang_code_lookup_add
 {
   lang_code_lookup_element_t *element;
   element = (lang_code_lookup_element_t *)calloc(1, sizeof(lang_code_lookup_element_t));
+  if (element == NULL) {
+    tvhabort(LS_LANG, "calloc is NULL");
+  }
   element->lang_code = code;
   RB_INSERT_SORTED(lookup_table, element, link, func);
   return 0;
@@ -546,8 +549,17 @@ static const lang_code_t *_lang_code_get ( const char *code, size_t len )
     const lang_code_t *c = lang_codes;
 
     lang_codes_code2b = (lang_code_lookup_t *)calloc(1, sizeof(lang_code_lookup_t));
+    if (lang_codes_code2b == NULL) {
+      tvhabort(LS_LANG, "calloc is NULL");
+    }
     lang_codes_code1 = (lang_code_lookup_t *)calloc(1, sizeof(lang_code_lookup_t));
+    if (lang_codes_code1 == NULL) {
+      tvhabort(LS_LANG, "calloc is NULL");
+    }
     lang_codes_code2t = (lang_code_lookup_t *)calloc(1, sizeof(lang_code_lookup_t));
+    if (lang_codes_code2t == NULL) {
+      tvhabort(LS_LANG, "calloc is NULL");
+    }
 
     while (c->code2b) {
       _lang_code_lookup_add(lang_codes_code2b, c, _lang_code2b_cmp);
@@ -660,6 +672,8 @@ const lang_code_list_t *lang_code_split ( const char *codes )
     ret->codeslen = n;
     ret->langs = strdup(codes);
     RB_INSERT_SORTED(&lang_code_split_tree, ret, link, _split_cmp);
+  } else {
+    tvhinfo(LS_LANG, "calloc is NULL");
   }
 
 unlock:
@@ -703,6 +717,9 @@ char *lang_code_user( const char *ucode )
   if (!ucode)
     return strdup(codes);
   ret = malloc(strlen(codes) + strlen(ucode) + 2);
+  if (ret == NULL) {
+    tvhabort(LS_LANG, "malloc is NULL");
+  }
   strcpy(ret, ucode);
   while (codes && *codes) {
     s = codes;

--- a/src/lang_str.c
+++ b/src/lang_str.c
@@ -53,8 +53,11 @@ lang_str_t *lang_str_create ( void )
 lang_str_t *lang_str_create2 ( const char *s, const char *lang )
 {
   lang_str_t *ls = lang_str_create();
-  if (ls)
+  if (ls) {
     lang_str_add(ls, s, lang);
+  } else {
+    tvhinfo(LS_LANG, "lang_str_create is NULL");
+  }
   return ls;
 }
 
@@ -76,9 +79,14 @@ lang_str_t *lang_str_copy ( const lang_str_t *ls )
 {
   lang_str_t *ret;
   lang_str_ele_t *e;
-  if (ls == NULL)
+  if (ls == NULL) {
+    tvhwarn(LS_LANG, "Parameter for lang_str_copy is NULL");
     return NULL;
+  }
   ret = lang_str_create();
+  if (ret == NULL) {
+      tvhabort(LS_LANG, "lang_str_create is NULL");
+  }
   RB_FOREACH(e, ls, link)
     lang_str_add(ret, e->str, e->lang);
   return ret;
@@ -140,6 +148,9 @@ static int _lang_str_add
   /* Create */
   if (!e) {
     e = malloc(sizeof(*e) + strlen(str) + 1);
+    if (e == NULL) {
+      tvhabort(LS_LANG, "malloc is NULL");
+    }
     strlcpy(e->lang, lang, sizeof(e->lang));
     strcpy(e->str, str);
     RB_INSERT_SORTED(ls, e, link, _lang_cmp);
@@ -153,6 +164,7 @@ static int _lang_str_add
       strcat(ae->str, str);
       save = 1;
     } else {
+      tvhinfo(LS_LANG, "realloc is NULL");
       ae = e;
     }
     RB_INSERT_SORTED(ls, ae, link, _lang_cmp);
@@ -169,6 +181,7 @@ static int _lang_str_add
         strcpy(ae->str, str);
         save = 1;
       } else {
+        tvhinfo(LS_LANG, "realloc is NULL");
         ae = e;
       }
       RB_INSERT_SORTED(ls, ae, link, _lang_cmp);
@@ -218,6 +231,9 @@ change:
   lang_str_destroy(*dst);
 change1:
   *dst = lang_str_create();
+  if (dst == NULL) {
+    tvhabort(LS_LANG, "lang_str_create ist NULL");
+  }
   lang_str_add(*dst, str, lang);
   return 1;
 }
@@ -275,6 +291,8 @@ void lang_str_serialize_one
     lang_str_add(l, str, lang);
     lang_str_serialize(l, m, f);
     lang_str_destroy(l);
+  } else {
+    tvhabort(LS_LANG, "lang_str_create is NULL");
   }
 }
 
@@ -291,6 +309,8 @@ lang_str_t *lang_str_deserialize_map ( htsmsg_t *map )
         lang_str_add(ret, str, htsmsg_field_name(f));
       }
     }
+  } else {
+    tvhinfo(LS_LANG, "lang_str_create is NULL");
   }
   return ret;
 }
@@ -305,6 +325,9 @@ lang_str_t *lang_str_deserialize ( htsmsg_t *m, const char *n )
     return lang_str_deserialize_map(a);
   } else if ((str = htsmsg_get_str(m, n))) {
     lang_str_t *ret = lang_str_create();
+    if (ret == NULL) {
+      tvhabort(LS_LANG, "lang_str_create is NULL");
+    }
     lang_str_add(ret, str, NULL);
     return ret;
   }

--- a/src/libav.c
+++ b/src/libav.c
@@ -12,7 +12,6 @@ libav_log_callback(void *ptr, int level, const char *fmt, va_list vl)
 {
   int severity = LOG_TVH_NOTIFY, l1, l2;
   const char *class_name;
-  char *fmt1;
 
   if (level != AV_LOG_QUIET &&
       ((level <= AV_LOG_INFO) || (tvhlog_options & TVHLOG_OPT_LIBAV))) {
@@ -24,7 +23,7 @@ libav_log_callback(void *ptr, int level, const char *fmt, va_list vl)
 
     l1 = strlen(fmt);
     l2 = strlen(class_name);
-    fmt1 = alloca(l1 + l2 + 3);
+    char fmt1[l1 + l2 + 3];
 
     strcpy(fmt1, class_name);
     if (class_name[0])

--- a/src/main.c
+++ b/src/main.c
@@ -438,6 +438,8 @@ tasklet_arm_alloc(tsk_callback_t *callback, void *opaque)
     memoryinfo_alloc(&tasklet_memoryinfo, sizeof(*tsk));
     tsk->tsk_free = free;
     tasklet_arm(tsk, callback, opaque);
+  } else {
+    tvhinfo(LS_MAIN, "calloc is NULL");
   }
   return tsk;
 }
@@ -1060,6 +1062,9 @@ main(int argc, char **argv)
       tmp = strdup(tvheadend_webroot);
     else {
       tmp = malloc(strlen(tvheadend_webroot)+2);
+      if (tmp == NULL) {
+        tvhabort(LS_MAIN, "malloc is NULL");
+      }
       *tmp = '/';
       strcpy(tmp+1, tvheadend_webroot);
     }

--- a/src/misc/json.c
+++ b/src/misc/json.c
@@ -74,6 +74,9 @@ json_parse_string(const char *s, const char **endp,
       /* End */
       l = s - start;
       r = malloc(l + 1);
+      if (r == NULL) {
+          tvhabort(LS_JSON, "malloc is NULL");
+      }
       memcpy(r, start, l);
       r[l] = 0;
 

--- a/src/muxer.c
+++ b/src/muxer.c
@@ -294,6 +294,9 @@ muxer_hints_t *
 muxer_hints_create(const char *agent)
 {
   muxer_hints_t *hints = calloc(1, sizeof(*hints));
+  if (hints == NULL) {
+    tvhabort(LS_MUXER, "calloc is NULL");
+  }
   mystrset(&hints->mh_agent, agent);
   return hints;
 }

--- a/src/muxer/ebml.c
+++ b/src/muxer/ebml.c
@@ -147,7 +147,7 @@ ebml_append_pad(htsbuf_queue_t *q, size_t pad)
   assert(pad < 0x3fff);
   pad -= pad > 0x7e;
 
-  void *data = alloca(pad);
+  void *data[pad];
   memset(data, 0, pad);
   ebml_append_bin(q, 0xec, data, pad);
 }

--- a/src/muxer/muxer_audioes.c
+++ b/src/muxer/muxer_audioes.c
@@ -306,6 +306,9 @@ audioes_muxer_create(const muxer_config_t *m_cfg,
     return NULL;
 
   am = calloc(1, sizeof(audioes_muxer_t));
+  if (am == NULL) {
+      tvhabort(LS_AUDIOES, "calloc is NULL");
+  }
   am->m_open_stream  = audioes_muxer_open_stream;
   am->m_open_file    = audioes_muxer_open_file;
   am->m_mime         = audioes_muxer_mime;

--- a/src/muxer/muxer_libav.c
+++ b/src/muxer/muxer_libav.c
@@ -653,6 +653,9 @@ lav_muxer_create(const muxer_config_t *m_cfg,
   }
 
   lm = calloc(1, sizeof(lav_muxer_t));
+  if (lm == NULL) {
+      tvhabort(LS_LIBAV, "calloc is NULL");
+  }
   lm->m_open_stream  = lav_muxer_open_stream;
   lm->m_open_file    = lav_muxer_open_file;
   lm->m_init         = lav_muxer_init;

--- a/src/muxer/muxer_mkv.c
+++ b/src/muxer/muxer_mkv.c
@@ -262,6 +262,9 @@ mk_build_tracks(mk_muxer_t *mk, streaming_start_t *ss)
   mk_track_t *tr;
 
   mk->tracks = calloc(1, sizeof(mk_track_t) * ss->ss_num_components);
+  if (mk->tracks == NULL) {
+      tvhabort(LS_MKV, "calloc is NULL");
+  }
   mk->ntracks = ss->ss_num_components;
   mk->cluster_maxsize = 4000000;
   for(i = 0; i < ss->ss_num_components; i++) {
@@ -939,6 +942,9 @@ static void
 addcue(mk_muxer_t *mk, int64_t pts, int tracknum)
 {
   mk_cue_t *mc = malloc(sizeof(mk_cue_t));
+  if (mc == NULL) {
+      tvhabort(LS_MKV, "malloc is NULL");
+  }
   mc->ts = pts;
   mc->tracknum = tracknum;
   mc->cluster_pos = mk->cluster_pos;
@@ -955,7 +961,9 @@ mk_add_chapter0(mk_muxer_t *mk, uint32_t uuid, int64_t ts)
   mk_chapter_t *ch;
 
   ch = malloc(sizeof(mk_chapter_t));
-
+  if (ch == NULL) {
+      tvhabort(LS_MKV, "malloc is NULL");
+  }
   ch->uuid = uuid;
   ch->ts = ts;
 
@@ -1547,6 +1555,9 @@ mkv_muxer_create(const muxer_config_t *m_cfg,
     return NULL;
 
   mk = calloc(1, sizeof(mk_muxer_t));
+  if (mk == NULL) {
+      tvhabort(LS_MKV, "calloc is NULL");
+  }
   mk->m_open_stream  = mkv_muxer_open_stream;
   mk->m_open_file    = mkv_muxer_open_file;
   mk->m_mime         = mkv_muxer_mime;

--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -353,6 +353,9 @@ pass_muxer_eit_cb(mpegts_psi_table_t *mt, const uint8_t *buf, int len)
   /* TODO: set free_CA_mode bit to zero */
 
   sbuf = malloc(len + 4);
+  if (sbuf == NULL) {
+      tvhabort(LS_PASS, "malloc is NULL");
+  }
   memcpy(sbuf, buf, len);
   sbuf[3] = pm->pm_dst_sid >> 8;
   sbuf[4] = pm->pm_dst_sid;
@@ -780,6 +783,9 @@ pass_muxer_create(const muxer_config_t *m_cfg,
     return NULL;
 
   pm = calloc(1, sizeof(pass_muxer_t));
+  if (pm == NULL) {
+      tvhabort(LS_PASS, "calloc is NULL");
+  }
   pm->m_open_stream  = pass_muxer_open_stream;
   pm->m_open_file    = pass_muxer_open_file;
   pm->m_init         = pass_muxer_init;

--- a/src/parsers/message.c
+++ b/src/parsers/message.c
@@ -375,6 +375,9 @@ parser_create(streaming_target_t *output, th_subscription_t *ts)
   parser_t *prs = calloc(1, sizeof(parser_t));
   service_t *t = ts->ths_service;
 
+  if (prs == NULL) {
+      tvhabort(LS_PARSER, "calloc is NULL");
+  }
   prs->prs_output = output;
   prs->prs_subscription = ts;
   prs->prs_service = t;

--- a/src/parsers/parser_avc.c
+++ b/src/parsers/parser_avc.c
@@ -136,6 +136,10 @@ isom_write_avcc(sbuf_t *sb, const uint8_t *data, int len)
 
     if ((nal_type == H264_NAL_SPS) && (size >= 4) && (size <= UINT16_MAX)) {
       sps_array = realloc(sps_array,sizeof(uint8_t*)*(sps_count+1));
+      // if realloc return NULL then the old pointer is still valid
+      if (sps_array == NULL) {
+          tvhabort(LS_AVC, "realloc is NULL");
+      }
       sps_size_array = realloc(sps_size_array,sizeof(uint32_t)*(sps_count+1));
       sps_array[sps_count] = buf;
       sps_size_array[sps_count] = size;

--- a/src/parsers/parser_h264.c
+++ b/src/parsers/parser_h264.c
@@ -48,6 +48,9 @@ h264_nal_deescape(bitstream_t *bs, const uint8_t *data, int size)
   const uint8_t *end, *end2;
 
   bs->rdata = d = malloc(size);
+  if (d == NULL) {
+      tvhabort(LS_H264, "malloc is NULL");
+  }
   bs->offset = 0;
 
   end2 = data + size;
@@ -232,6 +235,9 @@ h264_decode_seq_parameter_set(parser_es_t *st, bitstream_t *bs)
 
   if ((p = st->es_priv) == NULL) {
     p = st->es_priv = calloc(1, sizeof(h264_private_t));
+    if (p == NULL) {
+        tvhabort(LS_H264, "calloc is NULL");
+    }
     p->start = mclk();
   }
 
@@ -348,6 +354,9 @@ h264_decode_pic_parameter_set(parser_es_t *st, bitstream_t *bs)
 
   if((p = st->es_priv) == NULL) {
     p = st->es_priv = calloc(1, sizeof(h264_private_t));
+    if (p == NULL) {
+        tvhabort(LS_H264, "calloc is NULL");
+    }
     p->start = mclk();
   }
   

--- a/src/parsers/parser_hevc.c
+++ b/src/parsers/parser_hevc.c
@@ -689,8 +689,10 @@ static uint8_t *nal_unit_extract_rbsp(const uint8_t *src, uint32_t src_len,
     uint32_t i, len;
 
     dst = malloc(src_len);
-    if (!dst)
+    if (dst==NULL){
+        tvhinfo(LS_HEVC, "malloc is NULL");
         return NULL;
+    }
 
     /* NAL unit header (2 bytes) */
     i = len = 0;
@@ -744,8 +746,10 @@ static int hvcc_array_add_nal_unit(uint8_t *nal_buf, uint32_t nal_size,
         uint8_t i;
 
         n = realloc(hvcc->array, (index + 1) * sizeof(HVCCNALUnitArray));
-        if (n == NULL)
+        if (n == NULL) {
+            tvhinfo(LS_HEVC, "realloc is NULL");
             return -1;
+        }
         hvcc->array = n;
 
         for (i = hvcc->numOfArrays; i <= index; i++)
@@ -757,13 +761,17 @@ static int hvcc_array_add_nal_unit(uint8_t *nal_buf, uint32_t nal_size,
     numNalus = array->numNalus;
 
     n = realloc(array->nalUnit, (numNalus + 1) * sizeof(uint8_t*));
-    if (n == NULL)
+    if (n == NULL) {
+        tvhinfo(LS_HEVC, "realloc is NULL");
         return -1;
+    }
     array->nalUnit = n;
 
     n = realloc(array->nalUnitLength, (numNalus + 1) * sizeof(uint16_t));
-    if (n == NULL)
+    if (n == NULL) {
+        tvhinfo(LS_HEVC, "realloc is NULL");
         return -1;
+    }
     array->nalUnitLength = n;
 
     array->nalUnit      [numNalus] = nal_buf;
@@ -1297,8 +1305,12 @@ hevc_decode_vps(parser_es_t *st, bitstream_t *bs)
   if (read_bits1(bs)) /* zero bit */
     return -1;
 
-  if((p = st->es_priv) == NULL)
+  if((p = st->es_priv) == NULL) {
     p = st->es_priv = calloc(1, sizeof(hevc_private_t));
+    if (p == NULL) {
+        tvhabort(LS_HEVC, "calloc is NULL");
+    }
+  }
 
   skip_bits(bs, 15);  /* NAL type, Layer ID, Temporal ID */
 
@@ -1436,8 +1448,12 @@ hevc_decode_sps(parser_es_t *st, bitstream_t *bs)
   if (read_bits1(bs)) /* zero bit */
     return -1;
 
-  if((p = st->es_priv) == NULL)
+  if((p = st->es_priv) == NULL) {
     p = st->es_priv = calloc(1, sizeof(hevc_private_t));
+    if (p == NULL) {
+        tvhabort(LS_HEVC, "calloc is NULL");
+    }
+  }
 
   skip_bits(bs, 15);  /* NAL type, Layer ID, Temporal ID */
 
@@ -1608,8 +1624,12 @@ hevc_decode_pps(parser_es_t *st, bitstream_t *bs)
   if (read_bits1(bs)) /* zero bit */
     return -1;
 
-  if((p = st->es_priv) == NULL)
+  if((p = st->es_priv) == NULL) {
     p = st->es_priv = calloc(1, sizeof(hevc_private_t));
+    if (p == NULL) {
+        tvhabort(LS_HEVC, "calloc is NULL");
+    }
+  }
 
   skip_bits(bs, 15);  /* NAL type, Layer ID, Temporal ID */
 
@@ -1646,8 +1666,12 @@ hevc_decode_slice_header(parser_es_t *st, bitstream_t *bs, int *pkttype)
   if (read_bits1(bs)) /* zero bit */
     return -1;
 
-  if((p = st->es_priv) == NULL)
+  if((p = st->es_priv) == NULL) {
       p = st->es_priv = calloc(1, sizeof(hevc_private_t));
+      if (p == NULL) {
+          tvhabort(LS_HEVC, "calloc is NULL");
+      }
+  }
 
   nal_type = read_bits(bs, 6);
   skip_bits(bs, 6);   /* Layer ID */

--- a/src/parsers/parser_latm.c
+++ b/src/parsers/parser_latm.c
@@ -234,8 +234,12 @@ parse_latm_audio_mux_element(parser_t *t, parser_es_t *st,
 
   init_rbits(&bs, data, len * 8);
 
-  if((latm = st->es_priv) == NULL)
+  if((latm = st->es_priv) == NULL) {
     latm = st->es_priv = calloc(1, sizeof(latm_private_t));
+    if (latm == NULL) {
+        tvhabort(LS_LATM, "calloc is NULL");
+    }
+  }
 
   if(!read_bits1(&bs))
     if (read_stream_mux_config(st, latm, &bs) < 0)

--- a/src/parsers/parser_teletext.c
+++ b/src/parsers/parser_teletext.c
@@ -1,6 +1,6 @@
 /*
  *  Teletext parsing functions
- *  Copyright (C) 2007 Andreas Öman
+ *  Copyright (C) 2007 Andreas Ã–man
  *  Copyright (C) 2014 Jaroslav Kysela
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -124,16 +124,16 @@ static const uint8_t hamtable[] = {
 #define SUBSET_CZECH_SLOVAK    1  /* Cesky / Slovencina */
 #define SUBSET_ENGLISH         2  /* English */
 #define SUBSET_ESTONIAN        3  /* Eesti */
-#define SUBSET_FRENCH          4  /* Français */
+#define SUBSET_FRENCH          4  /* FranÃ§ais */
 #define SUBSET_GERMAN          5  /* German / Deutch */
 #define SUBSET_ITALIAN         6  /* Italiano */
 #define SUBSET_LETT_LITH       7  /* Lettish / Lietuviskai */
 #define SUBSET_POLISH          8  /* Polski */
-#define SUBSET_PORTUG_SPANISH  9  /* Português / Español */
-#define SUBSET_RUMANIAN        10 /* Româna */
+#define SUBSET_PORTUG_SPANISH  9  /* PortuguÃªs / EspaÃ±ol */
+#define SUBSET_RUMANIAN        10 /* RomÃ¢na */
 #define SUBSET_SERB_CRO_SLO    11 /* Srpski / Hrvatski / Slovenscina */
 #define SUBSET_SWE_FIN_HUN     12 /* Svenska / Suomi / Magyar */
-#define SUBSET_TURKISH         13 /* Türkçe */
+#define SUBSET_TURKISH         13 /* TÃ¼rkÃ§e */
 #define SUBSET_LAST            SUBSET_TURKISH
 
 #define SUBSET_CHARMAP_COUNT   13
@@ -869,6 +869,9 @@ tt_decode_line(parser_t *t, parser_es_t *st, uint8_t *buf)
   if(st->es_priv == NULL) {
     /* Allocate privdata for reassembly */
     ttp = st->es_priv = calloc(1, sizeof(tt_private_t));
+    if (ttp == NULL) {
+        tvhabort(LS_PARSER, "calloc is NULL");
+    }
   } else {
     ttp = st->es_priv;
   }

--- a/src/parsers/parsers.c
+++ b/src/parsers/parsers.c
@@ -1212,6 +1212,10 @@ parser_global_data_move(parser_es_t *st, const uint8_t *data, size_t len, int re
     int len2 = drop_trailing_zeroes(data, len);
     st->es_global_data = realloc(st->es_global_data,
                                  st->es_global_data_len + len2);
+    // if realloc return NULL then the old pointer is still valid
+    if (st->es_global_data == NULL) {
+        tvhabort(LS_PARSER, "realloc is NULL");
+    }
     memcpy(st->es_global_data + st->es_global_data_len, data, len2);
     st->es_global_data_len += len2;
   }
@@ -1285,8 +1289,12 @@ parse_mpeg2video(parser_t *t, parser_es_t *st, size_t len,
       if(parse_mpeg2video_seq_start(t, st, &bs) != PARSER_APPEND)
         return PARSER_RESET;
       parser_global_data_move(st, buf, len, 0);
-      if (!st->es_priv)
+      if (!st->es_priv) {
         st->es_priv = malloc(1); /* starting mark */
+        if (st->es_priv == NULL) {
+            tvhabort(LS_PARSER, "malloc is NULL");
+        }
+      }
     }
     return PARSER_DROP;
 

--- a/src/plumbing/globalheaders.c
+++ b/src/plumbing/globalheaders.c
@@ -438,6 +438,9 @@ streaming_target_t *
 globalheaders_create(streaming_target_t *output)
 {
   globalheaders_t *gh = calloc(1, sizeof(globalheaders_t));
+  if (gh == NULL) {
+      tvhabort(LS_GLOBALHEADERS, "calloc is NULL");
+  }
 
   TAILQ_INIT(&gh->gh_holdq);
 

--- a/src/plumbing/tsfix.c
+++ b/src/plumbing/tsfix.c
@@ -132,6 +132,10 @@ tsfix_add_stream(tsfix_t *tf, int index, streaming_component_type_t type)
 {
   tfstream_t *tfs = calloc(1, sizeof(tfstream_t));
 
+  if (tfs == NULL) {
+      tvhabort(LS_TSFIX, "calloc is NULL");
+  }
+
   tfs->tfs_type = type;
   if (SCT_ISVIDEO(type))
     tfs->tfs_video = 1;
@@ -702,6 +706,10 @@ streaming_target_t *
 tsfix_create(streaming_target_t *output)
 {
   tsfix_t *tf = calloc(1, sizeof(tsfix_t));
+
+  if (tf == NULL) {
+      tvhabort(LS_TSFIX, "calloc is NULL");
+  } 
 
   TAILQ_INIT(&tf->tf_ptsq);
 

--- a/src/profile.c
+++ b/src/profile.c
@@ -50,7 +50,13 @@ static profile_t *profile_default;
 void
 profile_register(const idclass_t *clazz, profile_builder_t builder)
 {
-  profile_build_t *pb = calloc(1, sizeof(*pb)), *pb2;
+  profile_build_t *pb = calloc(1, sizeof(*pb));
+  profile_build_t *pb2;
+
+  if (pb == NULL) {
+    tvhabort(LS_PROFILE, "calloc is NULL");
+  }
+
   idclass_register(clazz);
   pb->clazz = clazz;
   pb->build = builder;
@@ -726,6 +732,9 @@ profile_input_queue(void *opaque, streaming_message_t *sm)
   profile_chain_t *prch = opaque;
   profile_sharer_t *prsh = prch->prch_sharer;
   profile_sharer_message_t *psm = malloc(sizeof(*psm));
+  if (psm == NULL) {
+    tvhabort(LS_PROFILE, "malloc is NULL");
+  }
   psm->psm_prch = prch;
   psm->psm_sm = sm;
   tvh_mutex_lock(&prsh->prsh_queue_mutex);
@@ -865,6 +874,9 @@ profile_sharer_find(profile_chain_t *prch)
   }
   if (!prsh) {
     prsh = calloc(1, sizeof(*prsh));
+    if (prsh == NULL) {
+      tvhabort(LS_PROFILE, "calloc is NULL");
+    }
     prsh->prsh_do_queue = do_queue;
     tvh_mutex_init(&prsh->prsh_queue_mutex, NULL);
     tvh_cond_init(&prsh->prsh_queue_cond, 1);
@@ -1257,6 +1269,9 @@ static profile_t *
 profile_htsp_builder(void)
 {
   profile_t *pro = calloc(1, sizeof(*pro));
+  if (pro == NULL) {
+    tvhabort(LS_PROFILE, "calloc is NULL");
+  }
   pro->pro_sflags = SUBSCRIPTION_PACKET;
   pro->pro_work   = profile_htsp_work;
   return pro;
@@ -1491,6 +1506,9 @@ static profile_t *
 profile_mpegts_pass_builder(void)
 {
   profile_mpegts_t *pro = calloc(1, sizeof(*pro));
+  if (pro == NULL) {
+    tvhabort(LS_PROFILE, "calloc is NULL");
+  }
   pro->pro_sflags = SUBSCRIPTION_MPEGTS;
   pro->pro_reopen = profile_mpegts_pass_reopen;
   pro->pro_open   = profile_mpegts_pass_open;
@@ -1794,6 +1812,9 @@ static profile_t *
 profile_mpegts_spawn_builder(void)
 {
   profile_mpegts_spawn_t *pro = calloc(1, sizeof(*pro));
+  if (pro == NULL) {
+    tvhabort(LS_PROFILE, "calloc is NULL");
+  }
   pro->pro_sflags = SUBSCRIPTION_MPEGTS;
   pro->pro_free   = profile_mpegts_spawn_free;
   pro->pro_reopen = profile_mpegts_spawn_reopen;
@@ -1905,6 +1926,9 @@ static profile_t *
 profile_matroska_builder(void)
 {
   profile_matroska_t *pro = calloc(1, sizeof(*pro));
+  if (pro == NULL) {
+    tvhabort(LS_PROFILE, "calloc is NULL");
+  }
   pro->pro_sflags = SUBSCRIPTION_PACKET;
   pro->pro_reopen = profile_matroska_reopen;
   pro->pro_open   = profile_matroska_open;
@@ -2010,6 +2034,9 @@ static profile_t *
 profile_audio_builder(void)
 {
   profile_audio_t *pro = calloc(1, sizeof(*pro));
+  if (pro == NULL) {
+    tvhabort(LS_PROFILE, "calloc is NULL");
+  }
   pro->pro_sflags = SUBSCRIPTION_PACKET;
   pro->pro_reopen = profile_audio_reopen;
   pro->pro_open   = profile_audio_open;
@@ -2078,6 +2105,9 @@ static profile_t *
 profile_libav_mpegts_builder(void)
 {
   profile_libav_mpegts_t *pro = calloc(1, sizeof(*pro));
+  if (pro == NULL) {
+    tvhabort(LS_PROFILE, "calloc is NULL");
+  }
   pro->pro_sflags = SUBSCRIPTION_PACKET;
   pro->pro_reopen = profile_libav_mpegts_reopen;
   pro->pro_open   = profile_libav_mpegts_open;
@@ -2169,6 +2199,9 @@ static profile_t *
 profile_libav_matroska_builder(void)
 {
   profile_libav_matroska_t *pro = calloc(1, sizeof(*pro));
+  if (pro == NULL) {
+    tvhabort(LS_PROFILE, "calloc is NULL");
+  }
   pro->pro_sflags = SUBSCRIPTION_PACKET;
   pro->pro_reopen = profile_libav_matroska_reopen;
   pro->pro_open   = profile_libav_matroska_open;
@@ -2232,6 +2265,9 @@ static profile_t *
 profile_libav_mp4_builder(void)
 {
   profile_libav_mp4_t *pro = calloc(1, sizeof(*pro));
+  if (pro == NULL) {
+    tvhabort(LS_PROFILE, "calloc is NULL");
+  }
   pro->pro_sflags = SUBSCRIPTION_PACKET;
   pro->pro_reopen = profile_libav_mp4_reopen;
   pro->pro_open   = profile_libav_mp4_open;
@@ -2708,6 +2744,9 @@ static profile_t *
 profile_transcode_builder(void)
 {
   profile_transcode_t *pro = calloc(1, sizeof(*pro));
+  if (pro == NULL) {
+    tvhabort(LS_PROFILE, "calloc is NULL");
+  }
   pro->pro_sflags = SUBSCRIPTION_PACKET;
   pro->pro_free   = profile_transcode_free;
   pro->pro_work   = profile_transcode_work;

--- a/src/prop.c
+++ b/src/prop.c
@@ -24,6 +24,7 @@
 #include "prop.h"
 #include "tvh_locale.h"
 #include "lang_str.h"
+#include "tvhlog.h"
 
 char prop_sbuf[PROP_SBUF_LEN];
 const char *prop_sbuf_ptr = prop_sbuf;
@@ -626,6 +627,10 @@ prop_md_doc(const char **doc, const char *lang)
     } else {
       l += strlen(s) + 1;
       r = realloc(r, l);
+      // if the return value of realloc is NULL then the old pointer is still valid
+      if (r == NULL) {
+        tvhabort(LS_PROP, "realloc is NULL");
+      }
       strcat(r, s);
     }
   }

--- a/src/rtsp.c
+++ b/src/rtsp.c
@@ -36,7 +36,7 @@ rtsp_send_ext( http_client_t *hc, http_cmd_t cmd,
   size_t blen = 7 + strlen(hc->hc_host) +
                 (hc->hc_port != 554 ? 7 : 0) +
                 (path ? strlen(path) : 1) + 1;
-  char *buf = alloca(blen);
+  char buf[blen];
   char buf2[64];
   char buf_body[size + 3];
 

--- a/src/satip/rtp.c
+++ b/src/satip/rtp.c
@@ -314,6 +314,9 @@ satip_rtp_append_tcp_data(satip_rtp_session_t *rtp, uint8_t *data, size_t len)
 
   if (v->iov_base == NULL) {
     v->iov_base = malloc(rtp->tcp_payload);
+    if (v->iov_base == NULL) {
+        tvhabort(LS_RTP, "malloc is NULL");
+    }
     satip_rtp_header(rtp, v, 4);
   }
   assert(v->iov_len + len <= rtp->tcp_payload);
@@ -479,8 +482,10 @@ void *satip_rtp_queue(th_subscription_t *subs,
   socklen_t socklen;
   int dscp, payload;
 
-  if (rtp == NULL)
+  if (rtp == NULL) {
+    tvhinfo(LS_RTP, "calloc is NULL");
     return NULL;
+  }
 
   rtp->peer = *peer;
   rtp->peer2 = *peer;
@@ -592,6 +597,9 @@ void satip_rtp_update_pmt_pids(void *_rtp, mpegts_apids_t *pmt_pids)
         break;
     if (!tbl) {
       tbl = calloc(1, sizeof(*tbl));
+      if (tbl == NULL) {
+          tvhabort(LS_RTP, "calloc is NULL");
+      }
       dvb_table_parse_init(&tbl->tbl, "satip-pmt", LS_TBL_SATIP, pid,
                            DVB_PMT_BASE, DVB_PMT_MASK, rtp);
       tbl->pid = pid;
@@ -945,11 +953,12 @@ satip_rtcp_thread(void *aux)
       }
       if (rtp->port == RTSP_TCP_DATA) {
         msg1 = malloc(len);
-        if (msg1) {
+        if (msg1 != NULL) {
           memcpy(msg1, msg, len);
           err = satip_rtp_tcp_data(rtp, 1, msg1, len, 0);
           r = err ? -1 : 0;
         } else {
+          tvhinfo(LS_RTP, "malloc is NULL");
           r = -1;
           err = ENOMEM;
         }

--- a/src/satip/rtsp.c
+++ b/src/satip/rtsp.c
@@ -210,8 +210,10 @@ rtsp_new_session(const char *ipstr, int delsys, uint32_t nsession, int session)
   }
 
   rs = calloc(1, sizeof(*rs));
-  if (rs == NULL)
+  if (rs == NULL) {
+    tvhinfo(LS_RTSP, "calloc is NULL");
     return NULL;
+  }
 
   rs->peer_ipstr = strdup(ipstr);
   rs->nsession = nsession ?: session_number;
@@ -391,6 +393,10 @@ rtsp_slave_add
 {
   char buf[128];
   slave_subscription_t *sub = calloc(1, sizeof(*sub));
+
+  if (sub == NULL) {
+      tvhabort(LS_RTSP, "calloc is NULL");
+  }
 
   tvh_mutex_lock(&master->s_stream_mutex);
   if (master->s_slaves_pids == NULL)

--- a/src/satip/server.c
+++ b/src/satip/server.c
@@ -443,7 +443,7 @@ satips_upnp_discovery_received
 {
 #define MSEARCH "M-SEARCH * HTTP/1.1"
 
-  char *buf, *ptr, *saveptr;
+  char  *ptr, *saveptr;
   char *argv[10];
   char *st = NULL, *man = NULL, *host = NULL, *deviceid = NULL, *searchport = NULL;
   char buf2[64];
@@ -459,7 +459,7 @@ satips_upnp_discovery_received
 
 #undef MSEARCH
 
-  buf = alloca(len+1);
+  char buf[len+1];
   memcpy(buf, data, len);
   buf[len] = '\0';
   ptr = strtok_r(buf, "\r\n", &saveptr);

--- a/src/service.c
+++ b/src/service.c
@@ -1452,6 +1452,9 @@ service_instance_add(service_instance_list_t *sil,
 
   if(si == NULL) {
     si = calloc(1, sizeof(service_instance_t));
+    if (si == NULL) {
+      tvhabort(LS_SERVICE, "calloc is NULL");
+    }
     si->si_s = s;
     service_ref(s);
     si->si_instance = instance;
@@ -1703,6 +1706,9 @@ static void
 add_caid(elementary_stream_t *st, uint16_t caid, uint32_t providerid)
 {
   caid_t *c = malloc(sizeof(caid_t));
+  if (c == NULL) {
+    tvhabort(LS_SERVICE, "malloc is NULL");
+  }
   c->caid = caid;
   c->providerid = providerid;
   c->pid = 0;

--- a/src/service_mapper.c
+++ b/src/service_mapper.c
@@ -110,6 +110,9 @@ service_mapper_start ( const service_mapper_conf_t *conf, htsmsg_t *uuids )
       tvhtrace(LS_SERVICE_MAPPER, "  queue for checking");
       qd = 1;
       smi = malloc(sizeof(*smi));
+      if (smi == NULL) {
+        tvhabort(LS_SERVICE_MAPPER, "malloc is NULL");
+      }
       smi->s = s;
       smi->conf = *conf;
       TAILQ_INSERT_TAIL(&service_mapper_queue, smi, link);

--- a/src/settings.c
+++ b/src/settings.c
@@ -72,9 +72,8 @@ int
 hts_settings_makedirs ( const char *inpath )
 {
   size_t x = strlen(inpath) - 1;
-  char *path = alloca(x + 2);
+  char path[x + 2];
 
-  if (path == NULL) return -1;
   strcpy(path, inpath);
 
   while (x) {
@@ -229,6 +228,9 @@ hts_settings_load_one(const char *filename)
 
   /* Load data */
   mem    = malloc(size+1);
+  if (mem == NULL) {
+    tvhabort(LS_SETTINGS, "malloc is NULL");
+  }
   n      = fb_read(fp, mem, size);
   if (n >= 0) mem[n] = 0;
 

--- a/src/spawn.c
+++ b/src/spawn.c
@@ -78,6 +78,9 @@ spawn_pipe_read( th_pipe_t *p, char **_buf, int level )
 
   if (buf == NULL) {
     buf = malloc(SPAWN_PIPE_READ_SIZE);
+    if (buf == NULL) {
+        tvhabort(LS_SPAWN,"malloc is NULL");
+    }
     buf[0] = '\0';
     buf[SPAWN_PIPE_READ_SIZE - 1] = 0;
     *_buf = buf;
@@ -343,6 +346,9 @@ static spawn_t *
 spawn_enq(const char *name, int pid)
 {
   spawn_t *s = calloc(1, sizeof(spawn_t));
+  if (s == NULL) {
+    tvhabort(LS_SPAWN,"calloc is NULL");
+  }
   s->name = strdup(name);
   s->pid = pid;
   tvh_mutex_lock(&spawn_mutex);
@@ -367,6 +373,9 @@ spawn_parse_args(char ***argv, int argc, const char *cmd, const char **replace)
 
   s = tvh_strdupa(cmd);
   *argv = calloc(argc, sizeof(char *));
+  if (argv == NULL) {
+    tvhabort(LS_SPAWN,"calloc is NULL");
+  }
 
   while (*s && i < argc - 1) {
     while (*s == ' ')
@@ -422,6 +431,9 @@ spawn_parse_args(char ***argv, int argc, const char *cmd, const char **replace)
         if (p) {
           l = strlen(*r);
           a = malloc(strlen(f) + strlen(r[1]) + 1);
+          if (a == NULL) {
+            tvhabort(LS_SPAWN,"malloc is NULL");
+          }
           *p = '\0';
           strcpy(a, f);
           strcat(a, r[1]);

--- a/src/streaming.c
+++ b/src/streaming.c
@@ -25,6 +25,7 @@
 #include "atomic.h"
 #include "service.h"
 #include "timeshift.h"
+#include "tvhlog.h"
 
 static memoryinfo_t streaming_msg_memoryinfo = { .my_name = "Streaming message" };
 
@@ -202,6 +203,9 @@ streaming_message_t *
 streaming_msg_create(streaming_message_type_t type)
 {
   streaming_message_t *sm = malloc(sizeof(streaming_message_t));
+  if (sm == NULL) {
+    tvhabort(LS_STREAMING, "malloc is NULL");
+  }
   memoryinfo_alloc(&streaming_msg_memoryinfo, sizeof(*sm));
   sm->sm_type = type;
 #if ENABLE_TIMESHIFT
@@ -259,6 +263,10 @@ streaming_msg_clone(streaming_message_t *src)
   streaming_message_t *dst = malloc(sizeof(streaming_message_t));
   streaming_start_t *ss;
 
+  if (dst == NULL) {
+    tvhabort(LS_STREAMING, "malloc is NULL");
+  }
+
   memoryinfo_alloc(&streaming_msg_memoryinfo, sizeof(*dst));
 
   dst->sm_type      = src->sm_type;
@@ -281,21 +289,33 @@ streaming_msg_clone(streaming_message_t *src)
 
   case SMT_SKIP:
     dst->sm_data = malloc(sizeof(streaming_skip_t));
+    if (dst->sm_data == NULL) {
+      tvhabort(LS_STREAMING, "malloc is NULL");
+    }
     memcpy(dst->sm_data, src->sm_data, sizeof(streaming_skip_t));
     break;
 
   case SMT_SIGNAL_STATUS:
     dst->sm_data = malloc(sizeof(signal_status_t));
+    if (dst->sm_data == NULL) {
+      tvhabort(LS_STREAMING, "malloc is NULL");
+    }
     memcpy(dst->sm_data, src->sm_data, sizeof(signal_status_t));
     break;
 
   case SMT_DESCRAMBLE_INFO:
     dst->sm_data = malloc(sizeof(descramble_info_t));
+    if (dst->sm_data == NULL) {
+      tvhabort(LS_STREAMING, "malloc is NULL");
+    }
     memcpy(dst->sm_data, src->sm_data, sizeof(descramble_info_t));
     break;
 
   case SMT_TIMESHIFT_STATUS:
     dst->sm_data = malloc(sizeof(timeshift_status_t));
+    if (dst->sm_data == NULL) {
+      tvhabort(LS_STREAMING, "malloc is NULL");
+    }
     memcpy(dst->sm_data, src->sm_data, sizeof(timeshift_status_t));
     break;
 
@@ -530,6 +550,9 @@ streaming_start_copy(const streaming_start_t *src)
     sizeof(streaming_start_component_t) * src->ss_num_components;
 
   streaming_start_t *dst = malloc(siz);
+  if (dst == NULL) {
+    tvhabort(LS_STREAMING, "malloc is NULL");
+  }
 
   memcpy(dst, src, siz);
   service_source_info_copy(&dst->ss_si, &src->ss_si);

--- a/src/string_list.c
+++ b/src/string_list.c
@@ -21,6 +21,7 @@
 #include <ctype.h>
 #include <string.h>
 #include "htsmsg.h"
+#include "tvhlog.h"
 
 /// Sorted string list helper functions.
 void
@@ -33,6 +34,9 @@ string_list_t *
 string_list_create(void)
 {
   string_list_t *ret = calloc(1, sizeof(string_list_t));
+  if (ret == NULL) {
+    tvhabort(LS_STRING, "calloc is NULL");
+  }
   string_list_init(ret);
   return ret;
 }
@@ -76,6 +80,9 @@ string_list_insert(string_list_t *l, const char *id)
   if (!id) return;
 
   string_list_item_t *item = calloc(1, sizeof(string_list_item_t) + strlen(id) + 1);
+  if (item == NULL) {
+    tvhabort(LS_STRING, "calloc is NULL");
+  }
   strcpy(item->id, id);
   if (RB_INSERT_SORTED(l, item, h_link, string_list_item_cmp)) {
     /* Duplicate, so not inserted. */
@@ -86,10 +93,10 @@ string_list_insert(string_list_t *l, const char *id)
 void
 string_list_insert_lowercase(string_list_t *l, const char *id)
 {
-  char *s, *p;
+  char *p;
 
   if (!id) return;
-  s = alloca(strlen(id) + 1);
+  char s[strlen(id) + 1];
   for (p = s; *id; id++, p++)
     *p = tolower(*id);
   *p = '\0';

--- a/src/subscriptions.c
+++ b/src/subscriptions.c
@@ -767,6 +767,9 @@ subscription_create
    const char *username, const char *client)
 {
   th_subscription_t *s = calloc(1, sizeof(th_subscription_t));
+  if (s == NULL) {
+    tvhabort(LS_SUBSCRIPTION, "calloc is NULL");
+  }
   profile_t *pro = prch ? prch->prch_pro : NULL;
   streaming_target_t *st = prch ? prch->prch_st : NULL;
   static int tally;
@@ -776,6 +779,9 @@ subscription_create
   if (!ops) ops = &subscription_input_direct_ops;
   if (!st) {
     st = calloc(1, sizeof(streaming_target_t));
+    if (st == NULL) {
+      tvhabort(LS_SUBSCRIPTION, "calloc is NULL");
+    }
     streaming_target_init(st, &subscription_input_null_ops, s, 0);
   }
 
@@ -980,6 +986,9 @@ subscription_create_from_file(const char *name,
   if (str == NULL)
     str = strdup("error");
   url = malloc(strlen(str) + 7 + 1);
+  if (url == NULL) {
+    tvhabort(LS_SUBSCRIPTION, "malloc is NULL");
+  }
   strcpy(url, "file://");
   strcat(url, str);
   ts->ths_dvrfile = url;
@@ -1233,6 +1242,9 @@ subscription_set_skip ( th_subscription_t *s, const streaming_skip_t *skip )
 
   sm = streaming_msg_create(SMT_SKIP);
   sm->sm_data = malloc(sizeof(streaming_skip_t));
+  if (sm->sm_data == NULL) {
+    tvhabort(LS_SUBSCRIPTION, "malloc is NULL");
+  }
   memcpy(sm->sm_data, skip, sizeof(streaming_skip_t));
 
   streaming_target_deliver(s->ths_output, sm);
@@ -1317,8 +1329,14 @@ subscription_dummy_join(const char *id, int first)
   }
 
   prch = calloc(1, sizeof(*prch));
+  if (prch == NULL) {
+    tvhabort(LS_SUBSCRIPTION, "calloc is NULL");
+  }
   prch->prch_id = t;
   st = calloc(1, sizeof(*st));
+  if (st == NULL) {
+    tvhabort(LS_SUBSCRIPTION, "calloc is NULL");
+  }
   streaming_target_init(st, &dummy_ops, NULL, 0);
   prch->prch_st = st;
   s = subscription_create_from_service(prch, NULL, 1, "dummy", 0, NULL, NULL, "dummy", NULL);

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -302,9 +302,15 @@ tcp_fill_htsbuf_from_fd(int fd, htsbuf_queue_t *hq)
   }
   
   hd = malloc(sizeof(htsbuf_data_t));
+  if (hd == NULL) {
+    tvhabort(LS_TCP, "malloc is NULL");
+  }
   
   hd->hd_data_size = 1000;
   hd->hd_data = malloc(hd->hd_data_size);
+  if (hd->hd_data == NULL) {
+    tvhabort(LS_TCP, "malloc is NULL");
+  }
 
   do {
     r = read(fd, hd->hd_data, hd->hd_data_size);
@@ -341,6 +347,9 @@ tcp_read_line(int fd, htsbuf_queue_t *spill)
   } while (len == -1);
 
   buf = malloc(len+1);
+  if (buf == NULL) {
+    tvhabort(LS_TCP, "malloc is NULL");
+  }
   
   htsbuf_read(spill, buf, len);
   buf[len] = 0;
@@ -789,6 +798,9 @@ next:
 
     if(ev.events & TVHPOLL_IN) {
       tsl = malloc(sizeof(tcp_server_launch_t));
+      if (tsl == NULL) {
+        tvhabort(LS_TCP, "malloc is NULL");
+      }
       tsl->ops            = ts->ops;
       tsl->opaque         = ts->opaque;
       tsl->status         = NULL;
@@ -898,6 +910,9 @@ void *tcp_server_create
   listen(fd, 511);
 
   ts = malloc(sizeof(tcp_server_t));
+  if (ts == NULL) {
+    tvhabort(LS_TCP, "malloc is NULL");
+  }
   ts->serverfd = fd;
   ts->bound  = bound;
   ts->ops    = *ops;
@@ -965,6 +980,9 @@ tcp_server_create
   if (found) {
     /* use the systemd provided socket */
     ts = malloc(sizeof(tcp_server_t));
+    if (ts == NULL) {
+      tvhabort(LS_TCP, "malloc is NULL");
+    }
     ts->serverfd = fd;
     ts->bound  = bound;
     ts->ops    = *ops;

--- a/src/timeshift.c
+++ b/src/timeshift.c
@@ -457,6 +457,9 @@ streaming_target_t *timeshift_create
   (streaming_target_t *out, time_t max_time)
 {
   timeshift_t *ts = calloc(1, sizeof(timeshift_t));
+  if (ts == NULL) {
+    tvhabort(LS_TIMESHIFT, "calloc is NULL");
+  }
 
   memoryinfo_alloc(&timeshift_memoryinfo, sizeof(timeshift_t));
 

--- a/src/timeshift/timeshift_filemgr.c
+++ b/src/timeshift/timeshift_filemgr.c
@@ -179,6 +179,8 @@ void timeshift_filemgr_close ( timeshift_file_t *tsf )
       memoryinfo_append(&timeshift_memoryinfo_ram, tsf->ram_size - tsf->woff);
       tsf->ram = ram;
       tsf->ram_size = tsf->woff;
+    } else {
+      tvhinfo(LS_TIMESHIFT, "realloc is NULL");
     }
   }
   if (tsf->wfd >= 0)
@@ -237,6 +239,9 @@ static timeshift_file_t * timeshift_filemgr_file_init
   timeshift_file_t *tsf;
 
   tsf = calloc(1, sizeof(timeshift_file_t));
+  if (tsf == NULL) {
+      tvhabort(LS_TIMESHIFT, "calloc is NULL");
+  }
   memoryinfo_alloc(&timeshift_memoryinfo, sizeof(*tsf));
   tsf->time     = mono2sec(start_time) / TIMESHIFT_FILE_PERIOD;
   tsf->last     = start_time;
@@ -325,6 +330,7 @@ timeshift_file_t *timeshift_filemgr_get ( timeshift_t *ts, int64_t start_time )
           tsf_tmp->ram_size = MIN(16*1024*1024, timeshift_conf.ram_segment_size);
           tsf_tmp->ram = malloc(tsf_tmp->ram_size);
           if (!tsf_tmp->ram) {
+            tvhinfo(LS_TIMESHIFT, "malloc is NULL");
             free(tsf_tmp);
             tsf_tmp = NULL;
           } else {
@@ -371,6 +377,9 @@ timeshift_file_t *timeshift_filemgr_get ( timeshift_t *ts, int64_t start_time )
           tvhtrace(LS_TIMESHIFT, "ts %d copy smt_start to new file%s",
                    ts->id, ti ? " (from last file)" : "");
           timeshift_index_data_t *ti2 = calloc(1, sizeof(timeshift_index_data_t));
+          if (ti2 == NULL) {
+              tvhabort(LS_TIMESHIFT, "calloc is NULL");
+          }
           if (ti) {
             memoryinfo_alloc(&timeshift_memoryinfo, sizeof(timeshift_index_data_t));
             sm = streaming_msg_clone(ti->data);

--- a/src/timeshift/timeshift_reader.c
+++ b/src/timeshift/timeshift_reader.c
@@ -215,6 +215,9 @@ static ssize_t _read_msg ( timeshift_file_t *tsf, int fd, streaming_message_t **
     case SMT_MPEGTS:
     case SMT_PACKET:
       data = malloc(sz);
+      if (data == NULL) {
+          tvhabort(LS_TIMESHIFT, "malloc is NULL");
+      }
       r = _read_buf(tsf, fd, data, sz);
       if (r != sz) {
         free(data);
@@ -512,6 +515,9 @@ static void timeshift_status
   timeshift_status_t *status;
 
   status = calloc(1, sizeof(timeshift_status_t));
+  if (status == NULL) {
+      tvhabort(LS_TIMESHIFT, "calloc is NULL");
+  }
   timeshift_fill_status(ts, status, current_time);
   tsm = streaming_msg_create_data(SMT_TIMESHIFT_STATUS, status);
   streaming_target_deliver2(ts->output, tsm);

--- a/src/timeshift/timeshift_writer.c
+++ b/src/timeshift/timeshift_writer.c
@@ -257,7 +257,9 @@ static void _update_smt_start ( timeshift_t *ts, streaming_start_t *ss )
 static void _handle_sstart ( timeshift_t *ts, timeshift_file_t *tsf, streaming_message_t *sm )
 {
   timeshift_index_data_t *ti = calloc(1, sizeof(timeshift_index_data_t));
-
+  if (ti == NULL) {
+      tvhabort(LS_TIMESHIFT, "calloc is NULL");
+  }
   memoryinfo_alloc(&timeshift_memoryinfo, sizeof(*ti));
   ti->pos  = tsf->size;
   ti->data = sm;
@@ -287,6 +289,9 @@ static inline ssize_t _process_msg0
       if (pkt->pkt_componentindex == ts->vididx &&
           pkt->v.pkt_frametype    == PKT_I_FRAME) {
         timeshift_index_iframe_t *ti = calloc(1, sizeof(timeshift_index_iframe_t));
+        if (ti == NULL) {
+            tvhabort(LS_TIMESHIFT, "calloc is NULL");
+        }
         memoryinfo_alloc(&timeshift_memoryinfo, sizeof(*ti));
         ti->pos  = tsf->size;
         ti->time = sm->sm_time;

--- a/src/tprofile.c
+++ b/src/tprofile.c
@@ -57,6 +57,9 @@ static void tprofile_destroy(tprofile_t *tprof)
 void tprofile_done1(tprofile_t *tprof)
 {
   tprofile_t *fin = malloc(sizeof(*fin));
+  if (fin == NULL) {
+    tvhabort(LS_TPROF, "malloc is NULL");
+  }
   tvh_mutex_lock(&tprofile_mutex);
   LIST_REMOVE(tprof, link);
   if (fin) {
@@ -144,6 +147,9 @@ static void qprofile_destroy(qprofile_t *qprof)
 void tprofile_queue_done1(qprofile_t *qprof)
 {
   qprofile_t *fin = malloc(sizeof(*fin));
+  if (fin == NULL) {
+    tvhabort(LS_TPROF, "malloc is NULL");
+  }
   tvh_mutex_lock(&qprofile_mutex);
   LIST_REMOVE(qprof, link);
   if (fin) {

--- a/src/transcoding/codec/profile.c
+++ b/src/transcoding/codec/profile.c
@@ -41,6 +41,8 @@ tvh_codec_profile_alloc(TVHCodec *codec, htsmsg_t *conf)
                 return NULL;
             }
         }
+    } else {
+        tvhinfo(LS_TRANSCODE, "calloc is NULL");
     }
     return self;
 }

--- a/src/transcoding/memutils.c
+++ b/src/transcoding/memutils.c
@@ -37,6 +37,8 @@ str_add(const char *sep, const char *str)
         } else {
             result[0] = '\0';
         }
+    } else {
+        tvhinfo(LS_TRANSCODE, "malloc is NULL");
     }
     return result;
 }
@@ -50,8 +52,10 @@ str_vjoin(const char *separator, va_list ap)
     size_t str_len = 0, result_size = 1;
 
     result = calloc(1, result_size);
-    if (result == NULL)
+    if (result == NULL) {
+        tvhinfo(LS_TRANSCODE, "calloc is NULL");
         return NULL;
+    }
     while ((va_str = va_arg(ap, const char *))) {
         str_len = strlen(va_str);
         if (str_len == 0)
@@ -65,6 +69,7 @@ str_vjoin(const char *separator, va_list ap)
                     strcpy(result + result_size - 1, str);
                     result_size += str_len;
                 } else {
+                    tvhinfo(LS_TRANSCODE, "realloc is NULL");
                     str_clear(str);
                     goto reterr;
                 }

--- a/src/transcoding/transcode/transcoder.c
+++ b/src/transcoding/transcode/transcoder.c
@@ -242,6 +242,8 @@ tvh_transcoder_start(TVHTranscoder *self, tvh_ss_t *ss_src)
                 break;
             }
         }
+    } else {
+        tvhinfo(LS_TRANSCODE, "calloc is NULL");
     }
     return ss;
 }

--- a/src/trap.c
+++ b/src/trap.c
@@ -295,6 +295,8 @@ trap_init(const char *ver)
 	  SHA1_Final(digest, &binsum);
 	}
 	free(m);
+      } else {
+        tvhinfo(LS_CRASH, "malloc is NULL");
       }
     }
     close(fd);

--- a/src/tvh_locale.c
+++ b/src/tvh_locale.c
@@ -21,6 +21,7 @@
 #include "tvh_locale.h"
 #include "tvh_string.h"
 #include "redblack.h"
+#include "tvhlog.h"
 
 struct tvh_locale {
   const char *lang;
@@ -72,6 +73,9 @@ static void msg_add_strings(struct lng *lng, const char **strings)
 
   for (p = strings; *p; p += 2) {
     m = calloc(1, sizeof(*m));
+    if (m == NULL) {
+      tvhabort(LS_LOCAL, "calloc is NULL");
+    }
     m->src = p[0];
     m->dst = p[1];
     if (RB_INSERT_SORTED(&lng->msgs, m, link, msg_cmp))
@@ -102,6 +106,9 @@ static inline int lng_cmp(const struct lng *a, const struct lng *b)
 static struct lng *lng_add(const char *tvh_lang, const char *locale_lang)
 {
   struct lng *l = calloc(1, sizeof(*l));
+  if (l == NULL) {
+    tvhabort(LS_LOCAL, "calloc is NULL");
+  }
   l->tvh_lang = tvh_lang;
   l->locale_lang = locale_lang;
   if (RB_INSERT_SORTED(&lngs, l, link, lng_cmp))

--- a/src/tvh_thread.c
+++ b/src/tvh_thread.c
@@ -101,6 +101,9 @@ tvh_thread_create
 {
   int r;
   struct thread_state *ts = calloc(1, sizeof(struct thread_state));
+  if (ts == NULL) {
+    tvhabort(LS_THREAD, "calloc is NULL");
+  }
   pthread_attr_t _attr;
   if (attr == NULL) {
     pthread_attr_init(&_attr);
@@ -220,6 +223,9 @@ static tvh_mutex_waiter_t *
 tvh_mutex_add_to_waiters(tvh_mutex_t *mutex, const char *filename, int lineno)
 {
   tvh_mutex_waiter_t *w = malloc(sizeof(*w));
+  if (w == NULL) {
+    tvhabort(LS_THREAD, "malloc is NULL");
+  }
 
   pthread_mutex_lock(&thrwatch_mutex);
   if (filename != NULL) {

--- a/src/tvhlog.c
+++ b/src/tvhlog.c
@@ -439,6 +439,9 @@ void tvhlogv ( const char *file, int line, int severity,
 
   /* Store */
   tvhlog_msg_t *msg = calloc(1, sizeof(tvhlog_msg_t));
+  if (msg == NULL) {
+    tvhabort(LS_LOG, "calloc is NULL");
+  }
   gettimeofday(&msg->time, NULL);
   msg->msg      = strdup(buf);
   msg->severity = severity;

--- a/src/tvhlog.h
+++ b/src/tvhlog.h
@@ -198,6 +198,30 @@ enum {
 #if ENABLE_DDCI
   LS_DDCI,
 #endif
+  LS_DOWNLOAD,
+  LS_ESSTREAM,
+  LS_FILEBUNDLE,
+  LS_HTSBUF,
+  LS_HTSMSG,
+  LS_HTSSTR,
+  LS_HUFFMAN,
+  LS_INTLCONV,
+  LS_LANG,
+  LS_PACKET,
+  LS_PROP,
+  LS_STREAMING,
+  LS_STRING,
+  LS_LOCAL,
+  LS_LOG,
+  LS_UDP,
+  LS_UTILS,
+  LS_WIZARD,
+  LS_ZLIB,
+  LS_JSON,
+  LS_AVC,
+  LS_H264,
+  LS_LATM,
+  LS_RTP,
   LS_LAST     /* keep this last */
 };
 

--- a/src/tvhpoll.c
+++ b/src/tvhpoll.c
@@ -65,6 +65,9 @@ static void
 tvhpoll_alloc_events ( tvhpoll_t *tp, int fd )
 {
   tp->events = calloc(1, tp->nevents = 8);
+  if (tp->events == NULL) {
+    tvhabort(LS_TVHPOLL, "calloc is NULL");
+  }
   tp->events_off = fd;
 }
 
@@ -73,6 +76,9 @@ tvhpoll_realloc_events1 ( tvhpoll_t *tp, int fd )
 {
   uint32_t diff = tp->events_off - fd;
   uint8_t *evs = malloc(tp->nevents + diff);
+  if (evs == NULL) {
+    tvhabort(LS_TVHPOLL, "malloc is NULL");
+  }
   memset(evs, 0, diff);
   memcpy(evs + diff, tp->events, tp->nevents);
   free(tp->events);
@@ -86,6 +92,10 @@ tvhpoll_realloc_events2 ( tvhpoll_t *tp, int fd )
 {
   uint32_t size = (fd - tp->events_off) + 4;
   tp->events = realloc(tp->events, size);
+  // if the return value of realloc is NULL, the old pointer is still valid.
+  if (tp->events == NULL) {
+    tvhabort(LS_TVHPOLL, "realloc is NULL");
+  }
   memset(tp->events + tp->nevents, 0, size - tp->nevents);
   tp->nevents = size;
 }
@@ -122,6 +132,10 @@ tvhpoll_alloc ( tvhpoll_t *tp, uint32_t n )
 #if ENABLE_EPOLL || ENABLE_KQUEUE
   if (n > tp->nev) {
     tp->ev  = realloc(tp->ev, n * EV_SIZE);
+    // if the return value of realloc is NULL, the old pointer is still valid.
+    if (tp->ev == NULL) {
+      tvhabort(LS_TVHPOLL, "realloc is NULL");
+    }
     tp->nev = n;
   }
 #else
@@ -146,6 +160,9 @@ tvhpoll_create ( size_t n )
   fd = -1;
 #endif
   tvhpoll_t *tp = calloc(1, sizeof(tvhpoll_t));
+  if (tp == NULL) {
+    tvhabort(LS_TVHPOLL, "calloc is NULL");
+  }
   tvh_mutex_init(&tp->lock, NULL);
   tp->fd = fd;
   tvhpoll_alloc(tp, n);

--- a/src/udp.c
+++ b/src/udp.c
@@ -21,6 +21,7 @@
 #define _GNU_SOURCE
 #include "tvheadend.h"
 #include "udp.h"
+#include "tvhlog.h"
 
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -162,6 +163,9 @@ udp_bind ( int subsystem, const char *name,
   socklen_t addrlen;
 
   uc = calloc(1, sizeof(udp_connection_t));
+  if (uc == NULL) {
+    tvhabort(LS_UDP, "calloc is NULL");
+  }
   uc->fd                   = -1;
   uc->host                 = bindaddr ? strdup(bindaddr) : NULL;
   uc->port                 = port;
@@ -377,6 +381,9 @@ udp_sendinit ( int subsystem, const char *name,
   udp_connection_t *uc;
 
   uc = calloc(1, sizeof(udp_connection_t));
+  if (uc == NULL) {
+    tvhabort(LS_UDP, "calloc is NULL");
+  }
   uc->fd                   = -1;
   uc->ifname               = ifname ? strdup(ifname) : NULL;
   uc->subsystem            = subsystem;
@@ -612,6 +619,9 @@ udp_multirecv_init( udp_multirecv_t *um, int packets, int psize )
   um->um_iovec   = malloc(packets * sizeof(struct iovec));
   um->um_riovec  = malloc(packets * sizeof(struct iovec));
   um->um_msg     = calloc(packets,  sizeof(struct mmsghdr));
+  if (um->um_data == NULL || um->um_iovec == NULL || um->um_riovec == NULL || um->um_msg) {
+    tvhabort(LS_UDP, "calloc/malloc is NULL");
+  }
   for (i = 0; i < packets; i++) {
     ((struct mmsghdr *)um->um_msg)[i].msg_hdr.msg_iov    = &um->um_iovec[i];
     ((struct mmsghdr *)um->um_msg)[i].msg_hdr.msg_iovlen = 1;
@@ -730,6 +740,9 @@ udp_multisend_init( udp_multisend_t *um, int packets, int psize,
   um->um_data    = malloc(packets * psize);
   um->um_iovec   = malloc(packets * sizeof(struct iovec));
   um->um_msg     = calloc(packets,  sizeof(struct mmsghdr));
+  if (um->um_data == NULL || um->um_iovec == NULL || um->um_msg) {
+    tvhabort(LS_UDP, "calloc/malloc is NULL");
+  }
   for (i = 0; i < packets; i++) {
     ((struct mmsghdr *)um->um_msg)[i].msg_hdr.msg_iov    = &um->um_iovec[i];
     ((struct mmsghdr *)um->um_msg)[i].msg_hdr.msg_iovlen = 1;

--- a/src/upnp.c
+++ b/src/upnp.c
@@ -82,6 +82,9 @@ upnp_send( htsbuf_queue_t *q, struct sockaddr_storage *storage,
   if (!atomic_get(&upnp_running))
     return;
   data = calloc(1, sizeof(upnp_data_t));
+  if (data == NULL) {
+    tvhabort(LS_UPNP, "calloc is NULL");
+  }
   htsbuf_queue_init(&data->queue, 0);
   htsbuf_appendq(&data->queue, q);
   if (storage == NULL)

--- a/src/utils.c
+++ b/src/utils.c
@@ -376,8 +376,10 @@ sbuf_init_fixed(sbuf_t *sb, int len)
 {
   memset(sb, 0, sizeof(sbuf_t));
   sb->sb_data = malloc(len);
-  if (sb->sb_data == NULL)
+  if (sb->sb_data == NULL) {
+    tvhinfo(LS_UTILS, "malloc is NULL");
     sbuf_alloc_fail(len);
+  }
   sb->sb_size = len;
 }
 
@@ -398,6 +400,8 @@ sbuf_reset(sbuf_t *sb, int max_len)
     if (n) {
       sb->sb_data = n;
       sb->sb_size = max_len;
+    } else {
+      tvhinfo(LS_UTILS, "realloc is NULL");
     }
   }
 }
@@ -415,14 +419,19 @@ sbuf_alloc_(sbuf_t *sb, int len)
   if(sb->sb_data == NULL) {
     sb->sb_size = len * 4 > 4000 ? len * 4 : 4000;
     sb->sb_data = malloc(sb->sb_size);
+    if (sb->sb_data == NULL) {
+      tvhinfo(LS_UTILS, "malloc is NULL");
+    }
     return;
   } else {
     sb->sb_size += len * 4;
     sb->sb_data = realloc(sb->sb_data, sb->sb_size);
   }
 
-  if(sb->sb_data == NULL)
+  if(sb->sb_data == NULL) {
+    tvhinfo(LS_UTILS, "realloc is NULL");
     sbuf_alloc_fail(sb->sb_size);
+  }
 }
 
 void
@@ -434,14 +443,16 @@ sbuf_realloc(sbuf_t *sb, int len)
       if (n) {
         sb->sb_data = n;
         sb->sb_size = len;
-      }
+      } 
     }
   } else {
     sb->sb_data = malloc(len);
     sb->sb_size = len;
   }
-  if (sb->sb_data == NULL)
+  if (sb->sb_data == NULL) {
+    tvhinfo(LS_UTILS, "alloc is NULL");
     sbuf_alloc_fail(len);
+  }
 }
 
 void

--- a/src/uuid.c
+++ b/src/uuid.c
@@ -175,8 +175,10 @@ uuid_set_copy( tvh_uuid_set_t *dst, const tvh_uuid_set_t *src )
   dst->us_alloc_chunk = src->us_alloc_chunk;
   size = sizeof(tvh_uuid_t) * src->us_size;
   dst->us_array = malloc(size);
-  if (dst->us_array == NULL)
+  if (dst->us_array == NULL) {
+    tvhinfo(LS_UUID, "malloc is NULL");
     return NULL;
+  }
   memcpy(dst->us_array, src->us_array, size);
   dst->us_size = src->us_size;
   dst->us_count = src->us_count;
@@ -191,8 +193,10 @@ uuid_set_add ( tvh_uuid_set_t *us, const tvh_uuid_t *u )
 
   if (us->us_count >= us->us_size) {
     nu = realloc(us->us_array, sizeof(*u) * (us->us_size + us->us_alloc_chunk));
-    if (nu == NULL)
+    if (nu == NULL){
+      tvhinfo(LS_UUID, "realloc is NULL");
       return NULL;
+    }
     us->us_array = nu;
     us->us_size += us->us_alloc_chunk;
   }

--- a/src/webui/comet.c
+++ b/src/webui/comet.c
@@ -120,6 +120,10 @@ comet_mailbox_create(const char *lang)
   int i;
   SHA_CTX sha1;
 
+  if (cmb == NULL) {
+      tvhabort(LS_WEBUI, "calloc is NULL");
+  }
+
   gettimeofday(&tv, NULL);
 
   SHA1_Init(&sha1);

--- a/src/webui/simpleui.c
+++ b/src/webui/simpleui.c
@@ -64,6 +64,10 @@ dvr_query_add_entry(dvr_query_result_t *dqr, dvr_entry_t *de)
     dqr->dqr_alloced = MAX(100, dqr->dqr_alloced * 2);
     dqr->dqr_array = realloc(dqr->dqr_array,
 			     dqr->dqr_alloced * sizeof(dvr_entry_t *));
+    // if realloc return NULL then the old pointer is still valid
+    if (dqr->dqr_array == NULL) {
+        tvhabort(LS_WEBUI, "realloc is NULL");
+    }
   }
   dqr->dqr_array[dqr->dqr_entries++] = de;
 }

--- a/src/webui/webui.c
+++ b/src/webui/webui.c
@@ -124,7 +124,6 @@ static int
 page_no_webroot(http_connection_t *hc, const char *remain, void *opaque)
 {
   size_t l;
-  char *s;
 
   /* not found checks */
   if (!tvheadend_webroot)
@@ -137,7 +136,7 @@ page_no_webroot(http_connection_t *hc, const char *remain, void *opaque)
   /* redirect if url is not in the specified webroot */
   if (!remain)
     remain = "";
-  s = alloca(2 + strlen(remain));
+  char s[2 + strlen(remain)];
   s[0] = '/';
   strcpy(s + 1, remain);
   http_redirect(hc, s, &hc->hc_req_args, 0);

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -29,6 +29,7 @@
 #include "input/mpegts/iptv/iptv_private.h"
 #include "service_mapper.h"
 #include "wizard.h"
+#include "tvhlog.h"
 
 /*
  *
@@ -120,6 +121,9 @@ static wizard_page_t *page_init
 {
   wizard_page_t *page = calloc(1, sizeof(*page));
   idclass_t *ic = calloc(1, sizeof(*ic));
+  if (page == NULL || ic == NULL) {
+    tvhabort(LS_WIZARD, "calloc is NULL");
+  }
   page->name = name;
   page->idnode.in_class = ic;
   ic->ic_caption = caption;
@@ -252,6 +256,9 @@ wizard_page_t *wizard_hello(const char *lang)
   ic->ic_groups = groups;
   ic->ic_changed = hello_changed;
   page->aux = w = calloc(1, sizeof(wizard_hello_t));
+  if (page->aux == NULL) {
+    tvhabort(LS_WIZARD, "calloc is NULL");
+  }
 
   if (config.language_ui)
     strlcpy(w->ui_lang, config.language_ui, sizeof(w->ui_lang));
@@ -474,6 +481,9 @@ wizard_page_t *wizard_login(const char *lang)
   ic->ic_groups = groups;
   ic->ic_changed = login_changed;
   page->aux = w = calloc(1, sizeof(wizard_login_t));
+  if (page->aux == NULL) {
+    tvhabort(LS_WIZARD, "calloc is NULL");
+  }
 
   TAILQ_FOREACH(ae, &access_entries, ae_link) {
     if (!ae->ae_wizard)
@@ -677,6 +687,9 @@ wizard_page_t *wizard_network(const char *lang)
   int idx, nidx = 0;
 
   page->aux = w = calloc(1, sizeof(wizard_network_t));
+  if (page->aux == NULL) {
+    tvhabort(LS_WIZARD, "calloc is NULL");
+  }
   ic->ic_groups = groups;
   ic->ic_properties = w->props;
   ic->ic_changed = network_changed;
@@ -966,6 +979,9 @@ wizard_page_t *wizard_muxes(const char *lang)
   int idx, midx = 0;
 
   page->aux = w = calloc(1, sizeof(wizard_muxes_t));
+  if (page->aux == NULL) {
+    tvhabort(LS_WIZARD, "calloc is NULL");
+  }
   ic->ic_groups = groups;
   ic->ic_properties = w->props;
   ic->ic_changed = muxes_changed;
@@ -1142,6 +1158,9 @@ wizard_page_t *wizard_mapping(const char *lang)
   ic->ic_properties = props;
   ic->ic_changed = mapping_changed;
   page->aux = w = calloc(1, sizeof(wizard_mapping_t));
+  if (page->aux == NULL) {
+    tvhabort(LS_WIZARD, "calloc is NULL");
+  }
   w->provtags = service_mapper_conf.d.provider_tags;
   w->nettags = service_mapper_conf.d.network_tags;
   return page;

--- a/src/zlib.c
+++ b/src/zlib.c
@@ -17,6 +17,7 @@
  */
 
 #include "tvheadend.h"
+#include "tvhlog.h"
 
 #define ZLIB_CONST 1
 #include <zlib.h>
@@ -36,6 +37,9 @@ uint8_t *tvh_gzip_inflate ( const uint8_t *data, size_t size, size_t orig )
 
   /* Setup buffers */
   bufout = malloc(orig);
+  if (bufout == NULL) {
+    tvhabort(LS_ZLIB, "malloc is NULL");
+  }
 
   /* Setup zlib */
   memset(&zstr, 0, sizeof(zstr));
@@ -64,6 +68,9 @@ uint8_t *tvh_gzip_deflate ( const uint8_t *data, size_t orig, size_t *size )
 
   /* Setup buffers */
   bufout = malloc(orig);
+  if (bufout == NULL) {
+    tvhabort(LS_ZLIB, "malloc is NULL");
+  }
 
   /* Setup zlib */
   memset(&zstr, 0, sizeof(zstr));
@@ -80,6 +87,9 @@ uint8_t *tvh_gzip_deflate ( const uint8_t *data, size_t orig, size_t *size )
     /* Need more space */
     if (err == Z_OK && zstr.avail_out == 0) {
       bufout         = realloc(bufout, zstr.total_out * 2);
+      if (bufout == NULL) {
+        tvhabort(LS_ZLIB, "realloc is NULL");
+      }
       zstr.avail_out = zstr.total_out;
       zstr.next_out  = bufout + zstr.total_out;
       continue;
@@ -112,6 +122,9 @@ int tvh_gzip_deflate_fd ( int fd, const uint8_t *data, size_t orig, size_t *size
   *size  = 0;
   alloc  = MIN(orig, 256*1024);
   bufout = malloc(alloc);
+  if (bufout == NULL) {
+    tvhabort(LS_ZLIB, "malloc is NULL");
+  }
 
   /* Setup zlib */
   memset(&zstr, 0, sizeof(zstr));


### PR DESCRIPTION
malloc and calloc allocate memory and return NULL if this failes.
The return value is now checked and if there is a check for NULL a thvinfo is
added. If there was no NULL check a thvabort is added.
realloc is special that if it returns NULL the old pointer is still valid.
if the input pointer and the return  pointer is the same variable the old
pointer is lost. This is a memory leak.
Now there is also a thvinfo or thvabort added.