### PR TITLE
Add support for SCT_RDS, expose RDS flag via HTSP

### DIFF
--- a/src/esfilter.h
+++ b/src/esfilter.h
@@ -63,7 +63,7 @@ extern const idclass_t esfilter_class_other;
   SCT_MASK(SCT_CA)
 
 #define ESF_MASK_OTHER \
-  (SCT_MASK(SCT_MPEGTS) | SCT_MASK(SCT_HBBTV))
+  (SCT_MASK(SCT_MPEGTS) | SCT_MASK(SCT_HBBTV) | SCT_MASK(SCT_RDS))
 
 extern uint32_t esfilterclsmask[];
 

--- a/src/esstream.h
+++ b/src/esstream.h
@@ -45,6 +45,7 @@ enum streaming_component_type {
   SCT_CAT,     /* MPEG-TS CAT (EMM) data */
   SCT_CA,      /* MPEG-TS ECM data */
   SCT_HBBTV,   /* HBBTV info */
+  SCT_RDS,     /* Radio Data System */
   /* standard codecs */
   SCT_MPEG2VIDEO,
   SCT_MPEG2AUDIO,

--- a/src/esstream.h
+++ b/src/esstream.h
@@ -105,6 +105,7 @@ struct elementary_info {
   uint8_t es_sri;
   uint8_t es_ext_sri;
   uint16_t es_channels;
+  uint8_t es_rds_uecp; /* RDS via UECP data present */
 
   uint16_t es_composition_id;
   uint16_t es_ancillary_id;

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -50,7 +50,7 @@
 
 static void *htsp_server, *htsp_server_2;
 
-#define HTSP_PROTO_VERSION 35
+#define HTSP_PROTO_VERSION 36
 
 #define HTSP_ASYNC_OFF  0x00
 #define HTSP_ASYNC_ON   0x01
@@ -4213,6 +4213,7 @@ htsp_subscription_start(htsp_subscription_t *hs, const streaming_start_t *ss)
         htsmsg_add_u32(c, "channels", ssc->es_channels);
       if (ssc->es_sri)
         htsmsg_add_u32(c, "rate", ssc->es_sri);
+      htsmsg_add_u32(c, "rds_uecp", ssc->es_rds_uecp == 0 ? 0 : 1);
     }
 
     if (ssc->ssc_gh)

--- a/src/input/mpegts/dvb_psi_pmt.c
+++ b/src/input/mpegts/dvb_psi_pmt.c
@@ -248,6 +248,7 @@ dvb_psi_parse_pmt
   int position;
   int tt_position;
   int video_stream;
+  int rds_uecp;
   int pcr_shared = 0;
   const char *lang;
   uint8_t audio_type, audio_version;
@@ -309,6 +310,7 @@ dvb_psi_parse_pmt
     hts_stream_type = SCT_UNKNOWN;
     composition_id = -1;
     ancillary_id = -1;
+    rds_uecp = 0;
     position = 0;
     tt_position = 1000;
     lang = NULL;
@@ -438,10 +440,13 @@ dvb_psi_parse_pmt
         break;
 
       case DVB_DESC_ANCILLARY_DATA:
-        if(dlen < 1 || hts_stream_type != SCT_UNKNOWN)
+        if(dlen < 1)
           break;
 
-        if(estype == 0x89 && (ptr[0] & 0x40) == 0x40) // ancillary_data_id 0x40 : RDS via UECP
+        if((ptr[0] & 0x40) == 0x40) /* ancillary_data_id : RDS via UECP */
+          rds_uecp = 1;
+
+        if(rds_uecp && hts_stream_type == SCT_UNKNOWN && estype == 0x89)
           hts_stream_type = SCT_RDS;
         break;
 
@@ -510,6 +515,11 @@ dvb_psi_parse_pmt
         update |= PMT_UPDATE_ANCILLARY_ID;
       }
 
+      if(st->es_rds_uecp != rds_uecp) {
+        st->es_rds_uecp = rds_uecp;
+        update |= PMT_UPDATE_RDS_UECP;
+      }
+
       if (st->es_pid == set->set_pcr_pid)
         pcr_shared = 1;
     }
@@ -548,7 +558,7 @@ dvb_psi_parse_pmt
 
   if (update) {
     tvhdebug(mt->mt_subsys, "%s: Service \"%s\" PMT (version %d) updated"
-     "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
+     "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
      mt->mt_name,
      nicename, version,
      update&PMT_UPDATE_PCR               ? ", PCR PID changed":"",
@@ -566,6 +576,7 @@ dvb_psi_parse_pmt
      update&PMT_UPDATE_CA_PROVIDER_CHANGE? ", CA provider changed":"",
      update&PMT_UPDATE_CAID_DELETED      ? ", CAID deleted":"",
      update&PMT_UPDATE_CAID_PID          ? ", CAID PID changed":"",
+     update&PMT_UPDATE_RDS_UECP          ? ", RDS UECP flag changed":"",
      update&PMT_REORDERED                ? ", PIDs reordered":"");
   }
 

--- a/src/input/mpegts/dvb_psi_pmt.c
+++ b/src/input/mpegts/dvb_psi_pmt.c
@@ -437,6 +437,14 @@ dvb_psi_parse_pmt
           hts_stream_type = SCT_EAC3;
         break;
 
+      case DVB_DESC_ANCILLARY_DATA:
+        if(dlen < 1 || hts_stream_type != SCT_UNKNOWN)
+          break;
+
+        if(estype == 0x89 && (ptr[0] & 0x40) == 0x40) // ancillary_data_id 0x40 : RDS via UECP
+          hts_stream_type = SCT_RDS;
+        break;
+
       default:
         break;
       }

--- a/src/input/mpegts/dvb_psi_pmt.h
+++ b/src/input/mpegts/dvb_psi_pmt.h
@@ -39,7 +39,8 @@
 #define PMT_UPDATE_CA_PROVIDER_CHANGE (1<<12)
 #define PMT_UPDATE_CAID_DELETED       (1<<13)
 #define PMT_UPDATE_CAID_PID           (1<<14)
-#define PMT_REORDERED                 (1<<15)
+#define PMT_UPDATE_RDS_UECP           (1<<15)
+#define PMT_REORDERED                 (1<<16)
 
 uint32_t dvb_psi_parse_pmt
   (mpegts_table_t *mt, const char *nicename, elementary_set_t *set,

--- a/src/parsers/parsers.c
+++ b/src/parsers/parsers.c
@@ -1918,6 +1918,59 @@ parse_hbbtv(parser_t *t, parser_es_t *st, const uint8_t *data,
 }
 
 /**
+ * RDS parser
+ */
+static void
+parse_rds(parser_t *t, parser_es_t *st, const uint8_t *data,
+          int len, int start)
+{
+  th_pkt_t *pkt;
+  int psize, hlen;
+  const uint8_t *buf;
+  const uint8_t *d;
+
+  if(start) {
+    /* Payload unit start */
+    st->es_parser_state = 1;
+    sbuf_reset(&st->es_buf, 4000);
+  }
+
+  if(st->es_parser_state == 0)
+    return;
+
+  sbuf_append(&st->es_buf, data, len);
+
+  if(st->es_buf.sb_ptr < 6)
+    return;
+  d = st->es_buf.sb_data;
+
+  psize = d[4] << 8 | d[5];
+
+  if(st->es_buf.sb_ptr != psize + 6)
+    return;
+
+  st->es_parser_state = 0;
+
+  hlen = parse_pes_header(t, st, d + 6, st->es_buf.sb_ptr - 6);
+  if(hlen < 0)
+    return;
+
+  psize -= hlen;
+  buf = d + 6 + hlen;
+
+  if(psize < 2 || buf[0] != 0xfe || buf[psize-1] != 0xff)
+    return;
+
+  if(psize > 2) {
+    pkt = pkt_alloc(st->es_type, buf, psize,
+                    t->prs_current_pcr, t->prs_current_pcr, t->prs_current_pcr);
+    pkt->pkt_err = st->es_buf.sb_err;
+    parser_deliver(t, st, pkt);
+    sbuf_reset(&st->es_buf, 4000);
+  }
+}
+
+/**
  * for debugging
  */
 #if 0
@@ -2006,6 +2059,10 @@ parse_mpeg_ts(parser_t *t, parser_es_t *st, const uint8_t *data,
 
   case SCT_HBBTV:
     st->es_parse_callback = parse_hbbtv;
+    break;
+
+  case SCT_RDS:
+    st->es_parse_callback = parse_rds;
     break;
 
   default:

--- a/src/streaming.c
+++ b/src/streaming.c
@@ -570,6 +570,7 @@ static struct strtab streamtypetab[] = {
   { "CAT",        SCT_CAT },
   { "CA",         SCT_CA },
   { "HBBTV",      SCT_HBBTV },
+  { "RDS",        SCT_RDS },
   { "MPEG2VIDEO", SCT_MPEG2VIDEO },
   { "MPEG2AUDIO", SCT_MPEG2AUDIO },
   { "H264",       SCT_H264 },


### PR DESCRIPTION
Motivation: https://forum.kodi.tv/showthread.php?tid=336682&pid=3052210#pid3052210

This brings back RDS data for SWR, WDR, hr, SR in Kodi and allows other tvh clients to handle RDS data contained in private stream with id 0x89.

Thanks to @carsten-gross for figuring out the details.

Second commit exposes the information, that an audio stream contains RDS data via HTSP.