### PR TITLE
opentv: fix incorrect summaries for skyuk epg, fixes #5995

### DIFF
--- a/src/epggrab/module/opentv.c
+++ b/src/epggrab/module/opentv.c
@@ -140,6 +140,7 @@ typedef struct opentv_event
   char                  *desc;        ///< Event description
   uint8_t                cat;         ///< Event category
   uint16_t               serieslink;  ///< Series link ID
+  int                    cid;         ///< Channel ID
 } opentv_event_t;
 
 /* Queued (unresolved) event entry */
@@ -202,20 +203,28 @@ static void _opentv_event_free(opentv_event_t *ev)
   free(ev->desc);
 }
 
-/* Compare event id codes */
+/* Compare event id and channel id codes */
 static int _entry_cmp ( void *a, void *b )
 {
-  return (int)(((opentv_entry_t*)a)->event.eid) -
-         (int)(((opentv_entry_t*)b)->event.eid);
+  int eid_cmp, cid_cmp;
+
+  eid_cmp = (int)(((opentv_entry_t*)a)->event.eid) -
+            (int)(((opentv_entry_t*)b)->event.eid);
+
+  cid_cmp = ((opentv_entry_t*)a)->event.cid -
+            ((opentv_entry_t*)b)->event.cid;
+
+  return eid_cmp != 0 ? eid_cmp : cid_cmp;
 }
 
 /* Find event entry */
-static opentv_entry_t *opentv_find_entry(opentv_status_t *sta, uint16_t eid)
+static opentv_entry_t *opentv_find_entry(opentv_status_t *sta, uint16_t eid, int cid)
 {
   opentv_entry_t *oe, _tmp;
 
   if (sta == NULL) return NULL;
   _tmp.event.eid = eid;
+  _tmp.event.cid = cid;
   oe = RB_FIND(&sta->os_entries, &_tmp, link, _entry_cmp);
   return oe;
 }
@@ -341,6 +350,7 @@ static int _opentv_parse_event
   }
 
   ev->eid = ((uint16_t)buf[0] << 8) | buf[1];
+  ev->cid = cid;
 
   /* Process records */ 
   while (i < slen+4) {
@@ -503,7 +513,7 @@ opentv_parse_event_section_one
     if (ebc) {
       save |= opentv_do_event(mod, ebc, &ev, ch, lang, &changes);
       if (!merge) {
-        entry = opentv_find_entry(mod->sta, ev.eid);
+        entry = opentv_find_entry(mod->sta, ev.eid, cid);
         if (entry) {
           save |= opentv_do_event(mod, ebc, &entry->event, ch, lang, &changes);
           opentv_remove_entry(mod->sta, entry);


### PR DESCRIPTION
Events within the OpenTV SkyUK data can contain the same Event ID as another event on a different channel.

This results in missing or incorrect summary data in Tvheadend, since it's matching is based solely on the Event ID.

For example:
![incorrect-summaries](https://user-images.githubusercontent.com/14977362/135290000-c0137a21-a2ca-4719-b585-14ddb440d863.png)

Notice how several events have the wrong summary, and others are missing a summary (since that summary was incorrectly linked to a different event).

To help illustrate, I found the Event ID for the event highlighted in the above screenshot and using a forked version of the [openTVtoXML external scraper](https://github.com/dave-p/openTVtoXML) (modified to also output Event IDs) I found all events with that same event ID.

<details>
  <summary><b>Expand here to show full XML for those events</b></summary>
  
```
 <programme start="20210929163000 +0100" stop="20210929164500 +0100" channel="282_2_3780">
  <!-- EVENT ID: 971 -->
  <title lang="en">Pikwik Pack</title>
  <category lang="en">Children - Cartoons</category>
  <desc lang="en">Kip In The Caboose: Axel has made Tibor a Totally Axellent Taco that Tibor's afraid to tell him, is not-so-Excellent after all. Should Percy and Tibor tell the truth about what happened? (S1 Ep8)</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20211001034000 +0100" stop="20211001050500 +0100" channel="282_2_6200">
  <!-- EVENT ID: 971 -->
  <title lang="en">ITV Nightscreen</title>
  <category lang="en">Entertainment</category>
  <desc lang="en">Text-based information service.</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20211001100000 +0100" stop="20211001105000 +0100" channel="282_2_1066">
  <!-- EVENT ID: 971 -->
  <title lang="en">Covid-19 Pandemic</title>
  <category lang="en">News &amp; Documentaries - News</category>
  <desc lang="en">The novel coronavirus outbreak started in Wuhan in China and has now become a global pandemic. We take a look at the implications across the world.</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20211001090000 +0100" stop="20211001094500 +0100" channel="282_2_1244">
  <!-- EVENT ID: 971 -->
  <title lang="en">Polti Cordless Vacuum BlockBuster</title>
  <category lang="en">Shopping</category>
  <desc lang="en">The BlockBuster is the chance to get this product at the best offer - ever, while stocks last.</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20211006053000 +0100" stop="20211006060000 +0100" channel="282_2_3117">
  <!-- EVENT ID: 971 -->
  <title lang="en">Chaplet of St Michael</title>
  <category lang="en">News &amp; Documentaries - Religious</category>
  <desc lang="en">A traditional Roman Catholic prayer is recited to request the assistance of divine beings as well as that of St Michael the Archangel.</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20211001070000 +0100" stop="20211001073000 +0100" channel="282_2_1406">
  <!-- EVENT ID: 971 -->
  <title lang="en">Kay Burley</title>
  <category lang="en">News &amp; Documentaries - News</category>
  <desc lang="en">All the big stories of the morning presented by Kay Burley, with reports and analysis from the Sky News team, big name interviews and human interest stories.</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20211003180000 +0100" stop="20211003183000 +0100" channel="282_2_1104">
  <!-- EVENT ID: 971 -->
  <title lang="en">Darse Hadees</title>
  <category lang="en">News &amp; Documentaries - Religious</category>
  <desc lang="en">Informative lecture about Islamic teaching for youth.</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20210929193000 +0100" stop="20210929200000 +0100" channel="282_2_3205">
  <!-- EVENT ID: 971 -->
  <title lang="en">Jim Bakker</title>
  <category lang="en">News &amp; Documentaries - Religious</category>
  <desc lang="en">Healthy living ministry  with Jim Bakker</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20210930003000 +0100" stop="20210930010000 +0100" channel="282_2_3590">
  <!-- EVENT ID: 971 -->
  <title lang="en">Diners, Drive-Ins, And Dives</title>
  <category lang="en">Entertainment - Cooking</category>
  <desc lang="en">From North To South America. From a Houston joint's Argentinian empanadas to street tacos in Cancun, Mexico, Guy Fieri digs into flavours spanning the Americas. S26, Ep8</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20211004103000 +0100" stop="20211004110000 +0100" channel="282_2_1235">
  <!-- EVENT ID: 971 -->
  <title lang="en">Al Khalil &amp; Boruna Reports</title>
  <category lang="en">News &amp; Documentaries - Religious</category>
  <desc lang="en">A documentary feedback report containing the progress of projects delivered by Al Khalil and Boruna Madrasha</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20210929210000 +0100" stop="20210929211500 +0100" channel="282_2_4261">
  <!-- EVENT ID: 971 -->
  <title lang="en">Super Wings</title>
  <category lang="en">Children - Cartoons</category>
  <desc lang="en">Baby Tiger Delivery: Jett and Jett Pet join a girl and her father to look for a lost tiger kitten's mother in the jungle of Madhya Pradesh, India - the same jungle from &quot;The Jungle Book&quot;. (S5 Ep5)</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20210930143000 +0100" stop="20210930153000 +0100" channel="282_2_3687">
  <!-- EVENT ID: 971 -->
  <title lang="en">Directors</title>
  <category lang="en">Entertainment - Lifestyle</category>
  <desc lang="en">Profile documentary of great African filmmakers.</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20211003193000 +0100" stop="20211003194000 +0100" channel="282_2_1018">
  <!-- EVENT ID: 971 -->
  <title lang="en">The Greek Isles from &#x00A3;599pp</title>
  <category lang="en">Shopping</category>
  <desc lang="en">Another fabulous deal from Cruise1st.tv - call to book now on 0800 953 4700 (free of charge) or online at www.cruise1st.tv</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20210929170000 +0100" stop="20210929173000 +0100" channel="282_2_1130">
  <!-- EVENT ID: 971 -->
  <title lang="en">Wonder Core Flex Cycle</title>
  <category lang="en">Shopping</category>
  <desc lang="en">The ultra-versatile, 4-in-1 stationary bike that delivers fat burning cardio, lower body toning and core strengthening all in one! Call 0344 800 0800 (local rates apply) or visit highstreettv.com</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20211005231500 +0100" stop="20211005233000 +0100" channel="282_2_3147">
  <!-- EVENT ID: 971 -->
  <title lang="en">Newsline In Depth</title>
  <category lang="en">Genre 0xb3</category>
  <desc lang="en">Introducing a colourful variety of feature stories, including reports on daily life from locations throughout Japan as well as other parts of Asia and around the world.</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20211003233500 +0100" stop="20211004003500 +0100" channel="282_2_3028">
  <!-- EVENT ID: 971 -->
  <title lang="en">Portillo's Hidden History Of...</title>
  <category lang="en">Entertainment - Factual</category>
  <desc lang="en">...Britain. Documentary series. For almost a century, Orford Ness was owned by the MOD, a lens into a bygone era of secrets, spies and superpowers. (S1 Ep 2)</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20211002020000 +0100" stop="20211002020500 +0100" channel="282_2_1026">
  <!-- EVENT ID: 971 -->
  <title lang="en">Headline News</title>
  <category lang="en">News &amp; Documentaries - News</category>
  <desc lang="en">Latest news bulletin focusing on political, social and economic developments in Pakistan and around the globe. The show also features significant news stories from around the globe.</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20211002043000 +0100" stop="20211002050000 +0100" channel="282_2_1226">
  <!-- EVENT ID: 971 -->
  <title lang="en">Off The Grid</title>
  <category lang="en">Entertainment - Travel</category>
  <desc lang="en">Going local is the best way to travel. Alex uses the key to go up &amp; close with the fishermen of Kadmat, Lakshadweep's coral island.</desc>
  <rating system="BFRB"><value>PG</value></rating>
 </programme>

 <programme start="20211003192000 +0100" stop="20211003193000 +0100" channel="282_2_4262">
  <!-- EVENT ID: 971 -->
  <title lang="en">Grizzy And The Lemmings</title>
  <category lang="en">Children - Cartoons</category>
  <desc lang="en">Warning: Unlimited Lemmings: The Lemmings discover that by changing the speed limit sign on the side of the road they can create a huge wind that is perfect for their extreme kiting game. (S2 Ep30)</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20211004000000 +0100" stop="20211004003000 +0100" channel="282_2_5071">
  <!-- EVENT ID: 971 -->
  <title lang="en">News</title>
  <category lang="en">News &amp; Documentaries - News</category>
  <desc lang="en">TRT World brings the latest news from around the globe, when it happens.</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20211006140500 +0100" stop="20211006150000 +0100" channel="282_2_2296">
  <!-- EVENT ID: 971 -->
  <title lang="en">New: Prynhawn Da</title>
  <category lang="en">Entertainment - Magazine</category>
  <desc lang="en">Cyfres gylchgrawn gydag eitemau coginio a ffasiwn a chyngor am bopeth o addurno'ch cartref i ddewis llyfr da. Magazine series including features on fashion, style, antiques and cookery.</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20210930210000 +0100" stop="20210930213000 +0100" channel="282_2_3632">
  <!-- EVENT ID: 971 -->
  <title lang="en">Mann Egerton Watches</title>
  <category lang="en">Shopping</category>
  <desc lang="en">Mann Egerton watches demonstrate the mighty and robust qualities of its most famous creations and innovations. Buy now at www.mannegerton.net or call 0333 8806 230 (local call rate).</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20211002060000 +0100" stop="20211002063000 +0100" channel="282_2_5212">
  <!-- EVENT ID: 971 -->
  <title lang="en">Floating Mop</title>
  <category lang="en">Shopping</category>
  <desc lang="en">Floating Mop is the motorised, cordless, spinning mop that does the hard work for you! Call 0344 800 0800 (local rates apply) or visit www.highstreettv.com.</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20211004150000 +0100" stop="20211004150500 +0100" channel="282_2_4407">
  <!-- EVENT ID: 971 -->
  <title lang="en">GEO World News Headlines</title>
  <category lang="en">News &amp; Documentaries - News</category>
  <desc lang="en">Bringing you all the latest news from around the globe.</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20211003023600 +0100" stop="20211003024800 +0100" channel="282_2_4216">
  <!-- EVENT ID: 971 -->
  <title lang="en">Power Players</title>
  <category lang="en">Children - Cartoons</category>
  <desc lang="en">Joke's On You, Bro!: Annoyed with Galileo's pranks, Axel and the Power Players make him believe that he's stuck in invisible mode. (S1 Ep16)</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20211005030000 +0100" stop="20211005033000 +0100" channel="282_2_4645">
  <!-- EVENT ID: 971 -->
  <title lang="en">News</title>
  <category lang="en">News &amp; Documentaries - News</category>
  <desc lang="en">All the day's news from Sky News Arabia's correspondents across the Arab world and around the globe.</desc>
  <rating system="BFRB"><value>PG</value></rating>
 </programme>

 <programme start="20211005053000 +0100" stop="20211005060000 +0100" channel="282_2_5520">
  <!-- EVENT ID: 971 -->
  <title lang="en">Entertainment News</title>
  <category lang="en">Entertainment</category>
  <desc lang="en">A collection of entertainment events, stories and shows that take place in Nigeria and on the foreign scene.</desc>
  <rating system="BFRB"><value>U</value></rating>
 </programme>

 <programme start="20211002090000 +0100" stop="20211002093000 +0100" channel="282_2_1872">
  <!-- EVENT ID: 971 -->
  <title lang="en">Teleshopping</title>
  <category lang="en">Shopping</category>
  <desc lang="en">Teleshopping programming bringing you a selection of innovative products</desc>
  <rating system="BFRB"><value>PG</value></rating>
 </programme>
```

</details>

As you see, there are several events with Event ID: 971, and for the example in question the summary came from a broadcast on a different channel - namely "Covid-19 Pandemic"

This commit adjusts the opentv _entry_cmp function to match based on a combination of Event ID and Channel ID. This enables the RB_FIND & RB_INSERT_SORTED functions used within the OpenTV module to reliably insert and uniquely find the correct entry.

Here is a screenshot when running with this PR in place, scraping the correct summary data.

![corrected_summaries](https://user-images.githubusercontent.com/14977362/135298175-b7dca114-2774-4bb8-ab38-98c597788bb9.png)

