### PR TITLE
[4.2] Upgrade to libhdhomerun_20180817

### DIFF
--- a/Makefile.hdhomerun
+++ b/Makefile.hdhomerun
@@ -32,10 +32,10 @@ endif
 # Upstream Packages
 # ###########################################################################
 
-LIBHDHR         = libhdhomerun_20171221
+LIBHDHR         = libhdhomerun_20180817
 LIBHDHR_TB      = $(LIBHDHR).tgz
-LIBHDHR_URL     = http://download.silicondust.com/hdhomerun/$(LIBHDHR_TB)
-LIBHDHR_SHA1    = 6b019728eadea3af7a5686ed5ba44e970bca7365
+LIBHDHR_URL     = https://download.silicondust.com/hdhomerun/$(LIBHDHR_TB)
+LIBHDHR_SHA1    = 052868bde3a5713c55b4d060b77e0bc3a0d891d6
 
 # ###########################################################################
 # Library Config


### PR DESCRIPTION
Version of 4.2.8 is the only stable release for tvheadend. This PR fixes issue, which recently appeared. Are there any plans to release a new version of TVHeadend?

____

The previous tarball is not available and because of that, the
compilation of tvheadend does not proceed.

Log while building for OpenWrt:
```
DOWNLOAD        misc/staticlib/unknown/powerpc/hdhomerun-8081b801eb8e8403e7ba2d1b7c2015777051d47a.tgz / kZ54ee7ZUvsSYmb9VGSpnmoVzcAUhpBXLq8k
Traceback (most recent call last):
  File "/builder/shared-workdir/build/sdk/build_dir/target-powerpc_8540_musl/tvheadend-4.2.8/support/pcloud.py", line 13, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
FAILED TO DOWNLOAD  (BUT THIS IS NOT A FATAL ERROR! DO NOT REPORT THAT!)
make[5]: Leaving directory '/builder/shared-workdir/build/sdk/build_dir/target-powerpc_8540_musl/tvheadend-4.2.8'
make -f Makefile.hdhomerun build
make[5]: Entering directory '/builder/shared-workdir/build/sdk/build_dir/target-powerpc_8540_musl/tvheadend-4.2.8'
WGET            http://download.silicondust.com/hdhomerun/libhdhomerun_20171221.tgz
http://download.silicondust.com/hdhomerun/libhdhomerun_20171221.tgz:
2021-10-18 19:12:59 ERROR 404: Not Found.
make[5]: *** [Makefile.hdhomerun:79: /builder/shared-workdir/build/sdk/build_dir/target-powerpc_8540_musl/tvheadend-4.2.8/build.linux/hdhomerun/libhdhomerun_20171221/.tvh_download] Error 8
```

The latest version of libhdhomerun can not be used somehow as the compilation fails.

Let's update it to the next version since 2017 in the stable version to
ensure that it does not break anything. Also switch to https to download
tarball.