### PR TITLE
opentv: fix missing summary data on rescrape, #5995

### DIFF
--- a/src/epggrab/module/opentv.c
+++ b/src/epggrab/module/opentv.c
@@ -496,12 +496,12 @@ opentv_parse_event_section_one
       ebc = epg_broadcast_find_by_time(ch, src, ev.start, ev.stop,
                                        1, &save, &changes);
       tvhdebug(LS_OPENTV, "find by time start %"PRItime_t " stop "
-               "%"PRItime_t " eid %d = %p",
-               ev.start, ev.stop, ev.eid, ebc);
+               "%"PRItime_t " ch %"PRId64" eid %d = %p",
+               ev.start, ev.stop, ch->ch_number, ev.eid, ebc);
       save |= epg_broadcast_set_dvb_eid(ebc, ev.eid, &changes);
     } else {
       ebc = epg_broadcast_find_by_eid(ch, ev.eid);
-      tvhdebug(LS_OPENTV, "find by eid %d = %p", ev.eid, ebc);
+      tvhdebug(LS_OPENTV, "find by ch %"PRId64" eid %d = %p", ch->ch_number, ev.eid, ebc);
       if (ebc) {
         if (ebc->grabber != src)
           goto done;
@@ -517,6 +517,8 @@ opentv_parse_event_section_one
         if (entry) {
           save |= opentv_do_event(mod, ebc, &entry->event, ch, lang, &changes);
           opentv_remove_entry(mod->sta, entry);
+        } else {
+          merge = 1;
         }
       }
       save |= epg_broadcast_change_finish(ebc, changes, merge);


### PR DESCRIPTION
This fixes an issue whereby chunks of events within the OpenTV data can contain blank summaries following a re-scrape as shown below:

![image](https://user-images.githubusercontent.com/14977362/137934905-e58b921d-017f-4c08-b609-d81b54f77c44.png)

Prior to this scrape, the guide data in this section was complete including the summary data. 

![image](https://user-images.githubusercontent.com/14977362/137935256-1b1ea25b-b73d-4bf6-9903-d4a241079426.png)

On debugging the issue, I could see that both halves of the record (title and summary) were processed for these events, so something was going wrong in the matching or merging of this data.

<details>
<summary>Expand here for debug log extracts to go with the first screenshot above (re-scrape)</summary>


**Notice that the summary records were processed first.**

```
2021-10-19 15:05:28.266 [  DEBUG]:opentv: find by ch 609000000 eid 2965 = 0x7f0c68178390
2021-10-19 15:05:28.266 [  DEBUG]:opentv:   summary 'Beat the Drum, Catboy: Night Ninja plans to turn the daytime parade into the Night Ninja Parade Spectacular. Having stolen Catboy's parade drum, he's going to re-paint the floats and flags. (S1 Ep39)'
2021-10-19 15:05:28.266 [  DEBUG]:opentv: find by ch 609000000 eid 2969 = 0x7f0c681784f0
2021-10-19 15:05:28.266 [  DEBUG]:opentv:   summary 'Owlette of a Kind: When Romeo duplicates Owlette's powers and turns not only himself but Catboy and Gekko into fliers, Owlette feels she's lost what makes her special. (S1 Ep40)'
2021-10-19 15:05:28.266 [  DEBUG]:opentv: find by ch 609000000 eid 2983 = 0x7f0c68178650
2021-10-19 15:05:28.266 [  DEBUG]:opentv:   summary 'How Giganto Got His Roar: Rocky wants to roar just like Gigantosaurus, so he and Marsh set out to capture the beast's roar inside a coconut. If only Giganto would cooperate! (S1 Ep42)'
2021-10-19 15:05:28.266 [  DEBUG]:opentv: find by ch 609000000 eid 2475 = 0x7f0c681787b0
2021-10-19 15:05:28.266 [  DEBUG]:opentv:   summary 'An Artist Is Born: When Trey injures himself in a tree toppling accident, Tiny helps him find his inner artist. (S1 Ep43)'
2021-10-19 15:05:28.267 [  DEBUG]:opentv: find by ch 609000000 eid 2377 = 0x7f0c68178980
2021-10-19 15:05:28.267 [  DEBUG]:opentv:   summary 'Born Tree: Tiny grows very attached to a sapling tree that she nurses to health... and then has a hard time letting go when the tree is ready to be planted. (S1 Ep44)'
2021-10-19 15:05:28.267 [  DEBUG]:opentv: find by ch 609000000 eid 3241 = 0x7f0c68178b50
2021-10-19 15:05:28.267 [  DEBUG]:opentv:   summary 'The Five Friends: The dinos have a falling out over the legendary Five Friends Crest of Cretacia. (S1 Ep45)'
2021-10-19 15:05:28.267 [  DEBUG]:opentv: find by ch 609000000 eid 3243 = 0x7f0c68178d20
2021-10-19 15:05:28.267 [  DEBUG]:opentv:   summary 'Quartet Plus: Playing in a quartet is not as easy as it seems, especially if there's no slack between the musicians. This is what Masha tells Papa Bear. In the end, music unites everyone! (S3 Ep16)'
2021-10-19 15:05:28.267 [  DEBUG]:opentv: find by ch 609000000 eid 3244 = 0x7f0c68177f90
2021-10-19 15:05:28.267 [  DEBUG]:opentv:   summary 'Two Much: Masha decides to visit her sister, Dasha. Even though they look very much alike, they are very different! (S2 Ep10)'
2021-10-19 15:05:28.267 [  DEBUG]:opentv: find by ch 609000000 eid 3254 = 0x7f0c68178f40
2021-10-19 15:05:28.267 [  DEBUG]:opentv:   summary 'Surprise! Surprise!: The wolves come up with a new idea to get a stable and a nutritious food source... (S3 Ep11)'
2021-10-19 15:05:28.268 [  DEBUG]:opentv: find by ch 609000000 eid 3255 = 0x7f0c681790a0
2021-10-19 15:05:28.268 [  DEBUG]:opentv:   summary 'A Walk In The Park: Gordon builds a robotic dog so his PURST pals can ride inside it and join him in the dog park. (S1 Ep38)'
2021-10-19 15:05:28.268 [  DEBUG]:opentv: find by ch 609000000 eid 3407 = 0x7f0c68179260
2021-10-19 15:05:28.268 [  DEBUG]:opentv:   summary 'Purst Puzzlers: When a jigsaw puzzle piece of Small Human's goes missing, the PURST team set out to find it. (S1 Ep39)'
2021-10-19 15:05:28.268 [  DEBUG]:opentv: find by ch 609000000 eid 3257 = 0x7f0c68179420
2021-10-19 15:05:28.268 [  DEBUG]:opentv:   summary 'Giddyup Ol' Blue!: When Axel's truck breaks down, he's not sure Farmer Francis' beat-up old tractor will help them get their delivery to the Professor. (S1 Ep9)'
2021-10-19 15:05:28.268 [  DEBUG]:opentv: find by ch 609000000 eid 3268 = 0x7f0c681795f0
2021-10-19 15:05:28.268 [  DEBUG]:opentv:   summary 'Rude-speak: Iris' spell goes wrong and Daddy King and Mommy Queen get a bout of "Rude-Speak". It's down to Gus to fetch the remedy from Salted Butter Lake. (S1 Ep9)'
2021-10-19 15:05:28.268 [  DEBUG]:opentv: find by ch 609000000 eid 3370 = 0x7f0c68179810
2021-10-19 15:05:28.268 [  DEBUG]:opentv:   summary 'Dad's Favourite Golf Club: On the day of an important golf game, Dad can't find his favourite golf club. Detectives Ricky and Tyra are on the case, searching for evidence and witnesses. (S1 Ep30)'
2021-10-19 15:05:28.269 [  DEBUG]:opentv: find by ch 609000000 eid 3371 = 0x7f0c68179970
2021-10-19 15:05:28.269 [  DEBUG]:opentv:   summary 'Blue Lightning: As the city prepares for a hot air balloon race, Ricky declares that the biggest champion in the world is Dad Saur. (S1 Ep31)'
2021-10-19 15:05:28.269 [  DEBUG]:opentv: find by ch 609000000 eid 3373 = 0x7f0c68179ad0
2021-10-19 15:05:28.269 [  DEBUG]:opentv:   summary 'First One To Laugh Is The Loser: Simon is playing "first one who laughs loses" with Ferdinand and Lou. Each of them tries out his/her favourite joke as the teacher looks on, stunned! (S3 Ep17)'
2021-10-19 15:05:28.269 [  DEBUG]:opentv: find by ch 609000000 eid 3145 = 0x7f0c68179ca0
2021-10-19 15:05:28.269 [  DEBUG]:opentv:   summary 'Saving Super Spider!: It's rained a lot. And there is a little spider being swept down the current in the park creek. Simon and Gaspard rush off to save the little creature! (S3 Ep18)'
2021-10-19 15:05:28.270 [  DEBUG]:opentv: find by ch 609000000 eid 3146 = 0x7f0c68179e70
2021-10-19 15:05:28.270 [  DEBUG]:opentv:   summary 'A Very Special Concert: Jett and Jett Pet deliver a fan letter to Trevor, a young musician and old friend of the Super Wings, who is scheduled to perform with his band in New York City. (S5 Ep7)'
2021-10-19 15:05:28.270 [  DEBUG]:opentv: find by ch 609000000 eid 3151 = 0x7f0c68179fd0
2021-10-19 15:05:28.270 [  DEBUG]:opentv:   summary 'Ariplane Museum Adventure: A welcome ceremony at the National Aviation Museum in Seoul is being held for Korea's oldest plane. But the old plane crashes on the way! (S5 Ep8)'
2021-10-19 15:05:28.270 [  DEBUG]:opentv: opentv-skyuk: completed pid 54 table 000000A0 / 000000fc
```
...
```
2021-10-19 15:05:31.600 [  DEBUG]:opentv: find by time start 1634652000 stop 1634652900 ch 609000000 eid 2965 = 0x7f0c68178390
2021-10-19 15:05:31.600 [  DEBUG]:opentv:     title 'PJ Masks'
2021-10-19 15:05:31.600 [  DEBUG]:opentv: find by time start 1634652900 stop 1634653800 ch 609000000 eid 2969 = 0x7f0c681784f0
2021-10-19 15:05:31.600 [  DEBUG]:opentv:     title 'PJ Masks'
2021-10-19 15:05:31.600 [  DEBUG]:opentv: find by time start 1634653800 stop 1634654700 ch 609000000 eid 2983 = 0x7f0c68178650
2021-10-19 15:05:31.600 [  DEBUG]:opentv:     title 'Gigantosaurus'
2021-10-19 15:05:31.600 [  DEBUG]:opentv: find by time start 1634654700 stop 1634655600 ch 609000000 eid 2475 = 0x7f0c681787b0
2021-10-19 15:05:31.600 [  DEBUG]:opentv:     title 'Gigantosaurus'
2021-10-19 15:05:31.600 [  DEBUG]:opentv: find by time start 1634655600 stop 1634656500 ch 609000000 eid 2377 = 0x7f0c68178980
2021-10-19 15:05:31.600 [  DEBUG]:opentv:     title 'Gigantosaurus'
2021-10-19 15:05:31.600 [  DEBUG]:opentv: find by time start 1634656500 stop 1634657400 ch 609000000 eid 3241 = 0x7f0c68178b50
2021-10-19 15:05:31.600 [  DEBUG]:opentv:     title 'Gigantosaurus'
2021-10-19 15:05:31.600 [  DEBUG]:opentv: find by time start 1634657400 stop 1634658000 ch 609000000 eid 3243 = 0x7f0c68178d20
2021-10-19 15:05:31.600 [  DEBUG]:opentv:     title 'Masha and the Bear'
2021-10-19 15:05:31.600 [  DEBUG]:opentv: find by time start 1634658000 stop 1634658600 ch 609000000 eid 3244 = 0x7f0c68177f90
2021-10-19 15:05:31.600 [  DEBUG]:opentv:     title 'Masha And The Bear'
2021-10-19 15:05:31.600 [  DEBUG]:opentv: find by time start 1634658600 stop 1634659200 ch 609000000 eid 3254 = 0x7f0c68178f40
2021-10-19 15:05:31.600 [  DEBUG]:opentv:     title 'Masha and the Bear'
2021-10-19 15:05:31.600 [  DEBUG]:opentv: find by time start 1634659200 stop 1634660100 ch 609000000 eid 3255 = 0x7f0c681790a0
2021-10-19 15:05:31.600 [  DEBUG]:opentv:     title 'Agent Binky: Pets Of The Universe'
2021-10-19 15:05:31.600 [  DEBUG]:opentv: find by time start 1634660100 stop 1634661000 ch 609000000 eid 3407 = 0x7f0c68179260
2021-10-19 15:05:31.600 [  DEBUG]:opentv:     title 'Agent Binky: Pets Of The Universe'
2021-10-19 15:05:31.600 [  DEBUG]:opentv: find by time start 1634661000 stop 1634661900 ch 609000000 eid 3257 = 0x7f0c68179420
2021-10-19 15:05:31.600 [  DEBUG]:opentv:     title 'Pikwik Pack'
2021-10-19 15:05:31.600 [  DEBUG]:opentv: find by time start 1634661900 stop 1634662800 ch 609000000 eid 3268 = 0x7f0c681795f0
2021-10-19 15:05:31.600 [  DEBUG]:opentv:     title 'Gus - The Itsy Bitsy Knight'
2021-10-19 15:05:31.601 [  DEBUG]:opentv: find by time start 1634662800 stop 1634663100 ch 609000000 eid 3370 = 0x7f0c68179810
2021-10-19 15:05:31.601 [  DEBUG]:opentv:     title 'DinoCity'
2021-10-19 15:05:31.601 [  DEBUG]:opentv: find by time start 1634663100 stop 1634663700 ch 609000000 eid 3371 = 0x7f0c68179970
2021-10-19 15:05:31.601 [  DEBUG]:opentv:     title 'DinoCity'
2021-10-19 15:05:31.601 [  DEBUG]:opentv: find by time start 1634663700 stop 1634664000 ch 609000000 eid 3373 = 0x7f0c68179ad0
2021-10-19 15:05:31.601 [  DEBUG]:opentv:     title 'Simon'
2021-10-19 15:05:31.601 [  DEBUG]:opentv: find by time start 1634664000 stop 1634664600 ch 609000000 eid 3145 = 0x7f0c68179ca0
2021-10-19 15:05:31.601 [  DEBUG]:opentv:     title 'Simon'
2021-10-19 15:05:31.601 [  DEBUG]:opentv: find by time start 1634664600 stop 1634665500 ch 609000000 eid 3146 = 0x7f0c68179e70
2021-10-19 15:05:31.601 [  DEBUG]:opentv:     title 'Super Wings'
2021-10-19 15:05:31.601 [  DEBUG]:opentv: find by time start 1634665500 stop 1634666400 ch 609000000 eid 3151 = 0x7f0c68179fd0
2021-10-19 15:05:31.601 [  DEBUG]:opentv:     title 'Super Wings'
2021-10-19 15:05:31.605 [  DEBUG]:opentv: opentv-skyuk: completed pid 70 table 000000A8 / 000000fc
```
</details>


The title and summary records are received separately and are matched and merged into an event using the following block of code: https://github.com/tvheadend/tvheadend/blob/1ee9c5b9cc516d37cb55a9d924a4ca854a64f720/src/epggrab/module/opentv.c#L494-L523

When processing a title record the merge flag is set to 0
When processing a summary record the merge flag is set to 1

From my debugging, I can see that sometimes the title half of the record is processed first, and sometimes the summary half is done first (i.e. they can be processed in either order).

I found that the problem of missing summary data occurs when the following conditions are met:

1) Prior to the scrape, the event in question already exists in the guide data. It's important to mention that with a blank epg database as the starting point the problem does not occur.

2) The summary record for the event in question is processed first

3) The title record is processed second

In this scenario the epg_broadcast_change_finish procedure is called at line 522 with the merge flag set to 0, which therefore blanks out the summary information!

I made several attempts at re-writing this whole section of code; trying to find clever ways to ensure that the merge flag is set to 1 just prior to calling epg_broadcast_change_finish unless we're sure we have both halves of the event (summary and title) on the temporary ebc.

In the end, the fix was simple - just add an else condition to the existing if which checks whether we have the other half of the record. If we don't have both halves of the record then set the merge flag to 1 just prior to calling epg_broadcast_change_finish so that we merge whatever we do have into the existing ebc.

I verified the fix on my dev environment by performing scrapes and then viewing the EPG via the WebUI and sorting by summary (Extra Text) to pull events without a summary to the top of the list.

Without the fix, I performed a scrape against a full EPG database, and was left with approx. 10,300 out of 31,954 events in total that were missing Summary data!

With the fix in place I performed a further scrape and following this there were very few events ~50 out of 31,954 with missing summary data, and in each case I was able to explain why such as:

- It was an "out of hours" event which simply did not have summary data e.g. "Programmes start at 7.00am". This is normal and there are always a good number of these.

- No summary data record was ever received for the event during the scrape, as verified in debug logging. There were only a handful of these out of the ~32k events. An additional scrape or longer timeout may have found these.

- The summary field (0xb9) on the incoming summary event record was simply blank (as verified with debug logging).

To help identify the problem I added the channel number values to the existing debug lines. I found that this helped the debugging effort greatly, since the eid alone cannot be used to uniquely identify an event - you also need the channel number to find the log entries for the related summary record. I have therefore included this adjustment to the debug lines in this commit to help aid debugging in future.

I have now been running with this on my production environment for over a week and have not yet found any events through day-to-day usage where summary information is missing - whereas it was previously common and very noticeable.
