### PR TITLE
Fixed parsing pre-defined muxes in w_scan format

### DIFF
--- a/src/input/mpegts/scanfile.c
+++ b/src/input/mpegts/scanfile.c
@@ -132,9 +132,9 @@ scanfile_load_atsc ( dvb_mux_conf_t *mux, const char *line )
   char qam[20];
   int r;
 
+  dvb_mux_conf_init(NULL, mux, DVB_SYS_ATSC);
   r = sscanf(line, "%u %s", &mux->dmc_fe_freq, qam);
   if (r != 2) return 1;
-  dvb_mux_conf_init(NULL, mux, DVB_SYS_ATSC);
   if ((mux->dmc_fe_modulation = dvb_str2qam(qam)) == -1) return 1;
 
   return 0;


### PR DESCRIPTION
When parsing pre-defined muxes in the w_scan format, only one gets added and its frequency is 0MHz.

```
2021-11-12 15:18:14.867 [  TRACE]:scanfile: load file /ca-test-test (processed bytes 5334453)
2021-11-12 15:20:44.977 [  TRACE]:scanfile: [A 473000000     8VSB] OK
2021-11-12 15:22:29.084 [  TRACE]:scanfile: [A 485000000     8VSB] OK
2021-11-12 15:22:33.810 [  TRACE]:scanfile: [A 491000000     8VSB] OK
2021-11-12 15:22:34.496 [  TRACE]:scanfile: [A 497000000     8VSB] OK
2021-11-12 15:22:35.116 [  TRACE]:scanfile: [A 503000000     8VSB] OK
2021-11-12 15:22:35.763 [  TRACE]:scanfile: [A 509000000     8VSB] OK
2021-11-12 15:22:36.362 [  TRACE]:scanfile: [A 521000000     8VSB] OK
2021-11-12 15:22:36.968 [  TRACE]:scanfile: [A 533000000     8VSB] OK
2021-11-12 15:22:37.574 [  TRACE]:scanfile: [A 545000000     8VSB] OK
2021-11-12 15:22:38.191 [  TRACE]:scanfile: [A 581000000     8VSB] OK
2021-11-12 15:22:38.876 [  TRACE]:scanfile: [A 587000000     8VSB] OK
2021-11-12 15:22:39.486 [  TRACE]:scanfile: [A 599000000     8VSB] OK
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 ATSC-T freq 0 mod VSB/8 added to network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 skipped ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 exists ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 skipped ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 exists ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 skipped ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 exists ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 skipped ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 exists ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 skipped ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 exists ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 skipped ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 exists ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 skipped ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 exists ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 skipped ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 exists ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 skipped ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 exists ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 skipped ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 exists ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 skipped ATSC-T freq 0 mod VSB/8 in network ATSC-T
2021-11-12 15:22:39.486 [  TRACE]:scanfile: mux 0x7fffc800f070 exists ATSC-T freq 0 mod VSB/8 in network ATSC-T
```

This bug seems to have been introduced in https://github.com/tvheadend/tvheadend/commit/399aa99e8917784a96d012545bd8a9f547b2fd09. `dvb_mux_conf_init()` memsets the frequency to zero after it has already been set.

