### PR TITLE
configure: add execinfo option

### DIFF
--- a/configure
+++ b/configure
@@ -75,6 +75,7 @@ OPTIONS=(
   "ddci:yes"
   "cclang_threadsan:no"
   "gperftools:no"
+  "execinfo:auto"
 )
 
 #
@@ -150,11 +151,23 @@ if [ ${PLATFORM} = "freebsd" ]; then
     # If we don't have libunwind then fallback to execinfo.
     if ! enabled libunwind
     then
-        check_cc_header execinfo
+        if enabled_or_auto execinfo; then
+            if check_cc_header execinfo; then
+                enable execinfo
+            else
+                die "execinfo.h not found (use --disable-execinfo)"
+           fi
+        fi
     fi
 
 else
-    check_cc_header execinfo
+    if enabled_or_auto execinfo; then
+        if check_cc_header execinfo; then
+            enable execinfo
+        else
+            die "execinfo.h not found (use --disable-execinfo)"
+        fi
+    fi
 fi
 check_cc_option mmx
 check_cc_option sse2


### PR DESCRIPTION
Add execinfo option to allow the user to disable the feature even if `execinfo.h` is found on the system

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>