### PR TITLE
nvenc: Fix Werror=misleading-indentation FTBFS

### DIFF
--- a/src/transcoding/codec/codecs/libs/nvenc.c
+++ b/src/transcoding/codec/codecs/libs/nvenc.c
@@ -324,17 +324,19 @@ tvh_codec_profile_nvenc_h264_open(tvh_codec_profile_nvenc_t *self,
     }
 
     if (self->nvenc_profile != NV_ENC_PROFILE_UNKNOWN &&
-        (s = val2str(self->nvenc_profile, profiletab)) != NULL)
-      AV_DICT_SET(opts, "profile", s, 0);
-      // ------ Set Defaults ---------
-      AV_DICT_SET_INT(opts, "qmin", "-1", 0);
-      AV_DICT_SET_INT(opts, "qmax", "-1", 0);
-      AV_DICT_SET_INT(opts, "qdiff", "-1", 0);
-      AV_DICT_SET_INT(opts, "qblur", "-1", 0);
-      AV_DICT_SET_INT(opts, "qcomp", "-1", 0);
-      AV_DICT_SET_INT(opts, "g", "250", 0);
-      AV_DICT_SET_INT(opts, "bf", "0", 0);
-      AV_DICT_SET_INT(opts, "refs", "0", 0);
+        (s = val2str(self->nvenc_profile, profiletab)) != NULL) {
+        AV_DICT_SET(opts, "profile", s, 0);
+    }
+    
+    // ------ Set Defaults ---------
+    AV_DICT_SET_INT(opts, "qmin", "-1", 0);
+    AV_DICT_SET_INT(opts, "qmax", "-1", 0);
+    AV_DICT_SET_INT(opts, "qdiff", "-1", 0);
+    AV_DICT_SET_INT(opts, "qblur", "-1", 0);
+    AV_DICT_SET_INT(opts, "qcomp", "-1", 0);
+    AV_DICT_SET_INT(opts, "g", "250", 0);
+    AV_DICT_SET_INT(opts, "bf", "0", 0);
+    AV_DICT_SET_INT(opts, "refs", "0", 0);
     return 0;
 }
 


### PR DESCRIPTION
Commit 0165f365cd58bbcc3734e4ec9ce696b42870ff8e introduced an FTBFS
when -Werror=misleading-indentation is passed to the compiler.  It
appears from changes elsewhere in the file (around line 450) that
the "Set Defaults" statements were not intended to be included in
the if block, so this commit reformats it to make that obvious (and
also add curlybrackets as was done around 450.)