### PR TITLE
nvenc: Fix Werror=int-conversion FTBFS (and likely bug)

### DIFF
--- a/src/transcoding/codec/codecs/libs/nvenc.c
+++ b/src/transcoding/codec/codecs/libs/nvenc.c
@@ -329,14 +329,14 @@ tvh_codec_profile_nvenc_h264_open(tvh_codec_profile_nvenc_t *self,
     }
     
     // ------ Set Defaults ---------
-    AV_DICT_SET_INT(opts, "qmin", "-1", 0);
-    AV_DICT_SET_INT(opts, "qmax", "-1", 0);
-    AV_DICT_SET_INT(opts, "qdiff", "-1", 0);
-    AV_DICT_SET_INT(opts, "qblur", "-1", 0);
-    AV_DICT_SET_INT(opts, "qcomp", "-1", 0);
-    AV_DICT_SET_INT(opts, "g", "250", 0);
-    AV_DICT_SET_INT(opts, "bf", "0", 0);
-    AV_DICT_SET_INT(opts, "refs", "0", 0);
+    AV_DICT_SET_INT(opts, "qmin", -1, 0);
+    AV_DICT_SET_INT(opts, "qmax", -1, 0);
+    AV_DICT_SET_INT(opts, "qdiff", -1, 0);
+    AV_DICT_SET_INT(opts, "qblur", -1, 0);
+    AV_DICT_SET_INT(opts, "qcomp", -1, 0);
+    AV_DICT_SET_INT(opts, "g", 250, 0);
+    AV_DICT_SET_INT(opts, "bf", 0, 0);
+    AV_DICT_SET_INT(opts, "refs", 0, 0);
     return 0;
 }
 
@@ -449,14 +449,14 @@ tvh_codec_profile_nvenc_hevc_open(tvh_codec_profile_nvenc_t *self,
         }
     
     // ------ Set Defaults ---------
-    AV_DICT_SET_INT(opts, "qmin", "-1", 0);
-    AV_DICT_SET_INT(opts, "qmax", "-1", 0);
-    AV_DICT_SET_INT(opts, "qdiff", "-1", 0);
-    AV_DICT_SET_INT(opts, "qblur", "-1", 0);
-    AV_DICT_SET_INT(opts, "qcomp", "-1", 0);
-    AV_DICT_SET_INT(opts, "g", "250", 0);
-    AV_DICT_SET_INT(opts, "bf", "0", 0);
-    AV_DICT_SET_INT(opts, "refs", "0", 0);
+    AV_DICT_SET_INT(opts, "qmin", -1, 0);
+    AV_DICT_SET_INT(opts, "qmax", -1, 0);
+    AV_DICT_SET_INT(opts, "qdiff", -1, 0);
+    AV_DICT_SET_INT(opts, "qblur", -1, 0);
+    AV_DICT_SET_INT(opts, "qcomp", -1, 0);
+    AV_DICT_SET_INT(opts, "g", 250, 0);
+    AV_DICT_SET_INT(opts, "bf", 0, 0);
+    AV_DICT_SET_INT(opts, "refs", 0, 0);
     return 0;
 }
 


### PR DESCRIPTION
Commit 0165f365cd58bbcc3734e4ec9ce696b42870ff8e introduced an FTBFS
when -Werror=int-conversion is passed to the compiler.  For
reasons unknown to me, the "value" argument to AV_DICT_SET_INT was
written as a string (const char *) rather than the int64_t that
the function behind the macro was expecting in the "Set Defaults"
statements.  This was resulting in the value of the pointer to the
character array getting used as the argument rather than the
integer itself, which appears to be what was intended.  This
triggers the Werror=int-conversion error and also probably results
in unexpected behavior from passing the pointer values.