### PR TITLE
OpenTV: fix missing summaries when running continuously for a number of days without a restart

### DIFF
--- a/src/epg.c
+++ b/src/epg.c
@@ -1083,7 +1083,7 @@ epg_broadcast_t *epg_broadcast_find_by_eid ( channel_t *ch, uint16_t eid )
 {
   epg_broadcast_t *e;
   RB_FOREACH(e, &ch->ch_epg_schedule, sched_link) {
-    if (e->dvb_eid == eid) return e;
+    if (e->dvb_eid == eid && e->stop > gclk()) return e;
   }
   return NULL;
 }


### PR DESCRIPTION
I was finding that after running for around 3-4 weeks some of the events via the OpenTV: SkyUK data were coming through with a blank summary as shown in the following screenshot.

![screenshot](https://user-images.githubusercontent.com/14977362/151817491-4c3278f7-e5d8-466f-9be1-c633129f96b2.png)

Even forcing further scrapes (with maximum time-out) was not pulling through the summary data. However, I did discover that restarting TVHeadend and performing a further scrape would always resolve the issue. So seems related to something left in memory. It was hard to bottom this out as I had to enable opentv debug logging and leave it running for a number of weeks... but I've finally got some useful logging and found the cause...

epg_broadcast_find_by_eid was identifying past events with the same eid that were still lingering in memory. From my examinations of the OpenTV guide data it looks like the eids are re-used every 3-4 weeks on a given channel, which seems to fit with my findings that the problem starts to surface after 3-4 weeks of continuous usage.

Here are example log entries to go with the above screenshot:

eid 865 on channel 610 was used by event **Space Chickens In Space** broadcast on **10th Jan @01:48AM-02:00AM**

```
2022-01-03 00:31:12.554 [  DEBUG]:opentv: find by time start 1641779280 stop 1641780000 ch 610000000 eid 865 = 0x7f0f682770c0
2022-01-03 00:31:12.554 [  DEBUG]:opentv:     title 'Space Chickens In Space'

2022-01-03 00:31:15.398 [  DEBUG]:opentv: find by ch 610000000 eid 865 = 0x7f0f682770c0
2022-01-03 00:31:15.398 [  DEBUG]:opentv:   summary 'Try Not To Laugh: Starley takes pity on a pet mushroom which triggers an outbreak of spores making people allergic to laughter. (S1 Ep13)'
```

Note the memory address for this event: 0x7f0f682770c0

eid 865 is then used again on the same channel (610) for the event shown highlighted in the screenshot **Talking Tom and Friends** broadcast on **31st Jan @09:00AM-09:15AM**

```
2022-01-26 00:31:18.054 [  DEBUG]:opentv: find by time start 1643619600 stop 1643620500 ch 610000000 eid 865 = 0x7f0f69c4fff0
2022-01-26 00:31:18.054 [  DEBUG]:opentv:     title 'Talking Tom and Friends'
```

This is the title side of the record which creates a new event (memory address 0x7f0f69c4fff0) and this is the event you see in the guide (see previous screenshot).

However, when it encounters the summary side of the record it links this to the past event (memory address: 0x7f0f682770c0)::

```
2022-01-31 00:31:22.378 [  DEBUG]:opentv: find by ch 610000000 eid 865 = 0x7f0f682770c0
2022-01-31 00:31:22.378 [  DEBUG]:opentv:   summary 'The Love Ride: Talking Ben is thrilled because his online girlfriend Xenon is coming for a visit! There's just one problem: Xenon wants to go for a drive. (S2 Ep18)'
```

To fix this, I adjusted the comparison within epg_broadcast_find_by_eid to ensure that the event stop time is in the future, such that it will only return current and future events.

Seems the correct/safe thing to do since epg_broadcast_find_by_eid is only called from two places

1) opentv.c: opentv_parse_event_section_one
https://github.com/tvheadend/tvheadend/blob/c6bb43d8554643a772aa40c5e56904717b55a95f/src/epggrab/module/opentv.c#L503

2) psip.c: _psip_ett_callback
https://github.com/tvheadend/tvheadend/blob/10d117e6ed912759db59633ea426bed5ceb6819a/src/epggrab/module/psip.c#L596

Both pieces of code are processing new (future) events so it makes sense to add this extra sanity check to only match future events when identifying by eid

