### PR TITLE
Doozer: build for Fedora 34 and 35

### DIFF
--- a/.doozer.json
+++ b/.doozer.json
@@ -582,10 +582,10 @@
         "support/bintray.py publish filelist.txt"
       ]
     },
-    "fedora28-x86_64": {
-      "buildenv": "docker:fedora:28",
+    "fedora34-x86_64": {
+      "buildenv": "docker:fedora:34",
       "builddeps": [
-        ["https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-28.noarch.rpm"],
+        ["https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-34.noarch.rpm"],
         "gcc-c++",
         "which",
         "rpm-build",
@@ -612,10 +612,10 @@
         "support/bintray.py publish filelist.txt"
       ]
     },
-    "fedora29-x86_64": {
-      "buildenv": "docker:fedora:29",
+    "fedora35-x86_64": {
+      "buildenv": "docker:fedora:35",
       "builddeps": [
-        ["https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-29.noarch.rpm"],
+        ["https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-35.noarch.rpm"],
         "gcc-c++",
         "which",
         "rpm-build",


### PR DESCRIPTION
Hi!

I'm going to attempt and get tvheadend on Doozer to build against the newer Fedora versions. As I'm currently upgrading my system from Fedora 33 to 34, I'm not online on IRC, but you can usually ping me (rubdos) to take a further look.

In this first patch, I'm only changing out the version numbers. I don't expect anything weird to happen, but if it stops building from there on, you can expect further PRs.

I tried signing the CLA, but the page at https://www.clahub.com/agreements/tvheadend/tvheadend is blank on my browser.

Best,

Ruben