### PR TITLE
Update Python shebangs to python3 for Fedora

### DIFF
--- a/lib/py/tvh/tv_meta_tmdb.py
+++ b/lib/py/tvh/tv_meta_tmdb.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # Retrieve details for a movie from tmdb.
 #
 # This product uses the TMDb API but is not endorsed or certified by TMDb.

--- a/lib/py/tvh/tv_meta_tvdb.py
+++ b/lib/py/tvh/tv_meta_tvdb.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # Retrieve details for a series from tvdb.
 #
 # Required options:

--- a/support/tvhmeta
+++ b/support/tvhmeta
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 # Update Tvheadend recordings with additional external metadata such
 # as artwork.


### PR DESCRIPTION
RPM build currently gives these (e.g. https://doozer.io/tvheadend/tvheadend/buildlog/23860):

```
*** ERROR: ambiguous python shebang in /usr/bin/tv_meta_tvdb.py: #!/usr/bin/env python. Change it to python3 (or python2) explicitly.
*** ERROR: ambiguous python shebang in /usr/bin/tv_meta_tmdb.py: #!/usr/bin/env python. Change it to python3 (or python2) explicitly.
*** ERROR: ambiguous python shebang in /usr/bin/tvhmeta: #!/usr/bin/env python. Change it to python3 (or python2) explicitly.
error: Bad exit status from /var/tmp/rpm-tmp.FMb2Z3 (%install)
```

Changing the shebangs to python3 fixes the whole thing, which is what this patch is about. If you have some python2 systems to still support, feel free to close this, and I can supply a version that uses `sed` in the rpmbuild.  I have a local setup to test the RPM build now, and  with this fix I have an actual RPM! :-)