### PR TITLE
Add option to drop src-parameter from RTSP-requests

### DIFF
--- a/src/satip/rtsp.c
+++ b/src/satip/rtsp.c
@@ -1221,6 +1221,8 @@ rtsp_parse_cmd
 
   } else if (msys == DVB_SYS_DVBC_ANNEX_A || msys == DVB_SYS_DVBC_ANNEX_C) {
 
+    if(satip_server_conf.satip_drop_src)
+      http_arg_get_remove(&hc->hc_req_args, "src");
     freq *= 1000;
     if (freq < 0) goto end;
     c2tft = atoi(http_arg_get_remove(&hc->hc_req_args, "c2tft") ?: "0");

--- a/src/satip/server.c
+++ b/src/satip/server.c
@@ -970,6 +970,17 @@ const idclass_t satip_server_class = {
       .opts   = PO_EXPERT,
       .group  = 5,
     },
+    {
+      .type   = PT_BOOL,
+      .id     = "satip_drop_src",
+      .name   = N_("Drop \"src=\" parameter"),
+      .desc   = N_("Discard the source parameter in RTSP requests "
+                   "for DVB-C tuners, as some clients (e.g. Plex) "
+                   "incorrectly use it."),
+      .off    = offsetof(struct satip_server_conf, satip_drop_src),
+      .opts   = PO_EXPERT,
+      .group  = 5,
+    },
     {}
   },
 };

--- a/src/satip/server.h
+++ b/src/satip/server.h
@@ -52,6 +52,7 @@ struct satip_server_conf {
   int satip_anonymize;
   int satip_noupnp;
   int satip_drop_fe;
+  int satip_drop_src;
   int satip_restrict_pids_all;
   int satip_iptv_sig_level;
   int satip_force_sig_level;


### PR DESCRIPTION
This patch adds an option similar to the one for dropping
frontend-parameter from RTSP-requests, but this only applies
to DVB-C tuners. The reason for this patch is that it enables
Plex to work directly with the Tvheadend SAT>IP-server.

Signed-off-by: Nita Vesa <werecatf@outlook.com>