### PR TITLE
SAT>IP client: UPnP header field names are case insensitive

### DIFF
--- a/src/input/mpegts/satip/satip.c
+++ b/src/input/mpegts/satip/satip.c
@@ -1175,19 +1175,19 @@ satip_discovery_service_received
     if (ptr == NULL)
       break;
     if (http_tokenize(ptr, argv, 2, ':') == 2) {
-      if (strcmp(argv[0], "ST") == 0)
+      if (strcasecmp(argv[0], "ST") == 0)
         st = argv[1];
-      else if (strcmp(argv[0], "LOCATION") == 0)
+      else if (strcasecmp(argv[0], "LOCATION") == 0)
         location = argv[1];
-      else if (strcmp(argv[0], "SERVER") == 0)
+      else if (strcasecmp(argv[0], "SERVER") == 0)
         server = argv[1];
-      else if (strcmp(argv[0], "BOOTID.UPNP.ORG") == 0)
+      else if (strcasecmp(argv[0], "BOOTID.UPNP.ORG") == 0)
         bootid = argv[1];
-      else if (strcmp(argv[0], "CONFIGID.UPNP.ORG") == 0)
+      else if (strcasecmp(argv[0], "CONFIGID.UPNP.ORG") == 0)
         configid = argv[1];
-      else if (strcmp(argv[0], "DEVICEID.SES.COM") == 0)
+      else if (strcasecmp(argv[0], "DEVICEID.SES.COM") == 0)
         deviceid = argv[1];
-      else if (strcmp(argv[0], "USN") == 0) {
+      else if (strcasecmp(argv[0], "USN") == 0) {
         n = http_tokenize(argv[1], argv, ARRAY_SIZE(argv), ':');
         for (i = 0; i < n-1; i++)
           if (argv[i] && strcmp(argv[i], "uuid") == 0) {


### PR DESCRIPTION
- [SAT>IP Protocol Specification 1.2.2](https://www.satip.info/sites/satip/files/resource/satip_specification_version_1_2_2.pdf): 3.3.2 Server Advertisements: "Please note that in UPnP - header field names are case insensitive and header field values are case sensitive"
- some servers reply with e.g. "Location" or "Server" instead of "LOCATION" or "SERVER"