### PR TITLE
dvr_disk_space_cleanup() - do not return error if called again too so…

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -666,7 +666,7 @@ void dvr_spawn_fetch_artwork(dvr_entry_t *de);
 void dvr_vfs_refresh_entry(dvr_entry_t *de);
 void dvr_vfs_remove_entry(dvr_entry_t *de);
 int64_t dvr_vfs_update_filename(const char *filename, htsmsg_t *fdata);
-int64_t dvr_vfs_rec_start_check(dvr_config_t *cfg);
+int dvr_vfs_rec_start_check(dvr_config_t *cfg);
 
 void dvr_disk_space_boot(void);
 void dvr_disk_space_init(void);


### PR DESCRIPTION
…on

Fixes #6152

If two recordings begin simultaneously, and the free storage space is below the minimum, the second recording to be processed will fail.

File deletion and update of disk statistics, triggered by the start of the first recording, takes a finite time (possibly several seconds if a disk drive has to spin up). The second recording may therefore see the same space shortage as the first and trigger a further cleanup. However dvr_disk_space_cleanup() returns an error if called within 10 seconds of the last cleanup, causing the recording to fail.

The code is reworked to explicitly report and handle this condition.
