### PR TITLE
fix build with libressl

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -412,7 +412,7 @@ http_send_header(http_connection_t *hc, int rc, const char *content,
         http_auth_header(&hdrs, realm,
                          config.http_auth_algo == HTTP_AUTH_ALGO_SHA256 ?
                            "SHA-256" :
-#if OPENSSL_VERSION_NUMBER >= 0x1010101fL
+#if OPENSSL_VERSION_NUMBER >= 0x1010101fL && !defined(LIBRESSL_VERSION_NUMBER)
                              "SHA-512-256",
 #else
                              "SHA-256",

--- a/src/utils.c
+++ b/src/utils.c
@@ -616,7 +616,7 @@ sha256sum ( const char *str, int lowercase )
 char *
 sha512sum256 ( const char *str, int lowercase )
 {
-#if OPENSSL_VERSION_NUMBER >= 0x1010101fL
+#if OPENSSL_VERSION_NUMBER >= 0x1010101fL && !defined(LIBRESSL_VERSION_NUMBER)
   return openssl_hash_hexstr(str, lowercase, EVP_sha512_256(), 32);
 #else
   return NULL;


### PR DESCRIPTION
Fix the following build failure with libressl raised since https://github.com/tvheadend/tvheadend/commit/e61acb8ad4a3411f4e7acfd8133d222299f6d47e:

```
utils.c:(.text+0x1614): undefined reference to `EVP_sha512_256'
```

Fixes:
 - http://autobuild.buildroot.org/results/cb18f6533806f3729f9718bdcc719384be375b66

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>