### PR TITLE
add Access-Control-Allow-Headers content-length

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -370,7 +370,7 @@ http_send_header(http_connection_t *hc, int rc, const char *content,
     if (config.cors_origin && config.cors_origin[0]) {
       htsbuf_qprintf(&hdrs, "Access-Control-Allow-Origin: %s\r\n%s%s%s", config.cors_origin,
                             "Access-Control-Allow-Methods: POST, GET, OPTIONS\r\n",
-                            "Access-Control-Allow-Headers: x-requested-with,authorization\r\n",
+                            "Access-Control-Allow-Headers: x-requested-with,authorization,content-type\r\n",
                             "Access-Control-Allow-Credentials: true\r\n");
     }
   }


### PR DESCRIPTION
Issue originally reported: https://tvheadend.org/issues/6146

Re-verefied on master: 26713c1e451a74dbcc7aaec8427c0356cc2c546f
![image](https://user-images.githubusercontent.com/1442484/164720329-ca65cbca-e759-4f34-95fc-107d6b11f090.png)

![image](https://user-images.githubusercontent.com/1442484/164719326-8329cfe6-bd2c-49d2-8a56-59707dca5536.png)
![image](https://user-images.githubusercontent.com/1442484/164720816-623dbcf9-52dd-4a87-8269-3bd2bfec3392.png)

![image](https://user-images.githubusercontent.com/1442484/164719613-48112361-296b-4310-8d6f-691ff313fc03.png)
