### PR TITLE
Fix use-after-free

### DIFF
--- a/src/misc/json.c
+++ b/src/misc/json.c
@@ -115,9 +115,9 @@ json_parse_string(const char *s, const char **endp,
 		  v |= a[i] - 'F' + 10;
 		  break;
 		default:
-		  free(r);
 		  *failmsg = "Incorrect escape sequence";
 		  *failp = (a - r) + start;
+		  free(r);
 		  return NULL;
 		}
 	      }


### PR DESCRIPTION
Building Tvheadend on Raspberry Pi with gcc 12 fails with this error

src/misc/json.c: In function ‘json_parse_string’:
src/misc/json.c:120:31: error: pointer ‘r’ used after ‘free’ [-Werror=use-after-free]
  120 |                   *failp = (a - r) + start;
      |                            ~~~^~~~
src/misc/json.c:118:19: note: call to ‘free’ here
  118 |                   free(r);
      |                   ^~~~~~~

This PR appears correct and fixes the gcc error but has not been tested as it is an error path.