### PR TITLE
Added support for ATSC text mode == 0x3F

### DIFF
--- a/src/input/mpegts/dvb_support.c
+++ b/src/input/mpegts/dvb_support.c
@@ -507,6 +507,17 @@ atsc_get_string
         if (ls == NULL)
           ls = lang_str_create();
         lang_str_append(ls, buf, langcode);
+      }	else if (compressiontype == 0 && mode == 0x3F) {
+        tvhtrace(LS_MPEGTS, "atsc-str:    %d: comptype 0x%02x, mode 0x%02x, %d bytes: '%.*s'",
+                 j, compressiontype, mode, bytecount, bytecount, src);
+
+        /* let the atsc_utf16_to_utf8 function do the conversion;
+         * bytecount/2: since the function is handling both utf16 bytes in one count only half the length is needed */
+      	atsc_utf16_to_utf8(src, bytecount/2, buf, bufferSize);
+
+        if (ls == NULL)
+          ls = lang_str_create();
+        lang_str_append(ls, buf, langcode);
       } else {
         /* Unsupported text segment types:
          *
@@ -515,7 +526,6 @@ atsc_get_string
          * - compression type == 0x3 .. 0xFF (reserved)
          *
          * - text mode == 0x3E (Standard Compression Scheme for Unicode)
-         * - text mode == 0x3F (Select Unicode, UTF-16 Form)
          * - text mode == 0x40, 0x41 (ATSC Standard for Taiwan)
          * - text mode == 0x48 (ATSC Standard for South Korea)
          *


### PR DESCRIPTION
Added support for decoding ATSC's text mode 0x3F

I verified this on a RasPi system with a WinTV-dualHD (Model 1595) receiving South-Korean Terrestrial TV signals. It runs stable and gives the right naming of TV shows and station names.

Thanks to @NormRaden 's fix and implementation of the other text modes, this was very easy to implement. Thanks, mate!