### PR TITLE
Add support for LCN for provider DigiTV

### DIFF
--- a/src/input/mpegts/dvb_psi.c
+++ b/src/input/mpegts/dvb_psi.c
@@ -1355,7 +1355,7 @@ dvb_nit_mux
           priv == 0x3200 || priv == 0x3201) goto lcn;
       break;
     case 0x86:
-      if (priv == 0) goto lcn;
+      if (priv == 0 || priv == 0x1a0) goto lcn;
       break;
     case 0x88:
       if (priv == 0x28) {


### PR DESCRIPTION
I added support for the Logical Channel Numbering for the Romanian cable provider DigiTV (formerly known as RCS&RDS).

For the LCN data they are using private data specifier `0x1a0` and descriptor tag `0x86` 