### PR TITLE
epgdb: Resolve symlinks before using file location

### DIFF
--- a/src/epgdb.c
+++ b/src/epgdb.c
@@ -302,7 +302,9 @@ static void epg_save_tsk_callback ( void *p, int dearmed )
   int fd, r;
 
   tvhinfo(LS_EPGDB, "save start");
-  hts_settings_buildpath(path, sizeof(path), "epgdb.v%d", EPG_DB_VERSION);
+  hts_settings_buildpath(tmppath, sizeof(path), "epgdb.v%d", EPG_DB_VERSION);
+  if (!realpath(tmppath, path))
+    strlcpy(path, tmppath, sizeof(path));
   snprintf(tmppath, sizeof(tmppath), "%s.tmp", path);
   if (hts_settings_makedirs(tmppath))
     fd = -1;


### PR DESCRIPTION
The new epgdb is written to a temporary file and later renamed to override the old epgdb file atomically. If you diverted the epgdb to a different place away from your usual configuration (e.g. for space and/or disk usage reasons like on an OpenWrt router) this leads to overriding the symlink with a real file defeating the point.

By applying realpath on the path first we can resolve any symlink along the path, while not considering it a failure if the epgdb file doesn't exist yet. If on the other hand the path up to the file doesn't exist we default to the old way of just taking the path verbatim and let them be created by hts_settings_makedirs as before.

Note that this relies on the paths being sized PATH_MAX, which as the [manpage](https://manpages.debian.org/unstable/manpages-dev/realpath.3.en.html) notes is POSIX.1-2001 conform, but broken by design as PATH_MAX can't be relied upon, but the entire codebase makes heavy use of PATH_MAX and there is a pre-existing usage of realpath() in this way so lets pretend its okay for now.

References: b23686a55323625b15d4f99fd7af55259fa21828

---

I am unsure how contribution is supposed to work here as the guidelines make references to a CLA, but that website seems broken? Also to freenode irc… anyhow, I don't have an account in the forums/redmine either. I am not even set on using tvheadend yet as I am actually shopping around a bit in terms of if I want to drop my VDR usage for tvheadend – and if either will have a good time in their supposed new home… a router, which obviously has some space and usage constraints (although it has 4x arm64 @ 2.2GHz and 1GB RAM, so not THAT constraint). Just mentioning so you have an idea what my background is and why I might or might not come up with similar special interest features. And as a big sorry for probably ignoring all established project rules as I somewhat failed to find current ones… :pray: