### PR TITLE
iptv_auto: Add support for m3u "channel-number" tag

### DIFF
--- a/src/input/mpegts/iptv/iptv_auto.c
+++ b/src/input/mpegts/iptv/iptv_auto.c
@@ -105,6 +105,7 @@ iptv_auto_network_process_m3u_item(iptv_network_t *in,
 
   epgid = htsmsg_get_str(item, "tvh-chnum");
   if (!epgid) epgid = htsmsg_get_str(item, "tvg-chno");
+  if (!epgid) epgid = htsmsg_get_str(item, "channel-number");
   chnum2 = epgid ? channel_get_number_from_str(epgid) : 0;
 
   muxprio = htsmsg_get_s32_or_default(item, "tvh-prio", -1);


### PR DESCRIPTION
SiliconDust recently added m3u playlist generation support to the HDHomeRun products.  They use "channel-number" for the channel number, so add support for that value to TVHeadend.  It is used as a fallback only if the previously-supported "tvh-chnum" and "tvg-chno" tags aren't present.  This should be particularly useful for usage with ATSC 3.0 channels, as those aren't supported in the libhdhomerun library that TVHeadend normally uses for HDHomeRun devices.  Without this, the channel number for all channels imported from the HDHomeRun m3u is "0".