### PR TITLE
Avoid breaking strict aliasing in TCP code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,7 @@ CFLAGS  += -Werror
 endif
 CFLAGS  += -Wall -Wwrite-strings -Wno-deprecated-declarations
 CFLAGS  += -Wmissing-prototypes
-CFLAGS  += -fms-extensions -funsigned-char -fno-strict-aliasing
-ifeq ($(COMPILER), gcc)
-CFLAGS  += -Wno-stringop-truncation -Wno-stringop-overflow
-endif
+CFLAGS  += -fms-extensions -funsigned-char
 CFLAGS  += -D_FILE_OFFSET_BITS=64
 CFLAGS  += -I${BUILDDIR} -I${ROOTDIR}/src -I${ROOTDIR}
 ifeq ($(CONFIG_ANDROID),yes)

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -94,7 +94,7 @@ ip_check_is_local_address
     if (!ifaddr || !ifnetmask) continue;
     if (ifaddr->ss_family != local->ss_family) continue;
     if (!any_address && !ip_check_equal(ifaddr, local)) continue;
-    ret = !!ip_check_in_network_v4(ifaddr, ifnetmask, peer);
+    ret = !!ip_check_in_network(ifaddr, ifnetmask, peer);
     if (ret) {
       if (used_local)
         memcpy(used_local, ifaddr, sizeof(struct sockaddr));
@@ -1051,9 +1051,9 @@ tcp_default_ip_addr ( struct sockaddr_storage *deflt, int family )
   }
 
   if (ss.ss_family == AF_INET)
-    IP_AS_V4(ss, port) = 0;
+    IP_AS_V4(&ss, port) = 0;
   else
-    IP_AS_V6(ss, port) = 0;
+    IP_AS_V6(&ss, port) = 0;
 
   memset(deflt, 0, sizeof(*deflt));
   memcpy(deflt, &ss, ss_len);
@@ -1092,9 +1092,9 @@ tcp_server_bound ( void *server, struct sockaddr_storage *bound, int family )
   if (tcp_default_ip_addr(bound, family) < 0)
     return -1;
   if (bound->ss_family == AF_INET)
-    IP_AS_V4(*bound, port) = port;
+    IP_AS_V4(bound, port) = port;
   else
-    IP_AS_V6(*bound, port) = port;
+    IP_AS_V6(bound, port) = port;
   return 0;
 }
 

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -26,8 +26,8 @@
 #include <sys/socket.h>
 #endif
 
-#define IP_AS_V4(storage, f) ((struct sockaddr_in *)&(storage))->sin_##f
-#define IP_AS_V6(storage, f) ((struct sockaddr_in6 *)&(storage))->sin6_##f
+#define IP_AS_V4(storage, f) ((struct sockaddr_in *)(storage))->sin_##f
+#define IP_AS_V6(storage, f) ((struct sockaddr_in6 *)(storage))->sin6_##f
 #define IP_IN_ADDR(storage) \
   ((storage).ss_family == AF_INET6 ? \
       &((struct sockaddr_in6 *)&(storage))->sin6_addr : \

--- a/src/tvhlog.c
+++ b/src/tvhlog.c
@@ -587,7 +587,7 @@ tvhlog_init ( int level, int options, const char *path )
     if (rtport > 0) {
       tvhlog_rtfd = tvh_socket(AF_INET, SOCK_DGRAM, 0);
       tcp_get_ip_from_str("127.0.0.1", &tvhlog_rtss);
-      IP_AS_V4(tvhlog_rtss, port) = htons(rtport);
+      IP_AS_V4(&tvhlog_rtss, port) = htons(rtport);
     }
   }
 #endif

--- a/src/udp.c
+++ b/src/udp.c
@@ -76,15 +76,15 @@ udp_resolve( udp_connection_t *uc,
   }
   if (use->ai_family == AF_INET6) {
     ss->ss_family        = AF_INET6;
-    IP_AS_V6(*ss, port)  = htons(port);
-    memcpy(&IP_AS_V6(*ss, addr), &((struct sockaddr_in6 *)use->ai_addr)->sin6_addr,
+    IP_AS_V6(ss, port)  = htons(port);
+    memcpy(&IP_AS_V6(ss, addr), &((struct sockaddr_in6 *)use->ai_addr)->sin6_addr,
                                                              sizeof(struct in6_addr));
-    *multicast           = !!IN6_IS_ADDR_MULTICAST(&IP_AS_V6(*ss, addr));
+    *multicast           = !!IN6_IS_ADDR_MULTICAST(&IP_AS_V6(ss, addr));
   } else if (use->ai_family == AF_INET) {
     ss->ss_family        = AF_INET;
-    IP_AS_V4(*ss, port)  = htons(port);
-    IP_AS_V4(*ss, addr)  = ((struct sockaddr_in *)use->ai_addr)->sin_addr;
-    *multicast           = !!IN_MULTICAST(ntohl(IP_AS_V4(*ss, addr.s_addr)));
+    IP_AS_V4(ss, port)  = htons(port);
+    IP_AS_V4(ss, addr)  = ((struct sockaddr_in *)use->ai_addr)->sin_addr;
+    *multicast           = !!IN_MULTICAST(ntohl(IP_AS_V4(ss, addr.s_addr)));
   }
   freeaddrinfo(ressave);
   if (ss->ss_family != AF_INET && ss->ss_family != AF_INET6) {
@@ -207,9 +207,9 @@ udp_bind ( int subsystem, const char *name,
     /* Bind useful for receiver subsystem (not for udp streamer) */
     if (subsystem != LS_UDP) {
     if (bind(fd, (struct sockaddr *)&uc->ip, sizeof(struct sockaddr_in))) {
-      inet_ntop(AF_INET, &IP_AS_V4(uc->ip, addr), buf, sizeof(buf));
+      inet_ntop(AF_INET, &IP_AS_V4(&uc->ip, addr), buf, sizeof(buf));
       tvherror(subsystem, "%s - cannot bind %s:%hu [e=%s]",
-               name, buf, ntohs(IP_AS_V4(uc->ip, port)), strerror(errno));
+               name, buf, ntohs(IP_AS_V4(&uc->ip, port)), strerror(errno));
       goto error;
     }
     }  
@@ -221,7 +221,7 @@ udp_bind ( int subsystem, const char *name,
         struct ip_mreq_source ms;
         memset(&ms, 0, sizeof(ms));
 
-        ms.imr_multiaddr = IP_AS_V4(uc->ip, addr);
+        ms.imr_multiaddr = IP_AS_V4(&uc->ip, addr);
 
         /* Note, ip_mreq_source does not support the ifindex parameter,
            so we have to resolve to the ip of the interface on all platforms. */
@@ -253,7 +253,7 @@ udp_bind ( int subsystem, const char *name,
 #endif
         memset(&m,   0, sizeof(m));
 
-        m.imr_multiaddr      = IP_AS_V4(uc->ip, addr);
+        m.imr_multiaddr      = IP_AS_V4(&uc->ip, addr);
 #if !defined(PLATFORM_DARWIN)
         m.imr_address.s_addr = 0;
         m.imr_ifindex        = ifindex;
@@ -280,15 +280,15 @@ udp_bind ( int subsystem, const char *name,
 
     /* Bind */
     if (bind(fd, (struct sockaddr *)&uc->ip, sizeof(struct sockaddr_in6))) {
-      inet_ntop(AF_INET6, &IP_AS_V6(uc->ip, addr), buf, sizeof(buf));
+      inet_ntop(AF_INET6, &IP_AS_V6(&uc->ip, addr), buf, sizeof(buf));
       tvherror(subsystem, "%s - cannot bind %s:%hu [e=%s]",
-               name, buf, ntohs(IP_AS_V6(uc->ip, port)), strerror(errno));
+               name, buf, ntohs(IP_AS_V6(&uc->ip, port)), strerror(errno));
       goto error;
     }
 
     if (uc->multicast) {
       /* Join group */
-      m.ipv6mr_multiaddr = IP_AS_V6(uc->ip, addr);
+      m.ipv6mr_multiaddr = IP_AS_V6(&uc->ip, addr);
       m.ipv6mr_interface = ifindex;
 #ifdef SOL_IPV6
       if (setsockopt(fd, SOL_IPV6, IPV6_ADD_MEMBERSHIP, &m, sizeof(m))) {

--- a/src/upnp.c
+++ b/src/upnp.c
@@ -227,8 +227,8 @@ upnp_server_init(const char *bindaddr)
 
   memset(&upnp_ipv4_multicast, 0, sizeof(upnp_ipv4_multicast));
   upnp_ipv4_multicast.ss_family       = AF_INET;
-  IP_AS_V4(upnp_ipv4_multicast, port) = htons(1900);
-  r = inet_pton(AF_INET, "239.255.255.250", &IP_AS_V4(upnp_ipv4_multicast, addr));
+  IP_AS_V4(&upnp_ipv4_multicast, port) = htons(1900);
+  r = inet_pton(AF_INET, "239.255.255.250", &IP_AS_V4(&upnp_ipv4_multicast, addr));
   assert(r);
 
   tvh_mutex_init(&upnp_lock, NULL);


### PR DESCRIPTION
Hi,

as #1473 broke compiling with gcc-11 due to a false positive I feel responsible for making it work again, even if is somewhat easy to workaround and semi-temporary (just use a fixed compiler, right? :wink: ).

So what we do here is making tvheadend compile with strict-aliasing rules enabled, which as a by-product apparently doesn't lead gcc-11 down the wrong path. yeaha!

On the downside, I have basically only compile-tested this (on gcc-12 and a bit with gcc-11) as I run tvheadend with `--noacl` and many compiletime options disabled… and while I believe both Makefile changes should be done they might break compiling with older compiler versions or on code which breaks strict aliasing, but isn't detected (and hence potentially wrongly optimized). Disabling strict-aliasing on the entire codebase is not without bug potential either through as seen with the gcc-11 false positive. So I choose to do both in separate commits which could be easily reverted if it turns out the world burns with them. I would hope not, but you never know… (I wasn't really expecting running into compiler bugs either).