### PR TITLE
Add South Africa to Countries list.

### DIFF
--- a/src/input/mpegts/scanfile.c
+++ b/src/input/mpegts/scanfile.c
@@ -110,6 +110,7 @@ static const struct {
   {"uk", "United Kingdom"},
   {"us", "United States"},
   {"vn", "Vietnam"},
+  {"za", "South Africa"},
 };
 
 static const char *


### PR DESCRIPTION
dtv-scan-tables commit 28414c7 added muxes for South Africa. Add the country to the country codes list.