### PR TITLE
config: Enable HbbTV parser by default

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2596,6 +2596,7 @@ const idclass_t config_class = {
       .desc   = N_("Parse HbbTV information from services."),
       .off    = offsetof(config_t, hbbtv),
       .group  = 7,
+      .def.i  = 1,
     },
     {
       .type   = PT_BOOL,


### PR DESCRIPTION
It make sense to include it always when available

Link: https://tvheadend.org/issues/6223
Signed-off-by: Kacper Michajłow <kasper93@gmail.com>