### PR TITLE
Don't confuse GCC with zero-length array

### DIFF
--- a/src/htsmsg.h
+++ b/src/htsmsg.h
@@ -81,7 +81,7 @@ typedef struct htsmsg_field {
 #if ENABLE_SLOW_MEMORYINFO
   size_t hmf_edata_size;
 #endif
-  const char _hmf_name[0];
+  const char _hmf_name[];
 } htsmsg_field_t;
 
 #define hmf_s64     u.s64


### PR DESCRIPTION
Fix FTBFS introduced by 7b95ba4cf9113ae8808b3e4a9425010b607dbaca

Link: https://tvheadend.org/issues/6173
Link: https://tvheadend.org/issues/6226
References: 7b95ba4cf9113ae8808b3e4a9425010b607dbaca
Signed-off-by: Cédric Schieli <cschieli@gmail.com>