### PR TITLE
remove libavresample from build scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,6 @@ ifeq ($(CONFIG_LIBAV),yes)
 FFMPEG_LIBS := \
     libavfilter \
     libswresample \
-    libavresample \
     libswscale \
     libavformat \
     libavcodec \

--- a/configure
+++ b/configure
@@ -642,7 +642,6 @@ else
 
     check_pkg libavfilter   ">=6.47.100"  || has_libav=false
     check_pkg libswresample ">=2.1.100"   && has_resample=true
-    check_pkg libavresample ">=3.0.0"     && has_resample=true
     check_pkg libswscale    ">=4.1.100"   || has_libav=false
     check_pkg libavformat   ">=57.41.100" || has_libav=false
     check_pkg libavcodec    ">=57.48.101" || has_libav=false


### PR DESCRIPTION
libavresample is not being used. Builds should not depend on it.
Fixes #6084 and #6219