### PR TITLE
Add autorec duplicate handling default to dvr config.

### DIFF
--- a/docs/property/duplicate_handling.md
+++ b/docs/property/duplicate_handling.md
@@ -1,14 +1,15 @@
 :
 
-Option                                       | Description
----------------------------------------------|------------
-**Record all**                               | Record all matching events.
-**Record if different episode number**       | Record a matching event only if the episode number is different.
-**Record if different subtitle**             | Record a matching event only if the subtitle is different.
-**Record if different description**          | Record a matching event only if the description is different.
-**Record once per month**                    | Record the first matching event once per month. 
-**Record once per week**                     | Record the first matching event once a week.
-**Record once per day**                      | Record the first matching event once a day.
+Option                                                     | Description
+-----------------------------------------------------------|------------
+**Record all**                                             | Record all matching events.
+**Record if EPG/XMLTV indicates it is a unique programme** | Record only if no other timer or recording has the same EPG data including event ID.
+**Record if different episode number**                     | Record a matching event only if the episode number is different.
+**Record if different subtitle**                           | Record a matching event only if the subtitle is different.
+**Record if different description**                        | Record a matching event only if the description is different.
+**Record once per month**                                  | Record the first matching event once per month. 
+**Record once per week**                                   | Record the first matching event once a week.
+**Record once per day**                                    | Record the first matching event once a day.
 
 *Local* only checks for duplicates created by the same 
 autorec rule, *All* checks all the DVR logs for duplicates.

--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -127,6 +127,8 @@ typedef struct dvr_config {
 
   idnode_list_head_t dvr_accesses;
 
+  int dvr_autorec_dedup;
+
 } dvr_config_t;
 
 typedef enum {
@@ -753,6 +755,9 @@ int dvr_autorec_get_extra_time_pre( dvr_autorec_entry_t *dae );
 void dvr_autorec_completed( dvr_autorec_entry_t *dae, int error_code );
 
 uint32_t dvr_autorec_get_max_sched_count(dvr_autorec_entry_t *dae);
+
+htsmsg_t *
+dvr_autorec_entry_class_dedup_list ( void *o, const char *lang );
 
 /**
  *

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -399,6 +399,8 @@ dvr_autorec_create(const char *uuid, htsmsg_t *conf)
     return NULL;
   }
 
+  dvr_config_t *c = dvr_config_find_by_uuid(htsmsg_get_str(conf, "config_name"));
+  if (c && c->dvr_autorec_dedup) dae->dae_record = c->dvr_autorec_dedup;
   dae->dae_weekdays = 0x7f;
   dae->dae_pri = DVR_PRIO_DEFAULT;
   dae->dae_start = -1;
@@ -994,7 +996,7 @@ dvr_autorec_entry_class_content_type_list(void *o, const char *lang)
   return m;
 }
 
-static htsmsg_t *
+htsmsg_t *
 dvr_autorec_entry_class_dedup_list ( void *o, const char *lang )
 {
   static const struct strtab tab[] = {

--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -187,6 +187,7 @@ dvr_config_create(const char *name, const char *uuid, htsmsg_t *conf)
   cfg->dvr_autorec_max_count = 50;
   cfg->dvr_format_tvmovies_subdir = strdup("tvmovies");
   cfg->dvr_format_tvshows_subdir = strdup("tvshows");
+  cfg->dvr_autorec_dedup = 0;
 
   /* Muxer config */
   cfg->dvr_muxcnf.m_cache  = MC_CACHE_SYSTEM;
@@ -847,6 +848,7 @@ PROP_DOC(dvrconfig_whitespace)
 PROP_DOC(dvrconfig_unsafe)
 PROP_DOC(dvrconfig_windows)
 PROP_DOC(dvrconfig_fanart)
+PROP_DOC(duplicate_handling)
 
 const idclass_t dvr_config_class = {
   .ic_class      = "dvrconfig",
@@ -1400,6 +1402,18 @@ const idclass_t dvr_config_class = {
       .desc     = N_("The maximum number of recordings that can be scheduled."),
       .off      = offsetof(dvr_config_t, dvr_autorec_max_sched_count),
       .opts     = PO_ADVANCED,
+      .group    = 6,
+    },
+    {
+      .type     = PT_U32,
+      .id       = "record",
+      .name     = N_("Duplicate handling"),
+      .desc     = N_("Duplicate recording handling."),
+      .def.i    = DVR_AUTOREC_RECORD_ALL,
+      .doc      = prop_doc_duplicate_handling,
+      .off      = offsetof(dvr_config_t, dvr_autorec_dedup),
+      .list     = dvr_autorec_entry_class_dedup_list,
+      .opts     = PO_ADVANCED | PO_DOC_NLIST | PO_HIDDEN,
       .group    = 6,
     },
     {


### PR DESCRIPTION
When manually creating an autorec timer using the UI it is possible to specify how duplicate events will be handled. This option is not available if the autorec is created from the UI EPG screen, or using the HTTP API.

This PR adds a default 'duplicate handling' item to the Recording Profile parameters. This default will be applied to all new autorecs which do not specify their own duplicate handling behaviour.

The Kodi HTSP plugin has its own default for duplicate handling so will not be affected.

duplicate_handling.md: Add details of "Record if Unique" option.