### PR TITLE
Preserve existing Unicable idnode during the set operation

### DIFF
--- a/src/input/mpegts/linuxdvb/linuxdvb_en50494.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_en50494.c
@@ -224,7 +224,7 @@ linuxdvb_en50494_freq0
   /* transponder value - t */
   *t = round((((freq / 1000) + 2 + le->le_frequency) / 4) - 350);
   if (*t >= 1023) {
-    tvherror(LS_EN50494, "transponder value bigger then 1023 for freq %d (%d)", freq, le->le_frequency);
+    tvherror(LS_EN50494, "transponder value bigger than 1023 for freq %d (%d)", freq, le->le_frequency);
     return -1;
   }
 
@@ -240,7 +240,7 @@ linuxdvb_en50607_freq0
   /* transponder value - t */
   *t = round((double)freq / 1000) - 100;
   if (*t > 2047) {
-    tvherror(LS_EN50494, "transponder value bigger then 2047 for freq %d (%d)", freq, le->le_frequency);
+    tvherror(LS_EN50494, "transponder value bigger than 2047 for freq %d (%d)", freq, le->le_frequency);
     return -1;
   }
 

--- a/src/input/mpegts/linuxdvb/linuxdvb_satconf.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_satconf.c
@@ -1426,6 +1426,8 @@ linuxdvb_satconf_ele_class_en50494type_set ( void *o, const void *p )
 {
   linuxdvb_satconf_ele_t *ls  = o;
   const char             *str = p;
+  if (ls->lse_en50494 && !strcmp(str ?: "", ls->lse_en50494->ld_type))
+    return 0;
   if (ls->lse_en50494)
     linuxdvb_en50494_destroy(ls->lse_en50494);
   ls->lse_en50494 = linuxdvb_en50494_create0(str, NULL, ls, 0);


### PR DESCRIPTION
Currently, the Unicable settings are always cleared when enabling or disabling the corresponding satellite position or its owning adapter. The reason is that the `idnode` with Unicable configuration is always unconditionally deleted during the "set" operation.

This change adds a check for the existing Unicable configuration and preserves the existing `idnode` if its type remains the same.

The same logic is already used when changing the configuration related to LNB, switch and rotor.