### PR TITLE
vaapi update:

### DIFF
--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -69,11 +69,11 @@ LIBX265_DIFFS  = libx265.pic.diff
 endif
 LIBX265_DIFFS  += libx265-silence.patch
 
-LIBVPX_VER     = 1.9.0
+LIBVPX_VER     = 1.12.0
 LIBVPX         = libvpx-$(LIBVPX_VER)
 LIBVPX_TB      = $(LIBVPX).tar.gz
 LIBVPX_URL     = https://github.com/webmproject/libvpx/archive/v$(LIBVPX_VER)/$(LIBVPX_TB)
-LIBVPX_SHA1    = 2ab8203ad8922bdf3256e4a197d1348fa8db9a62
+LIBVPX_SHA1    = e5f344d28752344d4c6e0c83b055093932b8d2c9
 
 LIBOGG         = libogg-1.3.4
 LIBOGG_TB      = $(LIBOGG).tar.gz

--- a/src/webui/static/app/codec.js
+++ b/src/webui/static/app/codec.js
@@ -239,6 +239,7 @@ var codec_profile_forms = {
             var bit_rate_scale_factor_field = form.findField('bit_rate_scale_factor');
             var qp_field = form.findField('qp');
             var low_power_field = form.findField('low_power');
+            var desired_b_depth_field = form.findField('desired_b_depth');
 
             var platform = platform_field.getValue();
             switch (platform) {
@@ -252,9 +253,12 @@ var codec_profile_forms = {
                     bit_rate_scale_factor_field.setDisabled(false);
                     qp_field.setDisabled(false);
                     low_power_field.setDisabled(false);
+                    desired_b_depth_field.setDisabled(false);
                     break;
                 case 1:
                     // Intel
+                    // low_power is disabling Max B frame
+                    desired_b_depth_field.setDisabled(low_power_field.getValue());
                     var rc_mode = rc_mode_field.getValue();
                     switch (rc_mode) {
                         case -1:
@@ -314,11 +318,14 @@ var codec_profile_forms = {
                     // AMD --> will allow any combination of parameters
                     // I am unable to confirm this platform because I don't have the HW
                     // Is only going to override bf to 0 (as highlited by the previous implementation)
+                    // NOTE: filters to be added later
                     bit_rate_field.setDisabled(false);
                     max_bit_rate_field.setDisabled(false);
                     buff_factor_field.setDisabled(false);
                     bit_rate_scale_factor_field.setDisabled(false);
                     qp_field.setDisabled(false);
+                    low_power_field.setDisabled(false);
+                    desired_b_depth_field.setDisabled(false);
                     break;
                 default:
             }
@@ -326,15 +333,20 @@ var codec_profile_forms = {
 
         var platform_field = form.findField('platform');
         var rc_mode_field = form.findField('rc_mode');
+        var low_power_field = form.findField('low_power');
         // first time we have to call this manually
         updateFilters(form);
         
         // on platform change
-        platform_field.on('select', function(spinner) {
+        platform_field.on('select', function(combo, record, index) {
             updateFilters(form);
         });
         // on rc_mode change
-        rc_mode_field.on('select', function(spinner) {
+        rc_mode_field.on('select', function(combo, record, index) {
+            updateFilters(form);
+        });
+        // on low_power change
+        low_power_field.on('check', function(checkbox, value) {
             updateFilters(form);
         });
     },
@@ -349,6 +361,7 @@ var codec_profile_forms = {
             var bit_rate_scale_factor_field = form.findField('bit_rate_scale_factor');
             var qp_field = form.findField('qp');
             var low_power_field = form.findField('low_power');
+            var desired_b_depth_field = form.findField('desired_b_depth');
 
             var platform = platform_field.getValue();
             switch (platform) {
@@ -362,9 +375,12 @@ var codec_profile_forms = {
                     bit_rate_scale_factor_field.setDisabled(false);
                     qp_field.setDisabled(false);
                     low_power_field.setDisabled(false);
+                    desired_b_depth_field.setDisabled(false);
                     break;
                 case 1:
                     // Intel
+                    // low_power is disabling Max B frame
+                    desired_b_depth_field.setDisabled(low_power_field.getValue());
                     var rc_mode = rc_mode_field.getValue();
                     switch (rc_mode) {
                         case -1:
@@ -424,11 +440,14 @@ var codec_profile_forms = {
                     // AMD --> will allow any combination of parameters
                     // I am unable to confirm this platform because I don't have the HW
                     // Is only going to override bf to 0 (as highlited by the previous implementation)
+                    // NOTE: filters to be added later
                     bit_rate_field.setDisabled(false);
                     max_bit_rate_field.setDisabled(false);
                     buff_factor_field.setDisabled(false);
                     bit_rate_scale_factor_field.setDisabled(false);
                     qp_field.setDisabled(false);
+                    low_power_field.setDisabled(false);
+                    desired_b_depth_field.setDisabled(false);
                     break;
                 default:
             }
@@ -436,15 +455,20 @@ var codec_profile_forms = {
 
         var platform_field = form.findField('platform');
         var rc_mode_field = form.findField('rc_mode');
+        var low_power_field = form.findField('low_power');
         // first time we have to call this manually
         updateFilters(form);
         
         // on platform change
-        platform_field.on('select', function(spinner) {
+        platform_field.on('select', function(combo, record, index) {
             updateFilters(form);
         });
         // on rc_mode change
-        rc_mode_field.on('select', function(spinner) {
+        rc_mode_field.on('select', function(combo, record, index) {
+            updateFilters(form);
+        });
+        // on low_power change
+        low_power_field.on('check', function(checkbox, value) {
             updateFilters(form);
         });
     },
@@ -531,6 +555,7 @@ var codec_profile_forms = {
                     // AMD --> will allow any combination of parameters
                     // I am unable to confirm this platform because I don't have the HW
                     // Is only going to override bf to 0 (as highlited by the previous implementation)
+                    // NOTE: filters to be added later
                     bit_rate_field.setDisabled(false);
                     max_bit_rate_field.setDisabled(false);
                     buff_factor_field.setDisabled(false);
@@ -547,11 +572,11 @@ var codec_profile_forms = {
         updateFilters(form);
 
         // on platform change
-        platform_field.on('select', function(spinner) {
+        platform_field.on('select', function(combo, record, index) {
             updateFilters(form);
         });
         // on rc_mode change
-        rc_mode_field.on('select', function(spinner) {
+        rc_mode_field.on('select', function(combo, record, index) {
             updateFilters(form);
         });
     },
@@ -638,6 +663,7 @@ var codec_profile_forms = {
                     // AMD --> will allow any combination of parameters
                     // I am unable to confirm this platform because I don't have the HW
                     // Is only going to override bf to 0 (as highlited by the previous implementation)
+                    // NOTE: filters to be added later
                     bit_rate_field.setDisabled(false);
                     max_bit_rate_field.setDisabled(false);
                     buff_factor_field.setDisabled(false);
@@ -654,11 +680,11 @@ var codec_profile_forms = {
         updateFilters(form);
 
         // on platform change
-        platform_field.on('select', function(spinner) {
+        platform_field.on('select', function(combo, record, index) {
             updateFilters(form);
         });
         // on rc_mode change
-        rc_mode_field.on('select', function(spinner) {
+        rc_mode_field.on('select', function(combo, record, index) {
             updateFilters(form);
         });
     }


### PR DESCRIPTION
- replaced tvherror() with tvhinfo for bitrate report
- converted from bps to kbps
- reduced B frame to max 3 (4 is generating artifacts on my system)
- I had to set also bf otherwise will be set later in profile_video_class() with 3
- when low power is enabled max B frame will be disabled (because codec is not using B frames in low power mode)
- h264_vaapi and hevc_vaapi have also dynamic enable/disable for max B frame
- vp9 super frames can be enabled/disabled from the interface
- clean-up some javascript code