### PR TITLE
descrambler: detect and support icam patched libdvbcsa

### DIFF
--- a/configure
+++ b/configure
@@ -714,6 +714,14 @@ if enabled_or_auto tvhcsa; then
        check_cc_lib    dvbcsa dvbcsa_l) ||\
       die "Failed to find dvbcsa library"
       LDFLAGS="$LDFLAGS -ldvbcsa"
+      check_cc '
+      #include <dvbcsa/dvbcsa.h>
+      int test(void)
+      {
+      dvbcsa_bs_key_set_ecm(0, 0, (struct dvbcsa_bs_key_s *)0);
+      return 0;
+      }
+      ' && CFLAGS="$CFLAGS -DDVBCSA_ICAM"
     fi
   else
     disable tvhcsa

--- a/src/descrambler/descrambler.c
+++ b/src/descrambler/descrambler.c
@@ -966,20 +966,12 @@ key_flush( th_descrambler_runtime_t *dr, th_descrambler_key_t *tk, uint8_t chang
   /* update the keys */
   if (changed & 1) {
     debug2("%p: even key[%d] set for decoder", dr, tk->key_pid);
-#ifndef DVBCSA_ICAM
-    tvhcsa_set_key_even(&tk->key_csa, tk->key_data[0]);
-#else
     tvhcsa_set_key_even(&tk->key_csa, tk->key_data[0], dr->dr_ecm);
-#endif
     tk->key_valid |= 0x40;
   }
   if (changed & 2) {
     debug2("%p: odd key[%d] set for decoder", dr, tk->key_pid);
-#ifndef DVBCSA_ICAM
-    tvhcsa_set_key_odd(&tk->key_csa, tk->key_data[1]);
-#else
     tvhcsa_set_key_odd(&tk->key_csa, tk->key_data[1], dr->dr_ecm);
-#endif
     tk->key_valid |= 0x80;
   }
 }
@@ -1379,9 +1371,7 @@ descrambler_table_callback
                 }
               }
             }
-#ifdef DVBCSA_ICAM
             dr->dr_ecm = (ptr[2] - ptr[4]) == 4 ? ptr[0x15] : 0;
-#endif
             tvhtrace(LS_DESCRAMBLER, "ECM message %02x:%02x (section %d, len %d, pid %d) for service \"%s\"",
                      ptr[0], ptr[1], des->number, len, mt->mt_pid, t->s_dvb_svcname);
           }

--- a/src/descrambler/descrambler.c
+++ b/src/descrambler/descrambler.c
@@ -966,12 +966,20 @@ key_flush( th_descrambler_runtime_t *dr, th_descrambler_key_t *tk, uint8_t chang
   /* update the keys */
   if (changed & 1) {
     debug2("%p: even key[%d] set for decoder", dr, tk->key_pid);
+#ifndef DVBCSA_ICAM
     tvhcsa_set_key_even(&tk->key_csa, tk->key_data[0]);
+#else
+    tvhcsa_set_key_even(&tk->key_csa, tk->key_data[0], dr->dr_ecm);
+#endif
     tk->key_valid |= 0x40;
   }
   if (changed & 2) {
     debug2("%p: odd key[%d] set for decoder", dr, tk->key_pid);
+#ifndef DVBCSA_ICAM
     tvhcsa_set_key_odd(&tk->key_csa, tk->key_data[1]);
+#else
+    tvhcsa_set_key_odd(&tk->key_csa, tk->key_data[1], dr->dr_ecm);
+#endif
     tk->key_valid |= 0x80;
   }
 }
@@ -1371,6 +1379,9 @@ descrambler_table_callback
                 }
               }
             }
+#ifdef DVBCSA_ICAM
+            dr->dr_ecm = (ptr[2] - ptr[4]) == 4 ? ptr[0x15] : 0;
+#endif
             tvhtrace(LS_DESCRAMBLER, "ECM message %02x:%02x (section %d, len %d, pid %d) for service \"%s\"",
                      ptr[0], ptr[1], des->number, len, mt->mt_pid, t->s_dvb_svcname);
           }

--- a/src/descrambler/descrambler.h
+++ b/src/descrambler/descrambler.h
@@ -103,9 +103,7 @@ typedef struct th_descrambler_runtime {
   int64_t  dr_ecm_start[2];
   int64_t  dr_ecm_last_key_time;
   int64_t  dr_ecm_key_margin;
-#ifdef DVBCSA_ICAM
   uint8_t  dr_ecm;
-#endif
   int64_t  dr_last_err;
   int64_t  dr_force_skip;
   th_descrambler_key_t dr_keys[DESCRAMBLER_MAX_KEYS];

--- a/src/descrambler/descrambler.h
+++ b/src/descrambler/descrambler.h
@@ -103,6 +103,9 @@ typedef struct th_descrambler_runtime {
   int64_t  dr_ecm_start[2];
   int64_t  dr_ecm_last_key_time;
   int64_t  dr_ecm_key_margin;
+#ifdef DVBCSA_ICAM
+  uint8_t  dr_ecm;
+#endif
   int64_t  dr_last_err;
   int64_t  dr_force_skip;
   th_descrambler_key_t dr_keys[DESCRAMBLER_MAX_KEYS];

--- a/src/descrambler/tvhcsa.c
+++ b/src/descrambler/tvhcsa.c
@@ -220,12 +220,20 @@ tvhcsa_set_type( tvhcsa_t *csa, struct mpegts_service *s, int type )
 }
 
 
+#ifndef DVBCSA_ICAM
 void tvhcsa_set_key_even( tvhcsa_t *csa, const uint8_t *even )
+#else
+void tvhcsa_set_key_even( tvhcsa_t *csa, const uint8_t *even, const uint8_t ecm)
+#endif
 {
   switch (csa->csa_type) {
   case DESCRAMBLER_CSA_CBC:
 #if ENABLE_DVBCSA
+#ifndef DVBCSA_ICAM
     dvbcsa_bs_key_set(even, csa->csa_key_even);
+#else
+    dvbcsa_bs_key_set_ecm(ecm, even, csa->csa_key_even);
+#endif
 #endif
     break;
   case DESCRAMBLER_DES_NCB:
@@ -241,13 +249,21 @@ void tvhcsa_set_key_even( tvhcsa_t *csa, const uint8_t *even )
   }
 }
 
+#ifndef DVBCSA_ICAM
 void tvhcsa_set_key_odd( tvhcsa_t *csa, const uint8_t *odd )
+#else
+void tvhcsa_set_key_odd( tvhcsa_t *csa, const uint8_t *odd, const uint8_t ecm )
+#endif
 {
   assert(csa->csa_type);
   switch (csa->csa_type) {
   case DESCRAMBLER_CSA_CBC:
 #if ENABLE_DVBCSA
+#ifndef DVBCSA_ICAM
     dvbcsa_bs_key_set(odd, csa->csa_key_odd);
+#else
+    dvbcsa_bs_key_set_ecm(ecm, odd, csa->csa_key_odd);
+#endif
 #endif
     break;
   case DESCRAMBLER_DES_NCB:

--- a/src/descrambler/tvhcsa.c
+++ b/src/descrambler/tvhcsa.c
@@ -220,11 +220,7 @@ tvhcsa_set_type( tvhcsa_t *csa, struct mpegts_service *s, int type )
 }
 
 
-#ifndef DVBCSA_ICAM
-void tvhcsa_set_key_even( tvhcsa_t *csa, const uint8_t *even )
-#else
 void tvhcsa_set_key_even( tvhcsa_t *csa, const uint8_t *even, const uint8_t ecm)
-#endif
 {
   switch (csa->csa_type) {
   case DESCRAMBLER_CSA_CBC:
@@ -249,11 +245,7 @@ void tvhcsa_set_key_even( tvhcsa_t *csa, const uint8_t *even, const uint8_t ecm)
   }
 }
 
-#ifndef DVBCSA_ICAM
-void tvhcsa_set_key_odd( tvhcsa_t *csa, const uint8_t *odd )
-#else
 void tvhcsa_set_key_odd( tvhcsa_t *csa, const uint8_t *odd, const uint8_t ecm )
-#endif
 {
   assert(csa->csa_type);
   switch (csa->csa_type) {

--- a/src/descrambler/tvhcsa.h
+++ b/src/descrambler/tvhcsa.h
@@ -66,8 +66,13 @@ typedef struct tvhcsa
 
 int  tvhcsa_set_type( tvhcsa_t *csa, struct mpegts_service *s, int type );
 
+#ifndef DVBCSA_ICAM
 void tvhcsa_set_key_even( tvhcsa_t *csa, const uint8_t *even );
 void tvhcsa_set_key_odd ( tvhcsa_t *csa, const uint8_t *odd );
+#else
+void tvhcsa_set_key_even( tvhcsa_t *csa, const uint8_t *even, const uint8_t ecm );
+void tvhcsa_set_key_odd ( tvhcsa_t *csa, const uint8_t *odd, const uint8_t ecm );
+#endif
 
 void tvhcsa_init    ( tvhcsa_t *csa );
 void tvhcsa_destroy ( tvhcsa_t *csa );
@@ -76,8 +81,13 @@ void tvhcsa_destroy ( tvhcsa_t *csa );
 
 static inline int tvhcsa_set_type( tvhcsa_t *csa, struct mpegts_service *s, int type ) { return -1; }
 
+#ifndef DVBCSA_ICAM
 static inline void tvhcsa_set_key_even( tvhcsa_t *csa, const uint8_t *even ) { };
 static inline void tvhcsa_set_key_odd ( tvhcsa_t *csa, const uint8_t *odd ) { };
+#else
+static inline void tvhcsa_set_key_even( tvhcsa_t *csa, const uint8_t *even, const uint8_t ecm ) { };
+static inline void tvhcsa_set_key_odd ( tvhcsa_t *csa, const uint8_t *odd, const uint8_t ecm ) { };
+#endif
 
 static inline void tvhcsa_init ( tvhcsa_t *csa ) { };
 static inline void tvhcsa_destroy ( tvhcsa_t *csa ) { };

--- a/src/descrambler/tvhcsa.h
+++ b/src/descrambler/tvhcsa.h
@@ -66,13 +66,8 @@ typedef struct tvhcsa
 
 int  tvhcsa_set_type( tvhcsa_t *csa, struct mpegts_service *s, int type );
 
-#ifndef DVBCSA_ICAM
-void tvhcsa_set_key_even( tvhcsa_t *csa, const uint8_t *even );
-void tvhcsa_set_key_odd ( tvhcsa_t *csa, const uint8_t *odd );
-#else
 void tvhcsa_set_key_even( tvhcsa_t *csa, const uint8_t *even, const uint8_t ecm );
 void tvhcsa_set_key_odd ( tvhcsa_t *csa, const uint8_t *odd, const uint8_t ecm );
-#endif
 
 void tvhcsa_init    ( tvhcsa_t *csa );
 void tvhcsa_destroy ( tvhcsa_t *csa );
@@ -81,13 +76,8 @@ void tvhcsa_destroy ( tvhcsa_t *csa );
 
 static inline int tvhcsa_set_type( tvhcsa_t *csa, struct mpegts_service *s, int type ) { return -1; }
 
-#ifndef DVBCSA_ICAM
-static inline void tvhcsa_set_key_even( tvhcsa_t *csa, const uint8_t *even ) { };
-static inline void tvhcsa_set_key_odd ( tvhcsa_t *csa, const uint8_t *odd ) { };
-#else
 static inline void tvhcsa_set_key_even( tvhcsa_t *csa, const uint8_t *even, const uint8_t ecm ) { };
 static inline void tvhcsa_set_key_odd ( tvhcsa_t *csa, const uint8_t *odd, const uint8_t ecm ) { };
-#endif
 
 static inline void tvhcsa_init ( tvhcsa_t *csa ) { };
 static inline void tvhcsa_destroy ( tvhcsa_t *csa ) { };


### PR DESCRIPTION
This PR will detect icam patches in libdvbcsa at compile time, and add tvheadend support for it conditionally.
Fixes #6227
