### PR TITLE
iconv: Allow using GNU libiconv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ LDFLAGS += -Wl,-z,now
 ifeq ($(CONFIG_LIBICONV),yes)
 LDFLAGS += -liconv
 endif
+ifeq ($(CONFIG_GNU_LIBICONV),yes)
+CFLAGS += -D_GNU_LIBICONV
+LDFLAGS += -liconv
+endif
 ifeq ($(PLATFORM), darwin)
 LDFLAGS += -framework CoreServices
 else

--- a/configure
+++ b/configure
@@ -325,9 +325,19 @@ int test(void)
 }
 '
 
-# a check for the external iconv library
+# a check for the external (gnu)iconv library
 # for build-in libc iconv routines this check should fail
 # note that iconv routines are mandatory
+check_cc_snippet gnu_libiconv '
+#include <gnu-libiconv/iconv.h>
+#define TEST test
+int test(void)
+{
+  iconv_t ic = iconv_open("ASCII", "ASCII");
+  return 0;
+}
+' -liconv
+
 check_cc_snippet libiconv '
 #include <iconv.h>
 #define TEST test
@@ -338,7 +348,9 @@ int test(void)
 }
 ' -liconv
 
-if enabled libiconv; then
+if enabled gnu_libiconv; then
+  printf "    ^ using gnu libiconv library\n"
+elif enabled libiconv; then
   printf "    ^ using external iconv library\n"
 else
   printf "    ^ using build-in glibc iconv routines\n"

--- a/src/intlconv.c
+++ b/src/intlconv.c
@@ -1,4 +1,8 @@
+#ifdef _GNU_LIBICONV
+#include <gnu-libiconv/iconv.h>
+#else
 #include <iconv.h>
+#endif
 #include "tvheadend.h"
 #include "intlconv.h"
 


### PR DESCRIPTION
TVHeadend has a hard-dependency on libiconv. Lets make this a little bit more flexible by also allowing gnu-libiconv.

This helps with musl-based systems, such as Alpine Linux.

Contributes to #4940.