### PR TITLE
fix for 64bit time_t on 32bit systems

### DIFF
--- a/src/epggrab/otamux.c
+++ b/src/epggrab/otamux.c
@@ -723,7 +723,7 @@ epggrab_ota_start_cb ( void *p );
 static void
 epggrab_ota_next_arm( time_t next )
 {
-  tvhtrace(LS_EPGGRAB, "next ota start event in %li seconds", next - time(NULL));
+  tvhtrace(LS_EPGGRAB, "next ota start event in %"PRId64" seconds", next - time(NULL));
   gtimer_arm_absn(&epggrab_ota_start_timer, epggrab_ota_start_cb, NULL, next);
   dbus_emit_signal_s64("/epggrab/ota", "next", next);
 }

--- a/src/tvheadend.h
+++ b/src/tvheadend.h
@@ -337,7 +337,7 @@ void tvh_qsort_r(void *base, size_t nmemb, size_t size, int (*compar)(const void
 #if __WORDSIZE == 32 && defined(PLATFORM_FREEBSD)
 #define PRItime_t       "d"
 #else
-#define PRItime_t       "ld"
+#define PRItime_t       PRId64
 #endif
 
 /* transcoding */


### PR DESCRIPTION
on some 32bit systems   time_t  has a size of 64 bit  ( alpine with musl => 1.2, or glibc with D_TIME_BITS 64 option) 

tested on a  armv32 arm sbc and on x86 with qemu emulation
