### PR TITLE
updated 'AVCodec' to 'const AVCodec'

### DIFF
--- a/src/transcoding/codec.h
+++ b/src/transcoding/codec.h
@@ -59,7 +59,7 @@ struct tvh_codec {
     const char *name;
     size_t size;
     const codec_profile_class_t *idclass;
-    AVCodec *codec;
+    const AVCodec *codec;
     const AVProfile *profiles;
     int (*profile_init)(TVHCodecProfile *, htsmsg_t *conf);
     void (*profile_destroy)(TVHCodecProfile *);
@@ -114,7 +114,7 @@ tvh_codec_profile_get_name(TVHCodecProfile *self);
 const char *
 tvh_codec_profile_get_title(TVHCodecProfile *self);
 
-AVCodec *
+const AVCodec *
 tvh_codec_profile_get_avcodec(TVHCodecProfile *self);
 
 

--- a/src/transcoding/codec/codec.c
+++ b/src/transcoding/codec/codec.c
@@ -79,21 +79,21 @@ extern TVHCodec tvh_codec_omx_h264;
 /* AVCodec ================================================================== */
 
 static enum AVMediaType
-codec_get_type(AVCodec *self)
+codec_get_type(const AVCodec *self)
 {
     return self->type;
 }
 
 
 static const char *
-codec_get_type_string(AVCodec *self)
+codec_get_type_string(const AVCodec *self)
 {
     return av_get_media_type_string(self->type);
 }
 
 
 const char *
-codec_get_title(AVCodec *self)
+codec_get_title(const AVCodec *self)
 {
     static __thread char codec_title[TVH_TITLE_LEN];
 
@@ -113,7 +113,7 @@ codec_get_title(AVCodec *self)
 /* TVHCodec ================================================================= */
 
 static void
-tvh_codec_video_init(TVHVideoCodec *self, AVCodec *codec)
+tvh_codec_video_init(TVHVideoCodec *self, const AVCodec *codec)
 {
     if (!self->pix_fmts) {
         self->pix_fmts = codec->pix_fmts;
@@ -121,7 +121,7 @@ tvh_codec_video_init(TVHVideoCodec *self, AVCodec *codec)
 }
 
 static void
-tvh_codec_audio_init(TVHAudioCodec *self, AVCodec *codec)
+tvh_codec_audio_init(TVHAudioCodec *self, const AVCodec *codec)
 {
     static int default_sample_rates[] = {
         44100, 48000, 96000, 192000, 0
@@ -142,7 +142,7 @@ tvh_codec_audio_init(TVHAudioCodec *self, AVCodec *codec)
 
 
 static void
-tvh_codec_init(TVHCodec *self, AVCodec *codec)
+tvh_codec_init(TVHCodec *self, const AVCodec *codec)
 {
     if (!self->profiles) {
         self->profiles = codec->profiles;
@@ -164,7 +164,7 @@ static void
 tvh_codec_register(TVHCodec *self)
 {
     static const size_t min_size = sizeof(TVHCodecProfile);
-    AVCodec *codec = NULL;
+    const AVCodec *codec = NULL;
 
     if (tvh_str_default(self->name, NULL) == NULL ||
         self->size < min_size || !self->idclass) {
@@ -221,7 +221,7 @@ tvh_codec_get_type_string(TVHCodec *self)
 }
 
 
-AVCodec *
+const AVCodec *
 tvh_codec_get_codec(TVHCodec *self)
 {
     return self->codec;

--- a/src/transcoding/codec/internals.h
+++ b/src/transcoding/codec/internals.h
@@ -132,7 +132,7 @@ codec_profile_class_profile_get_opts(void *obj, uint32_t opts);
 /* AVCodec ================================================================== */
 
 const char *
-codec_get_title(AVCodec *self);
+codec_get_title(const AVCodec *self);
 
 
 /* TVHCodec ================================================================= */
@@ -143,7 +143,7 @@ tvh_codec_get_type(TVHCodec *self);
 const char *
 tvh_codec_get_type_string(TVHCodec *self);
 
-AVCodec *
+const AVCodec *
 tvh_codec_get_codec(TVHCodec *self);
 
 int

--- a/src/transcoding/codec/profile.c
+++ b/src/transcoding/codec/profile.c
@@ -197,7 +197,7 @@ tvh_codec_profile_get_title(TVHCodecProfile *self)
 }
 
 
-AVCodec *
+const AVCodec *
 tvh_codec_profile_get_avcodec(TVHCodecProfile *self)
 {
     TVHCodec *codec = tvh_codec_profile_get_codec(self);
@@ -211,7 +211,7 @@ tvh_codec_profile_is_copy(TVHCodecProfile *self, tvh_ssc_t *ssc)
 {
     const idclass_t *idclass = NULL;
     const codec_profile_class_t *codec_profile_class = NULL;
-    AVCodec *avcodec = NULL;
+    const AVCodec *avcodec = NULL;
     tvh_sct_t out_type = SCT_UNKNOWN;
 
 

--- a/src/transcoding/codec/profile_video_class.c
+++ b/src/transcoding/codec/profile_video_class.c
@@ -140,7 +140,7 @@ static int
 codec_profile_video_class_deinterlace_set(void *obj, const void *val)
 {
     TVHVideoCodecProfile *self = (TVHVideoCodecProfile *)obj;
-    AVCodec *avcodec = NULL;
+    const AVCodec *avcodec = NULL;
 
     if (self &&
         (avcodec = tvh_codec_profile_get_avcodec((TVHCodecProfile *)self))) {

--- a/src/transcoding/transcode/context.c
+++ b/src/transcoding/transcode/context.c
@@ -183,13 +183,12 @@ _context_wrap(TVHContext *self, AVPacket *avpkt, th_pkt_t *pkt)
 // creation
 
 static AVCodecContext *
-tvh_context_alloc_avctx(TVHContext *context, AVCodec *avcodec)
+tvh_context_alloc_avctx(TVHContext *context, const AVCodec *avcodec)
 {
     AVCodecContext *avctx = NULL;
 
     if ((avctx = avcodec_alloc_context3(avcodec))) {
         avctx->strict_std_compliance = FF_COMPLIANCE_EXPERIMENTAL;
-        avctx->refcounted_frames = 1;
         avctx->opaque = context;
     }
     return avctx;
@@ -197,7 +196,7 @@ tvh_context_alloc_avctx(TVHContext *context, AVCodec *avcodec)
 
 
 static int
-tvh_context_setup(TVHContext *self, AVCodec *iavcodec, AVCodec *oavcodec)
+tvh_context_setup(TVHContext *self, const AVCodec *iavcodec, const AVCodec *oavcodec)
 {
     enum AVMediaType media_type = iavcodec->type;
     const char *media_type_name = av_get_media_type_string(media_type);
@@ -684,7 +683,7 @@ tvh_context_handle(TVHContext *self, th_pkt_t *pkt)
 
 TVHContext *
 tvh_context_create(TVHStream *stream, TVHCodecProfile *profile,
-                   AVCodec *iavcodec, AVCodec *oavcodec, pktbuf_t *input_gh)
+                   const AVCodec *iavcodec, const AVCodec *oavcodec, pktbuf_t *input_gh)
 {
     TVHContext *self = NULL;
 

--- a/src/transcoding/transcode/internals.h
+++ b/src/transcoding/transcode/internals.h
@@ -191,7 +191,7 @@ tvh_context_deliver(TVHContext *self, th_pkt_t *pkt);
 
 TVHContext *
 tvh_context_create(TVHStream *stream, TVHCodecProfile *profile,
-                   AVCodec *iavcodec, AVCodec *oavcodec, pktbuf_t *input_gh);
+                   const AVCodec *iavcodec, const AVCodec *oavcodec, pktbuf_t *input_gh);
 
 void
 tvh_context_destroy(TVHContext *self);

--- a/src/transcoding/transcode/stream.c
+++ b/src/transcoding/transcode/stream.c
@@ -56,7 +56,7 @@ static int
 tvh_stream_setup(TVHStream *self, TVHCodecProfile *profile, tvh_ssc_t *ssc)
 {
     enum AVCodecID icodec_id = streaming_component_type2codec_id(ssc->es_type);
-    AVCodec *icodec = NULL, *ocodec = NULL;
+    const AVCodec *icodec = NULL, *ocodec = NULL;
 
     if (icodec_id == AV_CODEC_ID_NONE) {
         tvh_stream_log(self, LOG_ERR, "unknown decoder id for '%s'",


### PR DESCRIPTION
- updated 'AVCodec' to 'const AVCodec'
- "avctx->refcounted_frames = 1;" deprecated (not required with: avcodec_receive_frame())