### PR TITLE
remove deprecated av_frame_get_best_effort_timestamp()

### DIFF
--- a/src/transcoding/transcode/video.c
+++ b/src/transcoding/transcode/video.c
@@ -309,7 +309,6 @@ tvh_video_context_open(TVHContext *self, TVHOpenPhase phase, AVDictionary **opts
 static int
 tvh_video_context_encode(TVHContext *self, AVFrame *avframe)
 {
-    avframe->pts = av_frame_get_best_effort_timestamp(avframe);
     if (avframe->pts <= self->pts) {
         tvh_context_log(self, LOG_WARNING,
                         "Invalid pts (%"PRId64") <= last (%"PRId64"), dropping frame",


### PR DESCRIPTION
- av_frame_get_best_effort_timestamp() can be removed according to tvheadend/build.linux/ffmpeg/ffmpeg-4.4.3/libavutil/frame.h because is part of old API (FF_API_FRAME_GET_SET)