### PR TITLE
update to ffmpeg 5.1.2

### DIFF
--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -108,10 +108,10 @@ FFNVCODEC_TB   = $(FFNVCODEC).tar.gz
 FFNVCODEC_URL  = https://github.com/FFmpeg/nv-codec-headers/releases/download/n$(FFNVCODEC_VER)/nv-codec-headers-$(FFNVCODEC_VER).tar.gz
 FFNVCODEC_SHA1 = 89bee0d3025b813c513084ad8546b0261623fbb0
 
-FFMPEG         = ffmpeg-4.4.3
+FFMPEG         = ffmpeg-5.1.2
 FFMPEG_TB      = $(FFMPEG).tar.bz2
 FFMPEG_URL     = https://ffmpeg.org/releases/$(FFMPEG_TB)
-FFMPEG_SHA1    = a900f77ed16a18421983b499114c1595b8b765f2
+FFMPEG_SHA1    = f5215c15ca50a43856f641c714c6070aa148dd66
 
 
 # ##############################################################################

--- a/src/input/mpegts/iptv/iptv_libav.c
+++ b/src/input/mpegts/iptv/iptv_libav.c
@@ -24,6 +24,10 @@
 #include <fcntl.h>
 #include <signal.h>
 
+#if LIBAVCODEC_VERSION_MAJOR > 58
+#include <libavcodec/avcodec.h>
+#endif
+
 #define WRITE_BUFFER_SIZE (188*500)
 
 typedef struct {

--- a/src/muxer/muxer_libav.c
+++ b/src/muxer/muxer_libav.c
@@ -21,6 +21,10 @@
 #include <sys/stat.h>
 #include <libavformat/avformat.h>
 #include <libavutil/mathematics.h>
+#if LIBAVCODEC_VERSION_MAJOR > 58
+#include <libavcodec/bsf.h>
+#include <libavcodec/avcodec.h>
+#endif
 
 #include "tvheadend.h"
 #include "streaming.h"
@@ -343,7 +347,11 @@ lav_muxer_init(muxer_t* m, struct streaming_start *ss, const char *name)
   AVDictionary *opts = NULL;
   lav_muxer_t *lm = (lav_muxer_t*)m;
   char app[128];
+#if LIBAVCODEC_VERSION_MAJOR > 58
+  const AVOutputFormat *fmt;
+#else
   AVOutputFormat *fmt;
+#endif
   const char *muxer_name;
   int rc = -1;
 
@@ -690,7 +698,11 @@ lav_muxer_create(const muxer_config_t *m_cfg,
 {
   const char *mux_name;
   lav_muxer_t *lm;
+#if LIBAVCODEC_VERSION_MAJOR > 58
+  const AVOutputFormat *fmt;
+#else
   AVOutputFormat *fmt;
+#endif
 
   switch(m_cfg->m_type) {
   case MC_MPEGPS:

--- a/src/transcoding/transcode/video.c
+++ b/src/transcoding/transcode/video.c
@@ -17,7 +17,6 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #include "internals.h"
 
 #if ENABLE_HWACCELS
@@ -343,7 +342,12 @@ static int
 tvh_video_context_wrap(TVHContext *self, AVPacket *avpkt, th_pkt_t *pkt)
 {
     uint8_t *qsdata = NULL;
+#if LIBAVCODEC_VERSION_MAJOR < 59
     int qsdata_size = 0;
+#else
+    size_t qsdata_size = 0;
+#endif
+    
     enum AVPictureType pict_type = AV_PICTURE_TYPE_NONE;
 
     if (avpkt->flags & AV_PKT_FLAG_KEY) {

--- a/support/patches/ffmpeg.libx264.diff
+++ b/support/patches/ffmpeg.libx264.diff
@@ -1,12 +1,12 @@
-diff -urN ../ffmpeg-3.1.2.orig/libavcodec/libx264.c ./libavcodec/libx264.c
---- ../ffmpeg-3.1.2.orig/libavcodec/libx264.c	2016-08-09 00:53:26.000000000 +0200
-+++ ./libavcodec/libx264.c	2016-08-22 07:46:36.641867975 +0200
-@@ -902,7 +902,7 @@
+diff -urN ../ffmpeg-5.1.2.orig/libavcodec/libx264.c ./libavcodec/libx264.c
+--- ../ffmpeg-5.1.2.orig/libavcodec/libx264.c	2023-04-03 00:53:26.000000000 +0200
++++ ./libavcodec/libx264.c	2023-04-03 07:46:36.641867975 +0200
+@@ -1100,7 +1100,7 @@
  static const AVOption options[] = {
      { "preset",        "Set the encoding preset (cf. x264 --fullhelp)",   OFFSET(preset),        AV_OPT_TYPE_STRING, { .str = "medium" }, 0, 0, VE},
      { "tune",          "Tune the encoding params (cf. x264 --fullhelp)",  OFFSET(tune),          AV_OPT_TYPE_STRING, { 0 }, 0, 0, VE},
--    { "profile",       "Set profile restrictions (cf. x264 --fullhelp) ", OFFSET(profile),       AV_OPT_TYPE_STRING, { 0 }, 0, 0, VE},
-+    { "x264profile",   "Set profile restrictions (cf. x264 --fullhelp) ", OFFSET(profile),       AV_OPT_TYPE_STRING, { 0 }, 0, 0, VE},
+-    { "profile",       "Set profile restrictions (cf. x264 --fullhelp)",  OFFSET(profile_opt),       AV_OPT_TYPE_STRING, { 0 }, 0, 0, VE},
++    { "x264profile",       "Set profile restrictions (cf. x264 --fullhelp)",  OFFSET(profile_opt),       AV_OPT_TYPE_STRING, { 0 }, 0, 0, VE},
      { "fastfirstpass", "Use fast settings when encoding first pass",      OFFSET(fastfirstpass), AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1, VE},
      {"level", "Specify level (as defined by Annex A)", OFFSET(level), AV_OPT_TYPE_STRING, {.str=NULL}, 0, 0, VE},
      {"passlogfile", "Filename for 2 pass stats", OFFSET(stats), AV_OPT_TYPE_STRING, {.str=NULL}, 0, 0, VE},


### PR DESCRIPTION
- added new config flag: ffmpeg5
- Makefile.ffmpeg added to 5.1.2
- src/muxer/muxer_libav.c: update 'AVOutputFrmat' to 'const AVOutputFrmat'
- src/transcoding/transcode/hwaccels/vaapi.c --> incorporated the struct from libavcodec/vaapi.h (probably not the most optimal option)
- src/transcoding/transcode/video.c: update type for qdata_size