### PR TITLE
update vaapi

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -53,6 +53,9 @@ struct config config;
 static char config_lock[PATH_MAX];
 static int config_lock_fd;
 static int config_scanfile_ok;
+#if ENABLE_VAAPI
+int vainfo_probe_enabled;
+#endif
 
 /* *************************************************************************
  * Config migration
@@ -1839,6 +1842,9 @@ config_init ( int backup )
     if (config_migrate(backup))
       config_check();
   }
+#if ENABLE_VAAPI
+  vainfo_probe_enabled = config.enable_vainfo;
+#endif
   tvhinfo(LS_CONFIG, "loaded");
 }
 
@@ -2633,6 +2639,19 @@ const idclass_t config_class = {
       .opts   = PO_EXPERT,
       .group  = 7,
     },
+#if ENABLE_VAAPI
+    {
+      .type   = PT_BOOL,
+      .id     = "enable_vainfo",
+      .name   = N_("Enable vainfo detection"),
+      .desc   = N_("Enable vainfo detection in order to show only "
+                   "encoders that are advertized by VAAPI driver.\n"
+                   "NOTE: After save, Tvheadend restart is required!"),
+      .off    = offsetof(config_t, enable_vainfo),
+      .opts   = PO_EXPERT,
+      .group  = 7,
+    },
+#endif
     {
       .type   = PT_STR,
       .id     = "wizard",

--- a/src/config.h
+++ b/src/config.h
@@ -74,6 +74,9 @@ typedef struct config {
   char *hdhomerun_ip;
   char *local_ip;
   int local_port;
+#if ENABLE_VAAPI
+  int enable_vainfo;
+#endif
 } config_t;
 
 extern const idclass_t config_class;

--- a/src/idnode.c
+++ b/src/idnode.c
@@ -391,6 +391,7 @@ idnode_get_u32
       ptr = ((void*)self) + p->off;
     switch (p->type) {
       case PT_INT:
+      case PT_DYN_INT:
       case PT_BOOL:
         *u32 = *(int*)ptr;
         return 0;
@@ -425,6 +426,7 @@ idnode_get_s64
       ptr = ((void*)self) + p->off;
     switch (p->type) {
       case PT_INT:
+      case PT_DYN_INT:
       case PT_BOOL:
         *s64 = *(int*)ptr;
         return 0;
@@ -495,6 +497,7 @@ idnode_get_dbl
       ptr = ((void*)self) + p->off;
     switch (p->type) {
       case PT_INT:
+      case PT_DYN_INT:
       case PT_BOOL:
         *dbl = *(int*)ptr;
         return 0;
@@ -761,6 +764,7 @@ idnode_cmp_sort
       }
       break;
     case PT_INT:
+    case PT_DYN_INT:
     case PT_U16:
     case PT_BOOL:
     case PT_PERM:

--- a/src/main.c
+++ b/src/main.c
@@ -803,7 +803,9 @@ main(int argc, char **argv)
   } randseed;
   struct rlimit rl;
   extern int dvb_bouquets_parse;
-
+#if ENABLE_VAAPI
+  extern int vainfo_probe_enabled;
+#endif
   main_tid = pthread_self();
 
   /* Setup global mutexes */
@@ -1287,7 +1289,11 @@ main(int argc, char **argv)
   tvhftrace(LS_MAIN, fsmonitor_init);
   tvhftrace(LS_MAIN, libav_init);
   tvhftrace(LS_MAIN, tvhtime_init);
+#if ENABLE_VAAPI
+  tvhftrace(LS_MAIN, codec_init, vainfo_probe_enabled);
+#else
   tvhftrace(LS_MAIN, codec_init);
+#endif
   tvhftrace(LS_MAIN, profile_init);
   tvhftrace(LS_MAIN, imagecache_init);
   tvhftrace(LS_MAIN, http_client_init);

--- a/src/prop.c
+++ b/src/prop.c
@@ -46,6 +46,7 @@ static const struct strtab typetab[] = {
   { "s64",     PT_S64_ATOMIC },
   { "dbl",     PT_DBL },
   { "time",    PT_TIME },
+  { "int",     PT_DYN_INT },
   { "langstr", PT_LANGSTR },
   { "perm",    PT_PERM },
 };
@@ -84,6 +85,7 @@ prop_write_values
   uint32_t u32, opts;
   uint16_t u16;
   time_t tm;
+  int dyn_i;
 #define PROP_UPDATE(v, t)\
   snew = &v;\
   if (!p->set && (*((t*)cur) != *((t*)snew))) {\
@@ -210,6 +212,13 @@ prop_write_values
           continue;
         tm = s64;
         PROP_UPDATE(tm, time_t);
+        break;
+      }
+      case PT_DYN_INT: {
+        if (htsmsg_field_get_s64(f, &s64))
+          continue;
+        dyn_i = s64;
+        PROP_UPDATE(dyn_i, int);
         break;
       }
       case PT_LANGSTR: {
@@ -349,6 +358,9 @@ prop_read_value
     case PT_TIME:
       htsmsg_add_s64(m, name, *(time_t *)val);
       break;
+    case PT_DYN_INT:
+      htsmsg_add_s64(m, name, *(int *)val);
+      break;
     case PT_LANGSTR:
       lang_str_serialize(*(lang_str_t **)val, m, name);
       break;
@@ -480,6 +492,9 @@ prop_serialize_value
         break;
       case PT_TIME:
         htsmsg_add_s64(m, "default", pl->def.tm);
+        break;
+      case PT_DYN_INT:
+        htsmsg_add_s32(m, "default", pl->def.dyn_i());
         break;
       case PT_LANGSTR:
         /* TODO? */

--- a/src/prop.h
+++ b/src/prop.h
@@ -38,6 +38,7 @@ typedef enum {
   PT_S64_ATOMIC,
   PT_DBL,
   PT_TIME,
+  PT_DYN_INT,
   PT_LANGSTR,
   PT_PERM,                // like PT_U32 but with the special save
 } prop_type_t;
@@ -115,6 +116,7 @@ typedef struct property {
     double      d;   // PT_DBL
     time_t      tm;  // PT_TIME
     htsmsg_t *(*list)(void); // islist != 0
+    int       (*dyn_i)(void); // dynamically load a PT_DYN_INT
   } def;
 
   /* Extended options */

--- a/src/transcoding/codec.h
+++ b/src/transcoding/codec.h
@@ -166,7 +166,11 @@ htsmsg_t *
 codec_get_profiles_list(enum AVMediaType media_type);
 
 void
+#if ENABLE_VAAPI
+codec_init(int vainfo_probe_enabled);
+#else
 codec_init(void);
+#endif
 
 void
 codec_done(void);

--- a/src/transcoding/codec/codec.c
+++ b/src/transcoding/codec/codec.c
@@ -20,6 +20,9 @@
 
 #include "internals.h"
 
+#if ENABLE_VAAPI
+#include "vainfo.h"
+#endif
 
 struct TVHCodecs tvh_codecs;
 
@@ -250,7 +253,11 @@ tvh_codec_find(const char *name)
 
 
 void
+#if ENABLE_VAAPI
+tvh_codecs_register(int vainfo_probe_enabled)
+#else
 tvh_codecs_register()
+#endif
 {
     SLIST_INIT(&tvh_codecs);
     tvh_codec_register(&tvh_codec_mpeg2video);
@@ -287,10 +294,26 @@ tvh_codecs_register()
 #endif
 
 #if ENABLE_VAAPI
-    tvh_codec_register(&tvh_codec_vaapi_h264);
-    tvh_codec_register(&tvh_codec_vaapi_hevc);
-    tvh_codec_register(&tvh_codec_vaapi_vp8);
-    tvh_codec_register(&tvh_codec_vaapi_vp9);
+    if (vainfo_probe_enabled && !vainfo_init(VAINFO_SHOW_LOGS)) {
+        if (vainfo_encoder_isavailable(VAINFO_H264) || 
+            vainfo_encoder_isavailable(VAINFO_H264_LOW_POWER))
+            tvh_codec_register(&tvh_codec_vaapi_h264);
+        if (vainfo_encoder_isavailable(VAINFO_HEVC) || 
+            vainfo_encoder_isavailable(VAINFO_HEVC_LOW_POWER))
+            tvh_codec_register(&tvh_codec_vaapi_hevc);
+        if (vainfo_encoder_isavailable(VAINFO_VP8) || 
+            vainfo_encoder_isavailable(VAINFO_VP8_LOW_POWER))
+            tvh_codec_register(&tvh_codec_vaapi_vp8);
+        if (vainfo_encoder_isavailable(VAINFO_VP9) || 
+            vainfo_encoder_isavailable(VAINFO_VP9_LOW_POWER))
+            tvh_codec_register(&tvh_codec_vaapi_vp9);
+    }
+    else {
+        tvh_codec_register(&tvh_codec_vaapi_h264);
+        tvh_codec_register(&tvh_codec_vaapi_hevc);
+        tvh_codec_register(&tvh_codec_vaapi_vp8);
+        tvh_codec_register(&tvh_codec_vaapi_vp9);
+    }
 #endif
 
 #if ENABLE_NVENC

--- a/src/transcoding/codec/internals.h
+++ b/src/transcoding/codec/internals.h
@@ -153,7 +153,11 @@ TVHCodec *
 tvh_codec_find(const char *name);
 
 void
+#if ENABLE_VAAPI
+tvh_codecs_register(int vainfo_probe_enabled);
+#else
 tvh_codecs_register(void);
+#endif
 
 void
 tvh_codecs_forget(void);

--- a/src/transcoding/codec/module.c
+++ b/src/transcoding/codec/module.c
@@ -58,10 +58,18 @@ codec_get_profiles_list(enum AVMediaType media_type)
 
 
 void
+#if ENABLE_VAAPI
+codec_init(int vainfo_probe_enabled)
+#else
 codec_init(void)
+#endif
 {
     // codecs
+#if ENABLE_VAAPI
+    tvh_codecs_register(vainfo_probe_enabled);
+#else
     tvh_codecs_register();
+#endif
     // codec profiles
     tvh_codec_profiles_load();
 }

--- a/src/transcoding/codec/vainfo.c
+++ b/src/transcoding/codec/vainfo.c
@@ -1,0 +1,577 @@
+/*
+ *  tvheadend - Transcoding
+ *
+ *  Copyright (C) 2023 Tvheadend
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "vainfo.h"
+#include "internals.h"
+
+#if ENABLE_VAAPI
+#include <va/va.h>
+#include <fcntl.h>
+#include <va/va_drm.h>
+#include <va/va_str.h>
+#endif
+
+#define CODEC_IS_AVAILABLE      1
+#define CODEC_IS_NOT_AVAILABLE  0
+#define MIN_B_FRAMES            0
+#define MAX_B_FRAMES            7
+#define MIN_QUALITY             0
+#define MAX_QUALITY             15
+
+/* external =================================================================== */
+#if ENABLE_VAAPI
+// this variable is loaded from config: Enable vaapi detection
+extern int vainfo_probe_enabled;
+#endif
+
+/* internal =================================================================== */
+int encoder_h264_isavailable = 0;
+int encoder_h264lp_isavailable = 0;
+int encoder_hevc_isavailable = 0;
+int encoder_hevclp_isavailable = 0;
+int encoder_vp8_isavailable = 0;
+int encoder_vp8lp_isavailable = 0;
+int encoder_vp9_isavailable = 0;
+int encoder_vp9lp_isavailable = 0;
+
+int encoder_h264_maxBfreames = 0;
+int encoder_h264lp_maxBfreames = 0;
+int encoder_hevc_maxBfreames = 0;
+int encoder_hevclp_maxBfreames = 0;
+int encoder_vp8_maxBfreames = 0;
+int encoder_vp8lp_maxBfreames = 0;
+int encoder_vp9_maxBfreames = 0;
+int encoder_vp9lp_maxBfreames = 0;
+
+int encoder_h264_maxQuality = 0;
+int encoder_h264lp_maxQuality = 0;
+int encoder_hevc_maxQuality = 0;
+int encoder_hevclp_maxQuality = 0;
+int encoder_vp8_maxQuality = 0;
+int encoder_vp8lp_maxQuality = 0;
+int encoder_vp9_maxQuality = 0;
+int encoder_vp9lp_maxQuality = 0;
+
+#if ENABLE_VAAPI
+/**
+ * VAINFO was initialized
+ * @note
+ * return: 
+ * 0 - not initialized --> will return invalid data
+ * 1 - initialized properly
+ * 
+ * NOTE: initialization was performed in /src/transcoding/codec/codec.c
+ */
+int init_done = 0;
+
+int init(int show_log);
+
+static int drm_fd = -1;
+
+static VADisplay
+va_open_display_drm(void)
+{
+    VADisplay va_dpy;
+    int i;
+    static const char *drm_device_paths[] = {
+        "/dev/dri/renderD128",
+        "/dev/dri/card0",
+        "/dev/dri/renderD129",
+        "/dev/dri/card1",
+        NULL
+    };
+    for (i = 0; drm_device_paths[i]; i++) {
+        drm_fd = open(drm_device_paths[i], O_RDWR);
+        if (drm_fd < 0)
+            continue;
+        va_dpy = vaGetDisplayDRM(drm_fd);
+        if (va_dpy)
+            return va_dpy;
+
+        close(drm_fd);
+        drm_fd = -1;
+    }
+    return NULL;
+}
+
+static void
+va_close_display_drm(VADisplay va_dpy)
+{
+    if (drm_fd < 0)
+        return;
+
+    close(drm_fd);
+    drm_fd = -1;
+}
+
+
+static int 
+get_config_attributes(VADisplay va_dpy, VAProfile profile, VAEntrypoint entrypoint, int show_log, int codec)
+{
+
+    VAStatus va_status;
+    int i, temp;
+
+    VAConfigAttrib attrib_list[VAConfigAttribTypeMax];
+    int max_num_attributes = VAConfigAttribTypeMax;
+
+    for (i = 0; i < max_num_attributes; i++) {
+        attrib_list[i].type = i;
+    }
+
+    va_status = vaGetConfigAttributes(va_dpy,
+                                      profile, entrypoint,
+                                      attrib_list, max_num_attributes);
+    if (VA_STATUS_ERROR_UNSUPPORTED_PROFILE == va_status ||
+        VA_STATUS_ERROR_UNSUPPORTED_ENTRYPOINT == va_status)
+        return 0;
+
+    if (attrib_list[VAConfigAttribEncMaxRefFrames].value & (~VA_ATTRIB_NOT_SUPPORTED)) {
+        if (show_log) {
+            tvhinfo(LS_VAINFO, "            %-35s: l0=%d, l1=%d", vaConfigAttribTypeStr(attrib_list[VAConfigAttribEncMaxRefFrames].type),
+                attrib_list[VAConfigAttribEncMaxRefFrames].value & 0xffff, 
+                (attrib_list[VAConfigAttribEncMaxRefFrames].value >> 16) & 0xffff);
+        }
+        temp = (attrib_list[VAConfigAttribEncMaxRefFrames].value >> 16) & 0xffff;
+        if (temp)
+            // this value has to be increased by 1
+            temp++;
+        // limit to max space available in ui
+        if (temp > MAX_B_FRAMES) {
+            tvherror(LS_VAINFO, "show_config_attributes() failed to set max B frames (vainfo:%d --> max=%d)", temp, MAX_B_FRAMES);
+            temp = MAX_B_FRAMES;
+        }
+        switch (codec) {
+            case VAINFO_H264:
+                encoder_h264_maxBfreames = temp;
+                break;
+            case VAINFO_H264_LOW_POWER:
+                encoder_h264lp_maxBfreames = temp;
+                break;
+            case VAINFO_HEVC:
+                encoder_hevc_maxBfreames = temp;
+                break;
+            case VAINFO_HEVC_LOW_POWER:
+                encoder_hevclp_maxBfreames = temp;
+                break;
+            case VAINFO_VP8:
+                encoder_vp8_maxBfreames = temp;
+                break;
+            case VAINFO_VP8_LOW_POWER:
+                encoder_vp8lp_maxBfreames = temp;
+                break;
+            case VAINFO_VP9:
+                encoder_vp9_maxBfreames = temp;
+                break;
+            case VAINFO_VP9_LOW_POWER:
+                encoder_vp9lp_maxBfreames = temp;
+                break;
+            default:
+                tvherror(LS_VAINFO, "codec not available: codec=%d", codec);
+                break;
+        }
+    }
+
+    if (attrib_list[VAConfigAttribEncQualityRange].value != VA_ATTRIB_NOT_SUPPORTED) {
+        if (show_log) {
+            tvhinfo(LS_VAINFO, "            %-35s: number of supported quality levels is %d", vaConfigAttribTypeStr(attrib_list[VAConfigAttribEncQualityRange].type),
+                attrib_list[VAConfigAttribEncQualityRange].value <= 1 ? 1 : attrib_list[VAConfigAttribEncQualityRange].value);
+        }
+        temp = attrib_list[VAConfigAttribEncQualityRange].value <= 1 ? 1 : attrib_list[VAConfigAttribEncQualityRange].value;
+        // limit to max space available in ui
+        if (temp > MAX_QUALITY) {
+            tvherror(LS_VAINFO, "show_config_attributes() failed to set max quality (vainfo:%d --> max=%d)", temp, MAX_QUALITY);
+            temp = MAX_QUALITY;
+        }
+        switch (codec) {
+            case VAINFO_H264:
+                encoder_h264_maxQuality = temp;
+                break;
+            case VAINFO_H264_LOW_POWER:
+                encoder_h264lp_maxQuality = temp;
+                break;
+            case VAINFO_HEVC:
+                encoder_hevc_maxQuality = temp;
+                break;
+            case VAINFO_HEVC_LOW_POWER:
+                encoder_hevclp_maxQuality = temp;
+                break;
+            case VAINFO_VP8:
+                encoder_vp8_maxQuality = temp;
+                break;
+            case VAINFO_VP8_LOW_POWER:
+                encoder_vp8lp_maxQuality = temp;
+                break;
+            case VAINFO_VP9:
+                encoder_vp9_maxQuality = temp;
+                break;
+            case VAINFO_VP9_LOW_POWER:
+                encoder_vp9lp_maxQuality = temp;
+                break;
+            default:
+                tvherror(LS_VAINFO, "codec not available: codec=%d", codec);
+                break;
+        }
+    }
+    return 0;
+}
+
+int init(int show_log)
+{
+    VADisplay va_dpy;
+    VAStatus va_status;
+    int major_version, minor_version;
+    int ret_val;
+    const char *driver;
+    int num_entrypoint = 0;
+    VAEntrypoint entrypoint, *entrypoints = NULL;
+    int num_profiles, max_num_profiles, i;
+    VAProfile profile, *profile_list = NULL;
+
+    va_dpy = va_open_display_drm();
+    if (NULL == va_dpy) {
+        tvherror(LS_VAINFO, "vaGetDisplay() failed");
+        ret_val = 2;                                                      \
+        goto error_open_display;
+    }
+
+    va_status = vaInitialize(va_dpy, &major_version, &minor_version);
+    if (va_status != VA_STATUS_SUCCESS) { 
+        tvherror(LS_VAINFO, "vaInitialize failed with error code %d (%s)", va_status, vaErrorStr(va_status));
+        ret_val = 3;
+        goto error_Initialize;
+    }
+    if (show_log)
+        tvhinfo(LS_VAINFO, "VA-API version: %d.%d", major_version, minor_version);
+
+    driver = vaQueryVendorString(va_dpy);
+    if (show_log)
+        tvhinfo(LS_VAINFO, "Driver version: %s", driver ? driver : "<unknown>");
+
+    num_entrypoint = vaMaxNumEntrypoints(va_dpy);
+    entrypoints = malloc(num_entrypoint * sizeof(VAEntrypoint));
+    if (!entrypoints) {
+        tvherror(LS_VAINFO, "Failed to allocate memory for entrypoint list");
+        ret_val = -1;
+        goto error_entrypoints;
+    }
+
+    max_num_profiles = vaMaxNumProfiles(va_dpy);
+    profile_list = malloc(max_num_profiles * sizeof(VAProfile));
+
+    if (!profile_list) {
+        tvherror(LS_VAINFO, "Failed to allocate memory for profile list");
+        ret_val = 5;
+        goto error_profile_list;
+    }
+
+    va_status = vaQueryConfigProfiles(va_dpy, profile_list, &num_profiles);
+    if (va_status != VA_STATUS_SUCCESS) { 
+        tvherror(LS_VAINFO, "vaQueryConfigProfiles failed with error code %d (%s)", va_status, vaErrorStr(va_status));
+        ret_val = 6;
+        goto error_QueryConfigProfiles;
+    }
+
+    for (i = 0; i < num_profiles; i++) {
+        profile = profile_list[i];
+        va_status = vaQueryConfigEntrypoints(va_dpy, profile, entrypoints,
+                                                &num_entrypoint);
+        if (va_status == VA_STATUS_ERROR_UNSUPPORTED_PROFILE)
+            continue;
+
+        if (va_status != VA_STATUS_SUCCESS) { 
+            tvherror(LS_VAINFO, "vaQueryConfigEntrypoints failed with error code %d (%s)", va_status, vaErrorStr(va_status));
+            ret_val = 4;
+            goto error_QueryConfigProfiles;
+        }
+
+        for (entrypoint = 0; entrypoint < num_entrypoint; entrypoint++) {
+            if (show_log)
+                tvhinfo(LS_VAINFO, "       %-32s:	%s", vaProfileStr(profile), vaEntrypointStr(entrypoints[entrypoint]));
+            // h264
+            if (profile == VAProfileH264High || profile == VAProfileH264ConstrainedBaseline || profile == VAProfileH264Main) {
+                if (entrypoints[entrypoint] == VAEntrypointEncSlice) {
+                    encoder_h264_isavailable = 1;
+                    // extract attributes
+                    ret_val = get_config_attributes(va_dpy, profile_list[i], entrypoints[entrypoint], show_log, VAINFO_H264);
+                    if (ret_val) {
+                        tvherror(LS_VAINFO, "Failed to get config attributes (error %d)", ret_val);
+                    }
+                }
+                if (entrypoints[entrypoint] == VAEntrypointEncSliceLP) {
+                    encoder_h264lp_isavailable = 1;
+                    // extract attributes
+                    ret_val = get_config_attributes(va_dpy, profile_list[i], entrypoints[entrypoint], show_log, VAINFO_H264_LOW_POWER);
+                    if (ret_val) {
+                        tvherror(LS_VAINFO, "Failed to get config attributes (error %d)", ret_val);
+                    }
+                }
+            }
+            // hevc
+            if (profile == VAProfileHEVCMain || profile == VAProfileHEVCMain10) {
+                if (entrypoints[entrypoint] == VAEntrypointEncSlice) {
+                    encoder_hevc_isavailable = 1;
+                    // extract attributes
+                    ret_val = get_config_attributes(va_dpy, profile_list[i], entrypoints[entrypoint], show_log, VAINFO_HEVC);
+                    if (ret_val) {
+                        tvherror(LS_VAINFO, "Failed to get config attributes (error %d)", ret_val);
+                    }
+                }
+                if (entrypoints[entrypoint] == VAEntrypointEncSliceLP) {
+                    encoder_hevclp_isavailable = 1;
+                    // extract attributes
+                    ret_val = get_config_attributes(va_dpy, profile_list[i], entrypoints[entrypoint], show_log, VAINFO_HEVC_LOW_POWER);
+                    if (ret_val) {
+                        tvherror(LS_VAINFO, "Failed to get config attributes (error %d)", ret_val);
+                    }
+                }
+            }
+            // vp8
+            if (profile == VAProfileVP8Version0_3) {
+                if (entrypoints[entrypoint] == VAEntrypointEncSlice) {
+                    encoder_vp8_isavailable = 1;
+                    // extract attributes
+                    ret_val = get_config_attributes(va_dpy, profile_list[i], entrypoints[entrypoint], show_log, VAINFO_VP8);
+                    if (ret_val) {
+                        tvherror(LS_VAINFO, "Failed to get config attributes (error %d)", ret_val);
+                    }
+                }
+                if (entrypoints[entrypoint] == VAEntrypointEncSliceLP) {
+                    encoder_vp8lp_isavailable = 1;
+                    // extract attributes
+                    ret_val = get_config_attributes(va_dpy, profile_list[i], entrypoints[entrypoint], show_log, VAINFO_VP8_LOW_POWER);
+                    if (ret_val) {
+                        tvherror(LS_VAINFO, "Failed to get config attributes (error %d)", ret_val);
+                    }
+                }
+            }
+            // vp9
+            if (profile == VAProfileVP9Profile0 || profile == VAProfileVP9Profile1 || profile == VAProfileVP9Profile2 || profile == VAProfileVP9Profile3) {
+                if (entrypoints[entrypoint] == VAEntrypointEncSlice) {
+                    encoder_vp9_isavailable = 1;
+                    ret_val = get_config_attributes(va_dpy, profile_list[i], entrypoints[entrypoint], show_log, VAINFO_VP9);
+                    if (ret_val) {
+                        tvherror(LS_VAINFO, "Failed to get config attributes (error %d)", ret_val);
+                    }
+                }
+                if (entrypoints[entrypoint] == VAEntrypointEncSliceLP) {
+                    encoder_vp9lp_isavailable = 1;
+                    ret_val = get_config_attributes(va_dpy, profile_list[i], entrypoints[entrypoint], show_log, VAINFO_VP9_LOW_POWER);
+                    if (ret_val) {
+                        tvherror(LS_VAINFO, "Failed to get config attributes (error %d)", ret_val);
+                    }
+                }
+            }
+        }
+    }
+    init_done = 1;
+    ret_val = 0;
+
+error_QueryConfigProfiles:
+error_profile_list:
+    free(profile_list);
+error_entrypoints:
+    free(entrypoints);
+error_Initialize:
+    vaTerminate(va_dpy);
+error_open_display:
+    va_close_display_drm(va_dpy);
+    // if we had any errors we enable show all codecs (for debugging)
+    if (ret_val) {
+        encoder_h264_isavailable = 1;
+        encoder_h264lp_isavailable = 1;
+        encoder_hevc_isavailable = 1;
+        encoder_hevclp_isavailable = 1;
+        encoder_vp8_isavailable = 1;
+        encoder_vp8lp_isavailable = 1;
+        encoder_vp9_isavailable = 1;
+        encoder_vp9lp_isavailable = 1;
+    }
+
+    return ret_val;
+}
+#endif
+
+/* exposed =================================================================== */
+
+/**
+ * VAINFO initialize.
+ *
+ * @note
+ * Initialize all internal variables according to VAAPI advertised feature
+ * parameter: show_log
+ * 1 = will show vainfo logs with available VAAPI entries
+ * 0 = no logs generated
+ * 
+ */
+int vainfo_init(int show_log)
+{
+#if ENABLE_VAAPI
+    int ret = init(show_log);
+    if (ret) {
+        tvherror(LS_VAINFO, "vainfo_init() error: %d", ret);
+        return ret;
+    }
+#endif
+    return 0;
+}
+
+/**
+ * VAINFO Encoder availablity.
+ *
+ * @note
+ * param: CODEC_ID
+ *
+ * return: 
+ * 0 - if encoder is not available
+ * 1 - if encoder is available
+ * 
+ */
+int vainfo_encoder_isavailable(int codec)
+{
+#if ENABLE_VAAPI
+    if (vainfo_probe_enabled) {
+        if (!init_done)
+            tvherror(LS_VAINFO, "vainfo_init() was not run or generated errors");
+        switch (codec) {
+            case VAINFO_H264:
+                return encoder_h264_isavailable;
+            case VAINFO_H264_LOW_POWER:
+                return encoder_h264lp_isavailable;
+            case VAINFO_HEVC:
+                return encoder_hevc_isavailable;
+            case VAINFO_HEVC_LOW_POWER:
+                return encoder_hevclp_isavailable;
+            case VAINFO_VP8:
+                return encoder_vp8_isavailable;
+            case VAINFO_VP8_LOW_POWER:
+                return encoder_vp8lp_isavailable;
+            case VAINFO_VP9:
+                return encoder_vp9_isavailable;
+            case VAINFO_VP9_LOW_POWER:
+                return encoder_vp9lp_isavailable;
+            default:
+                tvherror(LS_VAINFO, "codec not available: codec=%d", codec);
+                return CODEC_IS_NOT_AVAILABLE;
+        }
+    }
+    else
+#endif
+        return CODEC_IS_AVAILABLE;
+}
+
+
+/**
+ * VAINFO Encoder support for B frames.
+ *
+ * @note
+ * return: 
+ * 0 - if encoder is not supporting B frames
+ * > 0 - if encoder is supporting B frames and how many (MAX = 7)
+ * 
+ */
+int vainfo_encoder_maxBfreames(int codec)
+{
+#if ENABLE_VAAPI
+    if (vainfo_probe_enabled) {
+        if (!init_done)
+            tvherror(LS_VAINFO, "vainfo_init() was not run or generated errors");
+        switch (codec) {
+            case VAINFO_H264:
+                return encoder_h264_maxBfreames;
+            case VAINFO_H264_LOW_POWER:
+                return encoder_h264lp_maxBfreames;
+            case VAINFO_HEVC:
+                return encoder_hevc_maxBfreames;
+            case VAINFO_HEVC_LOW_POWER:
+                return encoder_hevclp_maxBfreames;
+            case VAINFO_VP8:
+                return encoder_vp8_maxBfreames;
+            case VAINFO_VP8_LOW_POWER:
+                return encoder_vp8lp_maxBfreames;
+            case VAINFO_VP9:
+                return encoder_vp9_maxBfreames;
+            case VAINFO_VP9_LOW_POWER:
+                return encoder_vp9lp_maxBfreames;
+            default:
+                tvherror(LS_VAINFO, "codec not available: codec=%d", codec);
+                return MIN_B_FRAMES;
+        }
+    }
+    else
+#endif
+        return MAX_B_FRAMES;
+}
+
+
+/**
+ * VAINFO Encoder max Quality.
+ *
+ * @note
+ * return: 
+ * 0 - if encoder is not supporting Quality
+ * 1 - if encoder is supporting Quality and how much (MAX = 15)
+ * 
+ */
+int vainfo_encoder_maxQuality(int codec)
+{
+#if ENABLE_VAAPI
+    if (vainfo_probe_enabled) {
+        if (!init_done)
+            tvherror(LS_VAINFO, "vainfo_init() was not run or generated errors");
+        switch (codec) {
+            case VAINFO_H264:
+                return encoder_h264_maxQuality;
+            case VAINFO_H264_LOW_POWER:
+                return encoder_h264lp_maxQuality;
+            case VAINFO_HEVC:
+                return encoder_hevc_maxQuality;
+            case VAINFO_HEVC_LOW_POWER:
+                return encoder_hevclp_maxQuality;
+            case VAINFO_VP8:
+                return encoder_vp8_maxQuality;
+            case VAINFO_VP8_LOW_POWER:
+                return encoder_vp8lp_maxQuality;
+            case VAINFO_VP9:
+                return encoder_vp9_maxQuality;
+            case VAINFO_VP9_LOW_POWER:
+                return encoder_vp9lp_maxQuality;
+            default:
+                tvherror(LS_VAINFO, "codec not available: codec=%d", codec);
+                return MIN_QUALITY;
+        }
+    }
+    else
+#endif
+        return MAX_QUALITY;
+}
+
+
+/**
+ * VAINFO deinitialize.
+ *
+ * @note
+ * Return all variables to default state
+ * 
+ */
+void vainfo_deinit()
+{
+    // this function should not be called
+}

--- a/src/transcoding/codec/vainfo.h
+++ b/src/transcoding/codec/vainfo.h
@@ -1,0 +1,153 @@
+/*
+ *  tvheadend - Transcoding
+ *
+ *  Copyright (C) 2023 Tvheadend
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef TVH_TRANSCODING_TRANSCODE_CODEC_VAINFO_H__
+#define TVH_TRANSCODING_TRANSCODE_CODEC_VAINFO_H__
+
+
+/**
+ * VAINFO VAINFO_DONT_SHOW_LOGS.
+ *
+ * @note
+ * Will not print output with detected codec/profiles
+ * 
+ */
+#define VAINFO_DONT_SHOW_LOGS   0
+
+/**
+ * VAINFO VAINFO_SHOW_LOGS.
+ *
+ * @note
+ * Will print output with detected codec/profiles
+ * 
+ */
+#define VAINFO_SHOW_LOGS        1
+
+
+/**
+ * VAINFO CODEC DEFINE.
+ * @note
+ * Define used when calling functions for H264
+ */
+#define VAINFO_H264                 1
+/**
+ * VAINFO CODEC DEFINE.
+ * @note
+ * Define used when calling functions for H264 low power
+ */
+#define VAINFO_H264_LOW_POWER       2
+/**
+ * VAINFO CODEC DEFINE.
+ * @note
+ * Define used when calling functions for HEVC
+ */
+#define VAINFO_HEVC                 3
+/**
+ * VAINFO CODEC DEFINE.
+ * @note
+ * Define used when calling functions for HEVC low power
+ */
+#define VAINFO_HEVC_LOW_POWER       4
+/**
+ * VAINFO CODEC DEFINE.
+ * @note
+ * Define used when calling functions for VP8
+ */
+#define VAINFO_VP8                  5
+/**
+ * VAINFO CODEC DEFINE.
+ * @note
+ * Define used when calling functions for VP8 low power
+ */
+#define VAINFO_VP8_LOW_POWER        6
+/**
+ * VAINFO CODEC DEFINE.
+ * @note
+ * Define used when calling functions for VP9
+ */
+#define VAINFO_VP9                  7
+/**
+ * VAINFO CODEC DEFINE.
+ * @note
+ * Define used when calling functions for VP9 low power
+ */
+#define VAINFO_VP9_LOW_POWER        8
+
+/**
+ * VAINFO initialize.
+ *
+ * @note
+ * Initialize all internal variables according to VAAPI advertised feature
+ * parameter: show_log
+ * 1 = will show vainfo logs with available VAAPI entries
+ * 0 = no logs generated
+ * 
+ */
+int vainfo_init(int show_log);
+
+
+/**
+ * VAINFO Encoder availablity.
+ *
+ * @note
+ * param: CODEC_ID
+ *
+ * return: 
+ * 0 - if encoder is not available
+ * 1 - if encoder is available
+ * 
+ */
+int vainfo_encoder_isavailable(int codec);
+
+
+/**
+ * VAINFO Encoder support for B frames.
+ *
+ * @note
+ * return: 
+ * 0 - if encoder is not supporting B frames
+ * > 0 - if encoder is supporting B frames and how many (MAX = 7)
+ * 
+ */
+int vainfo_encoder_maxBfreames(int codec);
+
+
+/**
+ * VAINFO Encoder max Quality.
+ *
+ * @note
+ * return: 
+ * 0 - if encoder is not supporting Quality
+ * 1 - if encoder is supporting Quality and how much (MAX = 15)
+ * 
+ */
+int vainfo_encoder_maxQuality(int codec);
+
+
+/**
+ * VAINFO deinitialize.
+ *
+ * @note
+ * Return all variables to default state
+ * 
+ */
+void vainfo_deinit(void);
+
+#endif // TVH_TRANSCODING_TRANSCODE_CODEC_VAINFO_H__

--- a/src/tvhlog.c
+++ b/src/tvhlog.c
@@ -181,6 +181,7 @@ tvhlog_subsys_t tvhlog_subsystems[] = {
   [LS_TSDEBUG]       = { "tsdebug",       N_("MPEG-TS Input Debug") },
   [LS_CODEC]         = { "codec",         N_("Codec") },
   [LS_VAAPI]         = { "vaapi",         N_("VA-API") },
+  [LS_VAINFO]        = { "vainfo",        N_("VAINFO") },
 #if ENABLE_DDCI
   [LS_DDCI]          = { "ddci",          N_("DD-CI") },
 #endif

--- a/src/tvhlog.h
+++ b/src/tvhlog.h
@@ -195,6 +195,7 @@ enum {
   LS_TSDEBUG,
   LS_CODEC,
   LS_VAAPI,
+  LS_VAINFO,
 #if ENABLE_DDCI
   LS_DDCI,
 #endif


### PR DESCRIPTION
- add enable vainfo detection checkbox in config
- defined PT_DYN_INT to load integer field from function
- PT_DYN_INT must be paired with dyn_i
- show only VAAPI codecs advertized by vainfo
- defined two invisible fields: ui and uilp used for UI enable/disable features
- check if bitrate is greater than max_bitrate (fix to avoid tvh crash)
- vp8, vp9 separate Global Quality from Quality
- load quality and max B frames filters from vainfo
- UI has several constrains or warnings implemented using vainfo
- separated 'b_depth' from 'bf'