### PR TITLE
Fix a buffer overflow in dvr_rec

### DIFF
--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -1088,7 +1088,7 @@ pvr_generate_filename(dvr_entry_t *de, const streaming_start_t *ss)
       j--;
     s[j] = '\0';
     snprintf(path + l, sizeof(path) - l, "%s", s);
-    snprintf(path + l + j, sizeof(path) - l + j, "/%s", filename);
+    snprintf(path + l + j, sizeof(path) - (l + j), "/%s", filename);
   }
 
   /* Substitute time formatters */


### PR DESCRIPTION
`pvr_generate_filename` incorrectly formatted the generated filename, which triggered a buffer overflow check on recent Fedora.

Fixes https://tvheadend.org/issues/6272