### PR TITLE
config: Store recordings sensibly on servers

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -17,7 +17,7 @@
  */
 
 #include <ctype.h>
-#include <linux/limits.h>
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>

--- a/src/config.c
+++ b/src/config.c
@@ -1720,9 +1720,9 @@ static char *config_get_dir ( void )
       char hts_home_link[PATH_MAX];
 
       if ((readlink(hts_home, hts_home_link, sizeof(hts_home_link)) == -1) ||
-	  (stat(hts_home_link, &st) == -1)) {
-	tvherror(LS_CONFIG, ".hts/tvheadend is inaccessable: %s", strerror(errno));
-	return NULL;
+          (stat(hts_home_link, &st) == -1)) {
+        tvherror(LS_CONFIG, ".hts/tvheadend is inaccessable: %s", strerror(errno));
+        return NULL;
       }
       strncpy(hts_home, hts_home_link, sizeof(hts_home));
     }
@@ -1782,11 +1782,11 @@ config_boot
     config.confdir = strndup(path, PATH_MAX);
 
   if (config.confdir == NULL) {
-    tvherror(LS_START, "unable to determine tvheadend home\n");
+    tvherror(LS_START, "unable to determine tvheadend home");
     exit(EXIT_FAILURE);
   }
 
-  tvhinfo(LS_CONFIG, "Using configuration from '%s'\n", config.confdir);
+  tvhinfo(LS_CONFIG, "Using configuration from '%s'", config.confdir);
 
   /* Ensure directory exists */
   if (stat(config.confdir, &st)) {

--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -277,8 +277,10 @@ dvr_config_destroy(dvr_config_t *cfg, int delconf)
 static void
 dvr_config_storage_check(dvr_config_t *cfg)
 {
+  char recordings_dir[] = "/var/lib/tvheadend/recordings";
   char home_dir[PATH_MAX + sizeof("/Videos")];
   char dvr_dir[PATH_MAX];
+  uid_t uid = getuid();
   char *xdg_dir;
   struct stat st;
 
@@ -304,7 +306,9 @@ dvr_config_storage_check(dvr_config_t *cfg)
     free(xdg_dir);
   }
 
-  if((stat(dvr_dir, &st) == 0) && S_ISDIR(st.st_mode))
+  if ((stat(recordings_dir, &st) == 0) && (st.st_uid == uid))
+    cfg->dvr_storage = strndup(recordings_dir, sizeof(recordings_dir));
+  else if((stat(dvr_dir, &st) == 0) && S_ISDIR(st.st_mode))
       cfg->dvr_storage = strndup(dvr_dir, PATH_MAX);
   else if(stat(home_dir, &st) == 0 && S_ISDIR(st.st_mode))
       cfg->dvr_storage = strndup(home_dir, sizeof(home_dir));


### PR DESCRIPTION
For server configurations, we want to store recordings somewhere sensible.

While here, lets 'abuse' this merge request to fix the following:

The internal print functions already add the newline for us, so adding one manually is not needed.

Further more, a tab got snook in, where spaces where intended.

This fixes commit dbf973307ae3 ("dvr_storage: Use XDG spec directories") which accidentally introduced this.