### PR TITLE
Update Debian packaging to use the new configuration directories

### DIFF
--- a/debian/tvheadend.postinst
+++ b/debian/tvheadend.postinst
@@ -10,16 +10,14 @@ configure)
 
    if ! getent passwd $HTS_USER >/dev/null; then
         echo >&2 "Creating user: $HTS_USER..."
-        adduser --quiet --system --group --shell /bin/bash $HTS_USER
+        adduser --quiet --system --group --home /var/lib/tvheadend $HTS_USER
    fi
 
    HTS_HOME=`getent passwd $HTS_USER | cut -d':' -f6`
 
-   mkdir -p "${HTS_HOME}/.hts/tvheadend"
-   chown ${HTS_USER}:${HTS_USER} "${HTS_HOME}/.hts"
-   chown ${HTS_USER}:${HTS_USER} "${HTS_HOME}/.hts/tvheadend"
+   install -d -g ${HTS_USER} -o ${HTS_USER} "${HTS_HOME}/recordings"
 
-   HTS_SUPERUSERCONF="${HTS_HOME}/.hts/tvheadend/superuser"
+   HTS_SUPERUSERCONF="${HTS_HOME}/superuser"
    rm -f "${HTS_SUPERUSERCONF}"
    touch "${HTS_SUPERUSERCONF}"
    chmod 600 "${HTS_SUPERUSERCONF}"

--- a/debian/tvheadend.postrm
+++ b/debian/tvheadend.postrm
@@ -9,7 +9,7 @@ case "$1" in
 purge)
     if getent passwd $HTS_USER >/dev/null; then
         HTS_HOME=`getent passwd $HTS_USER | cut -d':' -f6`
-        rm -rf "${HTS_HOME}/.hts/tvheadend"
+        rm -rf "${HTS_HOME}"
     fi
     db_purge
    ;;

--- a/src/config.c
+++ b/src/config.c
@@ -1693,13 +1693,15 @@ config_check ( void )
 
 static int config_newcfg = 0;
 
-static char *config_get_dir ( void )
+static char *config_get_dir ( uid_t uid )
 {
   char hts_home[PATH_MAX + sizeof("/.hts/tvheadend")]; /* Must be largest of the 3 config strings! */
   char config_home[PATH_MAX];
   char home_dir[PATH_MAX];
-  uid_t uid = getuid();
   struct stat st;
+
+  if (uid == -1)
+    uid = getuid();
 
   snprintf(hts_home, sizeof(hts_home), "/var/lib/tvheadend");
   if ((stat(hts_home, &st) == 0) && (st.st_uid == uid))
@@ -1777,7 +1779,7 @@ config_boot
 
   /* Generate default */
   if (!path)
-    config.confdir = config_get_dir();
+    config.confdir = config_get_dir(uid);
   else
     config.confdir = strndup(path, PATH_MAX);
 

--- a/src/config.c
+++ b/src/config.c
@@ -1723,7 +1723,7 @@ static char *config_get_dir ( uid_t uid )
 
       if ((readlink(hts_home, hts_home_link, sizeof(hts_home_link)) == -1) ||
           (stat(hts_home_link, &st) == -1)) {
-        tvherror(LS_CONFIG, ".hts/tvheadend is inaccessable: %s", strerror(errno));
+        tvherror(LS_CONFIG, ".hts/tvheadend is inaccessible: %s", strerror(errno));
         return NULL;
       }
       strncpy(hts_home, hts_home_link, sizeof(hts_home));

--- a/src/main.c
+++ b/src/main.c
@@ -1113,7 +1113,7 @@ main(int argc, char **argv)
   signal(SIGPIPE, handle_sigpipe); // will be redundant later
   signal(SIGILL, handle_sigill);   // see handler..
 
-  /* Set priviledges */
+  /* Set privileges */
   if((opt_fork && getuid() == 0) || opt_group || opt_user) {
     const char *homedir;
     struct group  *grp = getgrnam(opt_group ?: "video");


### PR DESCRIPTION
This updates the Debian packaging to use the new configuration directories introduced by
https://github.com/tvheadend/tvheadend/pull/1535 and https://github.com/tvheadend/tvheadend/pull/1538.  Instead of being in /home/hts/.hts/tvheadend, the configuration will now be stored in /var/lib/tvheadend by default, which is consistent with how many other "server"-style Debian packages handle their home directories and configuration.

It also fixes the logic in config.c:config_get_dir() to properly support the forking mode of operation.  Since config_get_dir() is executed before forking, the uid will always be 0 at this point. Instead, use the uid of the user to which we will fork if a fork will occur.