### PR TITLE
Fix time for 32bit systems again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ CFLAGS  += -Wmissing-prototypes
 CFLAGS  += -fno-strict-aliasing
 CFLAGS  += -fms-extensions -funsigned-char
 CFLAGS  += -D_FILE_OFFSET_BITS=64
+CFLAGS  += -D_TIME_BITS=64
 CFLAGS  += -I${BUILDDIR} -I${ROOTDIR}/src -I${ROOTDIR}
 ifeq ($(CONFIG_ANDROID),yes)
 LDFLAGS += -ldl -lm

--- a/src/tvheadend.h
+++ b/src/tvheadend.h
@@ -334,10 +334,12 @@ void tvh_qsort_r(void *base, size_t nmemb, size_t size, int (*compar)(const void
 # endif /* ULONG_MAX */
 #endif /* __WORDSIZE */
 
-#if __WORDSIZE == 32 && defined(PLATFORM_FREEBSD)
-#define PRItime_t       "d"
+#if __WORDSIZE == 32
+# define PRItime_t "lld"
+#elif __WORDSIZE == 64
+# define PRItime_t "ld"
 #else
-#define PRItime_t       "ld"
+# error "__WORDSIZE not properly defined"
 #endif
 
 /* transcoding */


### PR DESCRIPTION
In issue #6257 an issue mentioning that time_t isn't properly supported when printing on 32-bit systems, specifically on FreeBSD. However, intel 32-bit systems suffer from a similar fate:

src/rtsp.c:333:30: error: format '%ld' expects argument of type 'long int', but argument 4 has type 'time_t' {aka 'long long int'} [-Werror=format=]
  333 |   snprintf(buf, sizeof(buf), "npt=%" PRItime_t "-", position);
      |                              ^~~~~~~                ~~~~~~~~
      |                                                     |
      |                                                     time_t {aka long long int}

In commit 76a6263f1be4 ("fix for 64bit time_t on 32bit systems") was attempted to be fixed by turning it into a PRId64, which was reverted again in commit 9e1eb89be731 ("Revert "fix for 64bit time_t on 32bit systems""), sadly without a reason as to why in the commit message.

We should however, migrate to 64bit timestamps on all platforms anyway, due to the Y2038 problem. Debian is heavily working on this issue too.

This commit is just the first step, in that we ensure our time_t is always 64bits.

The next steps would be to use difftime where possible instead of subtractions, and ensure all stored timestamps have room for 64bit time_t (htsmsg_get_u32_or_default for example breaks this presumption already).

To keep this issue small, and tackle one problem at a time, lets just fix time_t first. We do still have 15 years to fix the other issues.

Note, that this patch leaves out FreeBSD specifics, as it is unclear what is specific about 32bit FreeBSD. It should be using the same glibc headers after all. If not, we can always add if needed, but adding usless code doesn't help anyone generally.

```
diff --git a/src/tvheadend.h b/src/tvheadend.h
index c2fcee716..751d10d70 100644
--- a/src/tvheadend.h
+++ b/src/tvheadend.h
@@ -334,7 +334,9 @@ void tvh_qsort_r(void *base, size_t nmemb, size_t size, int (*compar)(const void
 # endif /* ULONG_MAX */
 #endif /* __WORDSIZE */

-#if __WORDSIZE == 32
+#if __WORDSIZE == 32 && defined(PLATFORM_FREEBSD)
+# define PRItime_t "d"
+#elif __WORDSIZE == 32
 # define PRItime_t "lld"
 #elif __WORDSIZE == 64
 # define PRItime_t "ld"
 #else
```