### PR TITLE
Bug Fix: epggrab: OTA EIT Parental Rating

### DIFF
--- a/src/epggrab/module/eit.c
+++ b/src/epggrab/module/eit.c
@@ -410,7 +410,7 @@ static int _eit_desc_content
 static int _eit_desc_parental
   ( epggrab_module_t *mod, const uint8_t *ptr, int len, eit_event_t *ev )
 {
-  int cnt = 0, sum = 0, i = 0;
+  int cnt = 0, sum = 0, i = 3;
   while (len > 3) {
     if ( ptr[i] && ptr[i] < 0x10 ) {
       cnt++;


### PR DESCRIPTION
The EIT grabber was looking for the rating byte at the wrong position.

[https://tvheadend.org/issues/6284](https://tvheadend.org/issues/6284)

ETSI EN 300 468 describes the 'parental_rating_descriptor' value is in the 4th byte of the payload, not the 1st byte.

![parental_rating_descriptor](https://github.com/tvheadend/tvheadend/assets/127641886/73c00d60-2250-4db6-a3a4-ec438d00d2f9)
