### PR TITLE
ffmpeg-static: fix nasm build dependancy

### DIFF
--- a/.doozer.json
+++ b/.doozer.json
@@ -22,6 +22,8 @@
         "debhelper",
         "ccache",
         "libx11-xcb-dev"
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-ffmpeg_static\\ --enable-hdhomerun_static\\ --nowerror ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
@@ -48,7 +50,9 @@
         "python",
         "python-requests",
         "debhelper",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-ffmpeg_static\\ --enable-hdhomerun_static\\ --nowerror ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
@@ -75,7 +79,9 @@
         "python",
         "python-requests",
         "debhelper",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-ffmpeg_static\\ --enable-hdhomerun_static ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
@@ -101,7 +107,9 @@
         "python",
         "python-requests",
         "debhelper",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-ffmpeg_static\\ --enable-hdhomerun_static ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
@@ -128,7 +136,9 @@
         "python",
         "python-requests",
         "debhelper",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-hdhomerun_static\\ --disable-ffmpeg_static ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
@@ -155,7 +165,9 @@
         "python",
         "python-requests",
         "debhelper",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-hdhomerun_static\\ --disable-ffmpeg_static ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
@@ -182,7 +194,9 @@
         "python",
         "python-requests",
         "debhelper",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-ffmpeg_static\\ --enable-hdhomerun_static ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
@@ -209,7 +223,9 @@
         "python",
         "python-requests",
         "debhelper",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-ffmpeg_static\\ --enable-hdhomerun_static ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
@@ -236,7 +252,9 @@
         "python3",
         "python3-requests",
         "debhelper",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-ffmpeg_static\\ --enable-hdhomerun_static\\ --python=python3 ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
@@ -266,6 +284,8 @@
         "debhelper",
         "ccache",
         "sudo",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "sudo wget -O /usr/lib/python2.7/dist-packages/urllib3/contrib/pyopenssl.py https://raw.githubusercontent.com/urllib3/urllib3/1.26.6/src/urllib3/contrib/pyopenssl.py",
@@ -296,6 +316,8 @@
         "debhelper",
         "ccache",
         "sudo",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "sudo wget -O /usr/lib/python2.7/dist-packages/urllib3/contrib/pyopenssl.py https://raw.githubusercontent.com/urllib3/urllib3/1.26.6/src/urllib3/contrib/pyopenssl.py",
@@ -324,7 +346,9 @@
         "python",
         "python-requests",
         "debhelper",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-ffmpeg_static\\ --enable-hdhomerun_static ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
@@ -352,7 +376,9 @@
         "python",
         "python-requests",
         "debhelper",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-ffmpeg_static\\ --enable-hdhomerun_static ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
@@ -380,7 +406,9 @@
         "python",
         "python-requests",
         "debhelper",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-ffmpeg_static\\ --enable-hdhomerun_static ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
@@ -408,7 +436,9 @@
         "python",
         "python-requests",
         "debhelper",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-ffmpeg_static\\ --enable-hdhomerun_static ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
@@ -436,7 +466,9 @@
         "python",
         "python3-requests",
         "debhelper",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-ffmpeg_static\\ --enable-hdhomerun_static ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
@@ -464,7 +496,9 @@
         "python",
         "python3-requests",
         "debhelper",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-ffmpeg_static\\ --enable-hdhomerun_static ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
@@ -492,7 +526,9 @@
         "python3",
         "python3-requests",
         "debhelper",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-ffmpeg_static\\ --enable-hdhomerun_static\\ --python=python3 ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
@@ -520,7 +556,9 @@
         "python3",
         "python3-requests",
         "debhelper",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-ffmpeg_static\\ --enable-hdhomerun_static\\ --python=python3 ./Autobuild.sh -t ${TARGET} -j ${PARALLEL} -w ${WORKDIR}",
@@ -549,6 +587,8 @@
         "debhelper",
         "ccache",
         "sudo",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-hdhomerun_static\\ --disable-ffmpeg_static ./Autobuild.sh -t raspbianjessie-armhf -j ${PARALLEL} -w ${WORKDIR}",
@@ -575,7 +615,9 @@
         "python",
         "python-requests",
         "debhelper",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\\ --enable-hdhomerun_static\\ --disable-ffmpeg_static ./Autobuild.sh -t raspbianstretch-armhf -j ${PARALLEL} -w ${WORKDIR}",
@@ -605,7 +647,9 @@
         "pcre2-devel",
         "python",
         "python-requests",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "./configure --disable-dvbscan --nowerror && make -C rpm build-doozer",
@@ -635,7 +679,9 @@
         "pcre2-devel",
         "python",
         "python-requests",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "./configure --disable-dvbscan --nowerror && make -C rpm build-doozer",
@@ -667,7 +713,9 @@
         "python3-requests",
         "python",
         "python-requests",
-        "ccache"
+        "ccache",
+        "asciidoc",
+        "xmlto"
       ],
       "buildcmd": [
         "./configure --disable-dvbscan --nowerror && make -C rpm build-doozer",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
             case "${{ matrix.distro }}" in
               ubuntu*|jessie|stretch|buster|bullseye)
                 apt-get update -y
-                DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y cmake git build-essential pkg-config gettext libavahi-client-dev libssl-dev zlib1g-dev wget bzip2 git-core liburiparser-dev libdvbcsa-dev python3 python3-requests debhelper ccache lsb-release
+                DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y cmake git build-essential pkg-config gettext libavahi-client-dev libssl-dev zlib1g-dev wget bzip2 git-core liburiparser-dev libdvbcsa-dev python3 python3-requests debhelper ccache lsb-release asciidoc xmlto
                 DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre3-dev || DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre2-dev
                 ;;
               fedora*)
@@ -163,7 +163,7 @@ jobs:
       - name: dependencies
         run: |
           apt-get update -y
-          DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y cmake git build-essential pkg-config gettext libavahi-client-dev libssl-dev zlib1g-dev wget bzip2 git-core liburiparser-dev libdvbcsa-dev python3 python3-requests debhelper ccache lsb-release
+          DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y cmake git build-essential pkg-config gettext libavahi-client-dev libssl-dev zlib1g-dev wget bzip2 git-core liburiparser-dev libdvbcsa-dev python3 python3-requests debhelper ccache lsb-release asciidoc xmlto
       - name: pcre-dependency
         run: |
           DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre3-dev || DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre2-dev
@@ -205,7 +205,7 @@ jobs:
           dnf install -y "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-${{matrix.releasever}}.noarch.rpm"
       - name: dependencies
         run: |
-          dnf install -y gcc-c++ gcc-c++ which rpm-build rpmdevtools git make cmake gettext-devel dbus-devel avahi-devel openssl-devel zlib-devel libdvbcsa-devel wget bzip2 uriparser-devel pcre2-devel python python-requests ccache systemd-units systemd-devel
+          dnf install -y gcc-c++ gcc-c++ which rpm-build rpmdevtools git make cmake gettext-devel dbus-devel avahi-devel openssl-devel zlib-devel libdvbcsa-devel wget bzip2 uriparser-devel pcre2-devel python python-requests ccache systemd-units systemd-devel asciidoc xmlto
       - uses: actions/checkout@v1
       - name: Workaround safe directory
         run: git config --global --add safe.directory /__w/tvheadend/tvheadend

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -16,7 +16,7 @@ jobs:
     - name: dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake git build-essential pkg-config gettext libavahi-client-dev libssl-dev zlib1g-dev wget bzip2 git-core liburiparser-dev libpcre2-dev libdvbcsa-dev python3 python3-requests debhelper ccache libomxil-bellagio-dev libva-dev nvidia-cuda-dev
+        sudo apt-get install -y cmake git build-essential pkg-config gettext libavahi-client-dev libssl-dev zlib1g-dev wget bzip2 git-core liburiparser-dev libpcre2-dev libdvbcsa-dev python3 python3-requests debhelper ccache libomxil-bellagio-dev libva-dev nvidia-cuda-dev asciidoc xmlto
     - name: Configure
       run: ./configure --disable-dvbcscan --enable-slow_memoryinfo --enable-libfdkaac --enable-nvenc --enable-vaapi --enable-omx
     - name: Download Coverity Build Tool

--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -19,6 +19,6 @@ jobs:
     - name: dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake git build-essential pkg-config gettext libavahi-client-dev libssl-dev zlib1g-dev wget bzip2 git-core liburiparser-dev libpcre2-dev libdvbcsa-dev python3 python3-requests debhelper ccache
+        sudo apt-get install -y cmake git build-essential pkg-config gettext libavahi-client-dev libssl-dev zlib1g-dev wget bzip2 git-core liburiparser-dev libpcre2-dev libdvbcsa-dev python3 python3-requests debhelper ccache asciidoc xmlto
     - name: build
       run: AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\ --enable-ffmpeg_static\ --enable-hdhomerun_static\ --python=python3 ./Autobuild.sh

--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -45,10 +45,10 @@ FILTERS        = yadif format hwupload hwdownload scale null aresample anull
 HWACCELS       =
 
 NASM_VER       = 2.16.01
-NASM           = nasm-$(NASM_VER)
+NASM           = nasm-nasm-$(NASM_VER)
 NASM_TB        = $(NASM).tar.gz
-NASM_URL       = https://www.nasm.us/pub/nasm/releasebuilds/$(NASM_VER)/$(NASM_TB)
-NASM_SHA1      = 13bf04e35e1042dc163d14aa124c68cfa7620871
+NASM_URL       = https://github.com/netwide-assembler/nasm/archive/refs/tags/$(NASM_TB)
+NASM_SHA1      = 39bdeac92abf7341edb757b563375dffc3f6ed3a
 NASM_DIFFS     = remove-invalid-pure_func-qualifiers.diff
 
 LIBX264_VER    = d2907f67227cbf38ac957efed84c532b12ce19cc

--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -193,7 +193,7 @@ $(LIB_ROOT)/$(NASM)/.tvh_build: \
 	cd $(LIB_ROOT)/$(NASM) && $(AUTOGEN) && $(CONFIGURE_PI) \
 		--libdir=/$(EPREFIX0)/lib
 	DESTDIR=$(EBUILDIR) \
-		$(MAKE) -C $(LIB_ROOT)/$(NASM) install
+		$(MAKE) -C $(LIB_ROOT)/$(NASM) manpages install
 	@touch $@
 
 

--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -46,7 +46,7 @@ HWACCELS       =
 
 NASM_VER       = 2.16.01
 NASM           = nasm-nasm-$(NASM_VER)
-NASM_TB        = $(NASM).tar.gz
+NASM_TB        = nasm-$(NASM_VER).tar.gz
 NASM_URL       = https://github.com/netwide-assembler/nasm/archive/refs/tags/$(NASM_TB)
 NASM_SHA1      = 39bdeac92abf7341edb757b563375dffc3f6ed3a
 NASM_DIFFS     = remove-invalid-pure_func-qualifiers.diff

--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -190,7 +190,7 @@ $(LIB_ROOT)/$(NASM)/.tvh_download:
 
 $(LIB_ROOT)/$(NASM)/.tvh_build: \
 		$(LIB_ROOT)/$(NASM)/.tvh_download
-	cd $(LIB_ROOT)/$(NASM) && $(CONFIGURE_PI) \
+	cd $(LIB_ROOT)/$(NASM) && $(AUTOGEN) && $(CONFIGURE_PI) \
 		--libdir=/$(EPREFIX0)/lib
 	DESTDIR=$(EBUILDIR) \
 		$(MAKE) -C $(LIB_ROOT)/$(NASM) install


### PR DESCRIPTION
Hi,
Not sure who does want to review this PR, but it's for fixing failed / breaking part of the ffmpeg build dependancy.

When its being selected the following `./configure` flag: `--enable-ffmpeg_static`

For some reason the SSL certificate authentication is now failing for NASM tarball / source code download from the ancient upstream `nasm.us` url... So it would seem like their SSL cert for that domain has now expired or fallen to neglect.

Anyhow since it was not possible (from client side) to properly (and safely) get the tarball from that historical download location. This now PR switches to a more modern / recent upstream NASM download url. Which is their (newer) official github repository. It's same official project, so not a 3rd party or other mirror.

They seem to be keeping it up to date. All was needed just some minor tweaking of the download URL (inside of tvheadend's ffmpeg's dep. Makefile).

With this changeset, then NASM now downloads, compiles, and installs*. And for modern latest ubuntu release 23.04 Lunar Lobster. These changes are fairly minimal.

To double check that this is the official NASM upstream project. it was checked the github organisation people. Are the following 2 long term (and still active) team members:

```sh
Cyrill Gorcunov | cyrillos | Admin
H. Peter Anvin | hpa | Admin
```
