### PR TITLE
Add 'age rating' field to recording metadata - Feature #6287

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -51,8 +51,8 @@ LIST_HEAD(dvr_vfs_list, dvr_vfs);
 #define DVR_FILESIZE_TOTAL      (1<<1)
 
 #define DVR_FINISHED_ALL             (1<<0)
-#define DVR_FINISHED_SUCCESS         (1<<1) 
-#define DVR_FINISHED_FAILED          (1<<2) 
+#define DVR_FINISHED_SUCCESS         (1<<1)
+#define DVR_FINISHED_FAILED          (1<<2)
 #define DVR_FINISHED_REMOVED_SUCCESS (1<<3) /* Removed recording, was succesful before */
 #define DVR_FINISHED_REMOVED_FAILED  (1<<4) /* Removed recording, was failed before */
 
@@ -196,7 +196,7 @@ typedef struct dvr_entry {
    */
 
   LIST_ENTRY(dvr_entry) de_global_link;
-  
+
   channel_t *de_channel;
   LIST_ENTRY(dvr_entry) de_channel_link;
 
@@ -235,7 +235,7 @@ typedef struct dvr_entry {
   char *de_image;               /* Programme Image */
   char *de_fanart_image;        /* Programme fanart image */
   htsmsg_t *de_files; /* List of all used files */
-  char *de_directory; /* Can be set for autorec entries, will override any 
+  char *de_directory; /* Can be set for autorec entries, will override any
                          directory setting from the configuration */
   lang_str_t *de_title;      /* Title in UTF-8 (from EPG) */
   lang_str_t *de_subtitle;   /* Subtitle in UTF-8 (from EPG) */
@@ -244,6 +244,7 @@ typedef struct dvr_entry {
   uint32_t de_content_type;  /* Content type (from EPG) (only code) */
   uint16_t de_copyright_year; /* Copyright year (from EPG) */
   uint16_t de_dvb_eid;
+  uint16_t de_age_rating; /* Age rating (from EPG) */
 
   int de_pri;
   int de_dont_reschedule;
@@ -285,7 +286,7 @@ typedef struct dvr_entry {
    * Last error, see SM_CODE_ defines
    */
   uint32_t de_last_error;
-  
+
 
   /**
    * Autorec linkage
@@ -380,7 +381,7 @@ typedef struct dvr_autorec_entry {
   char *dae_title;
   tvh_regex_t dae_title_regex;
   int dae_fulltext;
-  
+
   uint32_t dae_content_type;
   /* These categories (mainly from xmltv) such as Cooking, Dog racing, Movie.
    * This allows user to easily do filtering such as '"Movie" "Martial arts"'
@@ -423,9 +424,9 @@ typedef struct dvr_autorec_entry {
 
   time_t dae_start_extra;
   time_t dae_stop_extra;
-  
+
   int dae_record;
-  
+
 } dvr_autorec_entry_t;
 
 extern struct dvr_autorec_entry_queue autorec_entries;
@@ -591,7 +592,7 @@ dvr_entry_update( dvr_entry_t *de, int enabled,
                   time_t start, time_t stop,
                   time_t start_extra, time_t stop_extra,
                   dvr_prio_t pri, int retention, int removal,
-                  int playcount, int playposition);
+                  int playcount, int playposition, int age_rating);
 
 void dvr_destroy_by_channel(channel_t *ch, int delconf);
 

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1207,6 +1207,8 @@ dvr_entry_create_from_htsmsg(htsmsg_t *conf, epg_broadcast_t *e)
     genre = LIST_FIRST(&e->genre);
     if (genre)
       htsmsg_add_u32(conf, "content_type", genre->code / 16);
+    if(e->age_rating)
+      htsmsg_add_u32(conf, "age_rating", e->age_rating);
   }
 
   de = dvr_entry_create(NULL, conf, 0);
@@ -1907,7 +1909,7 @@ dvr_is_better_recording_timeslot(const epg_broadcast_t *new_bcast, const dvr_ent
     if (svf == PROFILE_SVF_UHD && !old_has_svf) {
       old_has_svf = channel_has_correct_service_filter(old_channel, PROFILE_SVF_FHD);
       new_has_svf = channel_has_correct_service_filter(new_channel, PROFILE_SVF_FHD);
-      
+
       if (!old_has_svf && new_has_svf)
         return 1;
 
@@ -2366,6 +2368,7 @@ dvr_timer_remove_files(void *aux)
 #define DVR_UPDATED_CONFIG       (1<<17)
 #define DVR_UPDATED_PLAYPOS      (1<<18)
 #define DVR_UPDATED_PLAYCOUNT    (1<<19)
+#define DVR_UPDATED_AGE_RATING   (1<<20)
 
 static char *dvr_updated_str(char *buf, size_t buflen, int flags)
 {
@@ -2413,7 +2416,7 @@ static dvr_entry_t *_dvr_entry_update
     const char *lang, time_t start, time_t stop,
     time_t start_extra, time_t stop_extra,
     dvr_prio_t pri, int retention, int removal,
-    int playcount, int playposition)
+    int playcount, int playposition, int age_rating)
 {
   char buf[40];
   int save = 0, updated = 0;
@@ -2529,6 +2532,11 @@ static dvr_entry_t *_dvr_entry_update
     updated = 1;
     dvr_entry_set_timer(de);
   }
+  /* Manual Age Rating */
+  if (age_rating != de->de_age_rating) {
+    de->de_age_rating = age_rating;
+    save |= DVR_UPDATED_AGE_RATING;
+  }
 
   /* Title */
   if (e && e->title) {
@@ -2555,6 +2563,12 @@ static dvr_entry_t *_dvr_entry_update
   if (e && e->dvb_eid != de->de_dvb_eid) {
     de->de_dvb_eid = e->dvb_eid;
     save |= DVR_UPDATED_EID;
+  }
+
+  /* Age Rating from EPG*/
+  if (e && e->age_rating != de->de_age_rating) {
+    de->de_age_rating = e->age_rating;
+    save |= DVR_UPDATED_AGE_RATING;
   }
 
   /* Description */
@@ -2639,12 +2653,14 @@ dvr_entry_update
     const char *summary, const char *desc, const char *lang,
     time_t start, time_t stop,
     time_t start_extra, time_t stop_extra,
-    dvr_prio_t pri, int retention, int removal, int playcount, int playposition )
+    dvr_prio_t pri, int retention, int removal, int playcount, int playposition,
+    int age_rating )
 {
   return _dvr_entry_update(de, enabled, dvr_config_uuid,
                            NULL, ch, title, subtitle, summary, desc, lang,
                            start, stop, start_extra, stop_extra,
-                           pri, retention, removal, playcount, playposition);
+                           pri, retention, removal, playcount, playposition,
+                           age_rating);
 }
 
 /**
@@ -2698,7 +2714,7 @@ dvr_event_replaced(epg_broadcast_t *e, epg_broadcast_t *new_e)
                           gmtime2local(e2->start, t1buf, sizeof(t1buf)),
                           gmtime2local(e2->stop, t2buf, sizeof(t2buf)));
           _dvr_entry_update(de, -1, NULL, e2, NULL, NULL, NULL, NULL, NULL,
-                            NULL, 0, 0, 0, 0, DVR_PRIO_NOTSET, 0, 0, -1, -1);
+                            NULL, 0, 0, 0, 0, DVR_PRIO_NOTSET, 0, 0, -1, -1, 0);
           return;
         }
       }
@@ -2739,7 +2755,7 @@ void dvr_event_updated(epg_broadcast_t *e)
     assert(de->de_bcast == e);
     if (de->de_sched_state != DVR_SCHEDULED) continue;
     _dvr_entry_update(de, -1, NULL, e, NULL, NULL, NULL, NULL, NULL,
-                      NULL, 0, 0, 0, 0, DVR_PRIO_NOTSET, 0, 0, -1, -1);
+                      NULL, 0, 0, 0, 0, DVR_PRIO_NOTSET, 0, 0, -1, -1, 0);
   }
   LIST_FOREACH(de, &e->channel->ch_dvrs, de_channel_link) {
     if (de->de_sched_state != DVR_SCHEDULED) continue;
@@ -2751,7 +2767,7 @@ void dvr_event_updated(epg_broadcast_t *e)
                             epg_broadcast_get_title(e, NULL),
                             channel_get_name(e->channel, channel_blank_name));
       _dvr_entry_update(de, -1, NULL, e, NULL, NULL, NULL, NULL, NULL,
-                        NULL, 0, 0, 0, 0, DVR_PRIO_NOTSET, 0, 0, -1, -1);
+                        NULL, 0, 0, 0, 0, DVR_PRIO_NOTSET, 0, 0, -1, -1, 0);
     }
   }
 }
@@ -4508,7 +4524,7 @@ const idclass_t dvr_entry_class = {
     {
       .type     = PT_U16,
       .id       = "copyright_year",
-      .name     = N_("The copyright year of the program."),
+      .name     = N_("Copyright year"),
       .desc     = N_("The copyright year of the program."),
       .off      = offsetof(dvr_entry_t, de_copyright_year),
       .opts     = PO_RDONLY | PO_EXPERT,
@@ -4623,6 +4639,14 @@ const idclass_t dvr_entry_class = {
       .desc     = N_("Genre of program"),
       .get      = dvr_entry_class_genre_get,
       .opts     = PO_RDONLY | PO_NOSAVE,
+    },
+    {
+      .type     = PT_U16,
+      .id       = "age_rating",
+      .name     = N_("Age Rating"),
+      .desc     = N_("The age rating of the program."),
+      .off      = offsetof(dvr_entry_t, de_age_rating),
+      .opts     = PO_RDONLY | PO_EXPERT,
     },
     {}
   }

--- a/src/muxer/muxer_mkv.c
+++ b/src/muxer/muxer_mkv.c
@@ -749,6 +749,7 @@ _mk_build_metadata(const dvr_entry_t *de, const epg_broadcast_t *ebc,
   const char *lang;
   const lang_code_list_t *langs;
   epg_episode_num_t num;
+  int tmp_age;
 
   if (de || ebc) {
     localtime_r(de ? &de->de_start : &ebc->start, &tm);
@@ -778,6 +779,13 @@ _mk_build_metadata(const dvr_entry_t *de, const epg_broadcast_t *ebc,
   }
   if(eg && epg_genre_get_str(eg, 1, 0, ctype, 100, NULL))
     addtag(q, build_tag_string("CONTENT_TYPE", ctype, NULL, 0, NULL));
+
+  //TODO - MKV The spec suggests that this tag can consist of multiple value types.
+  //https://www.matroska.org/technical/tagging.html
+  //==> Depending on the COUNTRY it’s the format of the rating of a movie
+  //==> (P, R, X in the USA, an age in other countries or a URI defining a logo).
+  tmp_age = ebc->age_rating;
+  addtag(q, build_tag_int("LAW_RATING", tmp_age, 0, NULL));
 
   if(ch)
     addtag(q, build_tag_string("TVCHANNEL",

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -73,6 +73,7 @@ tvheadend.dvrDetails = function(grid, index) {
         var genre = params[21].value;
         /* channelname is unused param 22 */
         var fanart_image = params[23].value;
+        var age_rating = params[25].value;
         var content = '<div class="dvr-details-dialog">' +
         '<div class="dvr-details-dialog-background-image"></div>' +
         '<div class="dvr-details-dialog-content">';
@@ -764,7 +765,7 @@ tvheadend.dvr_upcoming = function(panel, index) {
         del: true,
         list: 'category,enabled,duplicate,disp_title,disp_extratext,episode_disp,' +
               'channel,image,copyright_year,start_real,stop_real,duration,pri,filesize,' +
-              'sched_status,errors,data_errors,config_name,owner,creator,comment,genre,broadcast',
+              'sched_status,errors,data_errors,config_name,owner,creator,comment,genre,broadcast,age_rating',
         columns: {
             disp_title: {
                 renderer: tvheadend.displayWithYearAndDuplicateRenderer(),
@@ -866,7 +867,7 @@ tvheadend.dvr_finished = function(panel, index) {
             buttonFcn(store, select, 'api/dvr/entry/move/failed');
         }
     };
-    
+
     var removeButton = {
         name: 'remove',
         builder: function() {
@@ -954,7 +955,7 @@ tvheadend.dvr_finished = function(panel, index) {
         del: false,
         list: 'disp_title,disp_extratext,episode_disp,channel,channelname,' +
               'start_real,stop_real,duration,filesize,copyright_year,' +
-              'sched_status,errors,data_errors,playcount,url,config_name,owner,creator,comment,',
+              'sched_status,errors,data_errors,playcount,url,config_name,owner,creator,comment,age_rating',
         columns: {
             disp_title: {
                 renderer: tvheadend.displayWithYearRenderer(),
@@ -1074,7 +1075,7 @@ tvheadend.dvr_failed = function(panel, index) {
                      _('The associated file will be removed from storage.'),
         list: 'disp_title,disp_extratext,episode_disp,channel,channelname,' +
               'image,copyright_year,start_real,stop_real,duration,filesize,status,' +
-              'sched_status,errors,data_errors,playcount,url,config_name,owner,creator,comment',
+              'sched_status,errors,data_errors,playcount,url,config_name,owner,creator,comment,age_rating',
         columns: {
             disp_title: {
                 renderer: tvheadend.displayWithYearRenderer(),
@@ -1153,7 +1154,7 @@ tvheadend.dvr_removed = function(panel, index) {
         del: true,
         list: 'disp_title,disp_extratext,episode_disp,channel,channelname,image,' +
               'copyright_year,start_real,stop_real,duration,status,' +
-              'sched_status,errors,data_errors,url,config_name,owner,creator,comment',
+              'sched_status,errors,data_errors,url,config_name,owner,creator,comment,age_rating',
         columns: {
             disp_title: {
                 renderer: tvheadend.displayWithYearRenderer(),


### PR DESCRIPTION
An 'age_rating' field has been added to the recording objects stored in '{TVH}/dvr/log'.  It is populated from the associated EPG event when a recording is created using the WebUI, HTSP API or JSON API.  It is also populated via HTSP/JSON API if the field is specifically included during the manual creation of the recording object.

This field can be accessed via:

1) the WebUI recording list pages (Upcoming, current, finished, failed, removed);
2) the '/api/dvr/entry/???' JSON API in the new 'ageRating' property;
3) the HTSP API 'dvrEntryAdd' and 'dvrEntryUpdate' methods in the new 'ageRating' property and;
4) saved in the MKV 'LAW_RATING' tag as a number (for now).

The new property name 'ageRating' for the DVR recording API object was selected to be consistent with the existing EPG API object property name.

In order to protect legacy HTSP clients, the property is only provided when the client requests a HTSP API version greater than 35.

Client Testing:

This modification was tested with a Kodi 'Matrix' client with no issues noted.

Other Testing:

Creation: WebUI, HTSP, JSON, TVH autoRec

Modification: HTSP, EPG update

Output: WebUI lists, HTSP (Ver > 35), JSON

No issues were noted during these tests.