### PR TITLE
otamux: Make sure we use PRItime_t

### DIFF
--- a/src/epggrab/otamux.c
+++ b/src/epggrab/otamux.c
@@ -725,7 +725,7 @@ epggrab_ota_start_cb ( void *p );
 static void
 epggrab_ota_next_arm( time_t next )
 {
-  tvhtrace(LS_EPGGRAB, "next ota start event in %li seconds", next - time(NULL));
+  tvhtrace(LS_EPGGRAB, "next ota start event in %"PRItime_t" seconds", next - time(NULL));
   gtimer_arm_absn(&epggrab_ota_start_timer, epggrab_ota_start_cb, NULL, next);
   dbus_emit_signal_s64("/epggrab/ota", "next", next);
 }


### PR DESCRIPTION
As %li isn't supported equally, we must ensure we always use PRItime_t.