### PR TITLE
Debian 64-bit time compliance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ CFLAGS  += -Wmissing-prototypes
 CFLAGS  += -fno-strict-aliasing
 CFLAGS  += -fms-extensions -funsigned-char
 CFLAGS  += -D_FILE_OFFSET_BITS=64
+CFLAGS  += -D_TIME_BITS=64
 CFLAGS  += -I${BUILDDIR} -I${ROOTDIR}/src -I${ROOTDIR}
 ifeq ($(CONFIG_ANDROID),yes)
 LDFLAGS += -ldl -lm

--- a/configure
+++ b/configure
@@ -76,6 +76,7 @@ OPTIONS=(
   "cclang_threadsan:no"
   "gperftools:no"
   "execinfo:auto"
+  "year2038:no"
 )
 
 #
@@ -802,6 +803,25 @@ if enabled_or_auto libsystemd_daemon; then
   elif enabled libsystemd_daemon; then
     die "libsystemd-daemon development support not found (use --disable-systemd_daemon)"
   fi
+fi
+
+#
+# year2038
+#
+check_cc_snippet year2038 '
+#define _FILE_OFFSET_BITS 64
+#define _TIME_BITS 64
+#include <time.h>
+int test(void){
+  #define LARGE_TIME_T ((time_t) (((time_t) 1 << 30) - 1 + 3 * ((time_t) 1 << 30)))
+  int verify_time_t_range[(LARGE_TIME_T / 65537 == 65535 && LARGE_TIME_T % 65537 == 0) ? 1 : -1];
+  return 0;
+}
+' -Werror
+
+if disabled year2038; then
+  CFLAGS="-D_USE_32BIT_TIME_T ${CFLAGS}"
+  printf "    ^ WARNING: The 'time_t' type stops working after January 2038\n"
 fi
 
 # ###########################################################################

--- a/src/epggrab/otamux.c
+++ b/src/epggrab/otamux.c
@@ -723,7 +723,7 @@ epggrab_ota_start_cb ( void *p );
 static void
 epggrab_ota_next_arm( time_t next )
 {
-  tvhtrace(LS_EPGGRAB, "next ota start event in %li seconds", next - time(NULL));
+  tvhtrace(LS_EPGGRAB, "next ota start event in %" PRItime_t " seconds", next - time(NULL));
   gtimer_arm_absn(&epggrab_ota_start_timer, epggrab_ota_start_cb, NULL, next);
   dbus_emit_signal_s64("/epggrab/ota", "next", next);
 }

--- a/src/tvheadend.h
+++ b/src/tvheadend.h
@@ -334,10 +334,16 @@ void tvh_qsort_r(void *base, size_t nmemb, size_t size, int (*compar)(const void
 # endif /* ULONG_MAX */
 #endif /* __WORDSIZE */
 
-#if __WORDSIZE == 32 && defined(PLATFORM_FREEBSD)
-#define PRItime_t       "d"
+#if __WORDSIZE == 64
+# define PRItime_t      "ld"
 #else
-#define PRItime_t       "ld"
+# if defined(PLATFORM_FREEBSD)
+#  define PRItime_t     "d"
+# elif defined(_USE_32BIT_TIME_T)
+#  define PRItime_t     "ld"
+# else
+#  define PRItime_t     "lld"
+# endif
 #endif
 
 /* transcoding */


### PR DESCRIPTION
This patch will insure 64-bit time_t is used on 64-bit systems and GNU/Linux systems where glibc >=2.34.

Older 32-bit GNU/Linux systems (where glibc < 2.34) as well as 32-bit Darwin/BSD will continue to work as before.