### PR TITLE
support/mkbundle: switch from distutils to setuptools

### DIFF
--- a/support/mkbundle
+++ b/support/mkbundle
@@ -45,10 +45,10 @@ if opts.deps:
 # PNGquant
 pngquant_bin = '/usr/bin/pngquant'
 if opts.pngquant:
-  import distutils.spawn
+  from shutil import which
   import subprocess
   import time
-  distutils.spawn.find_executable('pngquant')
+  which('pngquant')
 
 # Build hierarchy
 root  = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '..'))


### PR DESCRIPTION
Fixes build error with python-3.12:

Traceback (most recent call last):
  File "support/mkbundle", line 48, in <module>
    import distutils.spawn
ModuleNotFoundError: No module named 'distutils'