### PR TITLE
satip server: Rename nosatip to nosatipcli CLI flag

### DIFF
--- a/docs/markdown/cmdline_options.md
+++ b/docs/markdown/cmdline_options.md
@@ -27,7 +27,7 @@ Usage: `tvheadend [OPTIONS]`
       --satip_bindaddr        Specify bind address for SAT>IP server
       --satip_rtsp            SAT>IP RTSP port number for server
                               (default: -1 = disable, 0 = webconfig, standard port is 554)
-      --nosatip               Disable SAT>IP client
+      --nosatipcli            Disable SAT>IP client
       --satip_xml             URL with the SAT>IP server XML location
 ```
 ### Server connectivity

--- a/man/tvheadend.1
+++ b/man/tvheadend.1
@@ -66,7 +66,7 @@ Only use specified DVB adapters (comma separated, -1 == none).
 SAT>IP RTSP port number for server (default: -1 = disable, 0 = 
 webconfig, standard port is 554).
 .TP
-\fB\-\-nosatip\fR
+\fB\-\-nosatipcli\fR
 Disable SAT>IP client.
 .TP
 \fB\-\-satip_xml\fR

--- a/src/main.c
+++ b/src/main.c
@@ -843,7 +843,7 @@ main(int argc, char **argv)
               opt_threadid     = 0,
               opt_libav        = 0,
               opt_ipv6         = 0,
-              opt_nosatip      = 0,
+              opt_nosatipcli   = 0,
               opt_satip_rtsp   = 0,
 #if ENABLE_TSFILE
               opt_tsfile_tuner = 0,
@@ -911,8 +911,10 @@ main(int argc, char **argv)
       OPT_INT, &opt_satip_rtsp },
 #endif
 #if ENABLE_SATIP_CLIENT
-    {   0, "nosatip",    N_("Disable SAT>IP client"),
-      OPT_BOOL, &opt_nosatip },
+    {   0, "nosatip",    N_("Disable SAT>IP client (deprecated flag, use nosatipcli)"),
+      OPT_BOOL, &opt_nosatipcli },
+    {   0, "nosatipcli",    N_("Disable SAT>IP client"),
+      OPT_BOOL, &opt_nosatipcli },
     {   0, "satip_xml",  N_("URL with the SAT>IP server XML location"),
       OPT_STR_LIST, &opt_satip_xml },
 #endif
@@ -1302,7 +1304,7 @@ main(int argc, char **argv)
   tvhftrace(LS_MAIN, descrambler_init);
   tvhftrace(LS_MAIN, dvb_init);
 #if ENABLE_MPEGTS
-  tvhftrace(LS_MAIN, mpegts_init, adapter_mask, opt_nosatip, &opt_satip_xml,
+  tvhftrace(LS_MAIN, mpegts_init, adapter_mask, opt_nosatipcli, &opt_satip_xml,
             &opt_tsfile, opt_tsfile_tuner);
 #endif
   tvhftrace(LS_MAIN, channel_init);


### PR DESCRIPTION
The satip_boot function was added to config_boot in commit 442a871839bb ("satip server: fixed the RTP TCP size initialization, fixes #4517"), which doesn't tell us at all why it is there.

Whats worse, the nosatip flag seems to be ignored and the satip server still gets loaded.

Move things around a little so we can put them together under the nosatip flag to honor the intend better.