### PR TITLE
CI: drop support for jessie and stretch

### DIFF
--- a/.github/workflows/build-cloudsmith.yml
+++ b/.github/workflows/build-cloudsmith.yml
@@ -64,18 +64,12 @@ jobs:
     strategy:
       matrix:
        arch: [ armv7, aarch64]
-       distro: [ stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04 ]
+       distro: [ buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04 ]
        include:
-         - arch: armv6
-           distro: jessie
-         - arch: armv6
-           distro: stretch
          - arch: armv6
            distro: buster
          - arch: armv6
            distro: bullseye
-         - arch: armv7
-           distro: jessie
 
     steps:
       - uses: actions/checkout@v3
@@ -115,9 +109,8 @@ jobs:
           # publicly in your project's package repository, so it is vital that
           # no secrets are present in the container state or logs.
           install: |
-            if [ '${{ matrix.distro }}' = 'jessie' ]; then sed -i 's/archive.raspbian.org/legacy.raspbian.org/g' /etc/apt/sources.list; fi
             case "${{ matrix.distro }}" in
-              ubuntu*|jessie|stretch|buster|bullseye)
+              ubuntu*|buster|bullseye)
                 apt-get update -y
                 DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y cmake git build-essential pkg-config gettext libavahi-client-dev libssl-dev zlib1g-dev wget bzip2 git-core liburiparser-dev libdvbcsa-dev python3 python3-requests debhelper ccache lsb-release
                 DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre3-dev || DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre2-dev
@@ -150,7 +143,7 @@ jobs:
     name: Build on native ${{ matrix.container }}
     strategy:
       matrix:
-        container: ["ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "ubuntu:kinetic", "ubuntu:trusty", "ubuntu:xenial", "i386/ubuntu:trusty", "i386/ubuntu:xenial", "debian:bookworm", "debian:bullseye", "debian:buster", "debian:sid", "debian:stretch", "i386/debian:bookworm", "i386/debian:bullseye", "i386/debian:buster", "i386/debian:sid", "i386/debian:stretch"]
+        container: ["ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "ubuntu:kinetic", "ubuntu:xenial", "i386/ubuntu:xenial", "debian:bookworm", "debian:bullseye", "debian:buster", "debian:sid", "i386/debian:bookworm", "i386/debian:bullseye", "i386/debian:buster", "i386/debian:sid"]
     container:
       image: ${{ matrix.container }}
     steps:
@@ -168,11 +161,11 @@ jobs:
         run: |
           DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre3-dev || DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre2-dev
       - uses: actions/checkout@v3
-        if: startsWith(matrix.container, 'i386') != true && matrix.container != 'debian:stretch'
+        if: startsWith(matrix.container, 'i386') != true
         with:
           fetch-depth: 0
       - uses: actions/checkout@v1
-        if: startsWith(matrix.container, 'i386') || matrix.container == 'debian:stretch'
+        if: startsWith(matrix.container, 'i386')
       - name: Workaround safe directory
         run: git config --global --add safe.directory /__w/tvheadend/tvheadend
       - name: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,18 +66,12 @@ jobs:
     strategy:
       matrix:
        arch: [ armv7, aarch64]
-       distro: [ stretch, buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04 ]
+       distro: [ buster, bullseye, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04 ]
        include:
-         - arch: armv6
-           distro: jessie
-         - arch: armv6
-           distro: stretch
          - arch: armv6
            distro: buster
          - arch: armv6
            distro: bullseye
-         - arch: armv7
-           distro: jessie
 
     steps:
       - uses: actions/checkout@v3
@@ -116,9 +110,8 @@ jobs:
           # publicly in your project's package repository, so it is vital that
           # no secrets are present in the container state or logs.
           install: |
-            if [ '${{ matrix.distro }}' = 'jessie' ]; then sed -i 's/archive.raspbian.org/legacy.raspbian.org/g' /etc/apt/sources.list; fi
             case "${{ matrix.distro }}" in
-              ubuntu*|jessie|stretch|buster|bullseye)
+              ubuntu*|buster|bullseye)
                 apt-get update -y
                 DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y cmake git build-essential pkg-config gettext libavahi-client-dev libssl-dev zlib1g-dev wget bzip2 git-core liburiparser-dev libdvbcsa-dev python3 python3-requests debhelper ccache lsb-release
                 DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre3-dev || DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre2-dev
@@ -150,7 +143,7 @@ jobs:
     name: Build on native ${{ matrix.container }}
     strategy:
       matrix:
-        container: ["ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "ubuntu:kinetic", "ubuntu:trusty", "ubuntu:xenial", "i386/ubuntu:trusty", "i386/ubuntu:xenial", "debian:bookworm", "debian:bullseye", "debian:buster", "debian:sid", "debian:stretch", "i386/debian:bookworm", "i386/debian:bullseye", "i386/debian:buster", "i386/debian:sid", "i386/debian:stretch"]
+        container: ["ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "ubuntu:kinetic", "ubuntu:xenial", "i386/ubuntu:xenial", "debian:bookworm", "debian:bullseye", "debian:buster", "debian:sid", "i386/debian:bookworm", "i386/debian:bullseye", "i386/debian:buster", "i386/debian:sid"]
     container:
       image: ${{ matrix.container }}
     steps:
@@ -168,11 +161,11 @@ jobs:
         run: |
           DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre3-dev || DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre2-dev
       - uses: actions/checkout@v3
-        if: startsWith(matrix.container, 'i386') != true && matrix.container != 'debian:stretch'
+        if: startsWith(matrix.container, 'i386') != true
         with:
           fetch-depth: 0
       - uses: actions/checkout@v1
-        if: startsWith(matrix.container, 'i386') || matrix.container == 'debian:stretch'
+        if: startsWith(matrix.container, 'i386')
       - name: Workaround safe directory
         run: git config --global --add safe.directory /__w/tvheadend/tvheadend
       - name: build

--- a/Autobuild/jessie-aarch64.sh
+++ b/Autobuild/jessie-aarch64.sh
@@ -1,2 +1,0 @@
-source Autobuild/aarch64.sh
-source Autobuild/jessie.sh

--- a/Autobuild/jessie-armv6l.sh
+++ b/Autobuild/jessie-armv6l.sh
@@ -1,3 +1,0 @@
-AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --disable-libx265_static --disable-libx265 --nowerror"
-source Autobuild/armv6l.sh
-source Autobuild/jessie.sh

--- a/Autobuild/jessie-armv7l.sh
+++ b/Autobuild/jessie-armv7l.sh
@@ -1,3 +1,0 @@
-AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --disable-libx265_static --disable-libx265 --nowerror"
-source Autobuild/armv7l.sh
-source Autobuild/jessie.sh

--- a/Autobuild/jessie-i386.sh
+++ b/Autobuild/jessie-i386.sh
@@ -1,2 +1,0 @@
-source Autobuild/i386.sh
-source Autobuild/jessie.sh

--- a/Autobuild/jessie-i686.sh
+++ b/Autobuild/jessie-i686.sh
@@ -1,2 +1,0 @@
-source Autobuild/i686.sh
-source Autobuild/jessie.sh

--- a/Autobuild/jessie-x86_64.sh
+++ b/Autobuild/jessie-x86_64.sh
@@ -1,2 +1,0 @@
-source Autobuild/x86_64.sh
-source Autobuild/jessie.sh

--- a/Autobuild/jessie.sh
+++ b/Autobuild/jessie.sh
@@ -1,2 +1,0 @@
-DEBDIST=jessie
-source Autobuild/debian.sh

--- a/Autobuild/stretch-aarch64.sh
+++ b/Autobuild/stretch-aarch64.sh
@@ -1,2 +1,0 @@
-source Autobuild/aarch64.sh
-source Autobuild/stretch.sh

--- a/Autobuild/stretch-armv6l.sh
+++ b/Autobuild/stretch-armv6l.sh
@@ -1,2 +1,0 @@
-source Autobuild/armv6l.sh
-source Autobuild/stretch.sh

--- a/Autobuild/stretch-armv7l.sh
+++ b/Autobuild/stretch-armv7l.sh
@@ -1,2 +1,0 @@
-source Autobuild/armv7l.sh
-source Autobuild/stretch.sh

--- a/Autobuild/stretch-i386.sh
+++ b/Autobuild/stretch-i386.sh
@@ -1,2 +1,0 @@
-source Autobuild/i386.sh
-source Autobuild/stretch.sh

--- a/Autobuild/stretch-i686.sh
+++ b/Autobuild/stretch-i686.sh
@@ -1,2 +1,0 @@
-source Autobuild/i686.sh
-source Autobuild/stretch.sh

--- a/Autobuild/stretch-x86_64.sh
+++ b/Autobuild/stretch-x86_64.sh
@@ -1,2 +1,0 @@
-source Autobuild/x86_64.sh
-source Autobuild/stretch.sh

--- a/Autobuild/stretch.sh
+++ b/Autobuild/stretch.sh
@@ -1,2 +1,0 @@
-DEBDIST=stretch
-source Autobuild/debian.sh


### PR DESCRIPTION
Jessie and Stretch have been End-of-Life for a long time. They do not get security updates etc. Also, it requires extra effort to get them to actually work again, due to the apt-repo's being archived.

Unless we have statistics that prove people are still downloading/using jessie and stretch, I think it's best to remove the maintenance burden on our side.