### PR TITLE
Warn missing config

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1114,6 +1114,9 @@ main(int argc, char **argv)
   signal(SIGPIPE, handle_sigpipe); // will be redundant later
   signal(SIGILL, handle_sigill);   // see handler..
 
+  if (opt_fork && !opt_user && !opt_config)
+    tvhwarn(LS_START, "Forking without --user or --config may use unexpected configuration location");
+
   /* Set privileges */
   if((opt_fork && getuid() == 0) || opt_group || opt_user) {
     const char *homedir;


### PR DESCRIPTION
When using the `--fork` flag, and no user or config arguments are
supplied, the configuration folder will end up with whatever the default
`daemon` user has set, which is often `/sbin` set as the homedir.
    
This is weird, but not 'wrong' per say. Lets warn the user that forking
can have an unexpected side effect.

Contributes to https://tvheadend.org/issues/6296