### PR TITLE
Fix htsstr_argsplit

### DIFF
--- a/src/htsstr.c
+++ b/src/htsstr.c
@@ -133,6 +133,7 @@ htsstr_argsplit_add
 char **
 htsstr_argsplit(const char *str) {
   int quote = 0;
+  int quote_inbetween = 0; // when quote isn't start of argument
   int inarg = 0;
   const char *start = NULL;
   const char *s;
@@ -147,16 +148,19 @@ htsstr_argsplit(const char *str) {
           break;
         case '"':
           if(quote) {
-            inarg = 0;
             quote = 0;
             if (start) {
               htsstr_argsplit_add(&argv, &argc, start, s);
               start = NULL;
             }
+          } else if (quote_inbetween) {
+            quote_inbetween = 0;
+          } else {
+            quote_inbetween = 1;
           }
           break;
         case ' ':
-          if(quote)
+          if(quote||quote_inbetween)
             break;
           inarg = 0;
           if (start) {
@@ -297,6 +301,8 @@ void main(int argc, char *argv[])
     "sh -c \"/bin/df -P -h /recordings >/config/.markers/recording-pre-process\"",
     "bash -c '/bin/df -P -h /recordings >/config/.markers/recording-pre-process'",
     "bash -c \"/bin/df -P -h /recordings | tee /config/.markers/recording-pre-process\"",
+    "/bin/grep --label=\"TVHeadend Recording\" \"start time\"",
+    "/bin/grep --label=\"TVHeadend Recordings \"File \"start time\" /recordings",
     NULL,
   };
   char **s = strings, **x;


### PR DESCRIPTION
There seemed to be a flaw in the splitting logic when it comes to quotes, e.g.: --output="filename" should be one argument, but htsstr_argsplit treated it as ['--output=', '"filename"] which I think is wrong.

I don't have the setup to test this code so I would appreciate it if someone else does.