### PR TITLE
Fix non-admin users not receiving any updates in web UI

### DIFF
--- a/src/api/api_service.c
+++ b/src/api/api_service.c
@@ -66,7 +66,7 @@ api_mapper_status
 void
 api_service_mapper_notify ( void )
 {
-  notify_by_msg("servicemapper", api_mapper_status_msg(), 0);
+  notify_by_msg("servicemapper", api_mapper_status_msg(), 1, 0);
 }
 
 static htsmsg_t *

--- a/src/dvr/dvr_vfsmgr.c
+++ b/src/dvr/dvr_vfsmgr.c
@@ -420,7 +420,7 @@ dvr_get_disk_space_tcb(void *opaque, int dearmed)
     htsmsg_add_s64(m, "freediskspace", dvr_bfree);
     htsmsg_add_s64(m, "useddiskspace", dvr_bused);
     htsmsg_add_s64(m, "totaldiskspace", dvr_btotal);
-    notify_by_msg("diskspaceUpdate", m, 0);
+    notify_by_msg("diskspaceUpdate", m, 0, 0);
 
     /* check free disk space for each dvr config and start cleanup if needed */
     dvr_disk_space_check();

--- a/src/idnode.c
+++ b/src/idnode.c
@@ -1922,7 +1922,7 @@ idnode_notify_title_changed (void *in)
 {
   htsmsg_t *m = htsmsg_create_map();
   htsmsg_add_uuid(m, "uuid", &((idnode_t *)in)->in_uuid);
-  notify_by_msg("title", m, NOTIFY_REWRITE_TITLE);
+  notify_by_msg("title", m, 0, NOTIFY_REWRITE_TITLE);
   idnode_notify_changed(in);
 }
 

--- a/src/input/mpegts/mpegts_input.c
+++ b/src/input/mpegts/mpegts_input.c
@@ -2045,7 +2045,7 @@ mpegts_input_status_timer ( void *p )
     mpegts_input_stream_status(mmi, &st);
     e = tvh_input_stream_create_msg(&st);
     htsmsg_add_u32(e, "update", 1);
-    notify_by_msg("input_status", e, 0);
+    notify_by_msg("input_status", e, 1, 0);
     subs += st.subs_count;
     tvh_input_stream_destroy(&st);
   }

--- a/src/notify.c
+++ b/src/notify.c
@@ -33,10 +33,10 @@ static pthread_t              notify_tid;
 static void*                  notify_thread(void* p);
 
 void
-notify_by_msg(const char *class, htsmsg_t *m, int rewrite)
+notify_by_msg(const char *class, htsmsg_t *m, int isrestricted, int rewrite)
 {
   htsmsg_add_str(m, "notificationClass", class);
-  comet_mailbox_add_message(m, 0, rewrite);
+  comet_mailbox_add_message(m, 0, isrestricted, rewrite);
   htsmsg_destroy(m);
 }
 
@@ -46,7 +46,7 @@ notify_reload(const char *class)
 {
   htsmsg_t *m = htsmsg_create_map();
   htsmsg_add_u32(m, "reload", 1);
-  notify_by_msg(class, m, 0);
+  notify_by_msg(class, m, 0, 0);
 }
 
 void
@@ -103,7 +103,7 @@ notify_thread ( void *p )
     tvh_mutex_lock(&global_lock);
 
     HTSMSG_FOREACH(f, q)
-      notify_by_msg(htsmsg_field_name(f), htsmsg_detach_submsg(f), 0);
+      notify_by_msg(htsmsg_field_name(f), htsmsg_detach_submsg(f), 0, 0);
 
     /* Finished */
     tvh_mutex_unlock(&global_lock);

--- a/src/notify.h
+++ b/src/notify.h
@@ -24,7 +24,7 @@
 #define NOTIFY_REWRITE_TITLE         1
 #define NOTIFY_REWRITE_SUBSCRIPTIONS 2
 
-void notify_by_msg(const char *class, htsmsg_t *m, int rewrite);
+void notify_by_msg(const char *class, htsmsg_t *m, int isrestricted, int rewrite);
 
 void notify_reload(const char *class);
 

--- a/src/subscriptions.c
+++ b/src/subscriptions.c
@@ -1124,7 +1124,7 @@ subscription_status_callback ( void *p )
 
     htsmsg_t *m = subscription_create_msg(s, NULL);
     htsmsg_add_u32(m, "updateEntry", 1);
-    notify_by_msg("subscriptions", m, NOTIFY_REWRITE_SUBSCRIPTIONS);
+    notify_by_msg("subscriptions", m, 1, NOTIFY_REWRITE_SUBSCRIPTIONS);
     count++;
   }
   if (old_count != count) {

--- a/src/webui/comet.c
+++ b/src/webui/comet.c
@@ -552,7 +552,7 @@ comet_mailbox_rewrite_msg(int rewrite, htsmsg_t *m, const char *lang)
  *
  */
 void
-comet_mailbox_add_message(htsmsg_t *m, int isdebug, int rewrite)
+comet_mailbox_add_message(htsmsg_t *m, int isdebug, int isrestricted, int rewrite)
 {
   comet_mailbox_t *cmb;
   htsmsg_t *e;
@@ -565,7 +565,7 @@ comet_mailbox_add_message(htsmsg_t *m, int isdebug, int rewrite)
   if (atomic_get(&comet_running)) {
     LIST_FOREACH(cmb, &mailboxes, cmb_link) {
 
-      if(cmb->cmb_restricted)
+      if(isrestricted && cmb->cmb_restricted)
         continue;
 
       if(isdebug && !cmb->cmb_debug)
@@ -593,6 +593,6 @@ comet_mailbox_add_logmsg(const char *txt, int isdebug, int rewrite)
   htsmsg_t *m = htsmsg_create_map();
   htsmsg_add_str(m, "notificationClass", "logmessage");
   htsmsg_add_str(m, "logtxt", txt);
-  comet_mailbox_add_message(m, isdebug, 0);
+  comet_mailbox_add_message(m, isdebug, 1, 0);
   htsmsg_destroy(m);
 }

--- a/src/webui/webui.h
+++ b/src/webui/webui.h
@@ -65,7 +65,7 @@ void comet_init(void);
 
 void comet_done(void);
 
-void comet_mailbox_add_message(htsmsg_t *m, int isdebug, int rewrite);
+void comet_mailbox_add_message(htsmsg_t *m, int isdebug, int isrestricted, int rewrite);
 
 void comet_mailbox_add_logmsg(const char *txt, int isdebug, int rewrite);
 


### PR DESCRIPTION
All the way back in 54e63e3f9af8fdc0d23f61f3cda7fa7b246c1732, there was a fix to stop non-admin users from receiving log messages with potentially-sensitive data.  However, this stopped non-admin webui users from receiving almost any updates over the websocket interface, which causes a bug where such users don't see newly- created DVR entries, etc. until refreshing the page.  This patch allows for more granular control over what non-admin users receive.  Specifically, messages originating from subscriptions.c, mpegts_input.c, and api_service.c, along with all log messages, are still only sent to admins because they may contain sensitive data and/or they are only relevant to administrative parts of the UI. Other messages, such as idnode, DVR, and EPG-related messages, are once again sent to all webui users to keep the UI up-to-date.