### PR TITLE
gitignore: add debian/.debhelper folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ nbproject
 *.orig
 *.patch
 
+debian/.debhelper
 debian/changelog
 debian/files
 debian/tvheadend


### PR DESCRIPTION
ignore the debhelper folder
```
cvh@PC:/mnt/d/GIT/tvheadend.git$ tree debian/.debhelper/
debian/.debhelper/
└── generated
    ├── tvheadend
    │   ├── installed-by-dh_installdocs
    │   ├── installed-by-dh_installman
    │   ├── postinst.service
    │   ├── postrm.service
    │   └── prerm.service
    └── tvheadend-dbg
        ├── installed-by-dh_installdocs
        └── installed-by-dh_installman
```