### PR TITLE
update ci builds

### DIFF
--- a/.github/workflows/build-cloudsmith.yml
+++ b/.github/workflows/build-cloudsmith.yml
@@ -124,7 +124,7 @@ jobs:
             if [ '${{ matrix.distro }}' = 'stretch' ]; then sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list; fi
             if [ '${{ matrix.distro }}' = 'stretch' ]; then sed -i '/stretch-updates/d' /etc/apt/sources.list; fi
             case "${{ matrix.distro }}" in
-              ubuntu*|jessie|stretch|buster|bullseye|bookworm)
+              ubuntu*|jessie|stretch|buster|bullseye|bookworm|trixie)
                 apt-get update -y
                 DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y cmake git build-essential pkg-config gettext libavahi-client-dev libssl-dev zlib1g-dev wget bzip2 git-core liburiparser-dev libdvbcsa-dev python3 python3-requests debhelper ccache lsb-release
                 DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre3-dev || DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre2-dev
@@ -157,7 +157,7 @@ jobs:
     name: Build on native ${{ matrix.container }}
     strategy:
       matrix:
-        container: ["ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "ubuntu:kinetic", "ubuntu:trusty", "ubuntu:xenial", "i386/ubuntu:trusty", "i386/ubuntu:xenial", "debian:bookworm", "debian:bullseye", "debian:buster", "debian:sid", "debian:stretch", "i386/debian:bookworm", "i386/debian:bullseye", "i386/debian:buster", "i386/debian:sid", "i386/debian:stretch"]
+        container: ["i386/ubuntu:trusty", "ubuntu:trusty", "i386/ubuntu:xenial", "ubuntu:xenial", "ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "i386/debian:stretch", "debian:stretch", "i386/debian:buster", "debian:buster", "i386/debian:bullseye", "debian:bullseye", "i386/debian:bookworm", "debian:bookworm", "i386/debian:trixie", "debian:trixie", "i386/debian:sid", "debian:sid"]
     container:
       image: ${{ matrix.container }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,7 @@ jobs:
     name: Build on native ${{ matrix.container }}
     strategy:
       matrix:
-        container: ["ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "ubuntu:kinetic", "ubuntu:trusty", "ubuntu:xenial", "i386/ubuntu:trusty", "i386/ubuntu:xenial", "debian:bookworm", "debian:bullseye", "debian:buster", "debian:sid", "debian:stretch", "i386/debian:bookworm", "i386/debian:bullseye", "i386/debian:buster", "i386/debian:sid", "i386/debian:stretch"]
+        container: ["i386/ubuntu:trusty", "ubuntu:trusty", "i386/ubuntu:xenial", "ubuntu:xenial", "ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "ubuntu:lunar", "ubuntu:mantic", "i386/debian:stretch", "debian:stretch", "i386/debian:buster", "debian:buster", "i386/debian:bullseye", "debian:bullseye", "i386/debian:bookworm", "debian:bookworm", "i386/debian:trixie", "debian:trixie", "debian:sid"]
     container:
       image: ${{ matrix.container }}
     steps:

--- a/Autobuild/lunar-aarch64.sh
+++ b/Autobuild/lunar-aarch64.sh
@@ -1,0 +1,2 @@
+source Autobuild/aarch64.sh
+source Autobuild/lunar.sh

--- a/Autobuild/lunar-armv7l.sh
+++ b/Autobuild/lunar-armv7l.sh
@@ -1,0 +1,2 @@
+source Autobuild/armv7l.sh
+source Autobuild/lunar.sh

--- a/Autobuild/lunar-x86_64.sh
+++ b/Autobuild/lunar-x86_64.sh
@@ -1,0 +1,2 @@
+source Autobuild/x86_64.sh
+source Autobuild/lunar.sh

--- a/Autobuild/lunar.sh
+++ b/Autobuild/lunar.sh
@@ -1,0 +1,2 @@
+DEBDIST=lunar
+source Autobuild/debian.sh

--- a/Autobuild/mantic-aarch64.sh
+++ b/Autobuild/mantic-aarch64.sh
@@ -1,0 +1,2 @@
+source Autobuild/aarch64.sh
+source Autobuild/mantic.sh

--- a/Autobuild/mantic-armv7l.sh
+++ b/Autobuild/mantic-armv7l.sh
@@ -1,0 +1,2 @@
+source Autobuild/armv7l.sh
+source Autobuild/mantic.sh

--- a/Autobuild/mantic-x86_64.sh
+++ b/Autobuild/mantic-x86_64.sh
@@ -1,0 +1,2 @@
+source Autobuild/x86_64.sh
+source Autobuild/mantic.sh

--- a/Autobuild/mantic.sh
+++ b/Autobuild/mantic.sh
@@ -1,0 +1,2 @@
+DEBDIST=mantic
+source Autobuild/debian.sh


### PR DESCRIPTION
blind changes, can't test locally

- remove EOL distros besides old TLS
- reorder releases by date
- add new build targets Ubuntu 23.04, 23.10 and Debian Trixie
- left out i386 for new targets, Ubuntu already dropped 32bit

not sure if Debian 13 i386 is needed ?
