### PR TITLE
Update copyright year and correct current surname

### DIFF
--- a/src/webui/extjs.c
+++ b/src/webui/extjs.c
@@ -187,7 +187,7 @@ page_about(http_connection_t *hc, const char *remain, void *opaque)
 
   htsbuf_qprintf(hq, "<center class=\"about-tab\">\n\
 <div class=\"about-title\">HTS Tvheadend %s</div>\n\
-<p>&copy; 2006 - 2021 Andreas Öman, Jaroslav Kysela, Adam Sutton, et al.</p>\n\
+<p>&copy; 2006 - 2024 Andreas Smas, Jaroslav Kysela, Adam Sutton, et al.</p>\n\
 <p><img class=\"logobig\" src=\"static/img/logobig.png\"></p>\n\
 <p><a href=\"https://tvheadend.org\">https://tvheadend.org</a></p>\n",
     tvheadend_version);


### PR DESCRIPTION
Simply update the WebUI copyright message so it's current, and correct Andreas' surname since it changed some time ago.