### PR TITLE
ci: don't trigger cloudsmith on .github changes

### DIFF
--- a/.github/workflows/build-cloudsmith.yml
+++ b/.github/workflows/build-cloudsmith.yml
@@ -3,7 +3,7 @@ name: Build Tvheadend Repo
 on:
   push:
     branches: [ master ]
-
+    paths-ignore: '.github'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
This prevents changes to `.github` and subdirs like `.github/workflows` from triggering a cloudsmith repo build.