### PR TITLE
ci: add concurrency to the main CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,13 @@ on:
   pull_request:
     branches:
       - master
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
+concurrency:
+  # auto-cancel previous runs if the pull request is force-push updated
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   build-raspberry:

--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -5,9 +5,13 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
+concurrency:
+  # auto-cancel previous runs if the pull request is force-push updated
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
  build-ubuntu-latest:


### PR DESCRIPTION
This PR adds concurrency to workflows so force pushes to a pull-request automatically cancel any active/pending runs that resulted from the original submission.