### PR TITLE
Replace "Tvheadend Foundation CIC" with "Tvheadend Project"

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -6,26 +6,12 @@ The project is currently licensed using GPLv3. For full text see:
 > http://www.gnu.org/licenses/gpl-3.0.txt   
 > [GPLv3](licenses/gpl-3.0.txt)
 
-However we are currently in the process of seeking CLAs from all contributors. This will provide the project with the potential to re-license under any OSI approved license.
-
-The intention is that once agreements have been received from all members we will begin to re-license the code under GPLv2.
-
 Should you be interested in using Tvheadend and wish to use another OSI license, then please contact admin at tvheadend dot org.
 
 Code not Covered
 ----------------
 
-Code in the "vendor" directory is not covered by our license, it is 3rd party
-provided code and as such is governed by individual licenses.
-
-Code that is not yet covered by the CLAs will retain the original copyright header and GPLv3 license. However as things are migrated the headers and in-line license details will be updated.
-
-Contributor License Agreement (CLA)
------------------------------------
-
-All contributors to Tvheadend are required to sign a CLA, which gives the
-project a perpetual license to use the contribution as the project deems best
-(within the terms of the agreement).
+Code in the "vendor" directory is not covered by our license, it is 3rd party provided code and as such is governed by individual licenses.
 
 Further Information
 -------------------
@@ -33,4 +19,3 @@ Further Information
 For more information regarding licensing and contributions, please see:
 
 > https://tvheadend.org/projects/tvheadend/wiki/Contributors    
-> https://tvheadend.org/projects/tvheadend/wiki/CLA   

--- a/Makefile.static
+++ b/Makefile.static
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2014 Tvheadend Foundation CIC
+# Copyright (C) 2008-2018 Tvheadend Project (https://tvheadend.org)
 #
 # This file is part of Tvheadend
 #

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![TVHeadend Logo](https://github.com/tvheadend/tvheadend/raw/master/src/webui/static/img/satip-icon120.png)
 Tvheadend
 ========================================
-(c) 2006 - 2022 Tvheadend Foundation CIC
+(c) 2006 - 2022 Tvheadend Project (https://tvheadend.org)
 
 Status
 ------

--- a/lib/api/python/README.md
+++ b/lib/api/python/README.md
@@ -1,6 +1,6 @@
 tvh-json.py
 =================================
-(c) 2017 Tvheadend Foundation CIC
+(c) 2017-2020 Tvheadend Project (https://tvheadend.org)
 
 The json import / export tool written in the python language.
 

--- a/src/string_list.c
+++ b/src/string_list.c
@@ -1,6 +1,6 @@
 /*
  *  Sorted String List Functions
- *  Copyright (C) 2017 Tvheadend Foundation CIC
+ *  Copyright (C) 2017 Tvheadend Project (https://tvheadend.org)
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/string_list.h
+++ b/src/string_list.h
@@ -1,6 +1,6 @@
 /*
  *  Sorted String List Functions
- *  Copyright (C) 2017 Tvheadend Foundation CIC
+ *  Copyright (C) 2017 Tvheadend Project (https://tvheadend.org)
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/webui/static/app/epgevent.js
+++ b/src/webui/static/app/epgevent.js
@@ -1,7 +1,7 @@
 /*
  * epgevent.js
  * EPG dialogs for broadcast events.
- * Copyright (C) 2018 Tvheadend Foundation CIC
+ * Copyright (C) 2018 Tvheadend Project (https://tvheadend.org)
  */
 
 /// Display dialog showing alternative showings for a broadcast event.

--- a/support/eitscrape_test.py
+++ b/support/eitscrape_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2017, 2018 Tvheadend Foundation CIC
+# Copyright (C) 2017, 2018 Tvheadend Project (https://tvheadend.org)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/support/lib.sh
+++ b/support/lib.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2008-2014 Tvheadend Foundation CIC
+# Copyright (C) 2008-2014 Tvheadend Project (https://tvheadend.org)
 #
 # This file is part of Tvheadend
 #

--- a/support/template/header.c
+++ b/support/template/header.c
@@ -1,6 +1,6 @@
 /* ****************************************************************************
  *
- * Copyright (C) 2016- Tvheadend Foundation CIC
+ * Copyright (C) 2016- Tvheadend Project (https://tvheadend.org)
  *
  * This file is part of Tvheadend
  *

--- a/support/template/header.h
+++ b/support/template/header.h
@@ -1,6 +1,6 @@
 /* ****************************************************************************
  *
- * Copyright (C) 2016- Tvheadend Foundation CIC
+ * Copyright (C) 2016- Tvheadend Project (https://tvheadend.org)
  *
  * This file is part of Tvheadend
  *

--- a/support/template/header.py
+++ b/support/template/header.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2008-2014 Tvheadend Foundation CIC
+# Copyright (C) 2008-2014 Tvheadend Project (https://tvheadend.org)
 #
 # This file is part of Tvheadend
 #

--- a/support/template/header.sh
+++ b/support/template/header.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2008-2014 Tvheadend Foundation CIC
+# Copyright (C) 2008-2014 Tvheadend Project (https://tvheadend.org)
 #
 # This file is part of Tvheadend
 #


### PR DESCRIPTION
Markdown docs and i18n files have been omitted as these files are likely to be replaced.