### PR TITLE
descrambler: support ICAM if detected in libdvbcsa

### DIFF
--- a/src/descrambler/caid.h
+++ b/src/descrambler/caid.h
@@ -46,6 +46,7 @@ uint16_t name2caid(const char *str);
 card_type_t detect_card_type(const uint16_t caid);
 
 static inline int caid_is_irdeto(uint16_t caid) { return (caid >> 8) == 0x06; }
+static inline int caid_is_videoguard(uint16_t caid) { return (caid >> 8) == 0x09; }
 static inline int caid_is_powervu(uint16_t caid) { return (caid >> 8) == 0x0e; }
 static inline int caid_is_betacrypt(uint16_t caid) { return (caid >> 8) == 0x17; }
 static inline int caid_is_dvn(uint16_t caid) { return caid == 0x4a30; }

--- a/src/descrambler/descrambler.c
+++ b/src/descrambler/descrambler.c
@@ -1301,6 +1301,8 @@ descrambler_table_callback
   int64_t clk, clk2, clk3;
   uint8_t ki;
   int i, j;
+  caid_t *ca;
+  elementary_stream_t *st;
 
   if (len < 6)
     return 0;
@@ -1362,13 +1364,20 @@ descrambler_table_callback
               if (dr->dr_ecm_parity == ECM_PARITY_81EVEN_80ODD)
                 j ^= 1;
               dr->dr_ecm_start[j] = clk;
-              if (dr->dr_quick_ecm) {
-                ki = 1 << (j + 6); /* 0x40 = even, 0x80 = odd */
-                for (i = 0; i < DESCRAMBLER_MAX_KEYS; i++) {
-                  tk = &dr->dr_keys[i];
+              ki = 1 << (j + 6); /* 0x40 = even, 0x80 = odd */
+              for (i = 0; i < DESCRAMBLER_MAX_KEYS; i++) {
+                tk = &dr->dr_keys[i];
+                if (dr->dr_quick_ecm)
                   tk->key_valid &= ~ki;
-                  if (tk->key_pid == 0) break;
+                TAILQ_FOREACH(st, &mt->mt_service->s_components.set_filter, es_filter_link) {
+                  if (st->es_pid != mt->mt_pid) continue;
+                    LIST_FOREACH(ca, &st->es_caids, link) {
+                    if (ca->use == 0) continue;
+                    tk->key_csa.csa_ecm = (caid_is_videoguard(ca->caid) && (ptr[2] - ptr[4]) == 4) ? ptr[21] : 0;
+                    tvhtrace(LS_DESCRAMBLER, "key ecm=%X (caid=%04X)", tk->key_csa.csa_ecm, ca->caid);
+                  }
                 }
+                if (tk->key_pid == 0) break;
               }
             }
             tvhtrace(LS_DESCRAMBLER, "ECM message %02x:%02x (section %d, len %d, pid %d) for service \"%s\"",

--- a/src/descrambler/tvhcsa.h
+++ b/src/descrambler/tvhcsa.h
@@ -47,6 +47,7 @@ typedef struct tvhcsa
   uint8_t *csa_tsbcluster;
   int      csa_fill;
   int      csa_fill_size;
+  uint8_t  csa_ecm;
 
 #if ENABLE_DVBCSA
   struct dvbcsa_bs_batch_s *csa_tsbbatch_even;
@@ -82,6 +83,11 @@ static inline void tvhcsa_set_key_odd ( tvhcsa_t *csa, const uint8_t *odd ) { };
 static inline void tvhcsa_init ( tvhcsa_t *csa ) { };
 static inline void tvhcsa_destroy ( tvhcsa_t *csa ) { };
 
+#endif
+
+#if ENABLE_DVBCSA
+typedef void* (*dvbcsa_dl_bs_key_set_type)(const unsigned char ecm, const dvbcsa_cw_t cw, struct dvbcsa_bs_key_s *key);
+void dvbcsa_bs_key_set_wrap(const unsigned char ecm, const dvbcsa_cw_t cw, struct dvbcsa_bs_key_s *key);
 #endif
 
 #endif /* __TVH_CSA_H__ */


### PR DESCRIPTION
A previous PR would detect ICAM capabilities in libdvbcsa at compile time.
The code in this PR will detect it at runtime, so tvheadend can be compiled using any libdvbcsa.