### PR TITLE
makefile: switch to using upstream dtv-scan-tables

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -179,6 +179,14 @@ jobs:
       - name: pcre-dependency
         run: |
           DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre3-dev || DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre2-dev
+      - name: Workaround old trusty gnutls and openssl
+        if: matrix.container == 'i386/ubuntu:trusty' || matrix.container == 'ubuntu:trusty'
+        run: |
+          add-apt-repository -y "deb http://security.ubuntu.com/ubuntu xenial-security main"
+          add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu xenial main universe"
+          apt-get update -y
+          DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y curl
+          git config --global http.sslVerify false
       - uses: actions/checkout@v3
         if: startsWith(matrix.container, 'i386') != true && matrix.container != 'debian:stretch'
         with:

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -104,7 +104,6 @@ jobs:
           env: | # YAML, but pipe character is necessary
             artifact_name: git-${{ matrix.distro }}_${{ matrix.arch }}
 
-
           # The shell to run commands with in the container
           shell: /bin/sh
 
@@ -128,6 +127,7 @@ jobs:
                 apt-get update -y
                 DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y cmake git build-essential pkg-config gettext libavahi-client-dev libssl-dev zlib1g-dev wget bzip2 git-core liburiparser-dev libdvbcsa-dev python3 python3-requests debhelper ccache lsb-release
                 DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre3-dev || DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre2-dev
+                if [ '${{ matrix.distro }}' = 'jessie' ]; then git config --global http.sslVerify false; fi
                 ;;
               fedora*)
                 dnf -y update

--- a/Makefile
+++ b/Makefile
@@ -888,7 +888,7 @@ ffmpeg_rebuild:
 
 # linuxdvb git tree
 $(ROOTDIR)/data/dvb-scan/.stamp:
-	@echo "Receiving data/dvb-scan from https://github.com/tvheadend/dtv-scan-tables.git#tvheadend"
+	@echo "Receiving data/dvb-scan from https://git.linuxtv.org/dtv-scan-tables.git"
 	@rm -rf $(ROOTDIR)/data/dvb-scan/*
 	@$(ROOTDIR)/support/getmuxlist $(ROOTDIR)/data/dvb-scan
 	@touch $@

--- a/docs/markdown/firstconfig.md
+++ b/docs/markdown/firstconfig.md
@@ -169,7 +169,7 @@ of the same type as necessary, e.g. to have two DVB-T networks defined,
 one with HD muxes, one without.
 
 The creation process allows you to select from a series of pre-defined mux
-lists for common DVB sources. These are available [here](https://github.com/tvheadend/dtv-scan-tables) -
+lists for common DVB sources. These are available [here](https://git.linuxtv.org/dtv-scan-tables.git) -
 but they do go out of date as broadcasters move services around and national
 authorities change entire pieces of spectrum. As such, you should try the
 pre-defined values, but you may need to add muxes manually.

--- a/docs/markdown/introduction.md
+++ b/docs/markdown/introduction.md
@@ -82,7 +82,7 @@ for both live and recorded streams in various formats.
 ### Easy to Configure and Administer
 * All setup and configuration is done from the built in web user interface.
 * All settings are stored in human-readable text files.
-* Initial setup can be done by choosing one of the pre-defined [linuxtv](http://git.linuxtv.org/cgit.cgi/dtv-scan-tables.git) networks
+* Initial setup can be done by choosing one of the pre-defined [linuxtv](https://git.linuxtv.org/dtv-scan-tables.git) networks
 or manually configured.
 * Idle scanning for automatic detection of muxes and services.
 * Support for broadcaster (primarily DVB-S) bouquets for easy channel mapping.

--- a/src/input/mpegts/scanfile.c
+++ b/src/input/mpegts/scanfile.c
@@ -954,7 +954,7 @@ scanfile_init ( const char *muxconf_path, int lock )
     tvhwarn(LS_SCANFILE, "no predefined muxes found, check path '%s%s'",
             path[0] == '/' ? path : TVHEADEND_DATADIR "/",
             path[0] == '/' ? "" : path);
-    tvhwarn(LS_SCANFILE, "expected tree structure - http://git.linuxtv.org/cgit.cgi/dtv-scan-tables.git/tree/");
+    tvhwarn(LS_SCANFILE, "expected tree structure - https://git.linuxtv.org/dtv-scan-tables.git/tree/");
     for (i = 0; i < REGIONS; i++)
       scanfile_done_region(&scanfile_regions_load[i]);
     memoryinfo_free(&scanfile_memoryinfo, REGIONS * sizeof(scanfile_region_list_t));

--- a/support/getmuxlist
+++ b/support/getmuxlist
@@ -4,8 +4,8 @@
 #
 
 # Arguments
-[ -z "$BRANCH" ] && BRANCH=tvheadend
-[ -z "$URL" ] && URL=https://github.com/tvheadend/dtv-scan-tables.git
+[ -z "$BRANCH" ] && BRANCH=master
+[ -z "$URL" ] && URL=https://git.linuxtv.org/dtv-scan-tables.git
 DIR="$1" && [ -z "$DIR" ] && DIR=$(dirname "$0")/../data/dvb-scan
 
 # Update


### PR DESCRIPTION
This PR switches the codebase to use the upstream https://git.linuxtv.org/dtv-scan-tables.git/ scan tables repo instead of using our own fork of someone else's fork of the upstream repo. The goals for this change are:
- Reduce downstream maintenance effort for Tvheadend
- Redirect and encourage user contributions upstream for the benefit of all Linux DTV users
- Promote usage of the upstream source to projects/distros that bundle/package Tvheadend

Sending changes to the linux-tv mailing list instead of creating a pull-request to our repo fork may/will require users to learn a new git trick but "it's not rocket science" and I will author a HOWTO guide on that topic for the README.md of our repo before we archive it, along with a future new-forum FAQ post or wiki article. I'm also happy to coach anyone on the process over IRC chat, and will do some outreach to authors of pending PRs submitted to our repo to encourage them to resubmit their changes upstream.

ping to @oliv3r for awareness