### PR TITLE
Add missing Lithuanian string template

### DIFF
--- a/intl/docs/tvheadend.doc.lt.po
+++ b/intl/docs/tvheadend.doc.lt.po
@@ -1,0 +1,7982 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-03-29 21:07+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: src/docs_inc.c:1844
+msgid ""
+"\n"
+"__Tip__ : By default Tvheadend will only show a small selection of entries - "
+"you can increase the number of entries displayed by using the paging "
+"selector at the bottom right of the page."
+msgstr ""
+
+#: src/docs_inc.c:1861
+msgid ""
+"\n"
+"__Tip__ : You can select all entries within the grid by pressing ctrl+A. You "
+"can also ctrl+click to make additional selections, or shift+click to select "
+"a range."
+msgstr ""
+
+#: src/docs_inc.c:105 src/docs_inc.c:145 src/docs_inc.c:185 src/docs_inc.c:423
+#: src/docs_inc.c:457 src/docs_inc.c:479 src/docs_inc.c:571 src/docs_inc.c:729
+#: src/docs_inc.c:735 src/docs_inc.c:1053 src/docs_inc.c:1501
+#: src/docs_inc.c:1677 src/docs_inc.c:1983 src/docs_inc.c:2044
+#: src/docs_inc.c:2052 src/docs_inc.c:2070 src/docs_inc.c:2096
+#: src/docs_inc.c:2104 src/docs_inc.c:2122 src/docs_inc.c:2135
+#: src/docs_inc.c:2168 src/docs_inc.c:2193 src/docs_inc.c:2258
+#: src/docs_inc.c:2271 src/docs_inc.c:2313 src/docs_inc.c:2342
+#: src/docs_inc.c:2428 src/docs_inc.c:2451 src/docs_inc.c:2492
+#: src/docs_inc.c:2533 src/docs_inc.c:2578 src/docs_inc.c:2638
+#: src/docs_inc.c:2644 src/docs_inc.c:2723 src/docs_inc.c:2744
+#: src/docs_inc.c:2750 src/docs_inc.c:2768 src/docs_inc.c:2803
+#: src/docs_inc.c:2812 src/docs_inc.c:2833 src/docs_inc.c:2846
+#: src/docs_inc.c:2867 src/docs_inc.c:2906 src/docs_inc.c:2933
+#: src/docs_inc.c:2978 src/docs_inc.c:3016 src/docs_inc.c:3039
+#: src/docs_inc.c:3086 src/docs_inc.c:3107 src/docs_inc.c:3132
+#: src/docs_inc.c:3157 src/docs_inc.c:3170 src/docs_inc.c:3196
+#: src/docs_inc.c:3230 src/docs_inc.c:3259 src/docs_inc.c:3271
+#: src/docs_inc.c:3302 src/docs_inc.c:3404 src/docs_inc.c:3461
+#: src/docs_inc.c:3470 src/docs_inc.c:3485 src/docs_inc.c:3496
+#: src/docs_inc.c:3502 src/docs_inc.c:3548 src/docs_inc.c:3583
+#: src/docs_inc.c:3664 src/docs_inc.c:3682 src/docs_inc.c:3703
+#: src/docs_inc.c:4106 src/docs_inc.c:4143 src/docs_inc.c:4152
+msgid "!"
+msgstr ""
+
+#: src/docs_inc.c:4440
+#, c-format
+msgid "%C"
+msgstr ""
+
+#: src/docs_inc.c:4330
+#, c-format
+msgid "%F"
+msgstr ""
+
+#: src/docs_inc.c:4334
+msgid "%R"
+msgstr ""
+
+#: src/docs_inc.c:4452
+#, c-format
+msgid "%c"
+msgstr ""
+
+#: src/docs_inc.c:4338
+#, c-format
+msgid "%x"
+msgstr ""
+
+#: src/docs_inc.c:2412
+msgid "'Accept/OK Icon'"
+msgstr ""
+
+#: src/docs_inc.c:2805
+msgid "'Access Control - Entries tab'"
+msgstr ""
+
+#: src/docs_inc.c:2908
+msgid "'Access Entries Grid'"
+msgstr ""
+
+#: src/docs_inc.c:2935
+msgid "'Access Entry Example'"
+msgstr ""
+
+#: src/docs_inc.c:3261
+msgid "'Add Bouquet Dialog'"
+msgstr ""
+
+#: src/docs_inc.c:2430
+msgid "'Add CA Config'"
+msgstr ""
+
+#: src/docs_inc.c:3666
+msgid "'Add Channel Dialog'"
+msgstr ""
+
+#: src/docs_inc.c:2814
+msgid "'Add Entries Dialog'"
+msgstr ""
+
+#: src/docs_inc.c:3504
+msgid "'Add Mux Dialog'"
+msgstr ""
+
+#: src/docs_inc.c:4154
+msgid "'Add Mux Schedule'"
+msgstr ""
+
+#: src/docs_inc.c:3018
+msgid "'Add New Profile'"
+msgstr ""
+
+#: src/docs_inc.c:2273
+msgid "'Add Password dialog'"
+msgstr ""
+
+#: src/docs_inc.c:2646
+msgid "'Add Profile Dialog'"
+msgstr ""
+
+#: src/docs_inc.c:2752
+msgid "'Add new network'"
+msgstr ""
+
+#: src/docs_inc.c:3406
+msgid "'Add new recording dialog'"
+msgstr ""
+
+#: src/docs_inc.c:2106
+msgid "'Add service to channel example'"
+msgstr ""
+
+#: src/docs_inc.c:2770
+msgid "'Add/Edit Network' Dialog - DVB-S/2"
+msgstr ""
+
+#: src/docs_inc.c:3159
+msgid "'Autorec' Tab"
+msgstr ""
+
+#: src/docs_inc.c:3172
+msgid "'Autorec' example entry"
+msgstr ""
+
+#: src/docs_inc.c:3232
+msgid "'Bouqets' Tab"
+msgstr ""
+
+#: src/docs_inc.c:2344
+msgid "'CA Client Configuration Example'"
+msgstr ""
+
+#: src/docs_inc.c:1699
+msgid "'Cancel'"
+msgstr ""
+
+#: src/docs_inc.c:3585
+msgid "'Channel lists'"
+msgstr ""
+
+#: src/docs_inc.c:3472
+msgid "'Channel tag dialog'"
+msgstr ""
+
+#: src/docs_inc.c:3463
+msgid "'Channel tag'"
+msgstr ""
+
+#: src/docs_inc.c:4108
+msgid "'Configuration - Image Cache tab'"
+msgstr ""
+
+#: src/docs_inc.c:2260
+msgid "'Configuration - Passwords tab'"
+msgstr ""
+
+#: src/docs_inc.c:2869
+msgid "'DVB-C frontend parameters'"
+msgstr ""
+
+#: src/docs_inc.c:3134
+msgid "'DVB-S frontend parameters'"
+msgstr ""
+
+#: src/docs_inc.c:2170
+msgid "'DVB-T frontend parameters'"
+msgstr ""
+
+#: src/docs_inc.c:3705
+msgid "'Debugging tab'"
+msgstr ""
+
+#: src/docs_inc.c:2980
+msgid "'Digital Video Recorder Profiles' Tab 1"
+msgstr ""
+
+#: src/docs_inc.c:3304
+msgid "'Digital Video Recorder' Tabs"
+msgstr ""
+
+#: src/docs_inc.c:2453
+msgid "'EPG Grabber Channels Tab'"
+msgstr ""
+
+#: src/docs_inc.c:2494 src/docs_inc.c:2535
+msgid "'EPG Grabber Configuration'"
+msgstr ""
+
+#: src/docs_inc.c:3198
+msgid "'Edit Autorec'"
+msgstr ""
+
+#: src/docs_inc.c:3684
+msgid "'Edit Channel Dialog'"
+msgstr ""
+
+#: src/docs_inc.c:573
+msgid "'Electronic Program Guide' Tab"
+msgstr ""
+
+#: src/docs_inc.c:2416
+msgid "'Error Icon'"
+msgstr ""
+
+#: src/docs_inc.c:2137
+msgid "'General Base' Tab Screenshot 1"
+msgstr ""
+
+#: src/docs_inc.c:2118
+msgid "'Information Icon'"
+msgstr ""
+
+#: src/docs_inc.c:2054 src/docs_inc.c:3273
+msgid "'Map All Services'"
+msgstr ""
+
+#: src/docs_inc.c:2072
+msgid "'Map selected'"
+msgstr ""
+
+#: src/docs_inc.c:3487
+msgid "'Mux List'"
+msgstr ""
+
+#: src/docs_inc.c:4145
+msgid "'Mux Schedule Entries'"
+msgstr ""
+
+#: src/docs_inc.c:2746 src/docs_inc.c:3498
+msgid "'Network selection'"
+msgstr ""
+
+#: src/docs_inc.c:2725
+msgid "'Networks' Tab Screenshot"
+msgstr ""
+
+#: src/docs_inc.c:1966
+msgid "'Play Icon Image'"
+msgstr ""
+
+#: src/docs_inc.c:3088
+msgid "'Removing a stream'"
+msgstr ""
+
+#: src/docs_inc.c:2195
+msgid "'SAT"
+msgstr ""
+
+#: src/docs_inc.c:3109
+msgid "'SAT>IP Panel'"
+msgstr ""
+
+#: src/docs_inc.c:2124
+msgid "'Service Information'"
+msgstr ""
+
+#: src/docs_inc.c:2098
+msgid "'Service filtering'"
+msgstr ""
+
+#: src/docs_inc.c:2046 src/docs_inc.c:3550
+msgid "'Service mapper dialog'"
+msgstr ""
+
+#: src/docs_inc.c:1985
+msgid "'Services'"
+msgstr ""
+
+#: src/docs_inc.c:1055 src/docs_inc.c:1075
+msgid "'Status - Stream' Tab"
+msgstr ""
+
+#: src/docs_inc.c:107 src/docs_inc.c:1503 src/docs_inc.c:1679
+msgid "'Status - Subscriptions' Tab"
+msgstr ""
+
+#: src/docs_inc.c:2420
+msgid "'Stop/Disabled Icon'"
+msgstr ""
+
+#: src/docs_inc.c:2580
+msgid "'Stream Profiles'"
+msgstr ""
+
+#: src/docs_inc.c:3041
+msgid "'Stream filters'"
+msgstr ""
+
+#: src/docs_inc.c:481
+msgid "'TV Adapter params'"
+msgstr ""
+
+#: src/docs_inc.c:459
+msgid "'TV Adapter tree'"
+msgstr ""
+
+#: src/docs_inc.c:2315
+msgid "'Timeshift Tab'"
+msgstr ""
+
+#: src/docs_inc.c:2640
+msgid "'Type select'"
+msgstr ""
+
+#: src/docs_inc.c:1439
+msgid "(/mux only) list of subscribed PIDs (comma separated)"
+msgstr ""
+
+#: src/docs_inc.c:1431
+msgid "(/service only) do not descramble (if set to 0)"
+msgstr ""
+
+#: src/docs_inc.c:1435
+msgid "(/service only) pass EMM to the stream (if set to 1)"
+msgstr ""
+
+#: src/docs_inc.c:4648
+msgid "(DVR),"
+msgstr ""
+
+#: src/docs_inc.c:333
+msgid ""
+"(For the technically-minded, these unique identifiers - the elementary "
+"streams - are referred to as 'packet identifiers' or 'PIDs')."
+msgstr ""
+
+#: src/docs_inc.c:1257
+msgid "(c) 2006 - 2016 Tvheadend Foundation CIC"
+msgstr ""
+
+#: src/docs_inc.c:1419
+msgid "(except /mux) Override streaming profile"
+msgstr ""
+
+#: src/docs_inc.c:1829
+msgid "(other clients may also be available)."
+msgstr ""
+
+#: src/docs_inc.c:4450
+msgid ")"
+msgstr ""
+
+#: src/docs_inc.c:2902
+msgid ") accounts are matched using the prefix only."
+msgstr ""
+
+#: src/docs_inc.c:5319 src/docs_inc.c:5397
+msgid ")! :)"
+msgstr ""
+
+#: src/docs_inc.c:4640 src/docs_inc.c:4644
+msgid ","
+msgstr ""
+
+#: src/docs_inc.c:2576
+msgid ", DVR Profiles or as parameter for HTTP Streaming."
+msgstr ""
+
+#: src/docs_inc.c:4446
+msgid ", but"
+msgstr ""
+
+#: src/docs_inc.c:5248
+msgid ", enabling/disabling per channel overrides the DVR profile setting."
+msgstr ""
+
+#: src/docs_inc.c:3606
+msgid ", especially useful if you change your Picon settings."
+msgstr ""
+
+#: src/docs_inc.c:1105
+msgid ""
+", note that not all devices supply correct signal information, the value "
+"here can sometimes be ambiguous."
+msgstr ""
+
+#: src/docs_inc.c:2689
+msgid "- Available worldwide"
+msgstr ""
+
+#: src/docs_inc.c:2715
+msgid "- IPTV using a playlist as the source"
+msgstr ""
+
+#: src/docs_inc.c:2693
+msgid ""
+"- available worldwide but common in Brazil and various other countries "
+"throughout south America"
+msgstr ""
+
+#: src/docs_inc.c:277
+msgid ""
+"- but they do go out of date as broadcasters move services around and "
+"national authorities change entire pieces of spectrum. As such, you should "
+"try the pre-defined values, but you may need to add muxes manually."
+msgstr ""
+
+#: src/docs_inc.c:2679 src/docs_inc.c:2703
+msgid "- common in Brazil and various other countries throughout south America"
+msgstr ""
+
+#: src/docs_inc.c:2675 src/docs_inc.c:2699
+msgid "- common in most of Europe"
+msgstr ""
+
+#: src/docs_inc.c:2707
+msgid "- common in north and central America"
+msgstr ""
+
+#: src/docs_inc.c:2683
+msgid "- common in north and central America and parts of south Asia"
+msgstr ""
+
+#: src/docs_inc.c:1615
+msgid ""
+"- this will not only tell you what's supported under Linux, but also how to "
+"get it all working."
+msgstr ""
+
+#: src/docs_inc.c:5058
+msgid "-1"
+msgstr ""
+
+#: src/docs_inc.c:155 src/docs_inc.c:357 src/docs_inc.c:1265
+#: src/docs_inc.c:1583 src/docs_inc.c:2563 src/docs_inc.c:2721
+#: src/docs_inc.c:2794 src/docs_inc.c:2820 src/docs_inc.c:2854
+#: src/docs_inc.c:3626 src/docs_inc.c:3678 src/docs_inc.c:4305
+#: src/docs_inc.c:4656 src/docs_inc.c:4666 src/docs_inc.c:4676
+#: src/docs_inc.c:4682 src/docs_inc.c:4688 src/docs_inc.c:4698
+#: src/docs_inc.c:4704 src/docs_inc.c:4710 src/docs_inc.c:4716
+#: src/docs_inc.c:4722 src/docs_inc.c:4852 src/docs_inc.c:4889
+#: src/docs_inc.c:4938 src/docs_inc.c:4969 src/docs_inc.c:5277
+#: src/docs_inc.c:5313 src/docs_inc.c:5391 src/docs_inc.c:5414
+msgid "."
+msgstr ""
+
+#: src/docs_inc.c:207
+msgid ""
+". Please use github's features if you want to provide patches. Contributions "
+"and improvements are always welcome."
+msgstr ""
+
+#: src/docs_inc.c:1968
+msgid ""
+". This will automatically launch an appropriate player, otherwise you will "
+"need to manually open the playlist to start watching (normally a double-"
+"click on the downloaded file)."
+msgstr ""
+
+#: src/docs_inc.c:41
+msgid "... produces:"
+msgstr ""
+
+#: src/docs_inc.c:3602
+msgid "/"
+msgstr ""
+
+#: src/docs_inc.c:1233
+msgid "/etc/default/tvheadend options"
+msgstr ""
+
+#: src/docs_inc.c:4365 src/docs_inc.c:4743 src/docs_inc.c:5165
+msgid "/home/user/Videos/News.mkv"
+msgstr ""
+
+#: src/docs_inc.c:1287
+msgid "/play/REMAIN"
+msgstr ""
+
+#: src/docs_inc.c:1309
+msgid "/playlist[/TYPE][/WHAT][/IDENTIFIER]"
+msgstr ""
+
+#: src/docs_inc.c:1381
+msgid "/stream/WHAT/IDENTIFIER"
+msgstr ""
+
+#: src/docs_inc.c:1441
+msgid "/xmltv[/WHAT][/IDENTIFIER]"
+msgstr ""
+
+#: src/docs_inc.c:4413 src/docs_inc.c:5217
+msgid "0"
+msgstr ""
+
+#: src/docs_inc.c:623
+msgid "00:00:01 to 00:15:00"
+msgstr ""
+
+#: src/docs_inc.c:627
+msgid "00:15:01 to 00:30:00"
+msgstr ""
+
+#: src/docs_inc.c:631
+msgid "00:30:01 to 01:30:00"
+msgstr ""
+
+#: src/docs_inc.c:635
+msgid "01:30:01 to 03:00:00"
+msgstr ""
+
+#: src/docs_inc.c:639
+msgid "03:00:00 to no maximum"
+msgstr ""
+
+#: src/docs_inc.c:255
+msgid "1. Ensure Tuners are Available for Use"
+msgstr ""
+
+#: src/docs_inc.c:1585
+msgid "1. Install the Tuner Hardware"
+msgstr ""
+
+#: src/docs_inc.c:4810
+msgid "100"
+msgstr ""
+
+#: src/docs_inc.c:4405 src/docs_inc.c:4779 src/docs_inc.c:5209
+msgid "1224421200"
+msgstr ""
+
+#: src/docs_inc.c:4409 src/docs_inc.c:4783 src/docs_inc.c:5213
+msgid "1224426600"
+msgstr ""
+
+#: src/docs_inc.c:5070
+msgid "14:12"
+msgstr ""
+
+#: src/docs_inc.c:503
+msgid "2 Port"
+msgstr ""
+
+#: src/docs_inc.c:1609
+msgid "2. Install Firmware and/or Drivers"
+msgstr ""
+
+#: src/docs_inc.c:267
+msgid "2. Set up Relevant Network(s)"
+msgstr ""
+
+#: src/docs_inc.c:5066
+msgid "2011-03-19"
+msgstr ""
+
+#: src/docs_inc.c:283
+msgid "3. Associate the Network with the Respective Tuner(s)"
+msgstr ""
+
+#: src/docs_inc.c:505
+msgid "4 Port"
+msgstr ""
+
+#: src/docs_inc.c:293
+msgid "4. If Necessary, Manually Add Muxes"
+msgstr ""
+
+#: src/docs_inc.c:327
+msgid "5. Scan for Services"
+msgstr ""
+
+#: src/docs_inc.c:4812
+msgid "50"
+msgstr ""
+
+#: src/docs_inc.c:4417 src/docs_inc.c:5221
+msgid "6"
+msgstr ""
+
+#: src/docs_inc.c:335
+msgid "6. Map Services to Channels"
+msgstr ""
+
+#: src/docs_inc.c:347
+msgid "6.1. Bouquets"
+msgstr ""
+
+#: src/docs_inc.c:359
+msgid "7. Watch TV"
+msgstr ""
+
+#: src/docs_inc.c:4814
+msgid "80"
+msgstr ""
+
+#: src/docs_inc.c:4195 src/docs_inc.c:4218 src/docs_inc.c:4245
+#: src/docs_inc.c:4258 src/docs_inc.c:4293 src/docs_inc.c:4324
+#: src/docs_inc.c:4432 src/docs_inc.c:4463 src/docs_inc.c:4476
+#: src/docs_inc.c:4499 src/docs_inc.c:4524 src/docs_inc.c:4547
+#: src/docs_inc.c:4588 src/docs_inc.c:4626 src/docs_inc.c:4794
+#: src/docs_inc.c:4831 src/docs_inc.c:4840 src/docs_inc.c:4867
+#: src/docs_inc.c:4896 src/docs_inc.c:4923 src/docs_inc.c:4932
+#: src/docs_inc.c:4947 src/docs_inc.c:4989 src/docs_inc.c:5081
+#: src/docs_inc.c:5097 src/docs_inc.c:5114 src/docs_inc.c:5236
+#: src/docs_inc.c:5271
+msgid ":"
+msgstr ""
+
+#: src/docs_inc.c:4353 src/docs_inc.c:5153
+#, c-format
+msgid ""
+": Command to run after finishing a recording. The command will be run in "
+"background and is executed even if a recording is aborted or an error "
+"occurred. Use the %e error formatting string to check for errors, the error "
+"string is “OK” if recording finished successfully."
+msgstr ""
+
+#: src/docs_inc.c:4731
+msgid ""
+": Command to run when a recording starts. The command will be run in "
+"background."
+msgstr ""
+
+#: src/docs_inc.c:4976
+msgid ": Example : every day at 2am is : `0 2 * * *`"
+msgstr ""
+
+#: src/docs_inc.c:5024
+msgid ""
+": The string allows you to manually specify the full path generation using "
+"the predefined modifiers for strftime (see `man strftime`, except `%n` and `"
+"%t`) and Tvheadend specific. Note that you may modify some of this format "
+"string setting using the GUI fields below."
+msgstr ""
+
+#: src/docs_inc.c:1601
+msgid "A Note on USB Tuners"
+msgstr ""
+
+#: src/docs_inc.c:399
+msgid ""
+"A __driver__ is the piece of software that your operating system uses to "
+"talk to the tuner. This can be built into the OS (e.g. 'supported since "
+"kernel X') or might be a separate piece of software that you need install, "
+"and maybe even compile, separately."
+msgstr ""
+
+#: src/docs_inc.c:391
+msgid ""
+"A __tuner__ is the hardware (chipset) needed to interpret a digital "
+"television signal and extract from it the programme stream. The tuner "
+"hardware is also responsible for communicating with your satellite dish via "
+"the LNB in the case of DVB-S."
+msgstr ""
+
+#: src/docs_inc.c:4286
+msgid ""
+"A combination of last two variants above - data is written immediately and "
+"then discarded from cache."
+msgstr ""
+
+#: src/docs_inc.c:1739
+msgid ""
+"A general-purpose MPEG-TS `pipe://` for analogue and non-broadcast sources"
+msgstr ""
+
+#: src/docs_inc.c:2667
+msgid ""
+"A network is the type of carrier for your television signals. Tvheadend "
+"supports several different types of network, notably:"
+msgstr ""
+
+#: src/docs_inc.c:4270
+msgid ""
+"A placeholder status, meaning that the configuration isn’t properly set."
+msgstr ""
+
+#: src/docs_inc.c:825
+msgid "AAC"
+msgstr ""
+
+#: src/docs_inc.c:1723
+msgid "AC-3, AAC and MP2 audio supported."
+msgstr ""
+
+#: src/docs_inc.c:991 src/docs_inc.c:2402
+msgid "AES constant code word client"
+msgstr ""
+
+#: src/docs_inc.c:3841
+msgid "API"
+msgstr ""
+
+#: src/docs_inc.c:4069
+msgid "ATSC PSIP EPG"
+msgstr ""
+
+#: src/docs_inc.c:3893
+msgid "ATSC SI Tables"
+msgstr ""
+
+#: src/docs_inc.c:537 src/docs_inc.c:549 src/docs_inc.c:2681
+msgid "ATSC-C"
+msgstr ""
+
+#: src/docs_inc.c:527 src/docs_inc.c:547 src/docs_inc.c:2705
+msgid "ATSC-T"
+msgstr ""
+
+#: src/docs_inc.c:3330
+msgid "Abort"
+msgstr ""
+
+#: src/docs_inc.c:4401 src/docs_inc.c:4995 src/docs_inc.c:5205
+msgid "Aborted by user"
+msgstr ""
+
+#: src/docs_inc.c:1005 src/docs_inc.c:1019 src/docs_inc.c:1251
+#: src/docs_inc.c:1483
+msgid "About"
+msgstr ""
+
+#: src/docs_inc.c:3332
+msgid "Abruptly stop the selected in-progress recording entries."
+msgstr ""
+
+#: src/docs_inc.c:3392
+msgid "Accept icon"
+msgstr ""
+
+#: src/docs_inc.c:4881
+msgid "Access"
+msgstr ""
+
+#: src/docs_inc.c:3821
+msgid "Access (ACL)"
+msgstr ""
+
+#: src/docs_inc.c:905 src/docs_inc.c:2277 src/docs_inc.c:2574
+#: src/docs_inc.c:4887 src/docs_inc.c:4967
+msgid "Access Entries"
+msgstr ""
+
+#: src/docs_inc.c:1807
+msgid ""
+"Access to system features (streaming, administration, configurations) can be "
+"configured based on username/password and/or IP address."
+msgstr ""
+
+#: src/docs_inc.c:5116
+msgid "Action"
+msgstr ""
+
+#: src/docs_inc.c:49
+msgid "Actual numbers don't matter, just that it's a number"
+msgstr ""
+
+#: src/docs_inc.c:1940 src/docs_inc.c:2362 src/docs_inc.c:2620
+#: src/docs_inc.c:2998 src/docs_inc.c:3314
+msgid "Add"
+msgstr ""
+
+#: src/docs_inc.c:2634
+msgid "Add a Profile"
+msgstr ""
+
+#: src/docs_inc.c:3316
+msgid "Add a new (one-time-only) recording entry."
+msgstr ""
+
+#: src/docs_inc.c:2364
+msgid "Add a new CA client configuration."
+msgstr ""
+
+#: src/docs_inc.c:2622 src/docs_inc.c:3000
+msgid "Add a new profile."
+msgstr ""
+
+#: src/docs_inc.c:1944
+msgid "Add entry"
+msgstr ""
+
+#: src/docs_inc.c:5142
+msgid ""
+"Add this elementary stream only when no elementary streams are used from "
+"previous rules. It does not match the implicit USE rules which are added "
+"after the user rules."
+msgstr ""
+
+#: src/docs_inc.c:1852
+msgid "Adding an Entry"
+msgstr ""
+
+#: src/docs_inc.c:3424
+msgid "Adding an Entry Using Autorec Rules"
+msgstr ""
+
+#: src/docs_inc.c:3408
+msgid "Adding an Entry Using the EPG"
+msgstr ""
+
+#: src/docs_inc.c:3492
+msgid "Adding an Entry/Mux"
+msgstr ""
+
+#: src/docs_inc.c:2740
+msgid "Adding an Entry/Network"
+msgstr ""
+
+#: src/docs_inc.c:2424
+msgid "Adding/Editing a CA Configuration"
+msgstr ""
+
+#: src/docs_inc.c:3012
+msgid "Adding/Editing a Profile"
+msgstr ""
+
+#: src/docs_inc.c:4650
+msgid "Admin"
+msgstr ""
+
+#: src/docs_inc.c:4311 src/docs_inc.c:4957
+msgid "Advanced"
+msgstr ""
+
+#: src/docs_inc.c:509
+msgid "Advanced LNB"
+msgstr ""
+
+#: src/docs_inc.c:1881
+msgid ""
+"After a cell is changed, a small red flag or triangle will appear in the top-"
+"left corner to indicate that it has been changed. These changes can now be "
+"kept (_[Save]_ button), or abandoned (_[Undo]_ button)."
+msgstr ""
+
+#: src/docs_inc.c:4389 src/docs_inc.c:4767 src/docs_inc.c:5189
+msgid "Afternoon"
+msgstr ""
+
+#: src/docs_inc.c:4482
+msgid "All (Streaming plus DVR)"
+msgstr ""
+
+#: src/docs_inc.c:5013
+msgid ""
+"All available tuners failed to tune (this can indicate a signal, driver or "
+"hardware problem)."
+msgstr ""
+
+#: src/docs_inc.c:1817
+msgid ""
+"All channel data, channel groups/tags, EPG and TV streaming is carried over "
+"a single TCP connection."
+msgstr ""
+
+#: src/docs_inc.c:1335 src/docs_inc.c:1451
+msgid "All channels"
+msgstr ""
+
+#: src/docs_inc.c:4604
+msgid "All lower-case"
+msgstr ""
+
+#: src/docs_inc.c:1835
+msgid ""
+"All major character encodings in DVB are supported (e.g. for localised EPG "
+"character sets)."
+msgstr ""
+
+#: src/docs_inc.c:1765
+msgid "All original streams (multiple audio tracks, etc) are recorded."
+msgstr ""
+
+#: src/docs_inc.c:1343
+msgid "All recordings"
+msgstr ""
+
+#: src/docs_inc.c:1255
+msgid ""
+"All rights reserved, and all implications of using, following, not "
+"following, or in any way even being aware of this documentation are "
+"expressly excluded. Use everything entirely at your own risk. If your "
+"television explodes, your house burns down or your kittens end up in tears, "
+"that's nothing to do with us."
+msgstr ""
+
+#: src/docs_inc.c:1793
+msgid "All settings are stored in human-readable text files."
+msgstr ""
+
+#: src/docs_inc.c:1791
+msgid ""
+"All setup and configuration is done from the built in web user interface."
+msgstr ""
+
+#: src/docs_inc.c:1787
+msgid ""
+"All sorting/filtering is then done in C by the main application for speed."
+msgstr ""
+
+#: src/docs_inc.c:1339
+msgid "All tags, for Enigma2 - tags are converted to labels"
+msgstr ""
+
+#: src/docs_inc.c:1833
+msgid "All text is encoded in UTF-8 to provide full international support."
+msgstr ""
+
+#: src/docs_inc.c:4484
+msgid "Allow access to all streaming options (including DVR functionality)."
+msgstr ""
+
+#: src/docs_inc.c:4860
+msgid "Allow the user to change the interface view level."
+msgstr ""
+
+#: src/docs_inc.c:4628
+msgid ""
+"Allows you to control which parameters are merged. If the _Change "
+"parameters_ flag is turned on and a parameter (permission flags, all types "
+"of profiles, channel tags and ranges) for an entry is not set the parameter "
+"(value, list or range) is cleared (unset). This allows the next matching "
+"entry (if any) in the sequence to set it."
+msgstr ""
+
+#: src/docs_inc.c:1163
+msgid ""
+"Alternatively, you can run Tvheadend on a server, perhaps on an always-on "
+"system that houses your media, perhaps on a dedicated low-power system - "
+"it's your choice."
+msgstr ""
+
+#: src/docs_inc.c:4230
+msgid "Always keep the mux regardless of whether it exists or not."
+msgstr ""
+
+#: src/docs_inc.c:4238
+msgid "Always reject but allow partial match."
+msgstr ""
+
+#: src/docs_inc.c:4234
+msgid "Always reject."
+msgstr ""
+
+#: src/docs_inc.c:1177
+msgid ""
+"An __Internet connection__ is recommended but not essential. You need to "
+"have an accurate clock for EPG timers to work, for example, but this can be "
+"synchronised from the broadcast signal if you're not in a position to use "
+"`ntp` or similar."
+msgstr ""
+
+#: src/docs_inc.c:2898
+msgid ""
+"An access entry is said to match if the username and the IP source address "
+"of the requesting peer is within the prefix (_Allowed networks_ ). Wildcard ("
+msgstr ""
+
+#: src/docs_inc.c:4798
+msgid "An example:"
+msgstr ""
+
+#: src/docs_inc.c:1237
+msgid "And I'm left with these final open questions:"
+msgstr ""
+
+#: src/docs_inc.c:53
+msgid "And another item."
+msgstr ""
+
+#: src/docs_inc.c:413
+msgid ""
+"And finally, services are mapped to __channels__ . These are what you and "
+"your client software think in terms of: _\"I'd like to watch BBC One now, "
+"please\"_ ."
+msgstr ""
+
+#: src/docs_inc.c:87
+msgid ""
+"And if you don't want a header, you can leave it out - but the cells remain "
+"in this theme, so I'd suggest you don't do this as it's ugly:"
+msgstr ""
+
+#: src/docs_inc.c:1135
+msgid ""
+"And the same drop-down menu also gives you access to a __filter__ function "
+"if defined. The filter does simple pattern-matching on any string you "
+"provide. A small blue flag or triangle will appear in the top-left corner to "
+"indicate that a filter is active."
+msgstr ""
+
+#: src/docs_inc.c:1175
+msgid ""
+"And, of course, you'll need one or more __TV tuners__ if you want to receive "
+"regular broadcast television - otherwise, you're limited to IP sources."
+msgstr ""
+
+#: src/docs_inc.c:1823
+msgid "Android"
+msgstr ""
+
+#: src/docs_inc.c:4654
+msgid "Anonymize HTSP access"
+msgstr ""
+
+#: src/docs_inc.c:2965
+msgid "Anonymous Access"
+msgstr ""
+
+#: src/docs_inc.c:45
+msgid "Another item"
+msgstr ""
+
+#: src/docs_inc.c:3279
+msgid ""
+"Any changes (mapped services, number changes etc) to the channels can be "
+"lost if new changes in the bouquet override them."
+msgstr ""
+
+#: src/docs_inc.c:1007
+msgid "Appendices"
+msgstr ""
+
+#: src/docs_inc.c:1009
+msgid "Appendix 1 - URL syntax (Exports)"
+msgstr ""
+
+#: src/docs_inc.c:1011
+msgid "Appendix 2 - FAQ"
+msgstr ""
+
+#: src/docs_inc.c:1013
+msgid "Appendix 3 - Command-line Options"
+msgstr ""
+
+#: src/docs_inc.c:1015
+msgid "Appendix 4 - Updating this documentation"
+msgstr ""
+
+#: src/docs_inc.c:1017
+msgid "Appendix 5 - Markdown Cribsheet"
+msgstr ""
+
+#: src/docs_inc.c:403
+msgid "Application/Tvheadend Fundamentals"
+msgstr ""
+
+#: src/docs_inc.c:3721
+msgid "Apply configuration (run-time only)"
+msgstr ""
+
+#: src/docs_inc.c:3723
+msgid "Apply the entered debugging settings."
+msgstr ""
+
+#: src/docs_inc.c:373
+msgid "Arranging your channels into groups (channel tags)"
+msgstr ""
+
+#: src/docs_inc.c:1617
+msgid ""
+"As a broad guide, though, you need two main components: a driver, and "
+"firmware."
+msgstr ""
+
+#: src/docs_inc.c:363
+msgid "As required, you may now wish to look into:"
+msgstr ""
+
+#: src/docs_inc.c:199
+msgid ""
+"As well as being able to record the input, Tvheadend also offers it up to "
+"client applications via HTTP (VLC, MPlayer), HTSP (Kodi, Movian) and SAT>IP "
+"streaming."
+msgstr ""
+
+#: src/docs_inc.c:1821
+msgid ""
+"As well as the web interface, which is accessible through VPN if required, "
+"third-party clients are available for both"
+msgstr ""
+
+#: src/docs_inc.c:157
+msgid ""
+"As you set things up, consult the on-line (web interface) help as well. "
+"Tvheadend includes copies of many of these pages in the application, which "
+"is easier to find when you're wondering what to do next."
+msgstr ""
+
+#: src/docs_inc.c:3640
+msgid "Assign Number"
+msgstr ""
+
+#: src/docs_inc.c:5284
+msgid ""
+"Assign predefined muxes to networks. To save you from manually entering "
+"muxes, Tvheadend includes predefined mux lists. Please select a list for "
+"each network below."
+msgstr ""
+
+#: src/docs_inc.c:3642
+msgid ""
+"Assign the lowest available channel number(s) to the selected channel(s)."
+msgstr ""
+
+#: src/docs_inc.c:287
+msgid ""
+"Associate each of your tuners with the correct network through _Parameters -"
+"> Basic Settings_ ."
+msgstr ""
+
+#: src/docs_inc.c:291
+msgid ""
+"At this point, your tuners now know what networks to use: one network can "
+"appear on multiple tuners (many-to-one), and one tuner can have multiple "
+"networks."
+msgstr ""
+
+#: src/docs_inc.c:2219
+msgid "Attempt to discover more SAT>IP servers on the network."
+msgstr ""
+
+#: src/docs_inc.c:967
+msgid "Audio Stream Filters"
+msgstr ""
+
+#: src/docs_inc.c:4224
+msgid "Auto"
+msgstr ""
+
+#: src/docs_inc.c:4534
+msgid "Auto check disabled"
+msgstr ""
+
+#: src/docs_inc.c:4530
+msgid "Auto check enabled"
+msgstr ""
+
+#: src/docs_inc.c:889
+msgid "Auto-recording (Autorecs)"
+msgstr ""
+
+#: src/docs_inc.c:3414
+msgid ""
+"Automatically record all upcoming events matching the program's title by "
+"pressing the _[Autorec]_ button."
+msgstr ""
+
+#: src/docs_inc.c:755 src/docs_inc.c:3434
+msgid "Autorec"
+msgstr ""
+
+#: src/docs_inc.c:3426
+msgid "Autorec rules allow you to match events using various options."
+msgstr ""
+
+#: src/docs_inc.c:749
+msgid "Autorecordings"
+msgstr ""
+
+#: src/docs_inc.c:3833
+msgid "Avahi"
+msgstr ""
+
+#: src/docs_inc.c:2390
+msgid "Available CA types"
+msgstr ""
+
+#: src/docs_inc.c:4373 src/docs_inc.c:4751 src/docs_inc.c:5173
+msgid "BBC world"
+msgstr ""
+
+#: src/docs_inc.c:4818
+msgid "BUSY"
+msgstr ""
+
+#: src/docs_inc.c:897
+msgid "Base"
+msgstr ""
+
+#: src/docs_inc.c:4303 src/docs_inc.c:4850
+msgid "Base Config"
+msgstr ""
+
+#: src/docs_inc.c:3877
+msgid "Base DVB SI Tables (PAT,CAT,PMT,SDT etc.)"
+msgstr ""
+
+#: src/docs_inc.c:1785
+msgid "Based on extJS, all pages are dynamic and self-refreshing."
+msgstr ""
+
+#: src/docs_inc.c:4367 src/docs_inc.c:4745 src/docs_inc.c:5167
+msgid "Basename of recording"
+msgstr ""
+
+#: src/docs_inc.c:4307 src/docs_inc.c:4953
+msgid "Basic"
+msgstr ""
+
+#: src/docs_inc.c:859 src/docs_inc.c:1157
+msgid "Basic Requirements"
+msgstr ""
+
+#: src/docs_inc.c:2945
+msgid ""
+"Be as limiting as possible especially when making Tvheadend available over "
+"the Internet."
+msgstr ""
+
+#: src/docs_inc.c:2275
+msgid ""
+"Be aware that the username you enter here must match a username/entry in the"
+msgstr ""
+
+#: src/docs_inc.c:4940
+msgid ""
+"Be sure to check you have enough free tuners available to record all "
+"scheduled recordings if they overlap."
+msgstr ""
+
+#: src/docs_inc.c:385
+msgid "Before You Begin"
+msgstr ""
+
+#: src/docs_inc.c:865
+msgid "Before you begin (concepts)"
+msgstr ""
+
+#: src/docs_inc.c:3082
+msgid "Below are some examples:"
+msgstr ""
+
+#: src/docs_inc.c:1089
+msgid "Bit Error Ratio"
+msgstr ""
+
+#: src/docs_inc.c:4873
+msgid "Blue"
+msgstr ""
+
+#: src/docs_inc.c:3837
+msgid "Bonjour"
+msgstr ""
+
+#: src/docs_inc.c:3676 src/docs_inc.c:3688 src/docs_inc.c:3957
+msgid "Bouquet"
+msgstr ""
+
+#: src/docs_inc.c:355 src/docs_inc.c:929
+msgid "Bouquets"
+msgstr ""
+
+#: src/docs_inc.c:3228
+msgid "Bouquets are broadcaster-defined groupings and orders of channels."
+msgstr ""
+
+#: src/docs_inc.c:3236
+msgid ""
+"Bouquets are usually obtained automatically from the DVB source during the "
+"mux scan period. Note that bouquets may use more muxes and only services "
+"from scanned muxes are added. The mux with bouquets might require another "
+"scan when all muxes are discovered (manually using the rescan checkbox)."
+msgstr ""
+
+#: src/docs_inc.c:691
+msgid "Broadcast details icon"
+msgstr ""
+
+#: src/docs_inc.c:765 src/docs_inc.c:795 src/docs_inc.c:819
+msgid "Browser"
+msgstr ""
+
+#: src/docs_inc.c:1659
+msgid "Build Tvheadend as you normally would, see the"
+msgstr ""
+
+#: src/docs_inc.c:1761
+msgid ""
+"Built in video recorder stores recorded programs as Transport Stream (.ts) "
+"or Matroska (.mkv) files."
+msgstr ""
+
+#: src/docs_inc.c:2584
+msgid "Built-in"
+msgstr ""
+
+#: src/docs_inc.c:119 src/docs_inc.c:465 src/docs_inc.c:653 src/docs_inc.c:1061
+#: src/docs_inc.c:1509 src/docs_inc.c:1685 src/docs_inc.c:1890
+#: src/docs_inc.c:1928 src/docs_inc.c:1992 src/docs_inc.c:2143
+#: src/docs_inc.c:2176 src/docs_inc.c:2203 src/docs_inc.c:2296
+#: src/docs_inc.c:2321 src/docs_inc.c:2350 src/docs_inc.c:2459
+#: src/docs_inc.c:2500 src/docs_inc.c:2541 src/docs_inc.c:2608
+#: src/docs_inc.c:2732 src/docs_inc.c:2875 src/docs_inc.c:2915
+#: src/docs_inc.c:2986 src/docs_inc.c:3048 src/docs_inc.c:3115
+#: src/docs_inc.c:3140 src/docs_inc.c:3213 src/docs_inc.c:3247
+#: src/docs_inc.c:3310 src/docs_inc.c:3562 src/docs_inc.c:3592
+#: src/docs_inc.c:3717 src/docs_inc.c:4114 src/docs_inc.c:4171
+msgid "Button"
+msgstr ""
+
+#: src/docs_inc.c:461 src/docs_inc.c:649 src/docs_inc.c:2172
+#: src/docs_inc.c:2292 src/docs_inc.c:2871 src/docs_inc.c:3111
+#: src/docs_inc.c:3136 src/docs_inc.c:3209 src/docs_inc.c:3558
+#: src/docs_inc.c:4167
+msgid "Buttons"
+msgstr ""
+
+#: src/docs_inc.c:223
+msgid ""
+"By default Tvheadend's _Play_ links are playlists, although not all players "
+"accept them (e.g. Media Player Classic Home Cinema). You can bypass this by "
+"removing the `/play/` path from the url."
+msgstr ""
+
+#: src/docs_inc.c:3973
+msgid "CA (descrambling) Client"
+msgstr ""
+
+#: src/docs_inc.c:973
+msgid "CA Stream Filters"
+msgstr ""
+
+#: src/docs_inc.c:985 src/docs_inc.c:2396
+msgid "CAPMT (Linux Network DVBAPI)"
+msgstr ""
+
+#: src/docs_inc.c:3981
+msgid "CAPMT CA Client"
+msgstr ""
+
+#: src/docs_inc.c:4049
+msgid "CI Module"
+msgstr ""
+
+#: src/docs_inc.c:3759 src/docs_inc.c:3761
+msgid "CPU"
+msgstr ""
+
+#: src/docs_inc.c:3743 src/docs_inc.c:3745
+msgid "CRASH"
+msgstr ""
+
+#: src/docs_inc.c:3977
+msgid "CSA (descrambling)"
+msgstr ""
+
+#: src/docs_inc.c:3985
+msgid "CWC CA Client"
+msgstr ""
+
+#: src/docs_inc.c:531
+msgid "Cable (DVB-C/ATSC-C/ISDB-C)"
+msgstr ""
+
+#: src/docs_inc.c:2671
+msgid "Cable TV, delivered via a cable to your house"
+msgstr ""
+
+#: src/docs_inc.c:191
+msgid "Cable TV, delivered via a cable to your house (DVB-C)"
+msgstr ""
+
+#: src/docs_inc.c:1735
+msgid "Cable signals via DVB-C"
+msgstr ""
+
+#: src/docs_inc.c:3566
+msgid "Cancel"
+msgstr ""
+
+#: src/docs_inc.c:3568
+msgid "Cancel mapping and close the dialog."
+msgstr ""
+
+#: src/docs_inc.c:1657
+msgid ""
+"Change markdown files in `docs/markdown`, `docs/markdown/inc`, `docs/class`, "
+"`docs/wizard`, etc. Images are placed in `src/webui/static/img/doc/`."
+msgstr ""
+
+#: src/docs_inc.c:4274
+msgid ""
+"Change nothing and rely on standard (default) system caching to behave as it "
+"normally would."
+msgstr ""
+
+#: src/docs_inc.c:3707
+msgid ""
+"Changes to any of these settings must be confirmed by pressing the _[Apply "
+"configuration]_ button before taking effect."
+msgstr ""
+
+#: src/docs_inc.c:3945
+msgid "Channel"
+msgstr ""
+
+#: src/docs_inc.c:923
+msgid "Channel / EPG"
+msgstr ""
+
+#: src/docs_inc.c:927
+msgid "Channel Tags"
+msgstr ""
+
+#: src/docs_inc.c:4371 src/docs_inc.c:4749 src/docs_inc.c:5048
+#: src/docs_inc.c:5171
+msgid "Channel name"
+msgstr ""
+
+#: src/docs_inc.c:4658
+msgid "Channel number range"
+msgstr ""
+
+#: src/docs_inc.c:1399
+msgid "Channel specified by channel UUID"
+msgstr ""
+
+#: src/docs_inc.c:1395
+msgid "Channel specified by channel name"
+msgstr ""
+
+#: src/docs_inc.c:1391
+msgid "Channel specified by channel number"
+msgstr ""
+
+#: src/docs_inc.c:1403
+msgid "Channel specified by short channel ID"
+msgstr ""
+
+#: src/docs_inc.c:4668 src/docs_inc.c:4674
+msgid "Channel tags"
+msgstr ""
+
+#: src/docs_inc.c:925 src/docs_inc.c:4503 src/docs_inc.c:4592
+msgid "Channels"
+msgstr ""
+
+#: src/docs_inc.c:597
+msgid ""
+"Channels in the drop down are ordered by name and can be filtered (by name) "
+"by typing in the box."
+msgstr ""
+
+#: src/docs_inc.c:4009
+msgid "Charset"
+msgstr ""
+
+#: src/docs_inc.c:1209
+msgid ""
+"Check all link from tvh (e.g. there are no help buttons on the 'Stream' tabs)"
+msgstr ""
+
+#: src/docs_inc.c:1203
+msgid ""
+"Check non-univeral (i.e. item-specific) configuration items (e.g. the IPTV "
+"mux parameters) and make sure they're documented"
+msgstr ""
+
+#: src/docs_inc.c:4517
+msgid ""
+"Choose this if your picon pack has icons that start with \"1_0_1_xxxx\"."
+msgstr ""
+
+#: src/docs_inc.c:4513
+msgid ""
+"Choose this if your picon pack uses the standard naming scheme, e.g "
+"\"1_0_19_xxxx\"."
+msgstr ""
+
+#: src/docs_inc.c:4126
+msgid "Clean image (icon) cache"
+msgstr ""
+
+#: src/docs_inc.c:4128
+msgid "Clean-up the stored image files (empty cache and re-fetch icons)."
+msgstr ""
+
+#: src/docs_inc.c:659
+msgid "Clears all search filters."
+msgstr ""
+
+#: src/docs_inc.c:487
+msgid "Click on an item to display more information."
+msgstr ""
+
+#: src/docs_inc.c:263
+msgid ""
+"Click on each tuner that you want Tvheadend to use, and ensure \"Enabled\" "
+"is checked in the 'Parameters' list"
+msgstr ""
+
+#: src/docs_inc.c:2068
+msgid ""
+"Click on the services you would like to map as channels, once you're done "
+"selecting press the \"Map services\" button and then \"Map selected services"
+"\"."
+msgstr ""
+
+#: src/docs_inc.c:2717
+msgid "Click the desired network type (above) to see all available"
+msgstr ""
+
+#: src/docs_inc.c:2116
+msgid "Clicking the !"
+msgstr ""
+
+#: src/docs_inc.c:543
+msgid "Client"
+msgstr ""
+
+#: src/docs_inc.c:683 src/docs_inc.c:3376
+msgid "Clock icon"
+msgstr ""
+
+#: src/docs_inc.c:2370 src/docs_inc.c:2628 src/docs_inc.c:3006
+msgid "Clone"
+msgstr ""
+
+#: src/docs_inc.c:2372
+msgid "Clone the currently selected configuration."
+msgstr ""
+
+#: src/docs_inc.c:2630 src/docs_inc.c:3008
+msgid "Clone the currently selected profile."
+msgstr ""
+
+#: src/docs_inc.c:987 src/docs_inc.c:2398
+msgid "Code word client (newcamd)"
+msgstr ""
+
+#: src/docs_inc.c:5107
+msgid "Combine channels with the same name into a single channel."
+msgstr ""
+
+#: src/docs_inc.c:1027
+msgid "Command-line Options"
+msgstr ""
+
+#: src/docs_inc.c:1201
+msgid ""
+"Complete the content for 4.0 (4.2 can wait) - strip out what isn't stricly "
+"necessary now (we can come back)"
+msgstr ""
+
+#: src/docs_inc.c:983
+msgid "Conditional Access (CA)"
+msgstr ""
+
+#: src/docs_inc.c:893 src/docs_inc.c:3817
+msgid "Configuration"
+msgstr ""
+
+#: src/docs_inc.c:249 src/docs_inc.c:871 src/docs_inc.c:3514
+msgid "Configure Tvheadend"
+msgstr ""
+
+#: src/docs_inc.c:2764
+msgid "Configure Tvheadend."
+msgstr ""
+
+#: src/docs_inc.c:2404
+msgid "Connection Status"
+msgstr ""
+
+#: src/docs_inc.c:4692
+msgid "Connection limit type"
+msgstr ""
+
+#: src/docs_inc.c:4690
+msgid "Connection limits"
+msgstr ""
+
+#: src/docs_inc.c:1001
+msgid "Connections"
+msgstr ""
+
+#: src/docs_inc.c:79
+msgid "Content from cell 1"
+msgstr ""
+
+#: src/docs_inc.c:81
+msgid "Content from cell 2"
+msgstr ""
+
+#: src/docs_inc.c:83
+msgid "Content in the first column"
+msgstr ""
+
+#: src/docs_inc.c:85
+msgid "Content in the second column"
+msgstr ""
+
+#: src/docs_inc.c:5052
+msgid "Content type"
+msgstr ""
+
+#: src/docs_inc.c:1275
+msgid "Contributor Licensing Agreement"
+msgstr ""
+
+#: src/docs_inc.c:1273
+msgid "Contributor information"
+msgstr ""
+
+#: src/docs_inc.c:665
+msgid "Create Autorec"
+msgstr ""
+
+#: src/docs_inc.c:271
+msgid ""
+"Create a network of the appropriate type here. You can have multiple "
+"networks of the same type as necessary, e.g. to have two DVB-T networks "
+"defined, one with HD muxes, one without."
+msgstr ""
+
+#: src/docs_inc.c:4908
+msgid "Create a tag based on the channel type and link it to the channel."
+msgstr ""
+
+#: src/docs_inc.c:4904
+msgid ""
+"Create a tag with the bouquets name and link it to all channels created by "
+"the bouquet."
+msgstr ""
+
+#: src/docs_inc.c:4912
+msgid ""
+"Create a tag with the channel provider's name and link it to the channel."
+msgstr ""
+
+#: src/docs_inc.c:4916
+msgid ""
+"Create a tag with the network name and link it to all channels created by "
+"the bouquet."
+msgstr ""
+
+#: src/docs_inc.c:4902
+msgid "Create bouquet tag"
+msgstr ""
+
+#: src/docs_inc.c:4914
+msgid "Create network name tags"
+msgstr ""
+
+#: src/docs_inc.c:4910
+msgid "Create provider name tags"
+msgstr ""
+
+#: src/docs_inc.c:1769
+msgid "Create rule sets manually or based on EPG queries."
+msgstr ""
+
+#: src/docs_inc.c:4906
+msgid "Create type-based tags"
+msgstr ""
+
+#: src/docs_inc.c:667
+msgid ""
+"Creates an auto-recording rule based on the current filter criteria (see "
+"below)."
+msgstr ""
+
+#: src/docs_inc.c:3825
+msgid "Cron"
+msgstr ""
+
+#: src/docs_inc.c:5201
+msgid "Current affairs"
+msgstr ""
+
+#: src/docs_inc.c:3829
+msgid "DBUS"
+msgstr ""
+
+#: src/docs_inc.c:989 src/docs_inc.c:2400
+msgid "DES constant code word client"
+msgstr ""
+
+#: src/docs_inc.c:4013
+msgid "DVB"
+msgstr ""
+
+#: src/docs_inc.c:3989
+msgid "DVB CAM Client"
+msgstr ""
+
+#: src/docs_inc.c:3881
+msgid "DVB CSA (descrambling) Tables"
+msgstr ""
+
+#: src/docs_inc.c:3885
+msgid "DVB EPG Tables"
+msgstr ""
+
+#: src/docs_inc.c:911
+msgid "DVB Inputs"
+msgstr ""
+
+#: src/docs_inc.c:453
+msgid "DVB Inputs - TV Adapters"
+msgstr ""
+
+#: src/docs_inc.c:3873
+msgid "DVB SI Tables"
+msgstr ""
+
+#: src/docs_inc.c:3889
+msgid "DVB Time Tables"
+msgstr ""
+
+#: src/docs_inc.c:1725
+msgid "DVB subtitles supported."
+msgstr ""
+
+#: src/docs_inc.c:535 src/docs_inc.c:2673
+msgid "DVB-C"
+msgstr ""
+
+#: src/docs_inc.c:2687
+msgid "DVB-S"
+msgstr ""
+
+#: src/docs_inc.c:553
+msgid "DVB-S (Master)"
+msgstr ""
+
+#: src/docs_inc.c:555
+msgid "DVB-S (Slave)"
+msgstr ""
+
+#: src/docs_inc.c:551 src/docs_inc.c:2697
+msgid "DVB-T"
+msgstr ""
+
+#: src/docs_inc.c:525
+msgid "DVB-T/DVB-T2"
+msgstr ""
+
+#: src/docs_inc.c:4490
+msgid "DVR"
+msgstr ""
+
+#: src/docs_inc.c:2852
+msgid "DVR Entry"
+msgstr ""
+
+#: src/docs_inc.c:4936 src/docs_inc.c:5275
+msgid "DVR Profile"
+msgstr ""
+
+#: src/docs_inc.c:4680
+msgid "DVR configuration profiles"
+msgstr ""
+
+#: src/docs_inc.c:4678
+msgid "DVR configurations"
+msgstr ""
+
+#: src/docs_inc.c:5246
+msgid "DVR profile"
+msgstr ""
+
+#: src/docs_inc.c:439
+msgid "Debian/Ubuntu installation instructions"
+msgstr ""
+
+#: src/docs_inc.c:1037
+msgid "Debug options"
+msgstr ""
+
+#: src/docs_inc.c:993
+msgid "Debugging"
+msgstr ""
+
+#: src/docs_inc.c:3650
+msgid "Decrement the selected channel numbers by 1."
+msgstr ""
+
+#: src/docs_inc.c:4299 src/docs_inc.c:4846
+msgid "Default"
+msgstr ""
+
+#: src/docs_inc.c:5032
+msgid "Default format (title, unique number, extension)"
+msgstr ""
+
+#: src/docs_inc.c:1948 src/docs_inc.c:2366 src/docs_inc.c:2471
+#: src/docs_inc.c:2624 src/docs_inc.c:3002
+msgid "Delete"
+msgstr ""
+
+#: src/docs_inc.c:2368
+msgid "Delete an existing CA client configuration."
+msgstr ""
+
+#: src/docs_inc.c:3004
+msgid "Delete an existing profile."
+msgstr ""
+
+#: src/docs_inc.c:2626
+msgid "Delete the selected entry."
+msgstr ""
+
+#: src/docs_inc.c:1950
+msgid "Delete the selected entry/entries."
+msgstr ""
+
+#: src/docs_inc.c:2473
+msgid "Delete the selected grid entries."
+msgstr ""
+
+#: src/docs_inc.c:3334
+msgid "Delete/Remove"
+msgstr ""
+
+#: src/docs_inc.c:3336
+msgid "Delete/Remove the selected grid entries."
+msgstr ""
+
+#: src/docs_inc.c:2440
+msgid "Deleting a CA Configuration"
+msgstr ""
+
+#: src/docs_inc.c:2658 src/docs_inc.c:3028
+msgid "Deleting a Profile"
+msgstr ""
+
+#: src/docs_inc.c:3530
+msgid ""
+"Deleting a mux will also remove any associated services, including those "
+"mapped to channels. If you have network discovery enabled any previously "
+"deleted muxes found in the NIT during a scan will automatically be re-added."
+msgstr ""
+
+#: src/docs_inc.c:1900
+msgid "Deleting an Entry"
+msgstr ""
+
+#: src/docs_inc.c:3526
+msgid "Deleting an Entry/Mux"
+msgstr ""
+
+#: src/docs_inc.c:3711
+msgid ""
+"Depending on your distribution, the default command-line configuration is "
+"usually stored in the `/etc/sysconfig` tree or an init script. You may also "
+"be able to change `/etc/default/tvheadend` to add additional command-line "
+"parameters."
+msgstr ""
+
+#: src/docs_inc.c:3969
+msgid "Descrambler"
+msgstr ""
+
+#: src/docs_inc.c:681 src/docs_inc.c:1547 src/docs_inc.c:2410
+#: src/docs_inc.c:3180 src/docs_inc.c:3374 src/docs_inc.c:4199
+#: src/docs_inc.c:4222 src/docs_inc.c:4266 src/docs_inc.c:4297
+#: src/docs_inc.c:4359 src/docs_inc.c:4480 src/docs_inc.c:4509
+#: src/docs_inc.c:4528 src/docs_inc.c:4551 src/docs_inc.c:4598
+#: src/docs_inc.c:4737 src/docs_inc.c:4844 src/docs_inc.c:4871
+#: src/docs_inc.c:4900 src/docs_inc.c:4951 src/docs_inc.c:4993
+#: src/docs_inc.c:5028 src/docs_inc.c:5118 src/docs_inc.c:5159
+#: src/docs_inc.c:5252
+msgid "Description"
+msgstr ""
+
+#: src/docs_inc.c:4634
+msgid "Description/Properties"
+msgstr ""
+
+#: src/docs_inc.c:3267
+msgid "Detaching Channels"
+msgstr ""
+
+#: src/docs_inc.c:3281
+msgid ""
+"Detaching channels from a bouquet will prevent any further updates provided "
+"by the bouquet, which unfortunately means you will have to manually re-map "
+"when changes to services occur (e.g, mux moves, ceased broadcasting etc)."
+msgstr ""
+
+#: src/docs_inc.c:485
+msgid "Device Configuration"
+msgstr ""
+
+#: src/docs_inc.c:475
+msgid "Device Tree"
+msgstr ""
+
+#: src/docs_inc.c:515
+msgid "DiSEqC Switch"
+msgstr ""
+
+#: src/docs_inc.c:879 src/docs_inc.c:1759 src/docs_inc.c:3993
+msgid "Digital Video Recorder"
+msgstr ""
+
+#: src/docs_inc.c:741 src/docs_inc.c:979
+msgid "Digital Video Recorder Profiles"
+msgstr ""
+
+#: src/docs_inc.c:4201
+msgid "Disable"
+msgstr ""
+
+#: src/docs_inc.c:4536
+msgid "Disable automatic service checking."
+msgstr ""
+
+#: src/docs_inc.c:4203
+msgid "Disable mux discovery."
+msgstr ""
+
+#: src/docs_inc.c:5262
+msgid "Disabled"
+msgstr ""
+
+#: src/docs_inc.c:2215
+msgid "Discover SAT"
+msgstr ""
+
+#: src/docs_inc.c:4211
+msgid "Discover new muxes and changes to existing muxes."
+msgstr ""
+
+#: src/docs_inc.c:4207
+msgid "Discover new muxes only."
+msgstr ""
+
+#: src/docs_inc.c:4045
+msgid "DiseqC"
+msgstr ""
+
+#: src/docs_inc.c:513
+msgid "DiseqC Rotor"
+msgstr ""
+
+#: src/docs_inc.c:1942
+msgid "Display the"
+msgstr ""
+
+#: src/docs_inc.c:2157
+msgid "Display the first-run set-up wizard."
+msgstr ""
+
+#: src/docs_inc.c:125 src/docs_inc.c:671 src/docs_inc.c:1067
+#: src/docs_inc.c:1515 src/docs_inc.c:1691 src/docs_inc.c:2388
+msgid "Display this help page."
+msgstr ""
+
+#: src/docs_inc.c:1129
+msgid "Displaying and Manipulating Columns"
+msgstr ""
+
+#: src/docs_inc.c:443
+msgid ""
+"Do not assume that your distro's package manager will give you the latest "
+"version of Tvheadend - indeed, give you any version at all. Always check."
+msgstr ""
+
+#: src/docs_inc.c:823
+msgid "Dolby Digital (AC3)"
+msgstr ""
+
+#: src/docs_inc.c:4276
+msgid "Don't keep"
+msgstr ""
+
+#: src/docs_inc.c:5264
+msgid "Don't use running state (EITp/f) detection."
+msgstr ""
+
+#: src/docs_inc.c:3342
+msgid "Download"
+msgstr ""
+
+#: src/docs_inc.c:3344
+msgid "Download the recording."
+msgstr ""
+
+#: src/docs_inc.c:3444
+msgid "Downloading a Recording"
+msgstr ""
+
+#: src/docs_inc.c:1621
+msgid ""
+"Driver software typically comes either built-in to the operating system (a "
+"clue here is documentation that says _\"supported since kernel 3.16\"_ , for "
+"example) or as an external program that needs to be compiled in (e.g. how "
+"you'd build TBS' or Digital Devices drivers, or perhaps where the driver is "
+"supported in a later version of LinuxTV V4L-DVB than has made it to your "
+"kernel - the giveaway here is _\"compile and install the latest media_build"
+"\"_ )."
+msgstr ""
+
+#: src/docs_inc.c:3610
+msgid "Drop down menu (see mapping button table below)."
+msgstr ""
+
+#: src/docs_inc.c:3614
+msgid "Drop down menu (see numbering button table below)."
+msgstr ""
+
+#: src/docs_inc.c:1998 src/docs_inc.c:2006
+msgid "Drop-down menu (see"
+msgstr ""
+
+#: src/docs_inc.c:5366
+msgid ""
+"During scanning, the number of muxes and services shown below should "
+"increase. If this doesn't happen, check the connection(s) to your device(s).."
+msgstr ""
+
+#: src/docs_inc.c:5238
+msgid ""
+"EITp/f (Event Information Table present/following) is broadcast alongside "
+"EPG data, it allows broadcasters to tell DVRs/STBs when a program starts, "
+"pauses or finishes."
+msgstr ""
+
+#: src/docs_inc.c:5140
+msgid "EMPTY"
+msgstr ""
+
+#: src/docs_inc.c:3420
+msgid "EPG"
+msgstr ""
+
+#: src/docs_inc.c:4001
+msgid "EPG Database"
+msgstr ""
+
+#: src/docs_inc.c:731
+msgid "EPG Detail 1"
+msgstr ""
+
+#: src/docs_inc.c:737
+msgid "EPG Detail 2"
+msgstr ""
+
+#: src/docs_inc.c:933 src/docs_inc.c:4005
+msgid "EPG Grabber"
+msgstr ""
+
+#: src/docs_inc.c:931
+msgid "EPG Grabber Channels"
+msgstr ""
+
+#: src/docs_inc.c:935
+msgid "EPG Grabber Modules"
+msgstr ""
+
+#: src/docs_inc.c:5136
+msgid "EXCLUSIVE"
+msgstr ""
+
+#: src/docs_inc.c:65
+msgid "Each numbered (ordered) list will restart from 1."
+msgstr ""
+
+#: src/docs_inc.c:3062
+msgid "Each rule is executed in sequence (as displayed in the grid)."
+msgstr ""
+
+#: src/docs_inc.c:1125
+msgid ""
+"Each tab is then typically laid out with a menu bar across the top that "
+"provides access to Add/Save/Edit-type functions, and a grid like a "
+"spreadsheet below that. The grid items are frequently editable."
+msgstr ""
+
+#: src/docs_inc.c:1789
+msgid "Easy to Configure and Administer"
+msgstr ""
+
+#: src/docs_inc.c:1952 src/docs_inc.c:2475 src/docs_inc.c:3338
+msgid "Edit"
+msgstr ""
+
+#: src/docs_inc.c:2648
+msgid "Edit a Profile"
+msgstr ""
+
+#: src/docs_inc.c:1954
+msgid "Edit the selected entries."
+msgstr ""
+
+#: src/docs_inc.c:2477 src/docs_inc.c:3340
+msgid "Edit the selected grid entries."
+msgstr ""
+
+#: src/docs_inc.c:1141
+msgid "Editing Fields"
+msgstr ""
+
+#: src/docs_inc.c:1869
+msgid "Editing an Entry"
+msgstr ""
+
+#: src/docs_inc.c:1873
+msgid "Editing in the Grid"
+msgstr ""
+
+#: src/docs_inc.c:565 src/docs_inc.c:877 src/docs_inc.c:1773
+#: src/docs_inc.c:3997
+msgid "Electronic Program Guide"
+msgstr ""
+
+#: src/docs_inc.c:3961
+msgid "Elementary Stream Filter"
+msgstr ""
+
+#: src/docs_inc.c:3066
+msgid ""
+"Elementary streams not marked IGNORE, USE or EXCLUSIVE will not be filtered "
+"out."
+msgstr ""
+
+#: src/docs_inc.c:2955
+msgid "Emergency/Backdoor Access"
+msgstr ""
+
+#: src/docs_inc.c:4532
+msgid "Enable automatic service checking."
+msgstr ""
+
+#: src/docs_inc.c:5260
+msgid "Enable running state (EITp/f) detection."
+msgstr ""
+
+#: src/docs_inc.c:5258
+msgid "Enabled"
+msgstr ""
+
+#: src/docs_inc.c:1323
+msgid "Enigma2"
+msgstr ""
+
+#: src/docs_inc.c:5345
+msgid ""
+"Enter the access control details to secure your system. The first part of "
+"this covers the network details for address-based access to the system; for "
+"example, 192.168.1.0/24 to allow local access only to 192.168.1.x clients, "
+"or 0.0.0.0/0 or empty value for access from any system."
+msgstr ""
+
+#: src/docs_inc.c:2913
+msgid ""
+"Entries are checked in order (when logging in, etc), the following functions "
+"allows you to change the ordering:"
+msgstr ""
+
+#: src/docs_inc.c:3368
+msgid "Entry Overview"
+msgstr ""
+
+#: src/docs_inc.c:4399 src/docs_inc.c:5203
+msgid "Error message"
+msgstr ""
+
+#: src/docs_inc.c:723
+msgid "Event Details and Recording"
+msgstr ""
+
+#: src/docs_inc.c:5044
+msgid "Event episode name"
+msgstr ""
+
+#: src/docs_inc.c:5036
+msgid "Event subtitle name"
+msgstr ""
+
+#: src/docs_inc.c:5040
+msgid "Event title name"
+msgstr ""
+
+#: src/docs_inc.c:2267 src/docs_inc.c:2842 src/docs_inc.c:2929
+#: src/docs_inc.c:3166 src/docs_inc.c:3257 src/docs_inc.c:3662
+#: src/docs_inc.c:5030
+msgid "Example"
+msgstr ""
+
+#: src/docs_inc.c:621
+msgid "Example Purpose"
+msgstr ""
+
+#: src/docs_inc.c:4361 src/docs_inc.c:4739 src/docs_inc.c:5161
+msgid "Example value"
+msgstr ""
+
+#: src/docs_inc.c:4619
+msgid "Example: `file:///home/hts/picons`"
+msgstr ""
+
+#: src/docs_inc.c:4456
+#, c-format
+msgid "Example: `file:///tmp/icons/%C.png` or `http://example.com/%c.png`"
+msgstr ""
+
+#: src/docs_inc.c:695 src/docs_inc.c:3388
+msgid "Exclamation icon"
+msgstr ""
+
+#: src/docs_inc.c:4670
+msgid "Exclude channel tags"
+msgstr ""
+
+#: src/docs_inc.c:1235
+msgid ""
+"Expand a bit on command-line options and give some examples of common usage"
+msgstr ""
+
+#: src/docs_inc.c:4315 src/docs_inc.c:4961
+msgid "Expert"
+msgstr ""
+
+#: src/docs_inc.c:1295 src/docs_inc.c:1375 src/docs_inc.c:1415
+msgid "Explanation"
+msgstr ""
+
+#: src/docs_inc.c:1597
+msgid ""
+"External HDHomeRun tuners that send MPEG-TS streams over a LAN connection"
+msgstr ""
+
+#: src/docs_inc.c:943
+msgid "External PyEPG"
+msgstr ""
+
+#: src/docs_inc.c:1595
+msgid "External SAT>IP tuners that send MPEG-TS streams over a LAN connection"
+msgstr ""
+
+#: src/docs_inc.c:1591
+msgid "External USB tuners that plug in"
+msgstr ""
+
+#: src/docs_inc.c:945
+msgid "External XMLTV"
+msgstr ""
+
+#: src/docs_inc.c:215
+msgid "FAQ: Frequently-asked Questions"
+msgstr ""
+
+#: src/docs_inc.c:885 src/docs_inc.c:3354
+msgid "Failed Recordings"
+msgstr ""
+
+#: src/docs_inc.c:3905
+msgid "Fastscan DVB"
+msgstr ""
+
+#: src/docs_inc.c:861
+msgid "Features"
+msgstr ""
+
+#: src/docs_inc.c:1717
+msgid "Features of Tvheadend"
+msgstr ""
+
+#: src/docs_inc.c:4999
+msgid "File missing"
+msgstr ""
+
+#: src/docs_inc.c:5060
+msgid "Filename extension (from the active stream muxer"
+msgstr ""
+
+#: src/docs_inc.c:3781
+msgid "Filesystem monitor"
+msgstr ""
+
+#: src/docs_inc.c:583
+msgid "Filter"
+msgstr ""
+
+#: src/docs_inc.c:3060
+msgid "Filter Basics"
+msgstr ""
+
+#: src/docs_inc.c:619
+msgid "Filter Range"
+msgstr ""
+
+#: src/docs_inc.c:593
+msgid "Filter channel..."
+msgstr ""
+
+#: src/docs_inc.c:605
+msgid "Filter content type..."
+msgstr ""
+
+#: src/docs_inc.c:611
+msgid "Filter duration..."
+msgstr ""
+
+#: src/docs_inc.c:599
+msgid "Filter tag..."
+msgstr ""
+
+#: src/docs_inc.c:579
+msgid "Filtering (or searching)"
+msgstr ""
+
+#: src/docs_inc.c:3084
+msgid "Filtering out a Stream"
+msgstr ""
+
+#: src/docs_inc.c:883 src/docs_inc.c:3362
+msgid "Finished Recordings"
+msgstr ""
+
+#: src/docs_inc.c:75
+msgid "First Header"
+msgstr ""
+
+#: src/docs_inc.c:43
+msgid "First ordered list item"
+msgstr ""
+
+#: src/docs_inc.c:1599
+msgid ""
+"Follow the appropriate installation instructions and, if relevant, the setup "
+"instruction (e.g. for SAT>IP, which are effectively small, standalone "
+"computers)."
+msgstr ""
+
+#: src/docs_inc.c:437
+msgid ""
+"Follow the instructions that are specific to your Linux distribution (Ubuntu/"
+"Debian/Mint, Arch, Fedora...). This will typically be PPA-and-dpkg for "
+"Debian, but most other distros will need you to build your own version from "
+"source."
+msgstr ""
+
+#: src/docs_inc.c:5074
+msgid ""
+"For $t and $s format strings, you may also limit the number of output "
+"characters using $99-t format string where 99 means the limit. As you can "
+"see, the delimiter can be also applied."
+msgstr ""
+
+#: src/docs_inc.c:727
+msgid ""
+"For EPG providers that supply series link information there will also be a "
+"_[Record series]_ button that will record all entries in the series."
+msgstr ""
+
+#: src/docs_inc.c:5445
+msgid ""
+"For devices with multiple tuners (e.g. either cable or terrestrial), be "
+"aware that many only allow you to use one tuner at a time. Selecting more "
+"than one tuner per device can thus result in unexpected behavior."
+msgstr ""
+
+#: src/docs_inc.c:733
+msgid ""
+"For events without any series link information, an _[Autorec]_ button will "
+"be provided to create a pseudo-series link using the autorec feature."
+msgstr ""
+
+#: src/docs_inc.c:19
+msgid ""
+"For example to include the passwd items you'd enter something like this:"
+msgstr ""
+
+#: src/docs_inc.c:4934
+msgid ""
+"For example, if a program is to start at 13:00 and you set a padding of 5 "
+"minutes, it will start recording at 12:54:30 (including a warm-up time of 30 "
+"seconds (user configurable)). Setting the padding per channel will override "
+"the padding set in the"
+msgstr ""
+
+#: src/docs_inc.c:4630
+msgid ""
+"For example, say you have a wildcard account with the theme set to Gray, and "
+"an admin account with the Blue theme. Unchecking the theme checkbox for the "
+"admin user would mean that the theme from the last matching entry (which in "
+"this case would be the wildcard account) applies instead."
+msgstr ""
+
+#: src/docs_inc.c:2947
+msgid ""
+"For extra security always enter (a comma-separated list of) network "
+"prefix(es) (_Allowed networks_ )."
+msgstr ""
+
+#: src/docs_inc.c:3418
+msgid ""
+"For full instructions on how to search and record using the EPG take a look "
+"at the"
+msgstr ""
+
+#: src/docs_inc.c:2762
+msgid "For more detailed information on networks and how to set them up, see"
+msgstr ""
+
+#: src/docs_inc.c:1269
+msgid ""
+"For more information regarding the project, licensing and contributions, "
+"please see:"
+msgstr ""
+
+#: src/docs_inc.c:3074
+msgid ""
+"For visual verification of filtering, there is the service info dialog in the"
+msgstr ""
+
+#: src/docs_inc.c:2736 src/docs_inc.c:3251
+msgid "Force Scan"
+msgstr ""
+
+#: src/docs_inc.c:2774
+msgid "Force Scanning"
+msgstr ""
+
+#: src/docs_inc.c:2738
+msgid ""
+"Force a new scan (i.e. scan all muxes for services) for the selected "
+"networks."
+msgstr ""
+
+#: src/docs_inc.c:2555
+msgid "Force an immediate tune to the OTA EPG mux(es) to request EPG updates."
+msgstr ""
+
+#: src/docs_inc.c:2778
+msgid ""
+"Force scanning can take some time. You may continue to use Tvheadend while a "
+"scan is in progress, but doing so will increase the time needed for it to "
+"complete. Note that the time required can vary depending on a number of "
+"factors, such as how many tuners you have available and the number of muxes "
+"on each."
+msgstr ""
+
+#: src/docs_inc.c:4357 src/docs_inc.c:4735 src/docs_inc.c:5026
+#: src/docs_inc.c:5157
+msgid "Format"
+msgstr ""
+
+#: src/docs_inc.c:4328
+msgid "Format Result"
+msgstr ""
+
+#: src/docs_inc.c:491 src/docs_inc.c:523 src/docs_inc.c:533 src/docs_inc.c:545
+msgid "Frontend"
+msgstr ""
+
+#: src/docs_inc.c:4363 src/docs_inc.c:4741 src/docs_inc.c:5163
+msgid "Full path to recording"
+msgstr ""
+
+#: src/docs_inc.c:1813
+msgid "Fully-Integrated with Mainstream Media Players"
+msgstr ""
+
+#: src/docs_inc.c:121 src/docs_inc.c:467 src/docs_inc.c:585 src/docs_inc.c:655
+#: src/docs_inc.c:1063 src/docs_inc.c:1511 src/docs_inc.c:1687
+#: src/docs_inc.c:1930 src/docs_inc.c:1994 src/docs_inc.c:2014
+#: src/docs_inc.c:2026 src/docs_inc.c:2145 src/docs_inc.c:2178
+#: src/docs_inc.c:2205 src/docs_inc.c:2298 src/docs_inc.c:2323
+#: src/docs_inc.c:2352 src/docs_inc.c:2461 src/docs_inc.c:2502
+#: src/docs_inc.c:2543 src/docs_inc.c:2610 src/docs_inc.c:2734
+#: src/docs_inc.c:2877 src/docs_inc.c:2917 src/docs_inc.c:2988
+#: src/docs_inc.c:3050 src/docs_inc.c:3117 src/docs_inc.c:3142
+#: src/docs_inc.c:3215 src/docs_inc.c:3249 src/docs_inc.c:3312
+#: src/docs_inc.c:3564 src/docs_inc.c:3594 src/docs_inc.c:3618
+#: src/docs_inc.c:3638 src/docs_inc.c:3719 src/docs_inc.c:4116
+#: src/docs_inc.c:4173 src/docs_inc.c:4438 src/docs_inc.c:5085
+msgid "Function"
+msgstr ""
+
+#: src/docs_inc.c:1267
+msgid "Further Information"
+msgstr ""
+
+#: src/docs_inc.c:1263
+msgid "GPLv3"
+msgstr ""
+
+#: src/docs_inc.c:875 src/docs_inc.c:895
+msgid "General"
+msgstr ""
+
+#: src/docs_inc.c:1115
+msgid "General Overview of Web Interface"
+msgstr ""
+
+#: src/docs_inc.c:4610
+msgid "Generate lower-case filenames using picon formatting."
+msgstr ""
+
+#: src/docs_inc.c:4606
+msgid "Generate lower-case filenames."
+msgstr ""
+
+#: src/docs_inc.c:1207
+msgid "Generate new webUI help pages and push them to the tvheadend repo"
+msgstr ""
+
+#: src/docs_inc.c:1031
+msgid "Generic options"
+msgstr ""
+
+#: src/docs_inc.c:863
+msgid "Getting Started"
+msgstr ""
+
+#: src/docs_inc.c:13
+msgid "GitHub mastering markdown"
+msgstr ""
+
+#: src/docs_inc.c:3917
+msgid "Global Headers"
+msgstr ""
+
+#: src/docs_inc.c:3753
+msgid "Global timer"
+msgstr ""
+
+#: src/docs_inc.c:303
+msgid "Good sources of transmitter/mux information include:"
+msgstr ""
+
+#: src/docs_inc.c:775 src/docs_inc.c:803 src/docs_inc.c:829
+msgid "Google Chrome"
+msgstr ""
+
+#: src/docs_inc.c:3328
+msgid "Gracefully stop the selected in-progress recording entries."
+msgstr ""
+
+#: src/docs_inc.c:4877
+msgid "Gray"
+msgstr ""
+
+#: src/docs_inc.c:673 src/docs_inc.c:1069 src/docs_inc.c:1517
+#: src/docs_inc.c:1693
+msgid "Grid Items"
+msgstr ""
+
+#: src/docs_inc.c:799
+msgid "H.264"
+msgstr ""
+
+#: src/docs_inc.c:1721
+msgid "H.265 (HEVC), H.264 (MPEG-4 AVC) and MPEG2 video supported."
+msgstr ""
+
+#: src/docs_inc.c:4421 src/docs_inc.c:5225
+msgid "H264,AC3,TELETEXT"
+msgstr ""
+
+#: src/docs_inc.c:1231
+msgid "HD Homerun setup"
+msgstr ""
+
+#: src/docs_inc.c:3925
+msgid "HEVC - H.265"
+msgstr ""
+
+#: src/docs_inc.c:1749
+msgid "HTSP (Home TV Streaming Protocol)."
+msgstr ""
+
+#: src/docs_inc.c:3865
+msgid "HTSP Answer"
+msgstr ""
+
+#: src/docs_inc.c:951 src/docs_inc.c:2586
+msgid "HTSP Profile"
+msgstr ""
+
+#: src/docs_inc.c:3861
+msgid "HTSP Request"
+msgstr ""
+
+#: src/docs_inc.c:3853
+msgid "HTSP Server"
+msgstr ""
+
+#: src/docs_inc.c:3857
+msgid "HTSP Subscription"
+msgstr ""
+
+#: src/docs_inc.c:3849
+msgid "HTTP Client"
+msgstr ""
+
+#: src/docs_inc.c:3845
+msgid "HTTP Server"
+msgstr ""
+
+#: src/docs_inc.c:1751
+msgid "HTTP streaming."
+msgstr ""
+
+#: src/docs_inc.c:389
+msgid "Hardware/Software Fundamentals"
+msgstr ""
+
+#: src/docs_inc.c:123 src/docs_inc.c:669 src/docs_inc.c:1065
+#: src/docs_inc.c:1513 src/docs_inc.c:1689 src/docs_inc.c:2386
+msgid "Help"
+msgstr ""
+
+#: src/docs_inc.c:3090
+msgid ""
+"Here we're removing the Bulgarian language audio from the input (first "
+"rule). However, if Bulgarian is the only language available add it back in "
+"as a last resort (second rule)."
+msgstr ""
+
+#: src/docs_inc.c:1902
+msgid ""
+"Highlight (select) the desired entries in the grid, then press the "
+"_[Delete]_ button on the menu bar."
+msgstr ""
+
+#: src/docs_inc.c:1875
+msgid "Highlight (select) the desired entry and then..:"
+msgstr ""
+
+#: src/docs_inc.c:2442 src/docs_inc.c:2660 src/docs_inc.c:3030
+msgid ""
+"Highlight (select) the desired entry from the grid, then press the "
+"_[Delete]_ button from the menu bar."
+msgstr ""
+
+#: src/docs_inc.c:3446
+msgid ""
+"Highlight (select) the desired entry, then press the _[Download]_ button on "
+"the menu bar."
+msgstr ""
+
+#: src/docs_inc.c:1892
+msgid ""
+"Highlight (select) the entries in the grid that you'd like to edit, then "
+"click the _[Edit]_ button from the menu bar, the edit dialog should now be "
+"displayed. Note that when editing multiple entries there is an additional "
+"check box before each setting, ticking it will apply that setting to all "
+"selected entries. After you've finished editing an entry you can save your "
+"pending changes using the _[Save]_ button (closing the dialog), save your "
+"changes and continue making further adjustments by pressing the _[Apply]_ "
+"button, or cancel any unsaved changes (and close the dialog) by pressing the "
+"_[Cancel]_ button."
+msgstr ""
+
+#: src/docs_inc.c:2776
+msgid ""
+"Highlight (select) the network(s) you would like to force scan, and then "
+"press the \"Force Scan\" button from the menu bar."
+msgstr ""
+
+#: src/docs_inc.c:2249
+msgid ""
+"Hopefully (and if everything went to plan) your client should have now "
+"detected Tvheadend as a SAT>IP server. If not, restart or force it to "
+"perform a service discovery."
+msgstr ""
+
+#: src/docs_inc.c:1179
+msgid "How Lightweight?"
+msgstr ""
+
+#: src/docs_inc.c:1181
+msgid "How about light enough to run on a travel router? Take a look at this"
+msgstr ""
+
+#: src/docs_inc.c:1241
+msgid ""
+"How deep do we want to (need to) get into setting up tuners - that's a "
+"constant source of woe for people?"
+msgstr ""
+
+#: src/docs_inc.c:2223
+msgid "How to Configure Tvheadend as a SAT"
+msgstr ""
+
+#: src/docs_inc.c:1223
+msgid "How to compile/install on _insert your distro here_"
+msgstr ""
+
+#: src/docs_inc.c:1215
+msgid "How to configure a recording"
+msgstr ""
+
+#: src/docs_inc.c:1221
+msgid "How to set up a multi-profile installation (access)"
+msgstr ""
+
+#: src/docs_inc.c:1219
+msgid ""
+"How to set up conditional access (\"Conditional Access System Configuration"
+"\")"
+msgstr ""
+
+#: src/docs_inc.c:1217
+msgid "How to watch Live TV"
+msgstr ""
+
+#: src/docs_inc.c:4820 src/docs_inc.c:4822
+msgid "IDLE"
+msgstr ""
+
+#: src/docs_inc.c:5144
+msgid "IGNORE"
+msgstr ""
+
+#: src/docs_inc.c:909
+msgid "IP Address Block List"
+msgstr ""
+
+#: src/docs_inc.c:2197
+msgid "IP Config tab'"
+msgstr ""
+
+#: src/docs_inc.c:2225
+msgid "IP Server (Basic Guide)"
+msgstr ""
+
+#: src/docs_inc.c:2217
+msgid "IP servers"
+msgstr ""
+
+#: src/docs_inc.c:2711 src/docs_inc.c:4033
+msgid "IPTV"
+msgstr ""
+
+#: src/docs_inc.c:2709
+msgid "IPTV - TV over the Internet via your broadband connection"
+msgstr ""
+
+#: src/docs_inc.c:2713
+msgid "IPTV Automatic Network"
+msgstr ""
+
+#: src/docs_inc.c:4037
+msgid "IPTV PCR"
+msgstr ""
+
+#: src/docs_inc.c:5311 src/docs_inc.c:5389
+msgid "IRC"
+msgstr ""
+
+#: src/docs_inc.c:539 src/docs_inc.c:2677
+msgid "ISDB-C"
+msgstr ""
+
+#: src/docs_inc.c:2691
+msgid "ISDB-S"
+msgstr ""
+
+#: src/docs_inc.c:529 src/docs_inc.c:2701
+msgid "ISDB-T"
+msgstr ""
+
+#: src/docs_inc.c:5064
+msgid "ISO 8601 date format"
+msgstr ""
+
+#: src/docs_inc.c:679 src/docs_inc.c:2408 src/docs_inc.c:3372
+msgid "Icon"
+msgstr ""
+
+#: src/docs_inc.c:3604
+msgid "Icon URL"
+msgstr ""
+
+#: src/docs_inc.c:297
+msgid ""
+"Ideally, this is where you'll see a list of the pre-populated muxes as "
+"created when you set up your initial network. However, should there be any "
+"issues, this is where you can manually add missing muxes. You only really "
+"need to worry about this if the pre-defined list didn't work (e.g. because "
+"of out-of-date data as broadcasters re-arrange their services or because "
+"automatic detection (network discovery) hasn't successfully found all the "
+"muxes over time."
+msgstr ""
+
+#: src/docs_inc.c:1553
+msgid "Idle"
+msgstr ""
+
+#: src/docs_inc.c:1801
+msgid "Idle scanning for automatic detection of muxes and services."
+msgstr ""
+
+#: src/docs_inc.c:3064
+msgid ""
+"If a rule removes a stream, it will not be available to other rules unless "
+"explicitly added back in (by another rule)."
+msgstr ""
+
+#: src/docs_inc.c:265
+msgid ""
+"If anything is obviously wrong at this point, you probably have a driver/"
+"firmware error which you'll need to resolve before going any further."
+msgstr ""
+
+#: src/docs_inc.c:5443
+msgid ""
+"If using IPTV, the playlist you enter must contain valid links to streams "
+"using codecs supported by Tvheadend."
+msgstr ""
+
+#: src/docs_inc.c:1243
+msgid ""
+"If we do all the above, do we need the FAQ pages? Check existing manual/guide"
+msgstr ""
+
+#: src/docs_inc.c:5410
+msgid ""
+"If you cannot see your preferred language in the language list and would "
+"like to help translate Tvheadend see"
+msgstr ""
+
+#: src/docs_inc.c:725
+msgid ""
+"If you click on a single event, a popup will display detailed information "
+"about the event. It also allows you to schedule the event for recording by "
+"clicking on the _[Record program]_ button."
+msgstr ""
+
+#: src/docs_inc.c:5381
+msgid ""
+"If you confirm this dialog, the default administrator account will be "
+"removed. Please then the use credentials you defined thru this wizard."
+msgstr ""
+
+#: src/docs_inc.c:299
+msgid ""
+"If you do need to add something manually, you'll need to search the Internet "
+"for details of the appropriate transmitter and settings: satellites tend not "
+"to change much and are universal over a large area, but terrestrial muxes "
+"are typically very localised and you'll need to know which specific "
+"transmitter you're listening to."
+msgstr ""
+
+#: src/docs_inc.c:3275
+msgid ""
+"If you do not detach channel(s) before mapping additional services the "
+"following changes can occur.."
+msgstr ""
+
+#: src/docs_inc.c:2602
+msgid ""
+"If you do not have a build of Tvheadend with transcoding enabled some of the "
+"above profiles (and their associated Help pages) will not be available."
+msgstr ""
+
+#: src/docs_inc.c:5416
+msgid ""
+"If you don't enter a preferred language, US English will be used as a "
+"default."
+msgstr ""
+
+#: src/docs_inc.c:5370
+msgid ""
+"If you don't see any signal information at all, but the number of muxes or "
+"services is increasing anyway, the driver used by your device isn't "
+"supplying signal information to Tvheadend. In most cases this isn't an "
+"issue.."
+msgstr ""
+
+#: src/docs_inc.c:159
+msgid "If you get really stuck, there's the"
+msgstr ""
+
+#: src/docs_inc.c:4465
+msgid ""
+"If you have _Network Discovery_ enabled, an out-of-date mux list isn't "
+"usually an issue provided that one of the muxes in the list scans "
+"successfully and has a"
+msgstr ""
+
+#: src/docs_inc.c:2094
+msgid ""
+"If you have a lot of services you may want to use filtering to limit the "
+"number of grid entries. You can do this by hovering your mouse over the "
+"_Service name_ column, a down arrow ▾ should now be visible, clicking the "
+"arrow will then display a list of options, move your mouse down to \"Filters"
+"\" and a text box should then appear, click on it and enter the desired "
+"service's name."
+msgstr ""
+
+#: src/docs_inc.c:3670
+msgid "If you have a lot of services you may want to use the"
+msgstr ""
+
+#: src/docs_inc.c:5355
+msgid ""
+"If you plan on accessing Tvheadend over the Internet, make sure you use "
+"strong credentials and ___do not allow anonymous access at all_ __ ."
+msgstr ""
+
+#: src/docs_inc.c:5305 src/docs_inc.c:5383
+msgid "If you require further help, check out"
+msgstr ""
+
+#: src/docs_inc.c:739
+msgid ""
+"If you schedule any kind of recording from this point, you can choose a "
+"specific DVR profile that will apply to the recording or autorec rule. This "
+"will normally show as _(default)_ , but you can define different profiles in "
+"the __Configuration -> Recording ->"
+msgstr ""
+
+#: src/docs_inc.c:2518
+msgid ""
+"If you use more than one grabber, be sure to give a higher priority to the "
+"grabber that provides you with richer data."
+msgstr ""
+
+#: src/docs_inc.c:761
+msgid ""
+"If you want to watch live TV in the web UI, the _[Watch TV]_ button will pop "
+"up a HTML5 video player, where you can select the channel to watch and a "
+"stream profile to use. A transcoding stream profile is required to transcode "
+"the stream to a format that is supported by your browser, as browsers only "
+"support certain formats and codecs."
+msgstr ""
+
+#: src/docs_inc.c:3168
+msgid ""
+"If you wanted to record any programs matching \"BBC News\" on BBC One you "
+"would enter something like this into the add entry dialog:"
+msgstr ""
+
+#: src/docs_inc.c:5330
+msgid ""
+"If you would like Tvheadend to do this for you, check the 'Map all services' "
+"option below, but be aware that this will also map encrypted services you "
+"may not have access to."
+msgstr ""
+
+#: src/docs_inc.c:2967
+msgid ""
+"If you would like to allow anonymous access to your Tvheadend server you may "
+"set-up a wildcard account, you can do this by creating a new user and "
+"entering an asterisk `*` in the username field."
+msgstr ""
+
+#: src/docs_inc.c:353
+msgid "If you would like to use bouquets see"
+msgstr ""
+
+#: src/docs_inc.c:3094
+msgid ""
+"If you'd like to ignore unknown elementary streams, add a rule to the end of "
+"grid with the _ANY_ (not defined) comparison(s) and the action set to "
+"_IGNORE_ ."
+msgstr ""
+
+#: src/docs_inc.c:3269
+msgid ""
+"If you're mapping another service to a channel created by a bouquet you must "
+"first detach the channel to prevent unexpected changes, you can do this by "
+"selecting the desired channels from within the grid and then pressing the "
+"_Detach selected channels from bouquet_ option from the _[Map services]_ "
+"button."
+msgstr ""
+
+#: src/docs_inc.c:229
+msgid ""
+"If you're not seeing any service names at all this may indicate an issue "
+"with your hardware and/or configuration."
+msgstr ""
+
+#: src/docs_inc.c:3512
+msgid ""
+"If you're not sure what to enter here, take a look at the \"If Necessary, "
+"Manually Add Muxes\" section on the"
+msgstr ""
+
+#: src/docs_inc.c:5290
+msgid ""
+"If you're unsure as to which list(s) to select you may want to look online "
+"for details about the various television reception choices available in your "
+"area."
+msgstr ""
+
+#: src/docs_inc.c:5146
+msgid ""
+"Ignore this elementary stream. This stream is not used. Another successfully "
+"compared rule with different action may override it."
+msgstr ""
+
+#: src/docs_inc.c:3092
+msgid "Ignoring Unknown Streams"
+msgstr ""
+
+#: src/docs_inc.c:899 src/docs_inc.c:3869
+msgid "Image Cache"
+msgstr ""
+
+#: src/docs_inc.c:1605
+msgid ""
+"In addition, even USB3 doesn't have the greatest practical bandwidth per "
+"bus. That means you're probably asking for problems if you have four DVB-S2 "
+"dongles on the same USB connection to the motherboard."
+msgstr ""
+
+#: src/docs_inc.c:7
+msgid ""
+"In general, __keep it simple__ , especially if you're contributing to the "
+"pages that get carried over into the web help. The simpler the formatting, "
+"the cleaner the conversion, the less tidying up there is afterwards."
+msgstr ""
+
+#: src/docs_inc.c:5328
+msgid ""
+"In order for your frontend client(s) (such as Kodi, Movian, and similar) to "
+"see/play channels, you must first map discovered services to channels."
+msgstr ""
+
+#: src/docs_inc.c:581
+msgid ""
+"In the EPG top tool bar you can access five input fields. These are used to "
+"filter/search for events. The form uses implicit AND between the input "
+"fields. This means that all filters must match for an event to be displayed."
+msgstr ""
+
+#: src/docs_inc.c:2233
+msgid ""
+"In the _Exported tuners_ section, enter the number of tuners (per delivery "
+"system) that you'd like to export. This setting lets the client know how "
+"many tuners are available for use, while you can enter any number you like "
+"here, exporting more tuners than you have can lead to scanning/tuning "
+"failures, e.g. \"No free tuner\"."
+msgstr ""
+
+#: src/docs_inc.c:3668
+msgid ""
+"In the above example image, we're creating a channel called Channel 4 and "
+"mapping it to the service of the same name. You can name a channel whatever "
+"you like, it doesn't have to match the service it's linking to."
+msgstr ""
+
+#: src/docs_inc.c:4824
+msgid ""
+"In the above table _Tuner A_ is busy so Tvheadend will have to use the next "
+"available idle tuner which in this example is _Tuner B_ and _Tuner C_ but "
+"because _Tuner C_ has the higher priority of the two Tvheadend will use that "
+"instead of _Tuner B_ . If no priority value is set for any tuners Tvheadend "
+"will use the first available idle tuner."
+msgstr ""
+
+#: src/docs_inc.c:5103
+msgid "Include channels even if the linked service is flagged as encrypted."
+msgstr ""
+
+#: src/docs_inc.c:5089
+msgid "Include channels with no channel number."
+msgstr ""
+
+#: src/docs_inc.c:5093
+msgid "Include channels with no name."
+msgstr ""
+
+#: src/docs_inc.c:5099
+msgid "Include radio channels."
+msgstr ""
+
+#: src/docs_inc.c:15
+msgid "Including Documentation/Items"
+msgstr ""
+
+#: src/docs_inc.c:3646
+msgid "Increment the selected channel number(s) by 1."
+msgstr ""
+
+#: src/docs_inc.c:261
+msgid ""
+"Individual tuners are then the next level down (e.g. `DiBcom 7000PC : DVB-T "
+"#0`)"
+msgstr ""
+
+#: src/docs_inc.c:3384
+msgid "Information icon"
+msgstr ""
+
+#: src/docs_inc.c:1795
+msgid "Initial setup can be done by choosing one of the pre-defined"
+msgstr ""
+
+#: src/docs_inc.c:1729
+msgid "Input Sources"
+msgstr ""
+
+#: src/docs_inc.c:433 src/docs_inc.c:869
+msgid "Install Tvheadend"
+msgstr ""
+
+#: src/docs_inc.c:1575
+msgid "Install Your Tuners"
+msgstr ""
+
+#: src/docs_inc.c:867
+msgid "Install hardware"
+msgstr ""
+
+#: src/docs_inc.c:1655
+msgid "Instructions For Built-in Help"
+msgstr ""
+
+#: src/docs_inc.c:441
+msgid "Instructions on how to build from source"
+msgstr ""
+
+#: src/docs_inc.c:313
+msgid "Interactive EU DVB-T map"
+msgstr ""
+
+#: src/docs_inc.c:1593
+msgid "Internal (e.g. PCI) tuners that go inside the computer chassis"
+msgstr ""
+
+#: src/docs_inc.c:939
+msgid "Internal PyEPG"
+msgstr ""
+
+#: src/docs_inc.c:941
+msgid "Internal XMLTV"
+msgstr ""
+
+#: src/docs_inc.c:1831
+msgid "Internationalisation"
+msgstr ""
+
+#: src/docs_inc.c:197
+msgid ""
+"Internet and LAN feeds, such as IPTV, SAT>IP, HDHomeRun and a general-"
+"purpose MPEG-TS `pipe://`"
+msgstr ""
+
+#: src/docs_inc.c:855
+msgid "Introduction"
+msgstr ""
+
+#: src/docs_inc.c:5240
+msgid ""
+"It is recommended that you only enable this option if you're absolutely sure "
+"the flags are sent correctly and on time. Incorrect EITp/f flags can result "
+"in failed/broken recordings. You can set this option per"
+msgstr ""
+
+#: src/docs_inc.c:189
+msgid "It supports input from:"
+msgstr ""
+
+#: src/docs_inc.c:1161
+msgid ""
+"It's perfectly possible to install and run Tvheadend as a single-seat "
+"installation, with the software running on the same system as any client "
+"software (e.g. Kodi), with all files stored locally."
+msgstr ""
+
+#: src/docs_inc.c:127
+msgid "Items"
+msgstr ""
+
+#: src/docs_inc.c:4228
+msgid "Keep"
+msgstr ""
+
+#: src/docs_inc.c:4226
+msgid "Keep the mux if it doesn't already exist."
+msgstr ""
+
+#: src/docs_inc.c:305
+msgid "KingofSat"
+msgstr ""
+
+#: src/docs_inc.c:165
+msgid "Kiwi IRC"
+msgstr ""
+
+#: src/docs_inc.c:1737
+msgid "LAN/IPTV signals such as IPTV, SAT>IP, HDHomeRun"
+msgstr ""
+
+#: src/docs_inc.c:4700 src/docs_inc.c:4702
+msgid "Language"
+msgstr ""
+
+#: src/docs_inc.c:663
+msgid "Launches Live TV via HTML5 video (see below)."
+msgstr ""
+
+#: src/docs_inc.c:1631
+msgid "LibreELEC"
+msgstr ""
+
+#: src/docs_inc.c:1259
+msgid "Licensing"
+msgstr ""
+
+#: src/docs_inc.c:4492
+msgid "Limit access to DVR functionality only."
+msgstr ""
+
+#: src/docs_inc.c:4488
+msgid "Limit access to streaming only (no DVR functionality)."
+msgstr ""
+
+#: src/docs_inc.c:4696
+msgid "Limit connections"
+msgstr ""
+
+#: src/docs_inc.c:4041
+msgid "LinuxDVB Input"
+msgstr ""
+
+#: src/docs_inc.c:1613
+msgid "LinuxTV wiki device library"
+msgstr ""
+
+#: src/docs_inc.c:2394
+msgid "List of types"
+msgstr ""
+
+#: src/docs_inc.c:37
+msgid "Lists"
+msgstr ""
+
+#: src/docs_inc.c:1747
+msgid "Local or remote disk, via the built-in digital video recorder."
+msgstr ""
+
+#: src/docs_inc.c:3785
+msgid "Locking"
+msgstr ""
+
+#: src/docs_inc.c:637
+msgid "Longer programs, e.g. films"
+msgstr ""
+
+#: src/docs_inc.c:317
+msgid "Lyngsat"
+msgstr ""
+
+#: src/docs_inc.c:1319
+msgid "M3U"
+msgstr ""
+
+#: src/docs_inc.c:1327
+msgid "M3U using SAT>IP extensions"
+msgstr ""
+
+#: src/docs_inc.c:961 src/docs_inc.c:2598
+msgid "MP4/libav Profile"
+msgstr ""
+
+#: src/docs_inc.c:769
+msgid "MPEG-PS"
+msgstr ""
+
+#: src/docs_inc.c:767 src/docs_inc.c:4017
+msgid "MPEG-TS"
+msgstr ""
+
+#: src/docs_inc.c:4097
+msgid "MPEG-TS File"
+msgstr ""
+
+#: src/docs_inc.c:3909
+msgid "MPEG-TS Parser"
+msgstr ""
+
+#: src/docs_inc.c:953 src/docs_inc.c:2588
+msgid "MPEG-TS Pass-thru Profile"
+msgstr ""
+
+#: src/docs_inc.c:957 src/docs_inc.c:2594
+msgid "MPEG-TS/libav Profile"
+msgstr ""
+
+#: src/docs_inc.c:821
+msgid "MPEG2 Audio"
+msgstr ""
+
+#: src/docs_inc.c:797
+msgid "MPEG2 Video"
+msgstr ""
+
+#: src/docs_inc.c:3749
+msgid "Main"
+msgstr ""
+
+#: src/docs_inc.c:2004 src/docs_inc.c:2008
+msgid "Maintenance"
+msgstr ""
+
+#: src/docs_inc.c:2024
+msgid "Maintenance Button"
+msgstr ""
+
+#: src/docs_inc.c:3400
+msgid "Manual Recording Entry Example"
+msgstr ""
+
+#: src/docs_inc.c:1625
+msgid ""
+"Many Linux distros include a package for the most common devices (e.g. "
+"_linux-firmwares_ under Ubuntu or _firmware-linux-nonfree_ under Debian). If "
+"this isn't sufficient, a good source of firmware files are the"
+msgstr ""
+
+#: src/docs_inc.c:5336
+msgid ""
+"Many providers include undesirable services - Teleshopping, Adult "
+"Entertainment, etc; using the 'Map all services' will include these."
+msgstr ""
+
+#: src/docs_inc.c:351
+msgid ""
+"Many service providers use bouquets for channel management and just like a "
+"standard set-top box Tvheadend can use these to automatically manage and "
+"keep your channels up-to-date."
+msgstr ""
+
+#: src/docs_inc.c:5431
+msgid "Many tuners are able to receive different signal types.."
+msgstr ""
+
+#: src/docs_inc.c:1623
+msgid ""
+"Many tuners then also require __firmware__ - normally, a binary file that's "
+"been extracted from the proprietary drivers used by Windows."
+msgstr ""
+
+#: src/docs_inc.c:3622
+msgid "Map"
+msgstr ""
+
+#: src/docs_inc.c:1996 src/docs_inc.c:2000 src/docs_inc.c:3570
+#: src/docs_inc.c:3608
+msgid "Map Services"
+msgstr ""
+
+#: src/docs_inc.c:2012
+msgid "Map Services Button"
+msgstr ""
+
+#: src/docs_inc.c:3630
+msgid "Map all available"
+msgstr ""
+
+#: src/docs_inc.c:2022
+msgid "Map all available services as channels."
+msgstr ""
+
+#: src/docs_inc.c:5326
+msgid "Map all discovered services to channels."
+msgstr ""
+
+#: src/docs_inc.c:2020 src/docs_inc.c:3628
+msgid "Map all services"
+msgstr ""
+
+#: src/docs_inc.c:5101
+msgid "Map encrypted services"
+msgstr ""
+
+#: src/docs_inc.c:5095
+msgid "Map radio channels"
+msgstr ""
+
+#: src/docs_inc.c:2016
+msgid "Map selected services"
+msgstr ""
+
+#: src/docs_inc.c:3620 src/docs_inc.c:3672
+msgid "Map services"
+msgstr ""
+
+#: src/docs_inc.c:111 src/docs_inc.c:2058 src/docs_inc.c:2076
+msgid "Map services to channels"
+msgstr ""
+
+#: src/docs_inc.c:2018
+msgid "Map the highlighted services within the grid."
+msgstr ""
+
+#: src/docs_inc.c:3572
+msgid "Map the services."
+msgstr ""
+
+#: src/docs_inc.c:5091
+msgid "Map unnamed channels"
+msgstr ""
+
+#: src/docs_inc.c:5087
+msgid "Map zero-numbered channels"
+msgstr ""
+
+#: src/docs_inc.c:2048
+msgid "Mapping All"
+msgstr ""
+
+#: src/docs_inc.c:3616
+msgid "Mapping Button"
+msgstr ""
+
+#: src/docs_inc.c:2066
+msgid "Mapping Selected"
+msgstr ""
+
+#: src/docs_inc.c:2040
+msgid "Mapping Services to Channels"
+msgstr ""
+
+#: src/docs_inc.c:2088
+msgid "Mapping/Removing a Service to/from an Existing Channel"
+msgstr ""
+
+#: src/docs_inc.c:11
+msgid "Markdown basics:"
+msgstr ""
+
+#: src/docs_inc.c:3
+msgid "Markdown/Formatting Crib Sheet"
+msgstr ""
+
+#: src/docs_inc.c:493
+msgid "Master"
+msgstr ""
+
+#: src/docs_inc.c:495
+msgid "Master (ISDB-S)"
+msgstr ""
+
+#: src/docs_inc.c:3183
+msgid "Matches \"BBC News\" exactly."
+msgstr ""
+
+#: src/docs_inc.c:3186
+msgid "Matches \"Regular Show\" and (if it exists) \"New: Regular Show\"."
+msgstr ""
+
+#: src/docs_inc.c:3188
+msgid "Matching events will be added to the _"
+msgstr ""
+
+#: src/docs_inc.c:771
+msgid "Matroska"
+msgstr ""
+
+#: src/docs_inc.c:955 src/docs_inc.c:2590
+msgid "Matroska Profile"
+msgstr ""
+
+#: src/docs_inc.c:3937
+msgid "Matroska muxer"
+msgstr ""
+
+#: src/docs_inc.c:959 src/docs_inc.c:2596
+msgid "Matroska/libav Profile"
+msgstr ""
+
+#: src/docs_inc.c:4664
+msgid "Maximal channel number"
+msgstr ""
+
+#: src/docs_inc.c:633
+msgid "Medium-length programs, e.g. documentaries"
+msgstr ""
+
+#: src/docs_inc.c:115 src/docs_inc.c:575 src/docs_inc.c:1057
+#: src/docs_inc.c:1505 src/docs_inc.c:1681 src/docs_inc.c:1924
+#: src/docs_inc.c:2139 src/docs_inc.c:2199 src/docs_inc.c:2317
+#: src/docs_inc.c:2346 src/docs_inc.c:2455 src/docs_inc.c:2496
+#: src/docs_inc.c:2537 src/docs_inc.c:2604 src/docs_inc.c:2982
+#: src/docs_inc.c:3306 src/docs_inc.c:3713 src/docs_inc.c:4110
+msgid "Menu Bar/Buttons"
+msgstr ""
+
+#: src/docs_inc.c:5105
+msgid "Merge same name"
+msgstr ""
+
+#: src/docs_inc.c:4660
+msgid "Minimal channel number"
+msgstr ""
+
+#: src/docs_inc.c:4538
+msgid "Missing In PAT/SDT"
+msgstr ""
+
+#: src/docs_inc.c:2032
+msgid "Missing in PAT/SDT"
+msgstr ""
+
+#: src/docs_inc.c:39
+msgid "Mixed lists don't work without further python extensions. Be careful."
+msgstr ""
+
+#: src/docs_inc.c:1819
+msgid "Mobile/Remote Client Support"
+msgstr ""
+
+#: src/docs_inc.c:3757
+msgid "Monitonic timer"
+msgstr ""
+
+#: src/docs_inc.c:609
+msgid ""
+"Most DVB networks classify their events into content groups. This field "
+"allows you to filter based on content type (e.g. “Sports” or “Game Show”). "
+"Supported tags are determined by your broadcaster. Again, simply start "
+"typing to filter the entries if you have a long list to choose from."
+msgstr ""
+
+#: src/docs_inc.c:1127
+msgid ""
+"Most configuration items - certainly the ones that are common to all types "
+"of item covered by that tab - are in this grid. However, some item-specific "
+"configuration items are then only available through the _Add_ and _Edit_ "
+"dialog boxes. For example, the main network configuration tab grid covers "
+"parameters common to DVB-S, -T, -C and IPTV networks, but specific things "
+"such as FEC rolloff or mux URL are then only in the dialogs for networks "
+"that need these values."
+msgstr ""
+
+#: src/docs_inc.c:1149
+msgid ""
+"Most rows are multi-selectable, so you can carry out certain actions on more "
+"than one entry at the same time. So, for example, you can select multiple "
+"items by using ctrl+click on each entry or click, shift+click to select a "
+"range."
+msgstr ""
+
+#: src/docs_inc.c:2378 src/docs_inc.c:2923 src/docs_inc.c:3056
+msgid "Move Down"
+msgstr ""
+
+#: src/docs_inc.c:2374 src/docs_inc.c:2919 src/docs_inc.c:3052
+msgid "Move Up"
+msgstr ""
+
+#: src/docs_inc.c:2380
+msgid "Move the selected CA client configuration down in the list."
+msgstr ""
+
+#: src/docs_inc.c:2376
+msgid "Move the selected CA client configuration up in the list."
+msgstr ""
+
+#: src/docs_inc.c:2925 src/docs_inc.c:3058
+msgid "Move the selected entry down the grid."
+msgstr ""
+
+#: src/docs_inc.c:2921 src/docs_inc.c:3054
+msgid "Move the selected entry up the grid."
+msgstr ""
+
+#: src/docs_inc.c:3352 src/docs_inc.c:3360
+msgid "Move the selected recording entries to the"
+msgstr ""
+
+#: src/docs_inc.c:3350
+msgid "Move to failed"
+msgstr ""
+
+#: src/docs_inc.c:3358
+msgid "Move to finished"
+msgstr ""
+
+#: src/docs_inc.c:1815
+msgid "Movian and Kodi are the main targets."
+msgstr ""
+
+#: src/docs_inc.c:5054
+msgid "Movie : Science fiction"
+msgstr ""
+
+#: src/docs_inc.c:785 src/docs_inc.c:811 src/docs_inc.c:839
+msgid "Mozilla Firefox"
+msgstr ""
+
+#: src/docs_inc.c:1805
+msgid "Multi-User Support"
+msgstr ""
+
+#: src/docs_inc.c:1771
+msgid ""
+"Multiple DVR profiles that support different target directories, post-"
+"processing options, filtering options, etc."
+msgstr ""
+
+#: src/docs_inc.c:1763
+msgid "Multiple simultaneous recordings are supported."
+msgstr ""
+
+#: src/docs_inc.c:4021
+msgid "Mux Scheduler"
+msgstr ""
+
+#: src/docs_inc.c:921
+msgid "Mux Schedulers"
+msgstr ""
+
+#: src/docs_inc.c:4141
+msgid ""
+"Mux Schedulers enable Tvheadend to automatically play channels. This is "
+"useful to get EPG, services or access rights updates."
+msgstr ""
+
+#: src/docs_inc.c:1411
+msgid "Mux specified by mux UUID"
+msgstr ""
+
+#: src/docs_inc.c:3929
+msgid "Muxer"
+msgstr ""
+
+#: src/docs_inc.c:917
+msgid "Muxes"
+msgstr ""
+
+#: src/docs_inc.c:3483
+msgid ""
+"Muxes are locations at which services can be found. On traditional networks "
+"(DVB-C, -T and -S), these are carrier signals on which the individual "
+"channels are multiplexed, hence the name. However, Tvheadend also uses the "
+"term ‘mux’ to describe a source for multiple IP streams - so an IP address, "
+"in effect."
+msgstr ""
+
+#: src/docs_inc.c:411
+msgid ""
+"Muxes then carry __services__ . These are the individual streams of data. "
+"They can be TV or radio programmes, they can provide data services such as "
+"digital teletext, or they can be used as part of the control code for catch-"
+"up IPTV services."
+msgstr ""
+
+#: src/docs_inc.c:5120
+msgid "NONE"
+msgstr ""
+
+#: src/docs_inc.c:3733
+msgid "Name"
+msgstr ""
+
+#: src/docs_inc.c:4467
+msgid "Network Information Table (NIT)"
+msgstr ""
+
+#: src/docs_inc.c:2669
+msgid "Network Types"
+msgstr ""
+
+#: src/docs_inc.c:281
+msgid ""
+"Network discovery (enabled by default) increases the likelihood of receiving "
+"all available muxes and services."
+msgstr ""
+
+#: src/docs_inc.c:915
+msgid "Networks"
+msgstr ""
+
+#: src/docs_inc.c:5292
+msgid "Networks already configured will not be shown below."
+msgstr ""
+
+#: src/docs_inc.c:409
+msgid ""
+"Networks then have __muxes__ . These are the carrier frequencies that exist "
+"on the old analogue channels that are used to transmit multiple digital "
+"signals rather than a single analogue one. These signals are multiplexed "
+"together, hence the name _mux_ ."
+msgstr ""
+
+#: src/docs_inc.c:4209
+msgid "New muxes + changed muxes"
+msgstr ""
+
+#: src/docs_inc.c:4205
+msgid "New muxes only"
+msgstr ""
+
+#: src/docs_inc.c:3520
+msgid "Newly added muxes are automatically set to the _PEND_ state."
+msgstr ""
+
+#: src/docs_inc.c:4385 src/docs_inc.c:4763 src/docs_inc.c:5185
+msgid "News"
+msgstr ""
+
+#: src/docs_inc.c:4397 src/docs_inc.c:4775 src/docs_inc.c:5197
+msgid "News and stories…"
+msgstr ""
+
+#: src/docs_inc.c:4369 src/docs_inc.c:4747 src/docs_inc.c:5169
+msgid "News.mkv"
+msgstr ""
+
+#: src/docs_inc.c:4854
+msgid "No"
+msgstr ""
+
+#: src/docs_inc.c:5122
+msgid "No action, may be used for the logging and a comparison verification."
+msgstr ""
+
+#: src/docs_inc.c:5009
+msgid "No free tuners - usually in-use by other subscription(s)."
+msgstr ""
+
+#: src/docs_inc.c:4600
+msgid "No scheme"
+msgstr ""
+
+#: src/docs_inc.c:5011
+msgid "No tuners are enabled and/or have no network assigned."
+msgstr ""
+
+#: src/docs_inc.c:3793
+msgid "Node subsystem"
+msgstr ""
+
+#: src/docs_inc.c:1131
+msgid ""
+"Not all columns are necessarily visible. If you hover your mouse over a "
+"column heading, you'll see a down arrow - click here, and a drop-down menu "
+"will appear to give you access to __which columns are shown and which are "
+"not__ ."
+msgstr ""
+
+#: src/docs_inc.c:5418
+msgid ""
+"Not selecting the correct EPG language can result in garbled EPG text; if "
+"this happens, don't panic, as you can easily change it later."
+msgstr ""
+
+#: src/docs_inc.c:5254
+msgid "Not set"
+msgstr ""
+
+#: src/docs_inc.c:3686
+msgid ""
+"Note that editing a channel created by a bouquet can have unexpected "
+"results, please see _Detaching Channels_ on the"
+msgstr ""
+
+#: src/docs_inc.c:2245
+msgid ""
+"Note that if you use a similar number for multiple networks, the first "
+"matched network containing the mux with the requested parameters will win "
+"(also applies to unknown muxes)."
+msgstr ""
+
+#: src/docs_inc.c:3709
+msgid ""
+"Note that settings are not saved to a storage. Any change is available only "
+"while Tvheadend is running, and will be lost on a restart. To change the "
+"default behaviour permanently, use command line options such as `-l,` `–"
+"debug`, `–trace`."
+msgstr ""
+
+#: src/docs_inc.c:3263
+msgid "Note that the URL must begin with `file://` or `http(s)://`."
+msgstr ""
+
+#: src/docs_inc.c:3398
+msgid ""
+"Note that the _[Add]_ functionality is only available in the _Upcoming/"
+"Current Recordings_ tab."
+msgstr ""
+
+#: src/docs_inc.c:1970
+msgid ""
+"Note that the links don't link to the actual stream but to a playlist for "
+"use with media players such as VLC, If you'd prefer to receive the raw "
+"stream instead, you can do so by removing the `/play/` path from the URL - "
+"see"
+msgstr ""
+
+#: src/docs_inc.c:2850
+msgid "Note that when you create a rule/entry it will also generate a"
+msgstr ""
+
+#: src/docs_inc.c:645
+msgid ""
+"Note that you don’t have to press a ‘Search’ button: the grid immediately "
+"updates itself as you change the filters."
+msgstr ""
+
+#: src/docs_inc.c:235
+msgid ""
+"Note: The above path only applies to Debian/Ubuntu systems others may differ."
+msgstr ""
+
+#: src/docs_inc.c:3508
+msgid ""
+"Note: You only really need to add muxes if the pre-defined list didn't work, "
+"e.g. because of out-of-date data as broadcasters re-arrange their services "
+"or because automatic detection (network discovery) hasn't successfully found "
+"all the muxes over time."
+msgstr ""
+
+#: src/docs_inc.c:2514
+msgid "Notes"
+msgstr ""
+
+#: src/docs_inc.c:5427
+msgid ""
+"Now let's get your tuners configured. Go ahead and select a network for each "
+"of the tuners you would like to use. if you do not assign a network to a "
+"tuner it will __not__ be used."
+msgstr ""
+
+#: src/docs_inc.c:3648
+msgid "Number Down"
+msgstr ""
+
+#: src/docs_inc.c:3612
+msgid "Number Operations"
+msgstr ""
+
+#: src/docs_inc.c:3644
+msgid "Number Up"
+msgstr ""
+
+#: src/docs_inc.c:4415 src/docs_inc.c:5219
+msgid "Number of data errors during recording"
+msgstr ""
+
+#: src/docs_inc.c:4411 src/docs_inc.c:5215
+msgid "Number of errors during recording"
+msgstr ""
+
+#: src/docs_inc.c:3636
+msgid "Numbering Button"
+msgstr ""
+
+#: src/docs_inc.c:5128
+msgid "ONE"
+msgstr ""
+
+#: src/docs_inc.c:937
+msgid "OTA Module"
+msgstr ""
+
+#: src/docs_inc.c:1205
+msgid ""
+"Obviously, fill in the minor gaps as highlighted in the document: buttons, "
+"descriptions, etc."
+msgstr ""
+
+#: src/docs_inc.c:63
+msgid "Oh, and"
+msgstr ""
+
+#: src/docs_inc.c:259
+msgid ""
+"On this tab, you'll see a tree structure, with the Linux device list at the "
+"top level (e.g. `/dev/dvb/adapter0`)"
+msgstr ""
+
+#: src/docs_inc.c:339
+msgid ""
+"Once scanning for services is complete, you need to map the services to "
+"channels so your client can actually request them (i.e. so you can watch or "
+"record)."
+msgstr ""
+
+#: src/docs_inc.c:2754
+msgid ""
+"Once you're happy with what you've entered into the dialog you can save the "
+"network using the _[Save]_ button (closing the dialog), save your pending "
+"changes and continue making further adjustments by pressing the _[Apply]_ "
+"button, or cancel any unsaved changes (and close the dialog) by pressing the "
+"_[Cancel]_ button."
+msgstr ""
+
+#: src/docs_inc.c:2758
+msgid ""
+"Once you've created a network (and added muxes) you must assign it to an "
+"__enabled__ adapter."
+msgstr ""
+
+#: src/docs_inc.c:2961
+msgid ""
+"Once you've created this file you must restart Tvheadend for it to take "
+"affect. Note that for security the superuser account is not listed in the "
+"access entries grid."
+msgstr ""
+
+#: src/docs_inc.c:2642
+msgid ""
+"Once you've selected a type you can then enter/select the desired options "
+"from the resultant _Add_ dialog."
+msgstr ""
+
+#: src/docs_inc.c:1371
+msgid "One DVR record specified by short DVR ID"
+msgstr ""
+
+#: src/docs_inc.c:1351 src/docs_inc.c:1459
+msgid "One channel specified by channel name"
+msgstr ""
+
+#: src/docs_inc.c:1347 src/docs_inc.c:1455
+msgid "One channel specified by channel number"
+msgstr ""
+
+#: src/docs_inc.c:1355 src/docs_inc.c:1463
+msgid "One channel specified by short channel ID"
+msgstr ""
+
+#: src/docs_inc.c:4925
+msgid ""
+"Only OTA EIT and PSIP (ATSC) grabbers are enabled by default. Also note that "
+"__EPG data isn't merged__ , so be sure to give the highest priority to the "
+"grabber that provides you with the best data available."
+msgstr ""
+
+#: src/docs_inc.c:2516
+msgid ""
+"Only OTA EIT and PSIP (ATSC) grabbers are enabled by default. If you're "
+"missing EPG data, make sure to enable the correct grabber(s) for your "
+"location/provider."
+msgstr ""
+
+#: src/docs_inc.c:601
+msgid ""
+"Only display events from channels which are included in the selected tag."
+msgstr ""
+
+#: src/docs_inc.c:595
+msgid "Only display events from the selected channel."
+msgstr ""
+
+#: src/docs_inc.c:613
+msgid ""
+"Only display events that fall between the given minimum and maximum "
+"durations."
+msgstr ""
+
+#: src/docs_inc.c:607
+msgid "Only display events that match the given content type tag."
+msgstr ""
+
+#: src/docs_inc.c:589
+msgid "Only display events that match the given title."
+msgstr ""
+
+#: src/docs_inc.c:1627
+msgid "OpenElec"
+msgstr ""
+
+#: src/docs_inc.c:4073
+msgid "OpenTV EPG"
+msgstr ""
+
+#: src/docs_inc.c:1293 src/docs_inc.c:1373 src/docs_inc.c:1413
+#: src/docs_inc.c:4197 src/docs_inc.c:4220 src/docs_inc.c:4295
+#: src/docs_inc.c:4478 src/docs_inc.c:4526 src/docs_inc.c:4549
+#: src/docs_inc.c:4632 src/docs_inc.c:4842 src/docs_inc.c:4869
+#: src/docs_inc.c:4898 src/docs_inc.c:4949 src/docs_inc.c:5083
+msgid "Option"
+msgstr ""
+
+#: src/docs_inc.c:59
+msgid "Or minuses"
+msgstr ""
+
+#: src/docs_inc.c:61
+msgid "Or pluses"
+msgstr ""
+
+#: src/docs_inc.c:51
+msgid "Ordered sub-list"
+msgstr ""
+
+#: src/docs_inc.c:975
+msgid "Other Stream Filters"
+msgstr ""
+
+#: src/docs_inc.c:1745
+msgid "Output Targets"
+msgstr ""
+
+#: src/docs_inc.c:1427
+msgid ""
+"Override queue size in bytes (default value is 1500000 for channel/service, "
+"10000000 for mux)"
+msgstr ""
+
+#: src/docs_inc.c:1379
+msgid ""
+"Override streaming profile, otherwise the default profile for the user is "
+"used."
+msgstr ""
+
+#: src/docs_inc.c:1423
+msgid "Override subscription weight"
+msgstr ""
+
+#: src/docs_inc.c:857
+msgid "Overview"
+msgstr ""
+
+#: src/docs_inc.c:179
+msgid "Overview of Tvheadend"
+msgstr ""
+
+#: src/docs_inc.c:4375 src/docs_inc.c:4753 src/docs_inc.c:5175
+msgid "Owner of this recording"
+msgstr ""
+
+#: src/docs_inc.c:1093
+msgid "Packet Error Ratio"
+msgstr ""
+
+#: src/docs_inc.c:1121
+msgid "Page Structure"
+msgstr ""
+
+#: src/docs_inc.c:25
+msgid "Paragraphs Versus Definition Lists"
+msgstr ""
+
+#: src/docs_inc.c:3933
+msgid "Pass-thru muxer"
+msgstr ""
+
+#: src/docs_inc.c:3897
+msgid "Passthrough Muxer SI Tables"
+msgstr ""
+
+#: src/docs_inc.c:907 src/docs_inc.c:2939
+msgid "Passwords"
+msgstr ""
+
+#: src/docs_inc.c:5250
+msgid "Per Channel Option"
+msgstr ""
+
+#: src/docs_inc.c:1159
+msgid "Physical Architecture"
+msgstr ""
+
+#: src/docs_inc.c:4436
+msgid "Placeholder"
+msgstr ""
+
+#: src/docs_inc.c:1229
+msgid "Platform differences - Ubuntu, Fedora, Red Hat, Arch, Android..."
+msgstr ""
+
+#: src/docs_inc.c:1227
+msgid ""
+"Platform differences - what you need to transcode, or what you can expect "
+"from Android vs GNU/Linux"
+msgstr ""
+
+#: src/docs_inc.c:1962
+msgid "Playing a Stream/File"
+msgstr ""
+
+#: src/docs_inc.c:1331 src/docs_inc.c:1447
+msgid "Playlist contents"
+msgstr ""
+
+#: src/docs_inc.c:1315
+msgid "Playlist type"
+msgstr ""
+
+#: src/docs_inc.c:1299
+msgid "Playlist type, can be"
+msgstr ""
+
+#: src/docs_inc.c:1285
+msgid "Please, add `http://IP:Port` to complete the URL."
+msgstr ""
+
+#: src/docs_inc.c:3769
+msgid "Poll multiplexer"
+msgstr ""
+
+#: src/docs_inc.c:1743
+msgid ""
+"Powerful many-to-many channel:service:tuner mapping that allows you to "
+"select channels irrespective of the underlying carrier (for channels that "
+"broadcast on multiple sources)."
+msgstr ""
+
+#: src/docs_inc.c:2050
+msgid "Press the _[Map services]_ button and then _[Map all services]_ ."
+msgstr ""
+
+#: src/docs_inc.c:3506
+msgid ""
+"Pressing the _[Save]_ button (at the bottom of the dialog) will commit your "
+"changes and close the dialog, pressing the _[Apply]_ button will commit your "
+"changes but won't close the dialog, pressing the _[Cancel]_ button closes "
+"the dialog - any unsaved changes will be lost."
+msgstr ""
+
+#: src/docs_inc.c:4856
+msgid ""
+"Prevent the user from changing their view level and hide the view level drop-"
+"dowm from the interface."
+msgstr ""
+
+#: src/docs_inc.c:4808
+msgid "Priority"
+msgstr ""
+
+#: src/docs_inc.c:5199
+msgid "Program content type"
+msgstr ""
+
+#: src/docs_inc.c:4395 src/docs_inc.c:4773 src/docs_inc.c:5195
+msgid "Program description"
+msgstr ""
+
+#: src/docs_inc.c:4391 src/docs_inc.c:4769 src/docs_inc.c:5191
+msgid "Program episode"
+msgstr ""
+
+#: src/docs_inc.c:4387 src/docs_inc.c:4765 src/docs_inc.c:5187
+msgid "Program subtitle"
+msgstr ""
+
+#: src/docs_inc.c:4383 src/docs_inc.c:4761 src/docs_inc.c:5183
+msgid "Program title"
+msgstr ""
+
+#: src/docs_inc.c:1271
+msgid "Project website"
+msgstr ""
+
+#: src/docs_inc.c:149
+msgid "Purpose"
+msgstr ""
+
+#: src/docs_inc.c:4077
+msgid "PyEPG Import"
+msgstr ""
+
+#: src/docs_inc.c:217
+msgid "Q: How do I get a playlist for all my channels?"
+msgstr ""
+
+#: src/docs_inc.c:231
+msgid "Q: I get a blank page when trying to view the web interface!"
+msgstr ""
+
+#: src/docs_inc.c:225
+msgid ""
+"Q: Tvheadend has scanned for services but some rows in the Service Name "
+"column are blank, is that normal?"
+msgstr ""
+
+#: src/docs_inc.c:221
+msgid "Q: Why am I getting a playlist when trying to view/stream a channel?"
+msgstr ""
+
+#: src/docs_inc.c:237
+msgid "Q: Why can't I see my tuners in Tvheadend's interface?"
+msgstr ""
+
+#: src/docs_inc.c:3805
+msgid "RTSP Protocol"
+msgstr ""
+
+#: src/docs_inc.c:4130
+msgid "Re-fetch images"
+msgstr ""
+
+#: src/docs_inc.c:3346
+msgid "Re-record"
+msgstr ""
+
+#: src/docs_inc.c:3448
+msgid "Re-recording an Entry/Re-schedule a Recording"
+msgstr ""
+
+#: src/docs_inc.c:4132
+msgid "Re-refresh image cache (reload images from upstream providers)."
+msgstr ""
+
+#: src/docs_inc.c:2557
+msgid "Re-run Internal EPG Grabbers"
+msgstr ""
+
+#: src/docs_inc.c:2559
+msgid "Re-run all enabled"
+msgstr ""
+
+#: src/docs_inc.c:3348
+msgid "Re-schedule the selected entry/recording if possible."
+msgstr ""
+
+#: src/docs_inc.c:4567
+msgid "Record a matching event only if the description is different."
+msgstr ""
+
+#: src/docs_inc.c:4559
+msgid "Record a matching event only if the episode number is different."
+msgstr ""
+
+#: src/docs_inc.c:4563
+msgid "Record a matching event only if the subtitle is different."
+msgstr ""
+
+#: src/docs_inc.c:4553
+msgid "Record all"
+msgstr ""
+
+#: src/docs_inc.c:4555
+msgid "Record all matching events."
+msgstr ""
+
+#: src/docs_inc.c:3416
+msgid ""
+"Record all upcoming series episodes by pressing the _[Record series]_ "
+"button. __This replaces the _[Autorec]_ button when series link information "
+"is available.__"
+msgstr ""
+
+#: src/docs_inc.c:3430
+msgid "Record events that broadcast between certain times or days of the week."
+msgstr ""
+
+#: src/docs_inc.c:3428
+msgid ""
+"Record events using regular expressions, they can be as simple or as "
+"powerful as you like."
+msgstr ""
+
+#: src/docs_inc.c:4565
+msgid "Record if different description"
+msgstr ""
+
+#: src/docs_inc.c:4557
+msgid "Record if different episode number"
+msgstr ""
+
+#: src/docs_inc.c:4561
+msgid "Record if different subtitle"
+msgstr ""
+
+#: src/docs_inc.c:4577
+msgid "Record once per day"
+msgstr ""
+
+#: src/docs_inc.c:4569
+msgid "Record once per month"
+msgstr ""
+
+#: src/docs_inc.c:4573
+msgid "Record once per week"
+msgstr ""
+
+#: src/docs_inc.c:3412
+msgid "Record the event once by pressing the _[Record program]_ button."
+msgstr ""
+
+#: src/docs_inc.c:4579
+msgid "Record the first matching event once a day."
+msgstr ""
+
+#: src/docs_inc.c:4575
+msgid "Record the first matching event once a week."
+msgstr ""
+
+#: src/docs_inc.c:4571
+msgid "Record the first matching event once per month."
+msgstr ""
+
+#: src/docs_inc.c:977
+msgid "Recording"
+msgstr ""
+
+#: src/docs_inc.c:687 src/docs_inc.c:3380
+msgid "Recording icon"
+msgstr ""
+
+#: src/docs_inc.c:9
+msgid "References"
+msgstr ""
+
+#: src/docs_inc.c:3178
+msgid "Regex"
+msgstr ""
+
+#: src/docs_inc.c:3176
+msgid "Regular expressions examples:"
+msgstr ""
+
+#: src/docs_inc.c:4232
+msgid "Reject"
+msgstr ""
+
+#: src/docs_inc.c:4236
+msgid "Reject exact match"
+msgstr ""
+
+#: src/docs_inc.c:425
+msgid "Relationship Between Tuners, Neworks, Muxes, Services and Channels"
+msgstr ""
+
+#: src/docs_inc.c:2436 src/docs_inc.c:2654
+msgid ""
+"Remember to _[Save]_ your changes before selecting another config from "
+"within the grid."
+msgstr ""
+
+#: src/docs_inc.c:3024
+msgid ""
+"Remember to _[Save]_ your changes before selecting another profile from "
+"within the grid."
+msgstr ""
+
+#: src/docs_inc.c:2937
+msgid "Remember to also add a password entry in the _"
+msgstr ""
+
+#: src/docs_inc.c:2038
+msgid "Remove all services not seen for 7+ days."
+msgstr ""
+
+#: src/docs_inc.c:2036
+msgid "Remove all unseen services"
+msgstr ""
+
+#: src/docs_inc.c:2030
+msgid "Remove services marked as"
+msgstr ""
+
+#: src/docs_inc.c:2028
+msgid "Remove unseen services (PAT/SDT) (7 days+)"
+msgstr ""
+
+#: src/docs_inc.c:887
+msgid "Removed Recordings"
+msgstr ""
+
+#: src/docs_inc.c:2592
+msgid "Requires Tvheadend to be built with transcoding/ffmpeg enabled."
+msgstr ""
+
+#: src/docs_inc.c:1811
+msgid "Requires a card server (newcamd and capmt protocol is supported)."
+msgstr ""
+
+#: src/docs_inc.c:3253
+msgid "Rescan the selected mux for changes to the bouquet."
+msgstr ""
+
+#: src/docs_inc.c:657
+msgid "Reset All"
+msgstr ""
+
+#: src/docs_inc.c:3596
+msgid "Reset Icon"
+msgstr ""
+
+#: src/docs_inc.c:3598
+msgid "Reset the selected channel(s)"
+msgstr ""
+
+#: src/docs_inc.c:1779
+msgid "Results can be scheduled for recording with a single click."
+msgstr ""
+
+#: src/docs_inc.c:1443
+msgid ""
+"Return the XMLTV EPG export. By default (if the rest of path is ommitted), "
+"an redirection answer will be sent where /channels remainder is used."
+msgstr ""
+
+#: src/docs_inc.c:1311
+msgid ""
+"Return the m3u playlist in Enigma2 format. By default (if the rest of path "
+"is ommitted), an redirection answer will be sent where /channels remainder "
+"is used."
+msgstr ""
+
+#: src/docs_inc.c:1289
+msgid ""
+"Return the playlist in _xspf_ or _m3u_ format. If the agent is in the list "
+"of direct agents (like wget/curl/vlc), the stream is returned instead."
+msgstr ""
+
+#: src/docs_inc.c:2384
+msgid "Reveal/Hide any stored CA client passwords."
+msgstr ""
+
+#: src/docs_inc.c:3324
+msgid "Revert all changes made to the grid entries since the last save."
+msgstr ""
+
+#: src/docs_inc.c:2213
+msgid "Revert all changes since last save."
+msgstr ""
+
+#: src/docs_inc.c:1938 src/docs_inc.c:2469 src/docs_inc.c:2510
+#: src/docs_inc.c:2551 src/docs_inc.c:4124
+msgid "Revert any changes made since the last save."
+msgstr ""
+
+#: src/docs_inc.c:2331
+msgid "Revert the changes made since last save."
+msgstr ""
+
+#: src/docs_inc.c:1781
+msgid "Rich Browser-Driven Interface"
+msgstr ""
+
+#: src/docs_inc.c:1775
+msgid "Rich EPG support, with data from DVB/OTA, XMLTV (scheduled and socket)."
+msgstr ""
+
+#: src/docs_inc.c:4636
+msgid "Rights"
+msgstr ""
+
+#: src/docs_inc.c:517
+msgid "Rotor (GOTOX)"
+msgstr ""
+
+#: src/docs_inc.c:519
+msgid "Rotor (USALS)"
+msgstr ""
+
+#: src/docs_inc.c:3068
+msgid ""
+"Rules with fields not defined (or set to _ANY_ ) will apply to ALL "
+"elementary streams. For example, not defining/selecting _ANY_ for the "
+"_Language_ field will apply the filter to all streams available/not already "
+"filtered out by another rule."
+msgstr ""
+
+#: src/docs_inc.c:1549
+msgid "Running"
+msgstr ""
+
+#: src/docs_inc.c:5046
+msgid "S02-E06"
+msgstr ""
+
+#: src/docs_inc.c:4393 src/docs_inc.c:4771 src/docs_inc.c:5193
+msgid "S02.E07"
+msgstr ""
+
+#: src/docs_inc.c:541
+msgid "SAT>IP (DVB-T/ATSC-T/ATSC-C/DVB-S)"
+msgstr ""
+
+#: src/docs_inc.c:4057
+msgid "SAT>IP Client"
+msgstr ""
+
+#: src/docs_inc.c:901 src/docs_inc.c:4061
+msgid "SAT>IP Server"
+msgstr ""
+
+#: src/docs_inc.c:3901
+msgid "SAT>IP Server SI Tables"
+msgstr ""
+
+#: src/docs_inc.c:2191
+msgid ""
+"SAT>IP Server is something like DVB network tuner. Tvheadend can forward "
+"mpegts input streams including on-the-fly descrambling to SAT>IP clients."
+msgstr ""
+
+#: src/docs_inc.c:1753
+msgid "SAT>IP server (including on-the-fly descrambling)."
+msgstr ""
+
+#: src/docs_inc.c:1719
+msgid "SDTV and HDTV support"
+msgstr ""
+
+#: src/docs_inc.c:3735 src/docs_inc.c:3737
+msgid "START"
+msgstr ""
+
+#: src/docs_inc.c:3739 src/docs_inc.c:3741
+msgid "STOP"
+msgstr ""
+
+#: src/docs_inc.c:489
+msgid "Satellite (DVB-S/ISDB-S)"
+msgstr ""
+
+#: src/docs_inc.c:499 src/docs_inc.c:557
+msgid "Satellite Configuration"
+msgstr ""
+
+#: src/docs_inc.c:507
+msgid "Satellite Configuration (Advanced)"
+msgstr ""
+
+#: src/docs_inc.c:1731
+msgid "Satellite signals via DVB-S and DVB-S2"
+msgstr ""
+
+#: src/docs_inc.c:2685
+msgid "Satellite, any signal coming in via a dish"
+msgstr ""
+
+#: src/docs_inc.c:193
+msgid "Satellite, so any signal coming in via a dish (DVB-S and DVB-S2)"
+msgstr ""
+
+#: src/docs_inc.c:469 src/docs_inc.c:1932 src/docs_inc.c:2147
+#: src/docs_inc.c:2180 src/docs_inc.c:2207 src/docs_inc.c:2300
+#: src/docs_inc.c:2325 src/docs_inc.c:2354 src/docs_inc.c:2463
+#: src/docs_inc.c:2504 src/docs_inc.c:2545 src/docs_inc.c:2612
+#: src/docs_inc.c:2879 src/docs_inc.c:2990 src/docs_inc.c:3119
+#: src/docs_inc.c:3144 src/docs_inc.c:3217 src/docs_inc.c:3318
+#: src/docs_inc.c:4118 src/docs_inc.c:4175
+msgid "Save"
+msgstr ""
+
+#: src/docs_inc.c:2209
+msgid "Save all changes."
+msgstr ""
+
+#: src/docs_inc.c:2356
+msgid "Save any changes made to the CA client configuration."
+msgstr ""
+
+#: src/docs_inc.c:2465
+msgid "Save any changes made to the grid."
+msgstr ""
+
+#: src/docs_inc.c:1934
+msgid "Save any changes made to the grid/entries."
+msgstr ""
+
+#: src/docs_inc.c:2614
+msgid "Save any changes made to the selected configuration."
+msgstr ""
+
+#: src/docs_inc.c:2992
+msgid "Save any changes made to the selected profile."
+msgstr ""
+
+#: src/docs_inc.c:2506 src/docs_inc.c:2547 src/docs_inc.c:4120
+msgid "Save any changes made to the tab."
+msgstr ""
+
+#: src/docs_inc.c:3320
+msgid "Save changes made to the grid entries."
+msgstr ""
+
+#: src/docs_inc.c:471 src/docs_inc.c:2149 src/docs_inc.c:2182
+#: src/docs_inc.c:2302 src/docs_inc.c:2327 src/docs_inc.c:2881
+#: src/docs_inc.c:3121 src/docs_inc.c:3146 src/docs_inc.c:3219
+#: src/docs_inc.c:4177
+msgid "Save the current configuration."
+msgstr ""
+
+#: src/docs_inc.c:4093
+msgid "Scanfile"
+msgstr ""
+
+#: src/docs_inc.c:4264 src/docs_inc.c:4507 src/docs_inc.c:4596
+msgid "Scheme"
+msgstr ""
+
+#: src/docs_inc.c:587
+msgid "Search title..."
+msgstr ""
+
+#: src/docs_inc.c:1777
+msgid "Searchable and filterable from the web user interface."
+msgstr ""
+
+#: src/docs_inc.c:77
+msgid "Second Header"
+msgstr ""
+
+#: src/docs_inc.c:341 src/docs_inc.c:2790 src/docs_inc.c:3432
+#: src/docs_inc.c:3552 src/docs_inc.c:4980
+msgid "See"
+msgstr ""
+
+#: src/docs_inc.c:5005
+msgid "See below."
+msgstr ""
+
+#: src/docs_inc.c:5288
+msgid ""
+"Select the closest transmitter if using an antenna (T); if using cable (C), "
+"select your provider; if using satellite (S), the orbital position of the "
+"satellite your dish is pointing towards; or if using IPTV, enter the URL to "
+"your playlist."
+msgstr ""
+
+#: src/docs_inc.c:5294
+msgid "Selecting the wrong list may cause the scan (on the next page) to fail."
+msgstr ""
+
+#: src/docs_inc.c:1003
+msgid "Server Mapper"
+msgstr ""
+
+#: src/docs_inc.c:1035
+msgid "Server connectivity"
+msgstr ""
+
+#: src/docs_inc.c:3941
+msgid "Service"
+msgstr ""
+
+#: src/docs_inc.c:2114
+msgid "Service Information"
+msgstr ""
+
+#: src/docs_inc.c:99 src/docs_inc.c:2062 src/docs_inc.c:2080
+#: src/docs_inc.c:3544 src/docs_inc.c:3953
+msgid "Service Mapper"
+msgstr ""
+
+#: src/docs_inc.c:1033
+msgid "Service configuration"
+msgstr ""
+
+#: src/docs_inc.c:4608
+msgid "Service name picons"
+msgstr ""
+
+#: src/docs_inc.c:1407
+msgid "Service specified by service UUID"
+msgstr ""
+
+#: src/docs_inc.c:343 src/docs_inc.c:919 src/docs_inc.c:3076
+#: src/docs_inc.c:3554
+msgid "Services"
+msgstr ""
+
+#: src/docs_inc.c:1981
+msgid ""
+"Services are automatically pulled from muxes and can be mapped to Channels."
+msgstr ""
+
+#: src/docs_inc.c:1225
+msgid "Setting up SAT>IP - as a client, as a server"
+msgstr ""
+
+#: src/docs_inc.c:2890
+msgid ""
+"Setting up access control is an important initial step as __the system is "
+"initially wide open__ ."
+msgstr ""
+
+#: src/docs_inc.c:377
+msgid ""
+"Setting up access control rules for different client types/permission levels"
+msgstr ""
+
+#: src/docs_inc.c:367
+msgid "Setting up channel icons"
+msgstr ""
+
+#: src/docs_inc.c:365
+msgid ""
+"Setting up different EPGs (inc. localised character sets and timing offsets)"
+msgstr ""
+
+#: src/docs_inc.c:369
+msgid "Setting up recording profiles"
+msgstr ""
+
+#: src/docs_inc.c:375
+msgid "Setting up softcams for descrambling"
+msgstr ""
+
+#: src/docs_inc.c:371
+msgid "Setting up streaming profiles (including transcoding)"
+msgstr ""
+
+#: src/docs_inc.c:3813
+msgid "Settings"
+msgstr ""
+
+#: src/docs_inc.c:629
+msgid "Short programs, e.g. daily soap operas"
+msgstr ""
+
+#: src/docs_inc.c:751
+msgid ""
+"Should you wish to record all events matching a specific query (to record "
+"your favourite show every week, for example) you can press the _[Create "
+"AutoRec]_ button in the top toolbar."
+msgstr ""
+
+#: src/docs_inc.c:4309 src/docs_inc.c:4955
+msgid "Show basic settings/information."
+msgstr ""
+
+#: src/docs_inc.c:4313 src/docs_inc.c:4959
+msgid "Show more advanced settings/information."
+msgstr ""
+
+#: src/docs_inc.c:4317 src/docs_inc.c:4963
+msgid "Show the expert (All) settings/information."
+msgstr ""
+
+#: src/docs_inc.c:2382
+msgid "Show/Hide Passwords"
+msgstr ""
+
+#: src/docs_inc.c:1611
+msgid ""
+"Similar to the above, Tvheadend can do nothing if your tuners aren't working "
+"properly. A good place to check how to set up your tuners is the"
+msgstr ""
+
+#: src/docs_inc.c:417
+msgid ""
+"Simply, because 'BBC One' might exist in many different places... it might "
+"have regional variations on multiple frequencies (so different services on "
+"different muxes); it might exist on more than one source (perhaps on two "
+"different satellites); and it might thus be accessible through more than one "
+"piece of hardware (two satellite tuners, or one satellite and one "
+"terrestrial tuner)."
+msgstr ""
+
+#: src/docs_inc.c:5050
+msgid "SkySport"
+msgstr ""
+
+#: src/docs_inc.c:497
+msgid "Slave"
+msgstr ""
+
+#: src/docs_inc.c:643
+msgid ""
+"So, if you only want to see Movies from your available HD channels, you "
+"would select ‘HDTV’ in the _[Filter tag…]_ field, and select ‘Movie / Drama’ "
+"in the _[Filter content type…]_ field. If you wish, you could then further "
+"limit the search to programs of between 90 minutes and 3 hours by selecting "
+"‘01:30:01 to 03:00:00’ in the _[Filter duration…]_ field."
+msgstr ""
+
+#: src/docs_inc.c:1809
+msgid "Software-Based CSA Descrambling"
+msgstr ""
+
+#: src/docs_inc.c:5
+msgid ""
+"Some notable items about how formatting is used on this particular site."
+msgstr ""
+
+#: src/docs_inc.c:3518
+msgid ""
+"Some tuners (or drivers) require more tuning parameters than others so be "
+"sure to enter as many tuning parameters as possible."
+msgstr ""
+
+#: src/docs_inc.c:3777
+msgid "Spawn"
+msgstr ""
+
+#: src/docs_inc.c:5038
+msgid "Sport"
+msgstr ""
+
+#: src/docs_inc.c:4511
+msgid "Standard"
+msgstr ""
+
+#: src/docs_inc.c:4403 src/docs_inc.c:4777 src/docs_inc.c:5207
+msgid "Start time stamp of recording, UNIX epoch"
+msgstr ""
+
+#: src/docs_inc.c:2155
+msgid "Start wizard"
+msgstr ""
+
+#: src/docs_inc.c:1545
+msgid "State"
+msgstr ""
+
+#: src/docs_inc.c:995 src/docs_inc.c:4816 src/docs_inc.c:4991
+msgid "Status"
+msgstr ""
+
+#: src/docs_inc.c:1671
+msgid "Status - Connections"
+msgstr ""
+
+#: src/docs_inc.c:1047
+msgid "Status - Stream"
+msgstr ""
+
+#: src/docs_inc.c:1495
+msgid "Status - Subscriptions"
+msgstr ""
+
+#: src/docs_inc.c:35
+msgid ""
+"Stick to paragraph formatting unless and until you have a need for "
+"definition lists."
+msgstr ""
+
+#: src/docs_inc.c:3326
+msgid "Stop"
+msgstr ""
+
+#: src/docs_inc.c:4407 src/docs_inc.c:4781 src/docs_inc.c:5211
+msgid "Stop time stamp of recording, UNIX epoch"
+msgstr ""
+
+#: src/docs_inc.c:947 src/docs_inc.c:997
+msgid "Stream"
+msgstr ""
+
+#: src/docs_inc.c:949 src/docs_inc.c:4249
+msgid "Stream Profiles"
+msgstr ""
+
+#: src/docs_inc.c:2572
+msgid ""
+"Stream Profiles are the settings for output formats. These are used for Live "
+"TV streaming and recordings. The profiles are assigned through the"
+msgstr ""
+
+#: src/docs_inc.c:1387
+msgid "Stream for"
+msgstr ""
+
+#: src/docs_inc.c:4486 src/docs_inc.c:4638
+msgid "Streaming"
+msgstr ""
+
+#: src/docs_inc.c:3965
+msgid "Streaming Profile"
+msgstr ""
+
+#: src/docs_inc.c:4833
+msgid ""
+"Streaming priority is like the _Priority_ setting (above) but only applies "
+"when streaming over HTTP or HTSP. If no streaming priority value is set (0) "
+"the _Priority_ value is used instead."
+msgstr ""
+
+#: src/docs_inc.c:4684 src/docs_inc.c:4686
+msgid "Streaming profiles"
+msgstr ""
+
+#: src/docs_inc.c:4419 src/docs_inc.c:5223
+msgid "Streams (comma separated)"
+msgstr ""
+
+#: src/docs_inc.c:1767
+msgid ""
+"Streams can be selected and filtered positively or negatively as required."
+msgstr ""
+
+#: src/docs_inc.c:4326
+msgid "String"
+msgstr ""
+
+#: src/docs_inc.c:1757
+msgid ""
+"Subject to your system's capabilities, support for on-the-fly transcoding "
+"for both live and recorded streams in various formats."
+msgstr ""
+
+#: src/docs_inc.c:3949
+msgid "Subscription"
+msgstr ""
+
+#: src/docs_inc.c:999
+msgid "Subscriptions"
+msgstr ""
+
+#: src/docs_inc.c:3731
+msgid "Subsystem"
+msgstr ""
+
+#: src/docs_inc.c:3727
+msgid "Subsystems"
+msgstr ""
+
+#: src/docs_inc.c:971
+msgid "Subtitle Stream Filters"
+msgstr ""
+
+#: src/docs_inc.c:1803
+msgid ""
+"Support for broadcaster (primarily DVB-S) bouquets for easy channel mapping."
+msgstr ""
+
+#: src/docs_inc.c:1741
+msgid ""
+"Support for multiple adapters of any mix, with each adapter able to receive "
+"simultaneously all programmes on the current mux."
+msgstr ""
+
+#: src/docs_inc.c:817
+msgid "Supported audio codecs"
+msgstr ""
+
+#: src/docs_inc.c:4355 src/docs_inc.c:4733 src/docs_inc.c:5155
+msgid "Supported format strings:"
+msgstr ""
+
+#: src/docs_inc.c:763
+msgid "Supported formats (containers)"
+msgstr ""
+
+#: src/docs_inc.c:793
+msgid "Supported video codecs"
+msgstr ""
+
+#: src/docs_inc.c:3652
+msgid "Swap Numbers"
+msgstr ""
+
+#: src/docs_inc.c:3654
+msgid "Swap the numbers of the"
+msgstr ""
+
+#: src/docs_inc.c:4280
+msgid "Sync"
+msgstr ""
+
+#: src/docs_inc.c:4284
+msgid "Sync + Don't keep"
+msgstr ""
+
+#: src/docs_inc.c:4272
+msgid "System"
+msgstr ""
+
+#: src/docs_inc.c:1167
+msgid "System Requirements"
+msgstr ""
+
+#: src/docs_inc.c:3801
+msgid "TCP Protocol"
+msgstr ""
+
+#: src/docs_inc.c:5130
+msgid "TIME"
+msgstr ""
+
+#: src/docs_inc.c:5134
+msgid ""
+"TIME action was matched, the new AC3 elementary stream will not be added if "
+"the language for new AC3 elementary stream is ‘eng’. Note that the second "
+"rule might not have the language filter (column) set. For the CA filter, "
+"this rule means that the new CA elementary stream is added only if another "
+"CA is not already used."
+msgstr ""
+
+#: src/docs_inc.c:3911
+msgid "TS"
+msgstr ""
+
+#: src/docs_inc.c:913 src/docs_inc.c:2792
+msgid "TV Adapters"
+msgstr ""
+
+#: src/docs_inc.c:4065
+msgid "TVHDHomeRun Client"
+msgstr ""
+
+#: src/docs_inc.c:1313
+msgid "TYPE"
+msgstr ""
+
+#: src/docs_inc.c:3046
+msgid "Tab specific functions:"
+msgstr ""
+
+#: src/docs_inc.c:853
+msgid "Table of Contents"
+msgstr ""
+
+#: src/docs_inc.c:67
+msgid "Tables"
+msgstr ""
+
+#: src/docs_inc.c:69
+msgid "Tables can be constructed as follows."
+msgstr ""
+
+#: src/docs_inc.c:1359 src/docs_inc.c:1467
+msgid "Tagged channels specified by UUID or tag name"
+msgstr ""
+
+#: src/docs_inc.c:1367 src/docs_inc.c:1475
+msgid "Tagged channels specified by short tag ID"
+msgstr ""
+
+#: src/docs_inc.c:1363 src/docs_inc.c:1471
+msgid "Tagged channels specified by tag name"
+msgstr ""
+
+#: src/docs_inc.c:603
+msgid ""
+"Tags are used for grouping channels together - such as ‘Radio’ or ‘HDTV’ - "
+"and are configured by the administrator. You can start typing a tag name to "
+"filter the list."
+msgstr ""
+
+#: src/docs_inc.c:969
+msgid "Teletext Stream Filters"
+msgstr ""
+
+#: src/docs_inc.c:1727
+msgid "Teletext subtitles supported."
+msgstr ""
+
+#: src/docs_inc.c:4278
+msgid ""
+"Tell the system that you’re not expecting to re-use the data soon, so don’t "
+"keep it in cache. The data will still be buffered for writing. Useful e.g. "
+"in a RAM-limited system like a Pi (given that you’re unlikely to be watching "
+"while recording, so data can be discarded now and read back from disc later)."
+msgstr ""
+
+#: src/docs_inc.c:4282
+msgid ""
+"Tell the system to write the data immediately. This doesn’t affect whether "
+"or not it’s cached. Useful e.g. if you’ve a particular problem with data "
+"loss due to delayed write (such as if you get frequent transient power "
+"problems)."
+msgstr ""
+
+#: src/docs_inc.c:5042
+msgid "Tennis - Wimbledon"
+msgstr ""
+
+#: src/docs_inc.c:5034
+msgid "Tennis - Wimbledon-1.mkv"
+msgstr ""
+
+#: src/docs_inc.c:521
+msgid "Terrestrial (DVB-T/ATSC-T/ISDB-T)"
+msgstr ""
+
+#: src/docs_inc.c:2695
+msgid ""
+"Terrestrial, over-the-air broadcasts received through a traditional "
+"television aerial"
+msgstr ""
+
+#: src/docs_inc.c:195
+msgid ""
+"Terrestrial, so over-the-air broadcasts received through a traditional "
+"television aerial (DVB-T and DVB-T2 in much of the world, ATSC in north and "
+"central America)"
+msgstr ""
+
+#: src/docs_inc.c:1733
+msgid "Terrestrial/Over-the-Air signals via DVB-T, DVB-T2 and ATSC"
+msgstr ""
+
+#: src/docs_inc.c:1557
+msgid "Testing"
+msgstr ""
+
+#: src/docs_inc.c:1039
+msgid "Testing options"
+msgstr ""
+
+#: src/docs_inc.c:5315 src/docs_inc.c:5393
+msgid "Thank you for using Tvheadend (and don't forget to"
+msgstr ""
+
+#: src/docs_inc.c:361
+msgid ""
+"That's it - you're done. You should now have a working basic Tvheadend "
+"installation with channels mapped and ready for use!"
+msgstr ""
+
+#: src/docs_inc.c:109 src/docs_inc.c:2056 src/docs_inc.c:2074
+msgid "The"
+msgstr ""
+
+#: src/docs_inc.c:569
+msgid ""
+"The EPG tab displays a filterable grid containing all events, sorted based "
+"on start time."
+msgstr ""
+
+#: src/docs_inc.c:405
+msgid ""
+"The Tvheadend software then sets up a series of configuration elements, and "
+"the way in which these interact determines how a TV signal ends up in front "
+"of you. They all use what's known as a _many-to-many_ relationship, in that "
+"one configuration element can be related to multiple elements of the next "
+"type, and vice versa: one tuner has multiple networks, one network can exist "
+"on multiple tuners."
+msgstr ""
+
+#: src/docs_inc.c:1649
+msgid "The User Guide in"
+msgstr ""
+
+#: src/docs_inc.c:4590
+msgid ""
+"The _Channel icon path_ (above) must be set to generate the filenames. Also "
+"note that changing the scheme will not update existing icons, you must use "
+"the _[Reset Icons]_ button in the"
+msgstr ""
+
+#: src/docs_inc.c:3370
+msgid ""
+"The _Details_ column gives a quick overview as to the status of each entry:"
+msgstr ""
+
+#: src/docs_inc.c:4501
+msgid ""
+"The _Picon path_ (above) must be set to generate the filenames. Also note "
+"that changing the scheme will not update existing icons, you must use the "
+"_[Reset Icons]_ button in the"
+msgstr ""
+
+#: src/docs_inc.c:2243
+msgid ""
+"The _SAT>IP source number_ is matched through the “src” parameter requested "
+"by the SAT>IP client. Usually (and by default) this value is 1. For "
+"satellite tuners, this value determines the satellite source (dish). By "
+"specification, position 1 = DiseqC AA, 2 = DiseqC AB, 3 = DiseqC BA and 4 = "
+"DiseqC BB."
+msgstr ""
+
+#: src/docs_inc.c:1619
+msgid ""
+"The __driver__ is the piece of software that, as far as the operating system "
+"is concerned, controls the tuner hardware."
+msgstr ""
+
+#: src/docs_inc.c:407
+msgid ""
+"The __network__ is the software definition of your carrier network. Broadly, "
+"it lays out what sort of network it is (such as DVB-T or DVB-S2), how it "
+"gets scanned, where the DVB-S satellite is in orbit, and similar. Networks "
+"are used by tuners so the hardware knows where to look for a signal."
+msgstr ""
+
+#: src/docs_inc.c:4724
+msgid ""
+"The above table displays the _Change parameters_ option name and the fields "
+"that it applies to, as shown in add/edit dialog(s)."
+msgstr ""
+
+#: src/docs_inc.c:455
+msgid "The adapters and tuners are listed and edited in a tree."
+msgstr ""
+
+#: src/docs_inc.c:5001
+msgid "The associated file(s) cannot be found on disk."
+msgstr ""
+
+#: src/docs_inc.c:1487
+msgid ""
+"The build arguments/options used during compilation can be seen by clicking "
+"the _Toggle details_ link (only visible to users with admin rights)."
+msgstr ""
+
+#: src/docs_inc.c:4454
+msgid "The channel name (URL encoded ASCII)"
+msgstr ""
+
+#: src/docs_inc.c:2414
+msgid "The client is connected."
+msgstr ""
+
+#: src/docs_inc.c:2422
+msgid "The client is disabled."
+msgstr ""
+
+#: src/docs_inc.c:203
+msgid "The code is hosted at"
+msgstr ""
+
+#: src/docs_inc.c:273
+msgid ""
+"The creation process allows you to select from a series of pre-defined mux "
+"lists for common DVB sources. These are available"
+msgstr ""
+
+#: src/docs_inc.c:4332
+msgid "The date in ISO-format (e.g. 2015-02-28)."
+msgstr ""
+
+#: src/docs_inc.c:4340
+msgid "The date, formatted according to your locale settings."
+msgstr ""
+
+#: src/docs_inc.c:4247
+msgid "The default profile and priorities can be changed in the"
+msgstr ""
+
+#: src/docs_inc.c:477
+msgid ""
+"The device tree lists the available frontends, LNB configuration and so on "
+"related to your device(s) in sections. Clicking on these sections will "
+"display available parameters and device information."
+msgstr ""
+
+#: src/docs_inc.c:1647
+msgid ""
+"The documentation is written in markdown, and then converted for direct "
+"inclusion to tvheadend binary. The markdown processor in tvheadend binary "
+"adds other information from the internal class system."
+msgstr ""
+
+#: src/docs_inc.c:1783
+msgid "The entire application is loaded into the browser."
+msgstr ""
+
+#: src/docs_inc.c:1261
+msgid "The entire project is currently licensed using"
+msgstr ""
+
+#: src/docs_inc.c:4342
+msgid "The escape-codes use the"
+msgstr ""
+
+#: src/docs_inc.c:3238
+msgid ""
+"The fastscan bouquets are pre-defined in the configuration tree. These "
+"bouquets must be manually enabled to let Tvheadend to subscribe and listen "
+"to the specific MPEG-TS PIDs."
+msgstr ""
+
+#: src/docs_inc.c:591
+msgid ""
+"The filter uses case-insensitive regular expressions. If you don’t know what "
+"a regular expression is, this simply means that you can type just parts of "
+"the title and filter on that - there’s no need for full, exact matching. If "
+"the fulltext checkbox is checked, the title text is matched against title, "
+"subtitle, summary and description."
+msgstr ""
+
+#: src/docs_inc.c:651
+msgid "The following buttons are also available:"
+msgstr ""
+
+#: src/docs_inc.c:2174 src/docs_inc.c:2294 src/docs_inc.c:2873
+#: src/docs_inc.c:3113 src/docs_inc.c:3138 src/docs_inc.c:3211
+#: src/docs_inc.c:4169
+msgid "The following buttons are available:"
+msgstr ""
+
+#: src/docs_inc.c:2392
+msgid ""
+"The following configuration parameters are used, depending on the type of CA "
+"access:"
+msgstr ""
+
+#: src/docs_inc.c:421
+msgid ""
+"The following diagram explains the relationship between these components:"
+msgstr ""
+
+#: src/docs_inc.c:3308
+msgid "The following functions are available (tab dependant):"
+msgstr ""
+
+#: src/docs_inc.c:117 src/docs_inc.c:463 src/docs_inc.c:577 src/docs_inc.c:1059
+#: src/docs_inc.c:1507 src/docs_inc.c:1683 src/docs_inc.c:1926
+#: src/docs_inc.c:2141 src/docs_inc.c:2201 src/docs_inc.c:2319
+#: src/docs_inc.c:2348 src/docs_inc.c:2457 src/docs_inc.c:2498
+#: src/docs_inc.c:2539 src/docs_inc.c:2606 src/docs_inc.c:2984
+#: src/docs_inc.c:3560 src/docs_inc.c:3715 src/docs_inc.c:4112
+msgid "The following functions are available:"
+msgstr ""
+
+#: src/docs_inc.c:1211
+msgid ""
+"The following major content items/chapters are then missing - based on most "
+"FAQs on the forum:"
+msgstr ""
+
+#: src/docs_inc.c:3729
+msgid ""
+"The following options can be passed to tvheadend to provide detailed "
+"debugging information while the application is running."
+msgstr ""
+
+#: src/docs_inc.c:4434
+msgid "The following placeholders are available:"
+msgstr ""
+
+#: src/docs_inc.c:1990 src/docs_inc.c:2730 src/docs_inc.c:3245
+msgid "The following tab specific buttons are available:"
+msgstr ""
+
+#: src/docs_inc.c:3590
+msgid "The following tab specific functions are available:"
+msgstr ""
+
+#: src/docs_inc.c:5072
+#, c-format
+msgid ""
+"The format strings `$t`,`$s`,`%e`,`$c` also have delimiter variants such as `"
+"$ t` (space after the dollar character), `$-t`, `$_t`, `$.t`, `$,t`, `$;t`. "
+"In these cases, the delimiter is applied only when the substituted string is "
+"not empty."
+msgstr ""
+
+#: src/docs_inc.c:2406
+msgid ""
+"The icon next to each entry within the grid indicates the client's "
+"connection status."
+msgstr ""
+
+#: src/docs_inc.c:1123
+msgid ""
+"The interface is made up of nested tabs, so similar functions are grouped "
+"together (e.g. all configuration items at the top level, then all "
+"configuration items for a particular topic are below that)."
+msgstr ""
+
+#: src/docs_inc.c:3277
+msgid ""
+"The last mapped service's values will override the channel values set by the "
+"bouquet, e,g, if service \"MyTV\" with channel number 155 gets mapped to the "
+"channel \"BBC One\" on channel number 1 it will be renamed \"MyTV\" with "
+"channel number 155."
+msgstr ""
+
+#: src/docs_inc.c:1103
+msgid "The level of a desired signal to the level of background noise"
+msgstr ""
+
+#: src/docs_inc.c:675 src/docs_inc.c:1071 src/docs_inc.c:1519
+#: src/docs_inc.c:1695
+msgid "The main grid items have the following functions:"
+msgstr ""
+
+#: src/docs_inc.c:3542
+msgid ""
+"The map services to channels dialog allows you to control which services are "
+"mapped. The options selected here get passed to the"
+msgstr ""
+
+#: src/docs_inc.c:71
+msgid "The markup code:"
+msgstr ""
+
+#: src/docs_inc.c:241
+msgid ""
+"The other major cause of this issue is when you're running Tvheadend as a "
+"user who doesn't have sufficient access to the tuners, such as not being a "
+"member of the _video_ group."
+msgstr ""
+
+#: src/docs_inc.c:4997
+msgid "The recording was interrupted by the user."
+msgstr ""
+
+#: src/docs_inc.c:1291
+msgid "The remain part can be any URL starting with /stream ."
+msgstr ""
+
+#: src/docs_inc.c:1133
+msgid ""
+"The same drop-down menu gives you access to a __sort__ function if defined "
+"(it doesn't always make sense to have a sortable column for some "
+"parameters). You can also sort a column by simply clicking on the column "
+"header; reverse the sort order by clicking again."
+msgstr ""
+
+#: src/docs_inc.c:4540
+msgid "The service is no longer available on this mux."
+msgstr ""
+
+#: src/docs_inc.c:5368
+msgid ""
+"The status tab (behind this wizard) will display signal information. If you "
+"notice a lot of errors or the signal strength appears low then this usually "
+"indicates a physical issue with your antenna, satellite dish or cable.."
+msgstr ""
+
+#: src/docs_inc.c:1551
+msgid "The subscription is active - the stream is being sent."
+msgstr ""
+
+#: src/docs_inc.c:1555
+msgid "The subscription is idling, waiting for the subscriber."
+msgstr ""
+
+#: src/docs_inc.c:5068
+msgid "The time in 24-hour notation"
+msgstr ""
+
+#: src/docs_inc.c:4336
+msgid "The time in 24h HH:MM format (e.g. 19:45)."
+msgstr ""
+
+#: src/docs_inc.c:4442
+msgid ""
+"The transliterated channel name in ASCII (safe characters, no spaces, etc. - "
+"so"
+msgstr ""
+
+#: src/docs_inc.c:4796
+msgid ""
+"The tuner (or network if using IPTV) with the highest priority value will be "
+"used out of preference. If the tuner is busy the next available with the "
+"highest priority value will be used."
+msgstr ""
+
+#: src/docs_inc.c:5015
+msgid "The underlying service for the channel is no longer available."
+msgstr ""
+
+#: src/docs_inc.c:4712 src/docs_inc.c:4714
+msgid "Theme"
+msgstr ""
+
+#: src/docs_inc.c:3500
+msgid "Then enter the mux information:"
+msgstr ""
+
+#: src/docs_inc.c:2748
+msgid ""
+"Then using the resultant dialog enter/select the desired network options."
+msgstr ""
+
+#: src/docs_inc.c:2042
+msgid ""
+"There are a number of methods to mapping available services, mapping uses "
+"the following dialog."
+msgstr ""
+
+#: src/docs_inc.c:387
+msgid ""
+"There are some basic concepts that will make life much easier if you "
+"understand them from the outset."
+msgstr ""
+
+#: src/docs_inc.c:1119
+msgid ""
+"There are some basic navigation concepts that will help you get around and "
+"make the best of it."
+msgstr ""
+
+#: src/docs_inc.c:1871
+msgid "There are two methods for editing an entry."
+msgstr ""
+
+#: src/docs_inc.c:2760
+msgid ""
+"There is a 5-10 minute delay before a scan starts, this is so you can make "
+"changes if needed (this does not apply to IPTV networks)."
+msgstr ""
+
+#: src/docs_inc.c:1579
+msgid "There is a discussion about supported hardware on"
+msgstr ""
+
+#: src/docs_inc.c:2418
+msgid "There was an error."
+msgstr ""
+
+#: src/docs_inc.c:1197
+msgid "These are not part of the final product, obviously!"
+msgstr ""
+
+#: src/docs_inc.c:33
+msgid ""
+"They may render the same here, but note the extra leading spaces in the "
+"second example: this means that they will convert differently for use in the "
+"web interface help. That in turn means your formatting will be all over the "
+"place unless you handle the dl/dt/dd formatting in Tvheadend's CSS."
+msgstr ""
+
+#: src/docs_inc.c:1199
+msgid ""
+"They're just some of the areas I'm aware of that we need to close off before "
+"release"
+msgstr ""
+
+#: src/docs_inc.c:1193
+msgid "Things To Do on This Guide..."
+msgstr ""
+
+#: src/docs_inc.c:1383
+msgid ""
+"This URL scheme is used for streaming. The stream contents depends on the "
+"streaming profile. It might be MPEG-TS, Matroska or MP4."
+msgstr ""
+
+#: src/docs_inc.c:615
+msgid ""
+"This allows you to filter for or against, say, a daily broadcast and a "
+"weekly omnibus edition of a program, or only look for short news bulletins "
+"and not the 24-hour rolling broadcasts."
+msgstr ""
+
+#: src/docs_inc.c:2229
+msgid ""
+"This can be anything you like, it is recommended that you use 9983 (to avoid "
+"permission issues). Entering zero (0) in this field will disable the server."
+msgstr ""
+
+#: src/docs_inc.c:289
+msgid ""
+"This can be as simple or as complex as necessary. You may simply have, for "
+"example, a single DVB-S2 network defined and then associate this with all "
+"DVB-S2 tuners. Or, you might have multiple networks defined - different "
+"satellites, different encoding. So, as further examples, you might define "
+"and then associate an HD DVB-T2 (e.g. H.264) network with HD tuners, while "
+"having a separate SD network associated with an independent SD (e.g. MPEG-2) "
+"tuner."
+msgstr ""
+
+#: src/docs_inc.c:4617
+msgid ""
+"This can be named however you wish, as either a local (file://) or remote "
+"(http://) location - however, remember that it’s pointing to a directory as "
+"the picon names are automatically generated from the service parameters "
+"frequency, orbital position (required), etc."
+msgstr ""
+
+#: src/docs_inc.c:151
+msgid ""
+"This document is intended to give you a high-level overview of how to set up "
+"Tvheadend for the first time. It does not aim to provide a complete "
+"description of every step or answer every question: more details are "
+"available on the tvheadend"
+msgstr ""
+
+#: src/docs_inc.c:1253
+msgid "This documentation forms part of the Tvheadend project."
+msgstr ""
+
+#: src/docs_inc.c:1645
+msgid "This information was last updated on 11 May 2016."
+msgstr ""
+
+#: src/docs_inc.c:103 src/docs_inc.c:1051 src/docs_inc.c:1499
+#: src/docs_inc.c:1675
+msgid "This is a read-only tab; nothing is configurable."
+msgstr ""
+
+#: src/docs_inc.c:2931
+msgid "This is an example of a limited user entry."
+msgstr ""
+
+#: src/docs_inc.c:3402
+msgid "This is an example of a one-time recording entry."
+msgstr ""
+
+#: src/docs_inc.c:2844
+msgid "This is an example of a one-time timer-based recording entry."
+msgstr ""
+
+#: src/docs_inc.c:2269
+msgid "This is an example of a password entry."
+msgstr ""
+
+#: src/docs_inc.c:5273
+msgid ""
+"This is extremely useful for those programs you think/know will overrun. Any "
+"value selected here will keep a tuner busy for longer, so be sure to check "
+"you have enough free tuners to record all scheduled recordings if they "
+"overlap. Setting the padding per channel will override the padding set in the"
+msgstr ""
+
+#: src/docs_inc.c:239
+msgid ""
+"This is normally because they're not installed properly. Check syslog/dmesg "
+"(e.g. `dmesg | grep dvb`) and see that you have startup messages that "
+"indicate whether or not the tuners have initialized properly. Similarly, "
+"check `/dev/dvb` to see if the block device files (i.e. the files used to "
+"communicate with the tuner) have been created correctly."
+msgstr ""
+
+#: src/docs_inc.c:1587
+msgid ""
+"This is obviously a core requirement that's outside of the scope of this "
+"guide."
+msgstr ""
+
+#: src/docs_inc.c:1607
+msgid ""
+"This is particularly true of systems such as the Raspberry Pi which share "
+"USB bandwidth with the Ethernet port. Don't be surprised if this kind of "
+"platform struggles and/or reports errors in a multi-tuner configuration, "
+"especially on high-bandwidth (e.g. HD) streams."
+msgstr ""
+
+#: src/docs_inc.c:2788
+msgid ""
+"This is the list of available parameters for the linuxdvb frontend. It is "
+"used as a base for other frontends."
+msgstr ""
+
+#: src/docs_inc.c:331
+msgid ""
+"This is where the services will appear as your tuners tune to the muxes "
+"based on the network you told them to look on. Again, remember what's "
+"happening: Tvheadend is telling your tuner hardware (via the drivers) to "
+"sequentially tune to each mux it knows about, and then see what 'programs' "
+"it can see on that mux, each of which is identified by a series of unique "
+"identifiers that describe the audio stream(s), the video stream(s), the "
+"subtitle stream(s) and language(s), and so on."
+msgstr ""
+
+#: src/docs_inc.c:1485
+msgid ""
+"This page displays general information about the current Tvheadend version."
+msgstr ""
+
+#: src/docs_inc.c:4165
+msgid ""
+"This panel displays all available SAT>IP DVB-T/DVB-S/DVB-C/ATSC-T/ATSC-C "
+"frontend parameters."
+msgstr ""
+
+#: src/docs_inc.c:3105
+msgid "This panel displays all available SAT>IP client parameters."
+msgstr ""
+
+#: src/docs_inc.c:2865
+msgid ""
+"This panel lists all the available Cable (DVB-C/C2/ISDB-C/ATSC-C) frontend "
+"parameters."
+msgstr ""
+
+#: src/docs_inc.c:2166
+msgid ""
+"This panel lists all the available Terrestrial (DVB-T/T2/ISDB-T/ATSC-T) "
+"frontend parameters."
+msgstr ""
+
+#: src/docs_inc.c:2290 src/docs_inc.c:3207
+msgid ""
+"This panel lists all the available satellite (DVB-S/ISDB-S) configuration "
+"parameters."
+msgstr ""
+
+#: src/docs_inc.c:3130
+msgid ""
+"This panel lists all the available satellite (DVB-S/ISDB-S) frontend "
+"parameters."
+msgstr ""
+
+#: src/docs_inc.c:251
+msgid ""
+"This section gives a high-level overview of the steps needed to get "
+"Tvheadend up and running. For more detailed information, please consult the "
+"rest of this guide - much of it is arranged in the same order as the tabs on "
+"the Tvheadend interface so you know where to look."
+msgstr ""
+
+#: src/docs_inc.c:435
+msgid ""
+"This section tells you how to get hold of the software in the first place, "
+"and how to get it onto your system."
+msgstr ""
+
+#: src/docs_inc.c:1577
+msgid ""
+"This section will give you some basic ideas on how to get your tuner working "
+"with your operating system. However, it's clearly way beyond the scope of "
+"this guide to tell you everything: consult specialist forums, search around, "
+"and at least do some research to work out what's likely to work or not "
+"before you hand over any money."
+msgstr ""
+
+#: src/docs_inc.c:4885 src/docs_inc.c:4965
+msgid "This setting can be overridden on a per-user basis, see"
+msgstr ""
+
+#: src/docs_inc.c:2801
+msgid ""
+"This tab allows to configure blocked IP ranges. Users within these ranges "
+"are not allowed to login (use any Tvheadend service)."
+msgstr ""
+
+#: src/docs_inc.c:3037
+msgid ""
+"This tab allows you to define rules that filter and order various elementary "
+"streams."
+msgstr ""
+
+#: src/docs_inc.c:3155
+msgid "This tab controls EPG-driven recording rules."
+msgstr ""
+
+#: src/docs_inc.c:2831
+msgid "This tab controls timer-driven recording rules."
+msgstr ""
+
+#: src/docs_inc.c:2449
+msgid "This tab displays EPG data used by channels."
+msgstr ""
+
+#: src/docs_inc.c:4186
+msgid ""
+"This tab displays various memory usage information useful for debugging."
+msgstr ""
+
+#: src/docs_inc.c:2256
+msgid ""
+"This tab is the second part of Tvheadend's access control mechanism. It is "
+"where you set and maintain all user passwords (e.g. for streaming or DVR "
+"access)."
+msgstr ""
+
+#: src/docs_inc.c:3459
+msgid ""
+"This tab is used to configure channel tags. Tags are used to define a set of "
+"channels - to group them, to aid searches, and similar. Tags are not "
+"required by Tvheadend itself, but are useful in media applications such as "
+"Kodi and are a requirement for using Tvheadend with Movian."
+msgstr ""
+
+#: src/docs_inc.c:2976
+msgid ""
+"This tab is used to configure operation of the Digital Video Recorder. It is "
+"not used for scheduling or administration of individual recordings."
+msgstr ""
+
+#: src/docs_inc.c:2527
+msgid "This tab is used to configure the Electronic Program Guide (EPG)"
+msgstr ""
+
+#: src/docs_inc.c:2490
+msgid ""
+"This tab is used to configure the Electronic Program Guide (EPG) grabber "
+"modules. Tvheadend supports a variety of different EPG grabbing mechanisms. "
+"These fall into 3 broad categories, within which there are a variety of "
+"specific grabber implementations."
+msgstr ""
+
+#: src/docs_inc.c:2311
+msgid "This tab is used to configure timeshift properties."
+msgstr ""
+
+#: src/docs_inc.c:3701
+msgid "This tab is used to configure various debugging options in tvheadend."
+msgstr ""
+
+#: src/docs_inc.c:3292
+msgid ""
+"This tab is where you manage your recordings. Each entry is moved between "
+"the _Upcoming / Current Recordings_ , _Finished Recordings_ and _Failed "
+"Recordings_ sub-tabs depending on its status."
+msgstr ""
+
+#: src/docs_inc.c:3581
+msgid "This tab lists all defined channels."
+msgstr ""
+
+#: src/docs_inc.c:1673
+msgid "This tab shows information about all active connections."
+msgstr ""
+
+#: src/docs_inc.c:1497
+msgid "This tab shows information about all active subscriptions to Tvheadend."
+msgstr ""
+
+#: src/docs_inc.c:1049
+msgid "This tab shows information about all currently-open streams."
+msgstr ""
+
+#: src/docs_inc.c:101
+msgid "This tab shows information about current service mapping activity."
+msgstr ""
+
+#: src/docs_inc.c:2133
+msgid ""
+"This tabs allow configuration of several general parameters that affect the "
+"core Tvheadend functionality."
+msgstr ""
+
+#: src/docs_inc.c:3174
+msgid ""
+"This uses a regular expression (regex) to match the program title \"BBC News"
+"\" exactly, otherwise event titles containing the phrase would also match, e."
+"g \"BBC News at One\" and \"BBC News at Six\" etc."
+msgstr ""
+
+#: src/docs_inc.c:233
+msgid ""
+"This usually happens when Tvheadend is installed incorrectly. As a start, "
+"make sure that the web interface path `/usr/share/tvheadend/src/webui/static/"
+"` exists and isn't empty."
+msgstr ""
+
+#: src/docs_inc.c:4104
+msgid ""
+"This will cache any channel icons or other images (such as EPG metadata) to "
+"be served from the local webserver. This can be useful for multi-client "
+"systems and, generally, to reduce hits on upstream providers."
+msgstr ""
+
+#: src/docs_inc.c:5347
+msgid ""
+"This works alongside the second part, which is a familiar username/password "
+"combination, so provide these for both an administrator and regular (day-to-"
+"day) user."
+msgstr ""
+
+#: src/docs_inc.c:3765
+msgid "Thread"
+msgstr ""
+
+#: src/docs_inc.c:3773
+msgid "Time"
+msgstr ""
+
+#: src/docs_inc.c:3921
+msgid "Time Stamp Fix"
+msgstr ""
+
+#: src/docs_inc.c:5003
+msgid "Time missed"
+msgstr ""
+
+#: src/docs_inc.c:5007
+msgid "Time missed can be caused by one (or more) of the following:"
+msgstr ""
+
+#: src/docs_inc.c:891
+msgid "Time-based Recording (Timers)"
+msgstr ""
+
+#: src/docs_inc.c:2835
+msgid "Timer Tab"
+msgstr ""
+
+#: src/docs_inc.c:2848
+msgid "Timer add example"
+msgstr ""
+
+#: src/docs_inc.c:981 src/docs_inc.c:4089
+msgid "Timeshift"
+msgstr ""
+
+#: src/docs_inc.c:3494
+msgid ""
+"To add a mux press the _[Add]_ button from the menu bar and select the "
+"network you want to add the mux to:"
+msgstr ""
+
+#: src/docs_inc.c:1147
+msgid ""
+"To add a new entry, press the _Add_ button. The new (empty) entry will be "
+"created on the server but will not be saved and will not necessarily be "
+"enabled. You can now change all the cells to the desired values, check the "
+"‘enable’ box if applicable and then press _Save_ to activate the new entry."
+msgstr ""
+
+#: src/docs_inc.c:1854
+msgid ""
+"To add an entry click the _[Add]_ button from the menu bar, the add dialog "
+"should now be displayed. Once you've filled in the required/desired fields "
+"you can then press _[Save]_ to add the entry, _[Apply]_ to commit and "
+"continue editing or _[Cancel]_ to abort (losing any unsaved changes)."
+msgstr ""
+
+#: src/docs_inc.c:5353
+msgid ""
+"To allow anonymous access for any account (administrative or regular user) "
+"enter an asterisk (*) in the username and password fields. ___It is not_ __ "
+"recommended that you allow anonymous access to the admin account."
+msgstr ""
+
+#: src/docs_inc.c:1145 src/docs_inc.c:1879
+msgid "To change a check box or radio button, click once."
+msgstr ""
+
+#: src/docs_inc.c:747
+msgid ""
+"To close the popup, just click on the [X] window button. The popup isn’t "
+"modal, so you don’t have to close it before doing something else, and you "
+"can open as many detailed information popups as you want."
+msgstr ""
+
+#: src/docs_inc.c:2742
+msgid ""
+"To create a network click the _[Add]_ button from the menu bar and then "
+"select the required network type:"
+msgstr ""
+
+#: src/docs_inc.c:2426
+msgid ""
+"To create a new CA configuration press the _[Add]_ button from the menu bar, "
+"you will then be asked to select a client type. Once you've selected a type "
+"you can then enter/select the desired options from the resultant _Add_ "
+"dialog."
+msgstr ""
+
+#: src/docs_inc.c:3014
+msgid ""
+"To create a new profile press the _[Add]_ button from the menu bar, a new "
+"entry \"! New config\" will be added to the grid, click on that entry to "
+"configure it - don't forget to save!"
+msgstr ""
+
+#: src/docs_inc.c:2636
+msgid ""
+"To create a new profile press the _[Add]_ button from the menu bar, you will "
+"then be asked to select a profile type."
+msgstr ""
+
+#: src/docs_inc.c:2959
+msgid ""
+"To create a superuser account you must have access to your Tvheadend "
+"configuration directory (most commonly `$HOME/.hts/tvheadend`) and be able "
+"to create a plain-text file named `superuser` with the following (JSON "
+"formatted) content:"
+msgstr ""
+
+#: src/docs_inc.c:3528
+msgid ""
+"To delete a mux highlight (select) the desired muxes from within the grid, "
+"and press the _[Delete]_ button from the menu bar."
+msgstr ""
+
+#: src/docs_inc.c:1877
+msgid "To edit a cell, double click on it."
+msgstr ""
+
+#: src/docs_inc.c:1143
+msgid ""
+"To edit a cell, double click on it. After a cell is changed, a small red "
+"flag or triangle will appear in the top-left corner to indicate that it has "
+"been changed. These changes can now be kept (_Save_ button), or abandoned "
+"(_Undo_ button)."
+msgstr ""
+
+#: src/docs_inc.c:2432 src/docs_inc.c:3020
+msgid ""
+"To edit an existing configuration, click on it from within the grid, the "
+"_Parameters_ panel should then appear on the right hand side."
+msgstr ""
+
+#: src/docs_inc.c:2650
+msgid ""
+"To edit an existing profile, click on it from within the grid, the "
+"_Parameters_ panel should then appear on the right hand side."
+msgstr ""
+
+#: src/docs_inc.c:21
+msgid "To include class documentation you'd use:"
+msgstr ""
+
+#: src/docs_inc.c:23
+msgid "To include multi-use docs (placed in the `docs/markdown/inc/` folder:"
+msgstr ""
+
+#: src/docs_inc.c:3234
+msgid ""
+"To use bouquets, ensure to add and scan all available muxes using the "
+"predefined muxes or manual configuration."
+msgstr ""
+
+#: src/docs_inc.c:4425 src/docs_inc.c:4787 src/docs_inc.c:5229
+msgid ""
+"To use special characters (e.g. spaces), either put the string in quotes or "
+"escape the individual characters."
+msgstr ""
+
+#: src/docs_inc.c:4029
+msgid "Transcode"
+msgstr ""
+
+#: src/docs_inc.c:963 src/docs_inc.c:2600
+msgid "Transcode Profile"
+msgstr ""
+
+#: src/docs_inc.c:1213
+msgid ""
+"Transcoding (updated for 4.2, so needs to be tagged properly and reversed as "
+"applicable to 4.0)"
+msgstr ""
+
+#: src/docs_inc.c:1755
+msgid "Transcoding Support"
+msgstr ""
+
+#: src/docs_inc.c:3913
+msgid "Transport Stream"
+msgstr ""
+
+#: src/docs_inc.c:2553
+msgid "Trigger OTA EPG Grabber"
+msgstr ""
+
+#: src/docs_inc.c:4800
+msgid "Tuner"
+msgstr ""
+
+#: src/docs_inc.c:4802
+msgid "Tuner A"
+msgstr ""
+
+#: src/docs_inc.c:4804
+msgid "Tuner B"
+msgstr ""
+
+#: src/docs_inc.c:4806
+msgid "Tuner C"
+msgstr ""
+
+#: src/docs_inc.c:5441
+msgid "Tuners already in use will not appear below."
+msgstr ""
+
+#: src/docs_inc.c:143
+msgid "Tvheadend 4.2 User Guide"
+msgstr ""
+
+#: src/docs_inc.c:147
+msgid "Tvheadend Logo"
+msgstr ""
+
+#: src/docs_inc.c:219
+msgid ""
+"Tvheadend can generate a playlist of all your mapped services (channels). "
+"You can download it from the webui at `http://IP:Port/playlist`, e.g. "
+"`http://192.168.0.2:9981/playlist`."
+msgstr ""
+
+#: src/docs_inc.c:567
+msgid ""
+"Tvheadend has a built-in Electronic Program Guide. The EPG is an in-memory "
+"database populated with all the information about events received from the "
+"DVB networks over-the-air or from external grabbers such as XMLTV."
+msgstr ""
+
+#: src/docs_inc.c:2957
+msgid ""
+"Tvheadend includes functionality that allows you to regain access to your "
+"Tvheadend instance in case of emergency or if you find yourself locked out, "
+"this is known as a superuser account. On some systems you may been asked to "
+"enter a superuser username and password during installation."
+msgstr ""
+
+#: src/docs_inc.c:187
+msgid "Tvheadend interface"
+msgstr ""
+
+#: src/docs_inc.c:183
+msgid ""
+"Tvheadend is a lightweight, easily-configured, general-purpose TV/video "
+"streaming server and recorder (PVR/DVR) for GNU/Linux, FreeBSD and Android."
+msgstr ""
+
+#: src/docs_inc.c:1173
+msgid ""
+"Tvheadend is intended to be lightweight, so it will run on a NAS or similar "
+"__low-powered CPU__ . Note that the exception here is transcoding: if you "
+"want to convert high-definition video in real time then you will need a "
+"powerful, multi-core system. It will happily run in less than __1GB of "
+"RAM__ , and many people run it successfully on original Raspberry Pis with "
+"perhaps only 256MB of usable free memory. This does depend on what else "
+"you're using the computer for, though, as a GUI will drain your system as "
+"will any serious file serving."
+msgstr ""
+
+#: src/docs_inc.c:5362
+msgid ""
+"Tvheadend is now scanning for available services. Please wait until the scan "
+"completes.."
+msgstr ""
+
+#: src/docs_inc.c:1117
+msgid "Tvheadend is operated primarily through a tabbed web interface."
+msgstr ""
+
+#: src/docs_inc.c:1559
+msgid ""
+"Tvheadend is testing the requested stream to see if it's available - if a "
+"subscription stays in this state too long it may indicate a signal issue."
+msgstr ""
+
+#: src/docs_inc.c:2340
+msgid ""
+"Tvheadend supports connecting to card clients via the cwc (newcamd) and "
+"capmt (linux network dvbapi) protocols for so-called 'softcam' descrambling."
+msgstr ""
+
+#: src/docs_inc.c:2892
+msgid ""
+"Tvheadend verifies access by scanning through all enabled access control "
+"entries in sequence, from the top of the list to the bottom. The permission "
+"flags, streaming profiles, DVR config profiles, channel tags, and channel "
+"number ranges are combined for all matching access entries. You can control "
+"which parameters are merged (on a per-entry basis), see _Change parameters_"
+msgstr ""
+
+#: src/docs_inc.c:5017
+msgid ""
+"Tvheadend wasn't running or crashed when a scheduled event/entry was to "
+"start."
+msgstr ""
+
+#: src/docs_inc.c:3522
+msgid ""
+"Tvheadend won't scan the newly added mux instantly, it can take up to 10 "
+"minutes to begin an initial scan."
+msgstr ""
+
+#: src/docs_inc.c:5307 src/docs_inc.c:5385
+msgid "Tvheadend.org"
+msgstr ""
+
+#: src/docs_inc.c:2582
+msgid "Types"
+msgstr ""
+
+#: src/docs_inc.c:1635
+msgid ""
+"Typically, download the binary file and install it into `/lib/firmware`, "
+"owned by `root:root`, permissions `rw-r--r--` (0644)"
+msgstr ""
+
+#: src/docs_inc.c:3809
+msgid "UPnP Protocol"
+msgstr ""
+
+#: src/docs_inc.c:3797
+msgid "URL"
+msgstr ""
+
+#: src/docs_inc.c:1972
+msgid "URL Syntax"
+msgstr ""
+
+#: src/docs_inc.c:1283
+msgid "URL syntax"
+msgstr ""
+
+#: src/docs_inc.c:1603
+msgid ""
+"USB tuners are cheap, work well and are frequently well-matched to "
+"physically-smaller builds (e.g. HTPCs) which simply don't have the internal "
+"slots. However, please remember that many need external power, or need a "
+"powered hub to work properly."
+msgstr ""
+
+#: src/docs_inc.c:5124
+msgid "USE"
+msgstr ""
+
+#: src/docs_inc.c:3070
+msgid ""
+"USE / EMPTY rules have precedence against IGNORE (if the stream is already "
+"selected - it cannot be ignored)."
+msgstr ""
+
+#: src/docs_inc.c:3789
+msgid "UUID"
+msgstr ""
+
+#: src/docs_inc.c:1936 src/docs_inc.c:2151 src/docs_inc.c:2211
+#: src/docs_inc.c:2329 src/docs_inc.c:2358 src/docs_inc.c:2467
+#: src/docs_inc.c:2508 src/docs_inc.c:2549 src/docs_inc.c:2616
+#: src/docs_inc.c:2994 src/docs_inc.c:3322 src/docs_inc.c:4122
+msgid "Undo"
+msgstr ""
+
+#: src/docs_inc.c:2360
+msgid ""
+"Undo any changes made to the CA client configuration since the last save."
+msgstr ""
+
+#: src/docs_inc.c:2618
+msgid ""
+"Undo any changes made to the selected configuration since the last save."
+msgstr ""
+
+#: src/docs_inc.c:2996
+msgid "Undo any changes made to the selected profile since the last save."
+msgstr ""
+
+#: src/docs_inc.c:2153
+msgid "Undo changes since the last save."
+msgstr ""
+
+#: src/docs_inc.c:4053
+msgid "Unicable (EN50494)"
+msgstr ""
+
+#: src/docs_inc.c:511
+msgid "Unicable EN50494 (experimental)"
+msgstr ""
+
+#: src/docs_inc.c:5056
+msgid "Unique number added when the file already exists"
+msgstr ""
+
+#: src/docs_inc.c:501
+msgid "Universal LNB"
+msgstr ""
+
+#: src/docs_inc.c:4268
+msgid "Unknown"
+msgstr ""
+
+#: src/docs_inc.c:57
+msgid "Unordered list can use asterisks"
+msgstr ""
+
+#: src/docs_inc.c:47
+msgid "Unordered sub-list."
+msgstr ""
+
+#: src/docs_inc.c:881
+msgid "Upcoming / Current Recordings"
+msgstr ""
+
+#: src/docs_inc.c:3190
+msgid "Upcoming/Current Recordings"
+msgstr ""
+
+#: src/docs_inc.c:1643
+msgid "Updating the Documentation"
+msgstr ""
+
+#: src/docs_inc.c:1029
+msgid "Usage: `tvheadend [OPTIONS]`"
+msgstr ""
+
+#: src/docs_inc.c:5256
+msgid "Use DVR profile setting."
+msgstr ""
+
+#: src/docs_inc.c:5138
+msgid ""
+"Use only this elementary stream. No other elementary streams will be used."
+msgstr ""
+
+#: src/docs_inc.c:4602
+msgid "Use service name \"as is\" to generate the filename."
+msgstr ""
+
+#: src/docs_inc.c:4848
+msgid "Use the \"Persistent user interface level\" value as set in"
+msgstr ""
+
+#: src/docs_inc.c:4875
+msgid "Use the (default) blue theme."
+msgstr ""
+
+#: src/docs_inc.c:4301
+msgid "Use the default view level value as set in"
+msgstr ""
+
+#: src/docs_inc.c:4879
+msgid "Use the gray theme."
+msgstr ""
+
+#: src/docs_inc.c:4883
+msgid "Use the high contrast accessibility theme."
+msgstr ""
+
+#: src/docs_inc.c:5132
+msgid ""
+"Use this elementary stream only one time per service type (like video, "
+"audio, subtitles) and language. The first sucessfully compared rule wins. "
+"For example, when one AC3 elementary stream is marked to be used with ‘eng’ "
+"language and another rule with the ONE"
+msgstr ""
+
+#: src/docs_inc.c:5126
+msgid "Use this elementary stream."
+msgstr ""
+
+#: src/docs_inc.c:3600
+msgid "User Icon"
+msgstr ""
+
+#: src/docs_inc.c:4718 src/docs_inc.c:4720
+msgid "User interface level"
+msgstr ""
+
+#: src/docs_inc.c:903
+msgid "Users"
+msgstr ""
+
+#: src/docs_inc.c:1886
+msgid "Using the"
+msgstr ""
+
+#: src/docs_inc.c:3410
+msgid ""
+"Using the Electronic Program Guide search functionality, find the program/"
+"event you would like to record. Click on it, then using the broadcast "
+"details dialog you can:"
+msgstr ""
+
+#: src/docs_inc.c:801
+msgid "VP8"
+msgstr ""
+
+#: src/docs_inc.c:641
+msgid "Very long programs, e.g. major sporting events"
+msgstr ""
+
+#: src/docs_inc.c:625
+msgid "Very short news bulletins, children's programs, etc."
+msgstr ""
+
+#: src/docs_inc.c:965
+msgid "Video Stream Filters"
+msgstr ""
+
+#: src/docs_inc.c:4646
+msgid "Video recorder"
+msgstr ""
+
+#: src/docs_inc.c:3072
+msgid "Visual Verification of Filtering"
+msgstr ""
+
+#: src/docs_inc.c:827
+msgid "Vorbis"
+msgstr ""
+
+#: src/docs_inc.c:1329 src/docs_inc.c:1385 src/docs_inc.c:1445
+msgid "WHAT"
+msgstr ""
+
+#: src/docs_inc.c:4262
+msgid ""
+"Warning, setting an incorrect scheme can lead to crashes. If you're unsure "
+"select _System_ ."
+msgstr ""
+
+#: src/docs_inc.c:661 src/docs_inc.c:759
+msgid "Watch TV"
+msgstr ""
+
+#: src/docs_inc.c:27
+msgid "Watch this one - indentation is key."
+msgstr ""
+
+#: src/docs_inc.c:1239
+msgid ""
+"We need the webUI pages documented (as they are). How much should they be "
+"the how-tos, and how much should these be separate?"
+msgstr ""
+
+#: src/docs_inc.c:91
+msgid ""
+"We're using default heading/cell justification, so it's consistent "
+"throughout."
+msgstr ""
+
+#: src/docs_inc.c:873
+msgid "Web Interface Guide"
+msgstr ""
+
+#: src/docs_inc.c:4085
+msgid "Web User Interface"
+msgstr ""
+
+#: src/docs_inc.c:4642
+msgid "Web interface"
+msgstr ""
+
+#: src/docs_inc.c:1837
+msgid "Web interface internationalization"
+msgstr ""
+
+#: src/docs_inc.c:4706 src/docs_inc.c:4708
+msgid "Web interface language"
+msgstr ""
+
+#: src/docs_inc.c:773
+msgid "WebM"
+msgstr ""
+
+#: src/docs_inc.c:181
+msgid "Welcome to Tvheadend!"
+msgstr ""
+
+#: src/docs_inc.c:5404
+msgid ""
+"Welcome to Tvheadend, your TV streaming server and video recorder. This "
+"wizard will help you get up and running fast. Let's start by configuring the "
+"basic language settings. Please select the default user interface and EPG "
+"language(s)."
+msgstr ""
+
+#: src/docs_inc.c:279
+msgid ""
+"When creating a DVB-S network, be sure to set the orbital position of the "
+"satellite to which your dish is pointing, as some satellites provide "
+"additional information related to other nearby satellites that you may not "
+"be able to receive."
+msgstr ""
+
+#: src/docs_inc.c:419
+msgid ""
+"When you select the channel you want to watch or record, Tvheadend can then "
+"map a path through all those variables to ask a particular tuner to go and "
+"get the signal for you."
+msgstr ""
+
+#: src/docs_inc.c:4260
+msgid ""
+"Whenever you read or write data to the filesystems, the information is kept "
+"(cached) in memory for a while. This means that regularly-accessed files are "
+"available quickly without going back to the disc; it also means that there’s "
+"a disconnect when writing between the write request (from the application) "
+"and the actual write itself (to the disc/storage) as changes are buffered to "
+"be written in one go."
+msgstr ""
+
+#: src/docs_inc.c:445
+msgid ""
+"Where a pre-built package exists, this will usually get you the last "
+"official stable version. However, more advanced users may be interested in "
+"running a development version - either a nightly build or a self-compiled "
+"version."
+msgstr ""
+
+#: src/docs_inc.c:1165
+msgid ""
+"Where you have aerial/coax connections might influence your choice - unless "
+"you use SAT>IP or have some other way to transport your TV signal over a "
+"LAN, your Tvheadend installation has to live where you can actually connect "
+"your tuners."
+msgstr ""
+
+#: src/docs_inc.c:1169
+msgid ""
+"Wherever you install it, Tvheadend primarily runs on __Linux__ - pre-built "
+"binaries are available for most Debian-based distributions (Debian itself, "
+"Ubuntu, Mint...) and RPMs for Fedora, or you can build it yourself. It runs "
+"on both 32- and 64-bit x86 and ARM processors, and so also can be built for "
+"Android (which uses the Linux kernel)."
+msgstr ""
+
+#: src/docs_inc.c:201
+msgid ""
+"While supported in previous versions, analogue video (V4L) is no longer "
+"supported directly. If you still need this, or need to input signals from "
+"video cameras or other non-broadcast sources, use `pipe://`."
+msgstr ""
+
+#: src/docs_inc.c:4379 src/docs_inc.c:4757 src/docs_inc.c:5179
+msgid "Who created this recording"
+msgstr ""
+
+#: src/docs_inc.c:415
+msgid "Why The Complexity?"
+msgstr ""
+
+#: src/docs_inc.c:4982
+msgid "Wikipedia for a detailed look into Cron."
+msgstr ""
+
+#: src/docs_inc.c:73
+msgid "Will generate:"
+msgstr ""
+
+#: src/docs_inc.c:1195
+msgid "Work-in-progress notes"
+msgstr ""
+
+#: src/docs_inc.c:4081
+msgid "XMLTV EPG Import"
+msgstr ""
+
+#: src/docs_inc.c:4858
+msgid "Yes"
+msgstr ""
+
+#: src/docs_inc.c:227
+msgid ""
+"Yes, not all services are given a name by providers. These services are "
+"usually hidden for a reason and are often used for things such as encrypted "
+"guide data for set-top boxes, interactive services, and so on."
+msgstr ""
+
+#: src/docs_inc.c:5301 src/docs_inc.c:5377
+msgid "You are now finished."
+msgstr ""
+
+#: src/docs_inc.c:1589
+msgid "You basically have the choice of:"
+msgstr ""
+
+#: src/docs_inc.c:253
+msgid ""
+"You can also consult the in-application help text, which mirrors this guide "
+"to a very great extent."
+msgstr ""
+
+#: src/docs_inc.c:321
+msgid "You can also use"
+msgstr ""
+
+#: src/docs_inc.c:753
+msgid "You can change or delete the autorec rules in the __"
+msgstr ""
+
+#: src/docs_inc.c:647
+msgid ""
+"You can clear an individual filter by simply deleting its contents, or by "
+"selecting _‘(Clear filter)’_ as appropriate on all except the title filter. "
+"If you want to clear all filters, just press the _[Reset All]_ button."
+msgstr ""
+
+#: src/docs_inc.c:2438 src/docs_inc.c:2656
+msgid "You can clone an existing config by clicking the _[Clone]_ button."
+msgstr ""
+
+#: src/docs_inc.c:3026
+msgid "You can clone an existing profile by clicking the _[Clone]_ button."
+msgstr ""
+
+#: src/docs_inc.c:2949
+msgid ""
+"You can have multiple entries using the same username with varying rights, "
+"allowing you to enable / disable each as needed. Note, matching (enabled) "
+"accounts will have permissions combined."
+msgstr ""
+
+#: src/docs_inc.c:17
+msgid ""
+"You can include documentation/items in other markdown files by using the "
+"tvh_class_doc, tvh_include and tvh_class_items tags."
+msgstr ""
+
+#: src/docs_inc.c:2090
+msgid ""
+"You can map/remove a service to/from an existing channel by doing the "
+"following:"
+msgstr ""
+
+#: src/docs_inc.c:1964
+msgid "You can play a stream/file by clicking the play icon !"
+msgstr ""
+
+#: src/docs_inc.c:3450
+msgid ""
+"You can re-schedule an entry by pressing the _[Re-record]_ button on the "
+"menu bar."
+msgstr ""
+
+#: src/docs_inc.c:55
+msgid "You can't have have properly indented paragraphs within list items."
+msgstr ""
+
+#: src/docs_inc.c:4978
+msgid ""
+"You cannot use non-standard predefined scheduling definitions for this field."
+msgstr ""
+
+#: src/docs_inc.c:5351
+msgid ""
+"You may enter a comma-separated list of network prefixes (IPv4/IPv6). If you "
+"were asked to enter a username and password during installation, we'd "
+"recommend not using the same details for a user here as it may cause "
+"unexpected behavior, incorrect permissions etc."
+msgstr ""
+
+#: src/docs_inc.c:5303 src/docs_inc.c:5379
+msgid ""
+"You may further customize your settings by editing channel numbers, etc."
+msgstr ""
+
+#: src/docs_inc.c:3240
+msgid "You may import your own bouquet using enigma2 (.tv) formatted files."
+msgstr ""
+
+#: src/docs_inc.c:5338
+msgid ""
+"You may need to enable specific EPG grabbers to receive OTA EPG data, See "
+"the _EPG Grabber Modules_ Help doc for details."
+msgstr ""
+
+#: src/docs_inc.c:2237
+msgid "You must enter a _SAT>IP source number_ for all the"
+msgstr ""
+
+#: src/docs_inc.c:745
+msgid ""
+"You will also see _[Search IMDB]_ and _[TheTVDB]_ buttons to look for the "
+"program by name on imdb.com/thetvdb.com, and a _[Play program]_ button to "
+"watch a program that’s already in progress. This second button downloads a "
+"playlist file (XSPF or M3U depending on your startup options); if your "
+"system is configured for it, this will automatically launch an appropriate "
+"player, otherwise you will need to manually open the playlist to start "
+"watching (normally a double-click on the downloaded file)."
+msgstr ""
+
+#: src/docs_inc.c:1171
+msgid ""
+"You will only need __c. 30MB disk space__ for the application and associated "
+"files, and maybe anything up to __1GB__ for your configuration - depending "
+"on how many tuners of what type you have, how many channels you receive, "
+"your choice of programme guide, and so on. You'll clearly need much more for "
+"your recordings, though: as a guide, an hour of SD MPEG-2 video will take "
+"about 1GB, while high bitrate HD H.264 will easily consume 5GB+ per hour."
+msgstr ""
+
+#: src/docs_inc.c:1888
+msgid "[Edit]"
+msgstr ""
+
+#: src/docs_inc.c:2941
+msgid "_ tab - not required for wildcard accounts."
+msgstr ""
+
+#: src/docs_inc.c:3192
+msgid ""
+"_ tab. __Note that if your rule matches any in-progress events they will "
+"automatically start being recorded.__"
+msgstr ""
+
+#: src/docs_inc.c:4423 src/docs_inc.c:4785 src/docs_inc.c:5227
+msgid "_Example usage_"
+msgstr ""
+
+#: src/docs_inc.c:4581
+msgid ""
+"_Local_ only checks for duplicates created by the same autorec rule, _All_ "
+"checks all the DVR logs for duplicates."
+msgstr ""
+
+#: src/docs_inc.c:2904
+msgid ""
+"_The order of entries is __extremely__ important!_ It's recommended that you "
+"put the wildcard (asterisk `*`) accounts at top and all other accounts (with "
+"special permissions) at the bottom."
+msgstr ""
+
+#: src/docs_inc.c:617
+msgid ""
+"_Title_ , _Channel_ , _Tag_ and _Content Type_ are dependent on your "
+"configuration and on what your broadcaster sends. Options for the _Duration_ "
+"are as follows:"
+msgstr ""
+
+#: src/docs_inc.c:1077
+msgid "__ : Clear all \"Uncorrected Blocks\", \"BER\", etc stats."
+msgstr ""
+
+#: src/docs_inc.c:1701
+msgid ""
+"__ : Forcefully kill the connection. Note that many applications such as "
+"Kodi will automatically reconnect when a connection is dropped."
+msgstr ""
+
+#: src/docs_inc.c:743
+msgid ""
+"__ tab. This allows you to set, for example, more post- broadcast padding "
+"for a channel that always runs late, or perhaps define a different post-"
+"processing command to strip adverts out on a commercial channel."
+msgstr ""
+
+#: src/docs_inc.c:757
+msgid ""
+"__ tab. Use that editor if you temporarily want to disable an autorecording "
+"or make adjustments to the channel, tag, or similar."
+msgstr ""
+
+#: src/docs_inc.c:2092
+msgid "__1)__ Find the desired service from within the services grid."
+msgstr ""
+
+#: src/docs_inc.c:2227
+msgid "__1. Define the RTSP Port__"
+msgstr ""
+
+#: src/docs_inc.c:2102
+msgid ""
+"__2)__ Double click on the channel field, a drop down listing of all defined "
+"channels will appear, check/uncheck the check box next to the channel you'd "
+"like to associate/disassociate the service with."
+msgstr ""
+
+#: src/docs_inc.c:2231
+msgid "__2. Export the Tuners__"
+msgstr ""
+
+#: src/docs_inc.c:2108
+msgid "__3)__ Press the _[Save]_ button from the menu bar, and you're done!"
+msgstr ""
+
+#: src/docs_inc.c:2235
+msgid "__3. Export Your Networks__"
+msgstr ""
+
+#: src/docs_inc.c:2247
+msgid "__4. Configure Your Client__"
+msgstr ""
+
+#: src/docs_inc.c:135
+msgid "__Active__ : Progress bar indicating mapping status."
+msgstr ""
+
+#: src/docs_inc.c:719
+msgid "__Age__ : Age rating of the program."
+msgstr ""
+
+#: src/docs_inc.c:1087
+msgid "__BER__ :"
+msgstr ""
+
+#: src/docs_inc.c:1085
+msgid "__Bandwidth__ : Total stream input bandwidth."
+msgstr ""
+
+#: src/docs_inc.c:1697
+msgid "__Cancel Icon !"
+msgstr ""
+
+#: src/docs_inc.c:1529
+msgid "__Channel__ : The name of the"
+msgstr ""
+
+#: src/docs_inc.c:715
+msgid ""
+"__Channel__ : The name of the broadcasting channel. _You can automatically "
+"set a filter to the value of this field by clicking on it (e.g. click on "
+"'Channel 4 HD' will automatically filter the whole grid to only show "
+"programs from that channel)._"
+msgstr ""
+
+#: src/docs_inc.c:721
+msgid ""
+"__Content Type__ : Any content/genre information as provided by the EPG "
+"provider. _You can automatically set a filter to the value of this field by "
+"clicking on it (e.g. click on 'Movie/Drama' will automatically filter the "
+"whole grid to only show programs of the same type)._"
+msgstr ""
+
+#: src/docs_inc.c:1099
+msgid ""
+"__Continuity Errors__ : Continuity Count Error. Number of stream errors, a "
+"high value here can indicate a signal problem."
+msgstr ""
+
+#: src/docs_inc.c:1904
+msgid "__Deleting can't be undone. You will be prompted to confirm. __"
+msgstr ""
+
+#: src/docs_inc.c:1561
+msgid "__Descramble__ : The CAID used to descramble the stream."
+msgstr ""
+
+#: src/docs_inc.c:677
+msgid ""
+"__Details__ : Displays the current status of a recording event for this "
+"program if one applies:"
+msgstr ""
+
+#: src/docs_inc.c:711
+msgid ""
+"__Duration__ : The scheduled duration (i.e. start time to end time) of the "
+"program."
+msgstr ""
+
+#: src/docs_inc.c:709
+msgid "__End Time__ : The scheduled end time of the program."
+msgstr ""
+
+#: src/docs_inc.c:705
+msgid "__Episode__ : Episode number, if given by your EPG provider."
+msgstr ""
+
+#: src/docs_inc.c:1563
+msgid "__Errors__ : Number of errors occurred sending the stream."
+msgstr ""
+
+#: src/docs_inc.c:1307
+msgid ""
+"__Example:__ `http://127.0.0.1:9981/play/stream/channelname/Life?"
+"playlist=xspf`"
+msgstr ""
+
+#: src/docs_inc.c:3298
+msgid ""
+"__Failed Recordings__ : This sub-tab lists all failed recording entries. "
+"Entries shown here have failed to record due to one (or more) errors that "
+"occurred during the recording."
+msgstr ""
+
+#: src/docs_inc.c:133
+msgid "__Failed__ : Number of services that failed to be mapped."
+msgstr ""
+
+#: src/docs_inc.c:3296
+msgid ""
+"__Finished Recordings__ : This sub-tab lists all completed recording "
+"entries. Entries shown here have reached the end of the scheduled (or EITp/f "
+"defined) recording time."
+msgstr ""
+
+#: src/docs_inc.c:401
+msgid ""
+"__Firmware__ is a small piece of binary microcode that your system driver "
+"sends to the tuner upon initialisation. This is the cause of more problems "
+"than you'd imagine... if you find yourself in trouble, this is the first "
+"thing to check along with kernel support for your hardware."
+msgstr ""
+
+#: src/docs_inc.c:1523
+msgid "__Hostname__ : Hostname/IP address using the subscription."
+msgstr ""
+
+#: src/docs_inc.c:1521
+msgid "__ID__ : Subscription ID."
+msgstr ""
+
+#: src/docs_inc.c:1705
+msgid "__IP Address__ : The IP address of the device."
+msgstr ""
+
+#: src/docs_inc.c:5435
+msgid ""
+"__If you receive your channels through a satellite dish__ then you would "
+"select the network under the tuners with DVB-S/S2 in the name."
+msgstr ""
+
+#: src/docs_inc.c:5433
+msgid ""
+"__If you receive your channels through an antenna (also known as an "
+"aerial)__ then you would select the network under the tuners with DVB-T/ATSC-"
+"T/ISDB-T in the name."
+msgstr ""
+
+#: src/docs_inc.c:5437
+msgid ""
+"__If you receive your channels via cable__ then you would select the network "
+"under the tuners with DVB-C/ATSC-C/ISDB-C in the name."
+msgstr ""
+
+#: src/docs_inc.c:131
+msgid "__Ignored__ : Number of services ignored."
+msgstr ""
+
+#: src/docs_inc.c:1079
+msgid "__Input__ : Device used to receive the stream."
+msgstr ""
+
+#: src/docs_inc.c:1565
+msgid "__Input__ : The input data rate in kb/s."
+msgstr ""
+
+#: src/docs_inc.c:4188
+msgid "__It does not have any user configurable options.__"
+msgstr ""
+
+#: src/docs_inc.c:129
+msgid "__Mapped__ : Number of services mapped."
+msgstr ""
+
+#: src/docs_inc.c:393
+msgid "__Network tuners__ are small (usually"
+msgstr ""
+
+#: src/docs_inc.c:301
+msgid ""
+"__Note__ : Some tuners (or drivers) require more tuning parameters than "
+"others so __be sure to enter as many tuning parameters as possible__ ."
+msgstr ""
+
+#: src/docs_inc.c:3452
+msgid ""
+"__Note__ : Your EPG data must have another matching event to be able to re-"
+"schedule the entry."
+msgstr ""
+
+#: src/docs_inc.c:2756 src/docs_inc.c:5286 src/docs_inc.c:5334
+#: src/docs_inc.c:5349 src/docs_inc.c:5364 src/docs_inc.c:5408
+#: src/docs_inc.c:5439
+msgid "__Notes__ :"
+msgstr ""
+
+#: src/docs_inc.c:713
+msgid ""
+"__Number__ : The channel number of the broadcasting channel, if defined."
+msgstr ""
+
+#: src/docs_inc.c:1567
+msgid "__Output__ : The output data rate in kb/s."
+msgstr ""
+
+#: src/docs_inc.c:1091
+msgid "__PER__ :"
+msgstr ""
+
+#: src/docs_inc.c:1535
+msgid "__Profile__ : The name of the"
+msgstr ""
+
+#: src/docs_inc.c:699
+msgid ""
+"__Progress__ : A bar graph display of how far through a program we currently "
+"are."
+msgstr ""
+
+#: src/docs_inc.c:1137
+msgid "__Re-arrange__ the columns by simply dragging he header to a new spot."
+msgstr ""
+
+#: src/docs_inc.c:1139
+msgid ""
+"__Re-size__ the columns by dragging the very edges of the column header as "
+"required."
+msgstr ""
+
+#: src/docs_inc.c:3300
+msgid ""
+"__Removed Recordings__ : This sub-tab lists all recording entries that have "
+"missing file(s). Entries shown here link to file(s) that Tvheadend cannot "
+"locate (files which have been externally removed)."
+msgstr ""
+
+#: src/docs_inc.c:1101
+msgid "__SNR__ : Signal (To) Noise Ratio."
+msgstr ""
+
+#: src/docs_inc.c:5429
+msgid "__Selecting the Right Network__ :"
+msgstr ""
+
+#: src/docs_inc.c:1107
+msgid ""
+"__Signal Strength__ : The signal strength as reported by the device, note "
+"that not all devices supply correct signal information, the value here can "
+"sometimes be ambiguous"
+msgstr ""
+
+#: src/docs_inc.c:717
+msgid "__Stars__ : Rating (in stars) of the program."
+msgstr ""
+
+#: src/docs_inc.c:707
+msgid "__Start Time__ : The scheduled start time of the program."
+msgstr ""
+
+#: src/docs_inc.c:1541
+msgid "__Start__ : The date (and time) the subscription was started."
+msgstr ""
+
+#: src/docs_inc.c:1709
+msgid "__Started__ : Date the connection started - YYYY-MM-DD HH:MM:SS."
+msgstr ""
+
+#: src/docs_inc.c:1543
+msgid "__State__ : The status of the subscription"
+msgstr ""
+
+#: src/docs_inc.c:1081
+msgid "__Sub No__ : Number of subscriptions using the stream."
+msgstr ""
+
+#: src/docs_inc.c:703
+msgid ""
+"__Subtitle__ : The subtitle of the program, if gien by your EPG provider. "
+"Note that some (notably, UK) providers use this for a program synopsis "
+"instead of a true subtitle."
+msgstr ""
+
+#: src/docs_inc.c:1073
+msgid "__Sweep/Clean Icon !"
+msgstr ""
+
+#: src/docs_inc.c:5420
+msgid ""
+"__The interface will reload in your chosen language (if the translation is "
+"available).__"
+msgstr ""
+
+#: src/docs_inc.c:31
+msgid "__This is definition list formatting__ : with a subsequent explanation"
+msgstr ""
+
+#: src/docs_inc.c:29
+msgid "__This is paragraph formatting__ : with a subsequent explanation"
+msgstr ""
+
+#: src/docs_inc.c:5406
+msgid ""
+"__This wizard should only be run on initial setup. Please cancel it if "
+"you're not willing to touch the current configuration, as continuing in such "
+"cases can lead to misconfiguration and not all changes made thru this wizard "
+"will take effect.__"
+msgstr ""
+
+#: src/docs_inc.c:2086
+msgid ""
+"__Tip__ : By default Tvheadend will only show a small selection of available "
+"services - you can increase this by using the paging selector at the bottom "
+"right of the page."
+msgstr ""
+
+#: src/docs_inc.c:2520
+msgid ""
+"__Tip__ : Don't forget to set the _EIT time offset_ for your network(s)."
+msgstr ""
+
+#: src/docs_inc.c:1906
+msgid ""
+"__Tip__ : Rather than deleting an entry, you can disable it instead by "
+"unchecking the \"Enabled\" check box (if available)."
+msgstr ""
+
+#: src/docs_inc.c:2100
+msgid ""
+"__Tip__ : Remember to remove the filter when you're finished (uncheck the "
+"check box next to the \"Filters\" option)."
+msgstr ""
+
+#: src/docs_inc.c:483
+msgid "__Tip__ : Remember to save your changes _before_ switching panels."
+msgstr ""
+
+#: src/docs_inc.c:2963
+msgid ""
+"__Tip__ : Remember to set the correct permissions so that Tvheadend is able "
+"to read the superuser file."
+msgstr ""
+
+#: src/docs_inc.c:2816
+msgid ""
+"__Tip__ : You can enter a comma-separated list of network prefixes, if "
+"you're unsure as to what to enter in the _Network prefix_ field take a look "
+"at"
+msgstr ""
+
+#: src/docs_inc.c:2434 src/docs_inc.c:2652 src/docs_inc.c:2943
+#: src/docs_inc.c:3022 src/docs_inc.c:3510
+msgid "__Tips__ :"
+msgstr ""
+
+#: src/docs_inc.c:701
+msgid ""
+"__Title__ : The title of the program. _You can automatically set a filter to "
+"the value of this field by clicking on it (e.g. click on 'Daily News' will "
+"automatically filter the whole grid to only show programs with the same "
+"name)._"
+msgstr ""
+
+#: src/docs_inc.c:1527
+msgid ""
+"__Title__ : Title of the application using the subscription - you will "
+"sometimes see \"epggrab\" here, this is an internal subscription used by "
+"tvheadend to grab EPG data."
+msgstr ""
+
+#: src/docs_inc.c:1097
+msgid ""
+"__Transport Errors__ : Number of transport streams errors. A fast increasing "
+"value here can indicate signal issues. Device drivers can sometimes send "
+"garbage data at the beginning of a stream, as long as the value doesn't "
+"increase at a fast pace and you have no playback issues, there is nothing to "
+"worry about."
+msgstr ""
+
+#: src/docs_inc.c:349
+msgid ""
+"__Tvheadend web interface: _Configuration -> Channel / EPG -> Bouquets_ __"
+msgstr ""
+
+#: src/docs_inc.c:295
+msgid "__Tvheadend web interface: _Configuration -> DVB Inputs -> Muxes_ __"
+msgstr ""
+
+#: src/docs_inc.c:269
+msgid "__Tvheadend web interface: _Configuration -> DVB Inputs -> Networks_ __"
+msgstr ""
+
+#: src/docs_inc.c:329 src/docs_inc.c:337
+msgid "__Tvheadend web interface: _Configuration -> DVB Inputs -> Services_ __"
+msgstr ""
+
+#: src/docs_inc.c:257 src/docs_inc.c:285
+msgid ""
+"__Tvheadend web interface: _Configuration -> DVB Inputs -> TV Adapters_ __"
+msgstr ""
+
+#: src/docs_inc.c:1703
+msgid "__Type__ : Connection type - HTSP or HTTP."
+msgstr ""
+
+#: src/docs_inc.c:1095
+msgid ""
+"__Uncorrected Blocks__ : Number of uncorrected blocks. A value higher than 0 "
+"can indicate a weak signal or interference, note that some devices can send "
+"a false value."
+msgstr ""
+
+#: src/docs_inc.c:3294
+msgid ""
+"__Upcoming / Current Recordings__ : This sub-tab lists current and upcoming "
+"recording entries. Entries shown here are either currently recording or are "
+"soon-to-be recorded."
+msgstr ""
+
+#: src/docs_inc.c:1707
+msgid ""
+"__Username__ : The username used to access tvheadend (a blank cell indicates "
+"no username was supplied)."
+msgstr ""
+
+#: src/docs_inc.c:1525
+msgid ""
+"__Username__ : Username using the subscription - a blank cell indicates the "
+"subscriber didn't supply a username."
+msgstr ""
+
+#: src/docs_inc.c:1916
+msgid ""
+"__View Level__ | Change the interface view level to show/hide more advanced "
+"options.\n"
+"__Help__ | Display this help page."
+msgstr ""
+
+#: src/docs_inc.c:2969
+msgid ""
+"__WARNING__ : Permissions given to a wildcard account apply to __all__ "
+"accounts."
+msgstr ""
+
+#: src/docs_inc.c:1083
+msgid "__Weight__ : Stream weighting."
+msgstr ""
+
+#: src/docs_inc.c:5332
+msgid ""
+"__You may omit this step (do not check 'Map all services') and map services "
+"to channels manually.__"
+msgstr ""
+
+#: src/docs_inc.c:3819
+msgid "access"
+msgstr ""
+
+#: src/docs_inc.c:1629 src/docs_inc.c:1825 src/docs_inc.c:4652
+#: src/docs_inc.c:4662 src/docs_inc.c:4672 src/docs_inc.c:4694
+msgid "and"
+msgstr ""
+
+#: src/docs_inc.c:163
+msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgstr ""
+
+#: src/docs_inc.c:2900
+msgid "anonymous"
+msgstr ""
+
+#: src/docs_inc.c:3839
+msgid "api"
+msgstr ""
+
+#: src/docs_inc.c:171
+msgid "are good web clients if you don't already have an IRC client installed."
+msgstr ""
+
+#: src/docs_inc.c:395
+msgid "arm"
+msgstr ""
+
+#: src/docs_inc.c:3634
+msgid "as channels"
+msgstr ""
+
+#: src/docs_inc.c:3831
+msgid "avahi"
+msgstr ""
+
+#: src/docs_inc.c:4469
+msgid ""
+"available. Tvheadend will parse the NIT then the add newly discovered muxes "
+"automatically."
+msgstr ""
+
+#: src/docs_inc.c:397
+msgid ""
+"based) computers that you connect to your network via Ethernet or Wifi, they "
+"often have a large number of tuners and are controlled via a web interface "
+"or software. Many work out-of-the-box with Tvheadend using SAT>IP or the "
+"HDHomeRun protocols."
+msgstr ""
+
+#: src/docs_inc.c:2894
+msgid "below"
+msgstr ""
+
+#: src/docs_inc.c:3835
+msgid "bonjour"
+msgstr ""
+
+#: src/docs_inc.c:3955
+msgid "bouquet"
+msgstr ""
+
+#: src/docs_inc.c:2002 src/docs_inc.c:2010
+msgid "button table below)."
+msgstr ""
+
+#: src/docs_inc.c:3971
+msgid "caclient"
+msgstr ""
+
+#: src/docs_inc.c:2531
+msgid "capabilities."
+msgstr ""
+
+#: src/docs_inc.c:3979
+msgid "capmt"
+msgstr ""
+
+#: src/docs_inc.c:1397 src/docs_inc.c:1531 src/docs_inc.c:3943
+#: src/docs_inc.c:5242
+msgid "channel"
+msgstr ""
+
+#: src/docs_inc.c:1353 src/docs_inc.c:1401 src/docs_inc.c:1461
+msgid "channelid"
+msgstr ""
+
+#: src/docs_inc.c:1349 src/docs_inc.c:1393 src/docs_inc.c:1457
+msgid "channelname"
+msgstr ""
+
+#: src/docs_inc.c:1345 src/docs_inc.c:1389 src/docs_inc.c:1453
+msgid "channelnumber"
+msgstr ""
+
+#: src/docs_inc.c:1333 src/docs_inc.c:1449
+msgid "channels"
+msgstr ""
+
+#: src/docs_inc.c:4007
+msgid "charset"
+msgstr ""
+
+#: src/docs_inc.c:693
+msgid "click to call up more detailed information about an event"
+msgstr ""
+
+#: src/docs_inc.c:3386
+msgid "click to display detailed information about the selected recording"
+msgstr ""
+
+#: src/docs_inc.c:3815
+msgid "config"
+msgstr ""
+
+#: src/docs_inc.c:3823
+msgid "cron"
+msgstr ""
+
+#: src/docs_inc.c:3975
+msgid "csa"
+msgstr ""
+
+#: src/docs_inc.c:3983
+msgid "cwc"
+msgstr ""
+
+#: src/docs_inc.c:3827
+msgid "dbus"
+msgstr ""
+
+#: src/docs_inc.c:1429
+msgid "descramble"
+msgstr ""
+
+#: src/docs_inc.c:3967
+msgid "descrambler"
+msgstr ""
+
+#: src/docs_inc.c:1661
+msgid "development page"
+msgstr ""
+
+#: src/docs_inc.c:113
+msgid "dialog determines how services are mapped."
+msgstr ""
+
+#: src/docs_inc.c:2078
+msgid ""
+"dialog will now be displayed with the __selected__ services checked - feel "
+"free to make changes. Once you're happy with the selection press the \"Map "
+"services\" button, you will then be taken to the"
+msgstr ""
+
+#: src/docs_inc.c:1946
+msgid "dialog."
+msgstr ""
+
+#: src/docs_inc.c:4043
+msgid "diseqc"
+msgstr ""
+
+#: src/docs_inc.c:1651
+msgid "documentatation repository"
+msgstr ""
+
+#: src/docs_inc.c:5317 src/docs_inc.c:5395
+msgid "donate"
+msgstr ""
+
+#: src/docs_inc.c:4011
+msgid "dvb"
+msgstr ""
+
+#: src/docs_inc.c:3987
+msgid "dvbcam"
+msgstr ""
+
+#: src/docs_inc.c:323
+msgid "dvbscan"
+msgstr ""
+
+#: src/docs_inc.c:3991
+msgid "dvr"
+msgstr ""
+
+#: src/docs_inc.c:1369
+msgid "dvrid"
+msgstr ""
+
+#: src/docs_inc.c:1321
+msgid "e2"
+msgstr ""
+
+#: src/docs_inc.c:1433
+msgid "emm"
+msgstr ""
+
+#: src/docs_inc.c:1317
+msgid "empty"
+msgstr ""
+
+#: src/docs_inc.c:4047
+msgid "en50221"
+msgstr ""
+
+#: src/docs_inc.c:4051
+msgid "en50494"
+msgstr ""
+
+#: src/docs_inc.c:3995
+msgid "epg"
+msgstr ""
+
+#: src/docs_inc.c:3999
+msgid "epgdb"
+msgstr ""
+
+#: src/docs_inc.c:4003
+msgid "epggrab"
+msgstr ""
+
+#: src/docs_inc.c:3959
+msgid "esfilter"
+msgstr ""
+
+#: src/docs_inc.c:1183
+msgid "example"
+msgstr ""
+
+#: src/docs_inc.c:3903
+msgid "fastscan"
+msgstr ""
+
+#: src/docs_inc.c:1653
+msgid ""
+"fetches the markdown files using the build-in web server and use them as "
+"source for mkdocs."
+msgstr ""
+
+#: src/docs_inc.c:1633
+msgid "firmware repositories on Github."
+msgstr ""
+
+#: src/docs_inc.c:2034
+msgid "for 7+ days."
+msgstr ""
+
+#: src/docs_inc.c:311
+msgid "for UK DVB-T transmitters"
+msgstr ""
+
+#: src/docs_inc.c:345
+msgid "for a detailed look into service mapping."
+msgstr ""
+
+#: src/docs_inc.c:307
+msgid "for all European satellite information"
+msgstr ""
+
+#: src/docs_inc.c:1663 src/docs_inc.c:2896
+msgid "for details."
+msgstr ""
+
+#: src/docs_inc.c:3556
+msgid "for more details on service mapping."
+msgstr ""
+
+#: src/docs_inc.c:1974
+msgid "for more info."
+msgstr ""
+
+#: src/docs_inc.c:3436
+msgid "for more information."
+msgstr ""
+
+#: src/docs_inc.c:315
+msgid "for primarily central and northern Europe"
+msgstr ""
+
+#: src/docs_inc.c:319
+msgid "for worldwide satellite information."
+msgstr ""
+
+#: src/docs_inc.c:4515
+msgid "force service type to 1"
+msgstr ""
+
+#: src/docs_inc.c:4346
+msgid "format."
+msgstr ""
+
+#: src/docs_inc.c:161
+msgid "forum"
+msgstr ""
+
+#: src/docs_inc.c:1185
+msgid "from one of our users..."
+msgstr ""
+
+#: src/docs_inc.c:3779
+msgid "fsmonitor"
+msgstr ""
+
+#: src/docs_inc.c:3674
+msgid "functions or a"
+msgstr ""
+
+#: src/docs_inc.c:205
+msgid "github"
+msgstr ""
+
+#: src/docs_inc.c:3915
+msgid "globalheaders"
+msgstr ""
+
+#: src/docs_inc.c:2561
+msgid "grabbers"
+msgstr ""
+
+#: src/docs_inc.c:2529
+msgid "grabbing"
+msgstr ""
+
+#: src/docs_inc.c:3751
+msgid "gtimer"
+msgstr ""
+
+#: src/docs_inc.c:275 src/docs_inc.c:5412
+msgid "here"
+msgstr ""
+
+#: src/docs_inc.c:3923
+msgid "hevc"
+msgstr ""
+
+#: src/docs_inc.c:3851
+msgid "htsp"
+msgstr ""
+
+#: src/docs_inc.c:3863
+msgid "htsp-ans"
+msgstr ""
+
+#: src/docs_inc.c:3859
+msgid "htsp-req"
+msgstr ""
+
+#: src/docs_inc.c:3855
+msgid "htsp-sub"
+msgstr ""
+
+#: src/docs_inc.c:3843
+msgid "http"
+msgstr ""
+
+#: src/docs_inc.c:3847
+msgid "httpc"
+msgstr ""
+
+#: src/docs_inc.c:1827
+msgid "iOS"
+msgstr ""
+
+#: src/docs_inc.c:3791
+msgid "idnode"
+msgstr ""
+
+#: src/docs_inc.c:3867
+msgid "imagecache"
+msgstr ""
+
+#: src/docs_inc.c:2120
+msgid "information icon will display service details."
+msgstr ""
+
+#: src/docs_inc.c:4031
+msgid "iptv"
+msgstr ""
+
+#: src/docs_inc.c:4035
+msgid "iptv-pcr"
+msgstr ""
+
+#: src/docs_inc.c:4023
+msgid "libav"
+msgstr ""
+
+#: src/docs_inc.c:4025
+msgid "libav / ffmpeg"
+msgstr ""
+
+#: src/docs_inc.c:4039
+msgid "linuxdvb"
+msgstr ""
+
+#: src/docs_inc.c:1797
+msgid "linuxtv"
+msgstr ""
+
+#: src/docs_inc.c:3783
+msgid "lock"
+msgstr ""
+
+#: src/docs_inc.c:1305
+msgid "m3u"
+msgstr ""
+
+#: src/docs_inc.c:3747
+msgid "main"
+msgstr ""
+
+#: src/docs_inc.c:3935 src/docs_inc.c:5062
+msgid "mkv"
+msgstr ""
+
+#: src/docs_inc.c:4015
+msgid "mpegts"
+msgstr ""
+
+#: src/docs_inc.c:3755
+msgid "mtimer"
+msgstr ""
+
+#: src/docs_inc.c:1409
+msgid "mux"
+msgstr ""
+
+#: src/docs_inc.c:3927
+msgid "muxer"
+msgstr ""
+
+#: src/docs_inc.c:4019
+msgid "muxsched"
+msgstr ""
+
+#: src/docs_inc.c:2239
+msgid "networks"
+msgstr ""
+
+#: src/docs_inc.c:1799
+msgid "networks or manually configured."
+msgstr ""
+
+#: src/docs_inc.c:777 src/docs_inc.c:779 src/docs_inc.c:787 src/docs_inc.c:789
+#: src/docs_inc.c:805 src/docs_inc.c:813 src/docs_inc.c:831 src/docs_inc.c:833
+#: src/docs_inc.c:841 src/docs_inc.c:843
+msgid "no"
+msgstr ""
+
+#: src/docs_inc.c:4071
+msgid "opentv"
+msgstr ""
+
+#: src/docs_inc.c:1303
+msgid "or"
+msgstr ""
+
+#: src/docs_inc.c:167
+msgid "or Freenode's"
+msgstr ""
+
+#: src/docs_inc.c:5309 src/docs_inc.c:5387
+msgid "or chat to us on"
+msgstr ""
+
+#: src/docs_inc.c:5244
+msgid "or per"
+msgstr ""
+
+#: src/docs_inc.c:3690
+msgid "page for info."
+msgstr ""
+
+#: src/docs_inc.c:3422 src/docs_inc.c:3516
+msgid "page."
+msgstr ""
+
+#: src/docs_inc.c:2719
+msgid "parameters"
+msgstr ""
+
+#: src/docs_inc.c:3907
+msgid "parser"
+msgstr ""
+
+#: src/docs_inc.c:3931
+msgid "pass"
+msgstr ""
+
+#: src/docs_inc.c:1437
+msgid "pids"
+msgstr ""
+
+#: src/docs_inc.c:1297
+msgid "playlist"
+msgstr ""
+
+#: src/docs_inc.c:1377 src/docs_inc.c:1417 src/docs_inc.c:1537
+#: src/docs_inc.c:3963
+msgid "profile"
+msgstr ""
+
+#: src/docs_inc.c:4067
+msgid "psip"
+msgstr ""
+
+#: src/docs_inc.c:4075
+msgid "pyepg"
+msgstr ""
+
+#: src/docs_inc.c:1425
+msgid "qsize"
+msgstr ""
+
+#: src/docs_inc.c:3382
+msgid "recording of the program is active and underway (current)"
+msgstr ""
+
+#: src/docs_inc.c:1341
+msgid "recordings"
+msgstr ""
+
+#: src/docs_inc.c:3803
+msgid "rtsp"
+msgstr ""
+
+#: src/docs_inc.c:1325 src/docs_inc.c:4055
+msgid "satip"
+msgstr ""
+
+#: src/docs_inc.c:4059
+msgid "satips"
+msgstr ""
+
+#: src/docs_inc.c:4091
+msgid "scanfile"
+msgstr ""
+
+#: src/docs_inc.c:3658
+msgid "selected channels."
+msgstr ""
+
+#: src/docs_inc.c:1405 src/docs_inc.c:3939
+msgid "service"
+msgstr ""
+
+#: src/docs_inc.c:3951
+msgid "service-mapper"
+msgstr ""
+
+#: src/docs_inc.c:3624 src/docs_inc.c:3632
+msgid "services"
+msgstr ""
+
+#: src/docs_inc.c:3811
+msgid "settings"
+msgstr ""
+
+#: src/docs_inc.c:3775
+msgid "spawn"
+msgstr ""
+
+#: src/docs_inc.c:4344
+msgid "strftime"
+msgstr ""
+
+#: src/docs_inc.c:3947
+msgid "subscription"
+msgstr ""
+
+#: src/docs_inc.c:2279
+msgid ""
+"tab for it to apply. You may have multiple password entries for the same "
+"username if you wish."
+msgstr ""
+
+#: src/docs_inc.c:4505 src/docs_inc.c:4594
+msgid "tab to re-generate them."
+msgstr ""
+
+#: src/docs_inc.c:3546
+msgid "tab when you press the _[Map services]_ button."
+msgstr ""
+
+#: src/docs_inc.c:2064 src/docs_inc.c:2082
+msgid "tab which will begin mapping the selected services to channels."
+msgstr ""
+
+#: src/docs_inc.c:3356 src/docs_inc.c:3364
+msgid "tab."
+msgstr ""
+
+#: src/docs_inc.c:4251
+msgid ""
+"tab. Note, when streaming using the HTSP Protocol e.g. Kodi (via pvr.hts) or "
+"Movian the HTSP profile will always be used."
+msgstr ""
+
+#: src/docs_inc.c:3078
+msgid ""
+"tab. This dialog shows the received PIDs and filtered PIDs in one window."
+msgstr ""
+
+#: src/docs_inc.c:1357 src/docs_inc.c:1465
+msgid "tag"
+msgstr ""
+
+#: src/docs_inc.c:1365 src/docs_inc.c:1473
+msgid "tagid"
+msgstr ""
+
+#: src/docs_inc.c:1361 src/docs_inc.c:1469
+msgid "tagname"
+msgstr ""
+
+#: src/docs_inc.c:1337
+msgid "tags"
+msgstr ""
+
+#: src/docs_inc.c:3871
+msgid "tbl"
+msgstr ""
+
+#: src/docs_inc.c:3891
+msgid "tbl-atsc"
+msgstr ""
+
+#: src/docs_inc.c:3875
+msgid "tbl-base"
+msgstr ""
+
+#: src/docs_inc.c:3879
+msgid "tbl-csa"
+msgstr ""
+
+#: src/docs_inc.c:3883
+msgid "tbl-eit"
+msgstr ""
+
+#: src/docs_inc.c:3895
+msgid "tbl-pass"
+msgstr ""
+
+#: src/docs_inc.c:3899
+msgid "tbl-satip"
+msgstr ""
+
+#: src/docs_inc.c:3887
+msgid "tbl-time"
+msgstr ""
+
+#: src/docs_inc.c:3799
+msgid "tcp"
+msgstr ""
+
+#: src/docs_inc.c:1581
+msgid "the Tvheadend forums"
+msgstr ""
+
+#: src/docs_inc.c:697 src/docs_inc.c:3390
+msgid "the program failed to record"
+msgstr ""
+
+#: src/docs_inc.c:689
+msgid "the program is currently recording"
+msgstr ""
+
+#: src/docs_inc.c:3378
+msgid "the program is scheduled (upcoming)"
+msgstr ""
+
+#: src/docs_inc.c:685
+msgid "the program is scheduled for recording"
+msgstr ""
+
+#: src/docs_inc.c:3394
+msgid "the program recorded successfully"
+msgstr ""
+
+#: src/docs_inc.c:1533
+msgid ""
+"the subscription is using - if the subscription is streaming a service/mux "
+"this cell will be blank."
+msgstr ""
+
+#: src/docs_inc.c:1539
+msgid "the subscription is using."
+msgstr ""
+
+#: src/docs_inc.c:2818
+msgid "this guide"
+msgstr ""
+
+#: src/docs_inc.c:3763
+msgid "thread"
+msgstr ""
+
+#: src/docs_inc.c:3771
+msgid "time"
+msgstr ""
+
+#: src/docs_inc.c:4087
+msgid "timeshift"
+msgstr ""
+
+#: src/docs_inc.c:325
+msgid "to force a scan and effectively ask your tuner what it can see."
+msgstr ""
+
+#: src/docs_inc.c:4027
+msgid "transcode"
+msgstr ""
+
+#: src/docs_inc.c:4095
+msgid "tsfile"
+msgstr ""
+
+#: src/docs_inc.c:3919
+msgid "tsfix"
+msgstr ""
+
+#: src/docs_inc.c:4063
+msgid "tvhdhomerun"
+msgstr ""
+
+#: src/docs_inc.c:3767
+msgid "tvhpoll"
+msgstr ""
+
+#: src/docs_inc.c:3656
+msgid "two"
+msgstr ""
+
+#: src/docs_inc.c:309
+msgid "ukfree.tv"
+msgstr ""
+
+#: src/docs_inc.c:3807
+msgid "upnp"
+msgstr ""
+
+#: src/docs_inc.c:3795
+msgid "url"
+msgstr ""
+
+#: src/docs_inc.c:4377 src/docs_inc.c:4381 src/docs_inc.c:4755
+#: src/docs_inc.c:4759 src/docs_inc.c:5177 src/docs_inc.c:5181
+msgid "user"
+msgstr ""
+
+#: src/docs_inc.c:3787
+msgid "uuid"
+msgstr ""
+
+#: src/docs_inc.c:169
+msgid "webchat"
+msgstr ""
+
+#: src/docs_inc.c:4083
+msgid "webui"
+msgstr ""
+
+#: src/docs_inc.c:1421
+msgid "weight"
+msgstr ""
+
+#: src/docs_inc.c:153
+msgid "wiki"
+msgstr ""
+
+#: src/docs_inc.c:4444 src/docs_inc.c:4448
+msgid "will be"
+msgstr ""
+
+#: src/docs_inc.c:2060
+msgid ""
+"will now be displayed with __all__ services checked - feel free to make "
+"changes. Once you're happy with the selection press the \"Map services\" "
+"button, you will then be taken to the"
+msgstr ""
+
+#: src/docs_inc.c:4079
+msgid "xmltv"
+msgstr ""
+
+#: src/docs_inc.c:1301
+msgid "xspf"
+msgstr ""
+
+#: src/docs_inc.c:781 src/docs_inc.c:783 src/docs_inc.c:791 src/docs_inc.c:807
+#: src/docs_inc.c:809 src/docs_inc.c:815 src/docs_inc.c:835 src/docs_inc.c:837
+#: src/docs_inc.c:845
+msgid "yes"
+msgstr ""
+
+#: src/docs_inc.c:2241
+msgid ""
+"you want to export. If you don't export any, you will see the following "
+"error message (in the log)."
+msgstr ""
+
+#: src/docs_inc.c:89
+msgid ""
+"| --------------------------- | ------------- Headless table cell 1 | "
+"Content from cell 2 Content in the first column | Content in the second "
+"column"
+msgstr ""


### PR DESCRIPTION
We have template discrepancies between `tvheadend/intl` and the sub-directories contain the .po strings. Language strings/templates for Lithuanian (lt) are in `tvheadend/intl` and `tvheadend/intl/js`, but are missing from `tvheadend/intl/docs`.

The language exists on Transifex, so I'm assuming that it's an import error (i.e. no target into which to import the translated strings). There appears to be nothing in the code or Makefile that creates these files otherwise.

This forces the creation of a template by simply copying the master `tvheadend/intl/docs/tvheadend.doc.pot` to `tvheadend/intl/docs/tvheadend.doc.lt.po`.