### PR TITLE
intl: update translation templates from code

### DIFF
--- a/intl/docs/tvheadend.doc.pot
+++ b/intl/docs/tvheadend.doc.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-29 21:07+0200\n"
+"POT-Creation-Date: 2024-02-01 08:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/docs_inc.c:1844
+#: src/docs_inc.c:5392
+msgid ""
+"\n"
+" By default all URLs (in a playlist) with path component changes are treated "
+"as new services. This causes channels linked to them to be marked `{name-not-"
+"set}` due to the previously-used URL \"no longer existing\" in the playlist, "
+"they in fact do exist but have changed slightly."
+msgstr ""
+
+#: src/docs_inc.c:2843
 msgid ""
 "\n"
 "__Tip__ : By default Tvheadend will only show a small selection of entries - "
@@ -25,615 +34,681 @@ msgid ""
 "selector at the bottom right of the page."
 msgstr ""
 
-#: src/docs_inc.c:1861
-msgid ""
-"\n"
-"__Tip__ : You can select all entries within the grid by pressing ctrl+A. You "
-"can also ctrl+click to make additional selections, or shift+click to select "
-"a range."
-msgstr ""
-
-#: src/docs_inc.c:105 src/docs_inc.c:145 src/docs_inc.c:185 src/docs_inc.c:423
-#: src/docs_inc.c:457 src/docs_inc.c:479 src/docs_inc.c:571 src/docs_inc.c:729
-#: src/docs_inc.c:735 src/docs_inc.c:1053 src/docs_inc.c:1501
-#: src/docs_inc.c:1677 src/docs_inc.c:1983 src/docs_inc.c:2044
-#: src/docs_inc.c:2052 src/docs_inc.c:2070 src/docs_inc.c:2096
-#: src/docs_inc.c:2104 src/docs_inc.c:2122 src/docs_inc.c:2135
-#: src/docs_inc.c:2168 src/docs_inc.c:2193 src/docs_inc.c:2258
-#: src/docs_inc.c:2271 src/docs_inc.c:2313 src/docs_inc.c:2342
-#: src/docs_inc.c:2428 src/docs_inc.c:2451 src/docs_inc.c:2492
-#: src/docs_inc.c:2533 src/docs_inc.c:2578 src/docs_inc.c:2638
-#: src/docs_inc.c:2644 src/docs_inc.c:2723 src/docs_inc.c:2744
-#: src/docs_inc.c:2750 src/docs_inc.c:2768 src/docs_inc.c:2803
-#: src/docs_inc.c:2812 src/docs_inc.c:2833 src/docs_inc.c:2846
-#: src/docs_inc.c:2867 src/docs_inc.c:2906 src/docs_inc.c:2933
-#: src/docs_inc.c:2978 src/docs_inc.c:3016 src/docs_inc.c:3039
-#: src/docs_inc.c:3086 src/docs_inc.c:3107 src/docs_inc.c:3132
-#: src/docs_inc.c:3157 src/docs_inc.c:3170 src/docs_inc.c:3196
-#: src/docs_inc.c:3230 src/docs_inc.c:3259 src/docs_inc.c:3271
-#: src/docs_inc.c:3302 src/docs_inc.c:3404 src/docs_inc.c:3461
-#: src/docs_inc.c:3470 src/docs_inc.c:3485 src/docs_inc.c:3496
-#: src/docs_inc.c:3502 src/docs_inc.c:3548 src/docs_inc.c:3583
-#: src/docs_inc.c:3664 src/docs_inc.c:3682 src/docs_inc.c:3703
-#: src/docs_inc.c:4106 src/docs_inc.c:4143 src/docs_inc.c:4152
+#: src/docs_inc.c:116 src/docs_inc.c:140 src/docs_inc.c:292 src/docs_inc.c:436
+#: src/docs_inc.c:662 src/docs_inc.c:780 src/docs_inc.c:1060
+#: src/docs_inc.c:1238 src/docs_inc.c:1256 src/docs_inc.c:1272
+#: src/docs_inc.c:1556 src/docs_inc.c:1594 src/docs_inc.c:1604
+#: src/docs_inc.c:1614 src/docs_inc.c:1634 src/docs_inc.c:1640
+#: src/docs_inc.c:1690 src/docs_inc.c:1824 src/docs_inc.c:1873
+#: src/docs_inc.c:1908 src/docs_inc.c:1971 src/docs_inc.c:2765
+#: src/docs_inc.c:3043 src/docs_inc.c:3075 src/docs_inc.c:3091
+#: src/docs_inc.c:3113 src/docs_inc.c:3275 src/docs_inc.c:3295
+#: src/docs_inc.c:3313 src/docs_inc.c:3329 src/docs_inc.c:3363
+#: src/docs_inc.c:3813 src/docs_inc.c:3859 src/docs_inc.c:3877
+#: src/docs_inc.c:3895 src/docs_inc.c:3975 src/docs_inc.c:4033
+#: src/docs_inc.c:4051 src/docs_inc.c:4069 src/docs_inc.c:4205
+#: src/docs_inc.c:4235 src/docs_inc.c:4253 src/docs_inc.c:4360
+#: src/docs_inc.c:4378 src/docs_inc.c:4390 src/docs_inc.c:4418
+#: src/docs_inc.c:4484 src/docs_inc.c:4504 src/docs_inc.c:4510
+#: src/docs_inc.c:4516 src/docs_inc.c:4528 src/docs_inc.c:4608
+#: src/docs_inc.c:4662 src/docs_inc.c:4686
 msgid "!"
 msgstr ""
 
-#: src/docs_inc.c:4440
+#: src/docs_inc.c:4882
+msgid "\"Change parameters\" \"Rights\" checked?"
+msgstr ""
+
+#: src/docs_inc.c:1596
+msgid "\"Column options\""
+msgstr ""
+
+#: src/docs_inc.c:1540
+msgid "\"Left Arrow\""
+msgstr ""
+
+#: src/docs_inc.c:1636
+msgid "\"Log closed\""
+msgstr ""
+
+#: src/docs_inc.c:1642
+msgid "\"Log open\""
+msgstr ""
+
+#: src/docs_inc.c:1274
+msgid "\"Menubar\""
+msgstr ""
+
+#: src/docs_inc.c:1692
+msgid "\"Multi-select\""
+msgstr ""
+
+#: src/docs_inc.c:1616
+msgid "\"Paging options\""
+msgstr ""
+
+#: src/docs_inc.c:1534
+msgid "\"Right Arrow\""
+msgstr ""
+
+#: src/docs_inc.c:1606
+msgid "\"Split panel example\""
+msgstr ""
+
+#: src/docs_inc.c:1258
+msgid "\"Tabs\""
+msgstr ""
+
+#: src/docs_inc.c:1558
+msgid "\"View level\""
+msgstr ""
+
+#: src/docs_inc.c:5038
 #, c-format
 msgid "%C"
 msgstr ""
 
-#: src/docs_inc.c:4330
+#: src/docs_inc.c:5266
 #, c-format
 msgid "%F"
 msgstr ""
 
-#: src/docs_inc.c:4334
+#: src/docs_inc.c:5270
 msgid "%R"
 msgstr ""
 
-#: src/docs_inc.c:4452
+#: src/docs_inc.c:5048
+msgid "%U"
+msgstr ""
+
+#: src/docs_inc.c:5044
 #, c-format
 msgid "%c"
 msgstr ""
 
-#: src/docs_inc.c:4338
+#: src/docs_inc.c:5274
 #, c-format
 msgid "%x"
 msgstr ""
 
-#: src/docs_inc.c:2412
+#: src/docs_inc.c:3169
 msgid "'Accept/OK Icon'"
 msgstr ""
 
-#: src/docs_inc.c:2805
-msgid "'Access Control - Entries tab'"
+#: src/docs_inc.c:3045
+msgid "'Access Entries' Tab"
 msgstr ""
 
-#: src/docs_inc.c:2908
-msgid "'Access Entries Grid'"
-msgstr ""
-
-#: src/docs_inc.c:2935
-msgid "'Access Entry Example'"
-msgstr ""
-
-#: src/docs_inc.c:3261
-msgid "'Add Bouquet Dialog'"
-msgstr ""
-
-#: src/docs_inc.c:2430
-msgid "'Add CA Config'"
-msgstr ""
-
-#: src/docs_inc.c:3666
-msgid "'Add Channel Dialog'"
-msgstr ""
-
-#: src/docs_inc.c:2814
-msgid "'Add Entries Dialog'"
-msgstr ""
-
-#: src/docs_inc.c:3504
-msgid "'Add Mux Dialog'"
-msgstr ""
-
-#: src/docs_inc.c:4154
-msgid "'Add Mux Schedule'"
-msgstr ""
-
-#: src/docs_inc.c:3018
-msgid "'Add New Profile'"
-msgstr ""
-
-#: src/docs_inc.c:2273
-msgid "'Add Password dialog'"
-msgstr ""
-
-#: src/docs_inc.c:2646
-msgid "'Add Profile Dialog'"
-msgstr ""
-
-#: src/docs_inc.c:2752
-msgid "'Add new network'"
-msgstr ""
-
-#: src/docs_inc.c:3406
-msgid "'Add new recording dialog'"
-msgstr ""
-
-#: src/docs_inc.c:2106
-msgid "'Add service to channel example'"
-msgstr ""
-
-#: src/docs_inc.c:2770
-msgid "'Add/Edit Network' Dialog - DVB-S/2"
-msgstr ""
-
-#: src/docs_inc.c:3159
-msgid "'Autorec' Tab"
-msgstr ""
-
-#: src/docs_inc.c:3172
-msgid "'Autorec' example entry"
-msgstr ""
-
-#: src/docs_inc.c:3232
+#: src/docs_inc.c:3077
 msgid "'Bouqets' Tab"
 msgstr ""
 
-#: src/docs_inc.c:2344
+#: src/docs_inc.c:3115
 msgid "'CA Client Configuration Example'"
 msgstr ""
 
-#: src/docs_inc.c:1699
+#: src/docs_inc.c:1836
 msgid "'Cancel'"
 msgstr ""
 
-#: src/docs_inc.c:3585
+#: src/docs_inc.c:3277
 msgid "'Channel lists'"
 msgstr ""
 
-#: src/docs_inc.c:3472
-msgid "'Channel tag dialog'"
-msgstr ""
-
-#: src/docs_inc.c:3463
+#: src/docs_inc.c:3297
 msgid "'Channel tag'"
 msgstr ""
 
-#: src/docs_inc.c:4108
-msgid "'Configuration - Image Cache tab'"
+#: src/docs_inc.c:4486
+msgid "'Complete rating labels list'"
 msgstr ""
 
-#: src/docs_inc.c:2260
-msgid "'Configuration - Passwords tab'"
+#: src/docs_inc.c:142
+msgid "'DVB Input tree explained' Tab"
 msgstr ""
 
-#: src/docs_inc.c:2869
-msgid "'DVB-C frontend parameters'"
+#: src/docs_inc.c:118
+msgid "'DVB Inputs' Tab"
 msgstr ""
 
-#: src/docs_inc.c:3134
-msgid "'DVB-S frontend parameters'"
-msgstr ""
-
-#: src/docs_inc.c:2170
-msgid "'DVB-T frontend parameters'"
-msgstr ""
-
-#: src/docs_inc.c:3705
+#: src/docs_inc.c:3365
 msgid "'Debugging tab'"
 msgstr ""
 
-#: src/docs_inc.c:2980
+#: src/docs_inc.c:3815
 msgid "'Digital Video Recorder Profiles' Tab 1"
 msgstr ""
 
-#: src/docs_inc.c:3304
+#: src/docs_inc.c:2767
 msgid "'Digital Video Recorder' Tabs"
 msgstr ""
 
-#: src/docs_inc.c:2453
+#: src/docs_inc.c:3879
 msgid "'EPG Grabber Channels Tab'"
 msgstr ""
 
-#: src/docs_inc.c:2494 src/docs_inc.c:2535
+#: src/docs_inc.c:3861 src/docs_inc.c:3897
 msgid "'EPG Grabber Configuration'"
 msgstr ""
 
-#: src/docs_inc.c:3198
-msgid "'Edit Autorec'"
+#: src/docs_inc.c:4512
+msgid "'EPG with placeholder rating'"
 msgstr ""
 
-#: src/docs_inc.c:3684
-msgid "'Edit Channel Dialog'"
-msgstr ""
-
-#: src/docs_inc.c:573
+#: src/docs_inc.c:294
 msgid "'Electronic Program Guide' Tab"
 msgstr ""
 
-#: src/docs_inc.c:2416
+#: src/docs_inc.c:3173
 msgid "'Error Icon'"
 msgstr ""
 
-#: src/docs_inc.c:2137
-msgid "'General Base' Tab Screenshot 1"
+#: src/docs_inc.c:3331
+msgid "'General Base'"
 msgstr ""
 
-#: src/docs_inc.c:2118
+#: src/docs_inc.c:4071
+msgid "'IP Blocking' Tab"
+msgstr ""
+
+#: src/docs_inc.c:4053
+msgid "'Image cache'"
+msgstr ""
+
+#: src/docs_inc.c:4374
 msgid "'Information Icon'"
 msgstr ""
 
-#: src/docs_inc.c:2054 src/docs_inc.c:3273
+#: src/docs_inc.c:3093
 msgid "'Map All Services'"
 msgstr ""
 
-#: src/docs_inc.c:2072
-msgid "'Map selected'"
-msgstr ""
-
-#: src/docs_inc.c:3487
+#: src/docs_inc.c:4207
 msgid "'Mux List'"
 msgstr ""
 
-#: src/docs_inc.c:4145
+#: src/docs_inc.c:4237
 msgid "'Mux Schedule Entries'"
 msgstr ""
 
-#: src/docs_inc.c:2746 src/docs_inc.c:3498
-msgid "'Network selection'"
-msgstr ""
-
-#: src/docs_inc.c:2725
+#: src/docs_inc.c:4255
 msgid "'Networks' Tab Screenshot"
 msgstr ""
 
-#: src/docs_inc.c:1966
+#: src/docs_inc.c:4506
+msgid "'Newly learned rating labels list'"
+msgstr ""
+
+#: src/docs_inc.c:4392
+msgid "'Passwords' Tab"
+msgstr ""
+
+#: src/docs_inc.c:2854
 msgid "'Play Icon Image'"
 msgstr ""
 
-#: src/docs_inc.c:3088
+#: src/docs_inc.c:4530
+msgid "'Rating label learned from xmltv'"
+msgstr ""
+
+#: src/docs_inc.c:4035
 msgid "'Removing a stream'"
 msgstr ""
 
-#: src/docs_inc.c:2195
+#: src/docs_inc.c:4610
 msgid "'SAT"
 msgstr ""
 
-#: src/docs_inc.c:3109
-msgid "'SAT>IP Panel'"
-msgstr ""
-
-#: src/docs_inc.c:2124
+#: src/docs_inc.c:4380
 msgid "'Service Information'"
 msgstr ""
 
-#: src/docs_inc.c:2098
-msgid "'Service filtering'"
+#: src/docs_inc.c:4664
+msgid "'Service mapper'"
 msgstr ""
 
-#: src/docs_inc.c:2046 src/docs_inc.c:3550
-msgid "'Service mapper dialog'"
-msgstr ""
-
-#: src/docs_inc.c:1985
+#: src/docs_inc.c:4362
 msgid "'Services'"
 msgstr ""
 
-#: src/docs_inc.c:1055 src/docs_inc.c:1075
+#: src/docs_inc.c:1826
+msgid "'Status - Connections' Tab"
+msgstr ""
+
+#: src/docs_inc.c:1875
+msgid "'Status - Service mapper'"
+msgstr ""
+
+#: src/docs_inc.c:1910 src/docs_inc.c:1920
 msgid "'Status - Stream' Tab"
 msgstr ""
 
-#: src/docs_inc.c:107 src/docs_inc.c:1503 src/docs_inc.c:1679
+#: src/docs_inc.c:1973
 msgid "'Status - Subscriptions' Tab"
 msgstr ""
 
-#: src/docs_inc.c:2420
+#: src/docs_inc.c:3177
 msgid "'Stop/Disabled Icon'"
 msgstr ""
 
-#: src/docs_inc.c:2580
+#: src/docs_inc.c:3315 src/docs_inc.c:4420
 msgid "'Stream Profiles'"
 msgstr ""
 
-#: src/docs_inc.c:3041
+#: src/docs_inc.c:3977
 msgid "'Stream filters'"
 msgstr ""
 
-#: src/docs_inc.c:481
-msgid "'TV Adapter params'"
-msgstr ""
-
-#: src/docs_inc.c:459
-msgid "'TV Adapter tree'"
-msgstr ""
-
-#: src/docs_inc.c:2315
+#: src/docs_inc.c:4688
 msgid "'Timeshift Tab'"
 msgstr ""
 
-#: src/docs_inc.c:2640
-msgid "'Type select'"
+#: src/docs_inc.c:4518
+msgid "'Updated rating label details'"
 msgstr ""
 
-#: src/docs_inc.c:1439
+#: src/docs_inc.c:2358
 msgid "(/mux only) list of subscribed PIDs (comma separated)"
 msgstr ""
 
-#: src/docs_inc.c:1431
+#: src/docs_inc.c:2350
 msgid "(/service only) do not descramble (if set to 0)"
 msgstr ""
 
-#: src/docs_inc.c:1435
+#: src/docs_inc.c:2354
 msgid "(/service only) pass EMM to the stream (if set to 1)"
 msgstr ""
 
-#: src/docs_inc.c:4648
+#: src/docs_inc.c:4948
 msgid "(DVR),"
 msgstr ""
 
-#: src/docs_inc.c:333
+#: src/docs_inc.c:856
 msgid ""
 "(For the technically-minded, these unique identifiers - the elementary "
 "streams - are referred to as 'packet identifiers' or 'PIDs')."
 msgstr ""
 
-#: src/docs_inc.c:1257
-msgid "(c) 2006 - 2016 Tvheadend Foundation CIC"
+#: src/docs_inc.c:5308
+msgid "(Movies)"
 msgstr ""
 
-#: src/docs_inc.c:1419
+#: src/docs_inc.c:1536
+msgid "(Next)"
+msgstr ""
+
+#: src/docs_inc.c:1542
+msgid "(Previous)"
+msgstr ""
+
+#: src/docs_inc.c:5316
+msgid "(TV Series)"
+msgstr ""
+
+#: src/docs_inc.c:134
+msgid "(Using the Interface) for details on how to use the tree/split panel."
+msgstr ""
+
+#: src/docs_inc.c:2435
+msgid "(_Using the Interface_ )."
+msgstr ""
+
+#: src/docs_inc.c:28
+msgid "(c) 2006 - 2017 Tvheadend Foundation CIC"
+msgstr ""
+
+#: src/docs_inc.c:455
+msgid "(default DVR Profile) drop-down"
+msgstr ""
+
+#: src/docs_inc.c:2338
 msgid "(except /mux) Override streaming profile"
 msgstr ""
 
-#: src/docs_inc.c:1829
+#: src/docs_inc.c:1190
 msgid "(other clients may also be available)."
 msgstr ""
 
-#: src/docs_inc.c:4450
-msgid ")"
+#: src/docs_inc.c:2410
+msgid "(standard) for the channel number"
 msgstr ""
 
-#: src/docs_inc.c:2902
-msgid ") accounts are matched using the prefix only."
+#: src/docs_inc.c:184
+msgid ") is using position 1 (or AA)."
 msgstr ""
 
-#: src/docs_inc.c:5319 src/docs_inc.c:5397
+#: src/docs_inc.c:6194 src/docs_inc.c:6218
 msgid ")! :)"
 msgstr ""
 
-#: src/docs_inc.c:4640 src/docs_inc.c:4644
+#: src/docs_inc.c:314
+msgid "), or those that are currently broadcasting ("
+msgstr ""
+
+#: src/docs_inc.c:318
+msgid "). Can be used with the other filters."
+msgstr ""
+
+#: src/docs_inc.c:4888
+msgid "* (Anon entry)."
+msgstr ""
+
+#: src/docs_inc.c:4896
+msgid "* (Another anon entry)."
+msgstr ""
+
+#: src/docs_inc.c:4940 src/docs_inc.c:4944
 msgid ","
 msgstr ""
 
-#: src/docs_inc.c:2576
-msgid ", DVR Profiles or as parameter for HTTP Streaming."
-msgstr ""
-
-#: src/docs_inc.c:4446
-msgid ", but"
-msgstr ""
-
-#: src/docs_inc.c:5248
+#: src/docs_inc.c:5970
 msgid ", enabling/disabling per channel overrides the DVR profile setting."
 msgstr ""
 
-#: src/docs_inc.c:3606
-msgid ", especially useful if you change your Picon settings."
-msgstr ""
-
-#: src/docs_inc.c:1105
+#: src/docs_inc.c:1952
 msgid ""
 ", note that not all devices supply correct signal information, the value "
 "here can sometimes be ambiguous."
 msgstr ""
 
-#: src/docs_inc.c:2689
-msgid "- Available worldwide"
+#: src/docs_inc.c:5424
+msgid ", so if that changes it won't make any difference."
 msgstr ""
 
-#: src/docs_inc.c:2715
-msgid "- IPTV using a playlist as the source"
-msgstr ""
-
-#: src/docs_inc.c:2693
-msgid ""
-"- available worldwide but common in Brazil and various other countries "
-"throughout south America"
-msgstr ""
-
-#: src/docs_inc.c:277
+#: src/docs_inc.c:800
 msgid ""
 "- but they do go out of date as broadcasters move services around and "
 "national authorities change entire pieces of spectrum. As such, you should "
 "try the pre-defined values, but you may need to add muxes manually."
 msgstr ""
 
-#: src/docs_inc.c:2679 src/docs_inc.c:2703
-msgid "- common in Brazil and various other countries throughout south America"
-msgstr ""
-
-#: src/docs_inc.c:2675 src/docs_inc.c:2699
-msgid "- common in most of Europe"
-msgstr ""
-
-#: src/docs_inc.c:2707
-msgid "- common in north and central America"
-msgstr ""
-
-#: src/docs_inc.c:2683
-msgid "- common in north and central America and parts of south Asia"
-msgstr ""
-
-#: src/docs_inc.c:1615
+#: src/docs_inc.c:989
 msgid ""
 "- this will not only tell you what's supported under Linux, but also how to "
 "get it all working."
 msgstr ""
 
-#: src/docs_inc.c:5058
+#: src/docs_inc.c:5554
 msgid "-1"
 msgstr ""
 
-#: src/docs_inc.c:155 src/docs_inc.c:357 src/docs_inc.c:1265
-#: src/docs_inc.c:1583 src/docs_inc.c:2563 src/docs_inc.c:2721
-#: src/docs_inc.c:2794 src/docs_inc.c:2820 src/docs_inc.c:2854
-#: src/docs_inc.c:3626 src/docs_inc.c:3678 src/docs_inc.c:4305
-#: src/docs_inc.c:4656 src/docs_inc.c:4666 src/docs_inc.c:4676
-#: src/docs_inc.c:4682 src/docs_inc.c:4688 src/docs_inc.c:4698
-#: src/docs_inc.c:4704 src/docs_inc.c:4710 src/docs_inc.c:4716
-#: src/docs_inc.c:4722 src/docs_inc.c:4852 src/docs_inc.c:4889
-#: src/docs_inc.c:4938 src/docs_inc.c:4969 src/docs_inc.c:5277
-#: src/docs_inc.c:5313 src/docs_inc.c:5391 src/docs_inc.c:5414
+#: src/docs_inc.c:36 src/docs_inc.c:682 src/docs_inc.c:874 src/docs_inc.c:957
+#: src/docs_inc.c:1254 src/docs_inc.c:1466 src/docs_inc.c:1476
+#: src/docs_inc.c:1700 src/docs_inc.c:1712 src/docs_inc.c:3059
+#: src/docs_inc.c:3205 src/docs_inc.c:4093 src/docs_inc.c:4336
+#: src/docs_inc.c:4806 src/docs_inc.c:4956 src/docs_inc.c:4966
+#: src/docs_inc.c:4976 src/docs_inc.c:4982 src/docs_inc.c:4988
+#: src/docs_inc.c:4998 src/docs_inc.c:5004 src/docs_inc.c:5010
+#: src/docs_inc.c:5016 src/docs_inc.c:5022 src/docs_inc.c:5206
+#: src/docs_inc.c:5254 src/docs_inc.c:5386 src/docs_inc.c:5414
+#: src/docs_inc.c:5434 src/docs_inc.c:5636 src/docs_inc.c:6082
+#: src/docs_inc.c:6100 src/docs_inc.c:6140 src/docs_inc.c:6168
+#: src/docs_inc.c:6188 src/docs_inc.c:6212
 msgid "."
 msgstr ""
 
-#: src/docs_inc.c:207
+#: src/docs_inc.c:1076
 msgid ""
 ". Please use github's features if you want to provide patches. Contributions "
 "and improvements are always welcome."
 msgstr ""
 
-#: src/docs_inc.c:1968
+#: src/docs_inc.c:2856
 msgid ""
 ". This will automatically launch an appropriate player, otherwise you will "
 "need to manually open the playlist to start watching (normally a double-"
 "click on the downloaded file)."
 msgstr ""
 
-#: src/docs_inc.c:41
+#: src/docs_inc.c:1757
 msgid "... produces:"
 msgstr ""
 
-#: src/docs_inc.c:3602
+#: src/docs_inc.c:480 src/docs_inc.c:5416 src/docs_inc.c:5426
+#: src/docs_inc.c:5432
 msgid "/"
 msgstr ""
 
-#: src/docs_inc.c:1233
+#: src/docs_inc.c:2135
 msgid "/etc/default/tvheadend options"
 msgstr ""
 
-#: src/docs_inc.c:4365 src/docs_inc.c:4743 src/docs_inc.c:5165
+#: src/docs_inc.c:5662 src/docs_inc.c:5762 src/docs_inc.c:5854
 msgid "/home/user/Videos/News.mkv"
 msgstr ""
 
-#: src/docs_inc.c:1287
+#: src/docs_inc.c:2156
 msgid "/play/REMAIN"
 msgstr ""
 
-#: src/docs_inc.c:1309
-msgid "/playlist[/TYPE][/WHAT][/IDENTIFIER]"
+#: src/docs_inc.c:2178
+msgid "/playlist[/AUTH][/TYPE][/WHAT][/IDENTIFIER]"
 msgstr ""
 
-#: src/docs_inc.c:1381
+#: src/docs_inc.c:2412
+msgid "/special/srvid2"
+msgstr ""
+
+#: src/docs_inc.c:2300
 msgid "/stream/WHAT/IDENTIFIER"
 msgstr ""
 
-#: src/docs_inc.c:1441
+#: src/docs_inc.c:2360
 msgid "/xmltv[/WHAT][/IDENTIFIER]"
 msgstr ""
 
-#: src/docs_inc.c:4413 src/docs_inc.c:5217
+#: src/docs_inc.c:5406 src/docs_inc.c:5722 src/docs_inc.c:5810
 msgid "0"
 msgstr ""
 
-#: src/docs_inc.c:623
+#: src/docs_inc.c:356
 msgid "00:00:01 to 00:15:00"
 msgstr ""
 
-#: src/docs_inc.c:627
+#: src/docs_inc.c:360
 msgid "00:15:01 to 00:30:00"
 msgstr ""
 
-#: src/docs_inc.c:631
+#: src/docs_inc.c:364
 msgid "00:30:01 to 01:30:00"
 msgstr ""
 
-#: src/docs_inc.c:635
+#: src/docs_inc.c:368
 msgid "01:30:01 to 03:00:00"
 msgstr ""
 
-#: src/docs_inc.c:639
+#: src/docs_inc.c:372
 msgid "03:00:00 to no maximum"
 msgstr ""
 
-#: src/docs_inc.c:255
+#: src/docs_inc.c:5410 src/docs_inc.c:5418
+msgid "1"
+msgstr ""
+
+#: src/docs_inc.c:148
+msgid "1. /dev/dvb/adapter0"
+msgstr ""
+
+#: src/docs_inc.c:4624
+msgid "1. Define the RTSP Port"
+msgstr ""
+
+#: src/docs_inc.c:772
 msgid "1. Ensure Tuners are Available for Use"
 msgstr ""
 
-#: src/docs_inc.c:1585
+#: src/docs_inc.c:959
 msgid "1. Install the Tuner Hardware"
 msgstr ""
 
-#: src/docs_inc.c:4810
+#: src/docs_inc.c:674
+msgid "1. Welcome"
+msgstr ""
+
+#: src/docs_inc.c:5938
 msgid "100"
 msgstr ""
 
-#: src/docs_inc.c:4405 src/docs_inc.c:4779 src/docs_inc.c:5209
+#: src/docs_inc.c:5714 src/docs_inc.c:5802 src/docs_inc.c:5898
 msgid "1224421200"
 msgstr ""
 
-#: src/docs_inc.c:4409 src/docs_inc.c:4783 src/docs_inc.c:5213
+#: src/docs_inc.c:5718 src/docs_inc.c:5806 src/docs_inc.c:5902
 msgid "1224426600"
 msgstr ""
 
-#: src/docs_inc.c:5070
+#: src/docs_inc.c:5566
 msgid "14:12"
 msgstr ""
 
-#: src/docs_inc.c:503
+#: src/docs_inc.c:5470
+msgid "192=20"
+msgstr ""
+
+#: src/docs_inc.c:5428
+msgid "2"
+msgstr ""
+
+#: src/docs_inc.c:2666
 msgid "2 Port"
 msgstr ""
 
-#: src/docs_inc.c:1609
+#: src/docs_inc.c:2668
+msgid "2 Port configuration."
+msgstr ""
+
+#: src/docs_inc.c:684
+msgid "2. Access Control"
+msgstr ""
+
+#: src/docs_inc.c:4628
+msgid "2. Export the Tuners"
+msgstr ""
+
+#: src/docs_inc.c:983
 msgid "2. Install Firmware and/or Drivers"
 msgstr ""
 
-#: src/docs_inc.c:267
+#: src/docs_inc.c:158
+msgid "2. Panasonic MN88472 #0 : DVB-T #0"
+msgstr ""
+
+#: src/docs_inc.c:790
 msgid "2. Set up Relevant Network(s)"
 msgstr ""
 
-#: src/docs_inc.c:5066
+#: src/docs_inc.c:5562
 msgid "2011-03-19"
 msgstr ""
 
-#: src/docs_inc.c:283
+#: src/docs_inc.c:5474
+msgid "208=16"
+msgstr ""
+
+#: src/docs_inc.c:5478
+msgid "224=35"
+msgstr ""
+
+#: src/docs_inc.c:806
 msgid "3. Associate the Network with the Respective Tuner(s)"
 msgstr ""
 
-#: src/docs_inc.c:505
+#: src/docs_inc.c:4632
+msgid "3. Export Your Networks"
+msgstr ""
+
+#: src/docs_inc.c:694
+msgid "3. Tuner and Network"
+msgstr ""
+
+#: src/docs_inc.c:168
+msgid "3. Tvheadend:9983 cd33bf4ce5 - 192.168.1.3"
+msgstr ""
+
+#: src/docs_inc.c:5734 src/docs_inc.c:5906
+msgid "3cf44328eda87a428ba9a8b14876ab80"
+msgstr ""
+
+#: src/docs_inc.c:2670
 msgid "4 Port"
 msgstr ""
 
-#: src/docs_inc.c:293
+#: src/docs_inc.c:2672
+msgid "4 Port configuration."
+msgstr ""
+
+#: src/docs_inc.c:4644
+msgid "4. Configure Your Client"
+msgstr ""
+
+#: src/docs_inc.c:816
 msgid "4. If Necessary, Manually Add Muxes"
 msgstr ""
 
-#: src/docs_inc.c:327
+#: src/docs_inc.c:178
+msgid "4. Position #1 (AA)"
+msgstr ""
+
+#: src/docs_inc.c:716
+msgid "4. Predefined Muxes"
+msgstr ""
+
+#: src/docs_inc.c:850
 msgid "5. Scan for Services"
 msgstr ""
 
-#: src/docs_inc.c:4812
+#: src/docs_inc.c:728
+msgid "5. Scanning"
+msgstr ""
+
+#: src/docs_inc.c:5940
 msgid "50"
 msgstr ""
 
-#: src/docs_inc.c:4417 src/docs_inc.c:5221
+#: src/docs_inc.c:5726 src/docs_inc.c:5814
 msgid "6"
 msgstr ""
 
-#: src/docs_inc.c:335
+#: src/docs_inc.c:858
 msgid "6. Map Services to Channels"
 msgstr ""
 
-#: src/docs_inc.c:347
-msgid "6.1. Bouquets"
+#: src/docs_inc.c:738
+msgid "6. Service Mapping"
 msgstr ""
 
-#: src/docs_inc.c:359
+#: src/docs_inc.c:766
+msgid "7. Finished"
+msgstr ""
+
+#: src/docs_inc.c:876
 msgid "7. Watch TV"
 msgstr ""
 
-#: src/docs_inc.c:4814
+#: src/docs_inc.c:5942
 msgid "80"
 msgstr ""
 
-#: src/docs_inc.c:4195 src/docs_inc.c:4218 src/docs_inc.c:4245
-#: src/docs_inc.c:4258 src/docs_inc.c:4293 src/docs_inc.c:4324
-#: src/docs_inc.c:4432 src/docs_inc.c:4463 src/docs_inc.c:4476
-#: src/docs_inc.c:4499 src/docs_inc.c:4524 src/docs_inc.c:4547
-#: src/docs_inc.c:4588 src/docs_inc.c:4626 src/docs_inc.c:4794
-#: src/docs_inc.c:4831 src/docs_inc.c:4840 src/docs_inc.c:4867
-#: src/docs_inc.c:4896 src/docs_inc.c:4923 src/docs_inc.c:4932
-#: src/docs_inc.c:4947 src/docs_inc.c:4989 src/docs_inc.c:5081
-#: src/docs_inc.c:5097 src/docs_inc.c:5114 src/docs_inc.c:5236
-#: src/docs_inc.c:5271
+#: src/docs_inc.c:4698 src/docs_inc.c:4736 src/docs_inc.c:4772
+#: src/docs_inc.c:4788 src/docs_inc.c:4816 src/docs_inc.c:4842
+#: src/docs_inc.c:4876 src/docs_inc.c:5030 src/docs_inc.c:5062
+#: src/docs_inc.c:5098 src/docs_inc.c:5122 src/docs_inc.c:5156
+#: src/docs_inc.c:5200 src/docs_inc.c:5214 src/docs_inc.c:5248
+#: src/docs_inc.c:5260 src/docs_inc.c:5360 src/docs_inc.c:5368
+#: src/docs_inc.c:5440 src/docs_inc.c:5624 src/docs_inc.c:5830
+#: src/docs_inc.c:5922 src/docs_inc.c:5958 src/docs_inc.c:5992
+#: src/docs_inc.c:6018 src/docs_inc.c:6040 src/docs_inc.c:6048
+#: src/docs_inc.c:6060 src/docs_inc.c:6088 src/docs_inc.c:6118
+#: src/docs_inc.c:6146
 msgid ":"
 msgstr ""
 
-#: src/docs_inc.c:4353 src/docs_inc.c:5153
+#: src/docs_inc.c:1384
+msgid ""
+": Assign the lowest available channel number(s) to the selected channel(s)."
+msgstr ""
+
+#: src/docs_inc.c:5650 src/docs_inc.c:5750
 #, c-format
 msgid ""
 ": Command to run after finishing a recording. The command will be run in "
@@ -642,29 +717,82 @@ msgid ""
 "string is “OK” if recording finished successfully."
 msgstr ""
 
-#: src/docs_inc.c:4731
+#: src/docs_inc.c:5842
 msgid ""
 ": Command to run when a recording starts. The command will be run in "
 "background."
 msgstr ""
 
-#: src/docs_inc.c:4976
+#: src/docs_inc.c:1392
+msgid ": Decrement the selected channel numbers by 1."
+msgstr ""
+
+#: src/docs_inc.c:1364
+msgid ""
+": Detach the (selected) services from it's bouquet (to prevent changes)."
+msgstr ""
+
+#: src/docs_inc.c:5144
 msgid ": Example : every day at 2am is : `0 2 * * *`"
 msgstr ""
 
-#: src/docs_inc.c:5024
+#: src/docs_inc.c:1388
+msgid ": Increment the selected channel number(s) by 1."
+msgstr ""
+
+#: src/docs_inc.c:1360
+msgid ": Map all services to channels."
+msgstr ""
+
+#: src/docs_inc.c:1356
+msgid ": Map the selected services to channels."
+msgstr ""
+
+#: src/docs_inc.c:241
+msgid ""
+": Play the selected entry. Downloads an m3u, or opens the m3u in your "
+"default media player. __Finished/Failed Recordings tabs only.__"
+msgstr ""
+
+#: src/docs_inc.c:1376
+msgid ": Remove all services not seen for 7+ days."
+msgstr ""
+
+#: src/docs_inc.c:1372
+msgid ": Remove services marked as Missing in PAT/SDT for 7+ days."
+msgstr ""
+
+#: src/docs_inc.c:1396
+msgid ": Swap the numbers of the two selected channels."
+msgstr ""
+
+#: src/docs_inc.c:5492
 msgid ""
 ": The string allows you to manually specify the full path generation using "
-"the predefined modifiers for strftime (see `man strftime`, except `%n` and `"
-"%t`) and Tvheadend specific. Note that you may modify some of this format "
+"the predefined modifiers for strftime (see `man strftime`, except `%n` and "
+"`%t`) and Tvheadend specific. Note that you may modify some of this format "
 "string setting using the GUI fields below."
 msgstr ""
 
-#: src/docs_inc.c:1601
+#: src/docs_inc.c:4488
+msgid ""
+"A 'rating label' is a text code like 'PG', 'PG-13' or 'FSK 12' used to "
+"identify the parental rating classification of a TV programme."
+msgstr ""
+
+#: src/docs_inc.c:975
 msgid "A Note on USB Tuners"
 msgstr ""
 
-#: src/docs_inc.c:399
+#: src/docs_inc.c:3189 src/docs_inc.c:3217
+msgid ""
+"A TCP connection to the server is created. All EMM/ECM data is sent to OSCam "
+"using this connection without the need for real linuxdvb devices to be "
+"present in the system. This mode is suitable for all DVB devices including "
+"SAT"
+msgstr ""
+
+#: src/docs_inc.c:1214
 msgid ""
 "A __driver__ is the piece of software that your operating system uses to "
 "talk to the tuner. This can be built into the OS (e.g. 'supported since "
@@ -672,7 +800,7 @@ msgid ""
 "and maybe even compile, separately."
 msgstr ""
 
-#: src/docs_inc.c:391
+#: src/docs_inc.c:1206
 msgid ""
 "A __tuner__ is the hardware (chipset) needed to interpret a digital "
 "television signal and extract from it the programme stream. The tuner "
@@ -680,230 +808,255 @@ msgid ""
 "the LNB in the case of DVB-S."
 msgstr ""
 
-#: src/docs_inc.c:4286
+#: src/docs_inc.c:4870
 msgid ""
 "A combination of last two variants above - data is written immediately and "
 "then discarded from cache."
 msgstr ""
 
-#: src/docs_inc.c:1739
-msgid ""
-"A general-purpose MPEG-TS `pipe://` for analogue and non-broadcast sources"
+#: src/docs_inc.c:4444
+msgid "A general Matroska container profile."
 msgstr ""
 
-#: src/docs_inc.c:2667
+#: src/docs_inc.c:1100
+msgid ""
+"A general-purpose MPEG-TS `pipe://` (or `file://`) for analogue and non-"
+"broadcast sources."
+msgstr ""
+
+#: src/docs_inc.c:4251
 msgid ""
 "A network is the type of carrier for your television signals. Tvheadend "
-"supports several different types of network, notably:"
+"supports several different types of network."
 msgstr ""
 
-#: src/docs_inc.c:4270
+#: src/docs_inc.c:4854
 msgid ""
 "A placeholder status, meaning that the configuration isn’t properly set."
 msgstr ""
 
-#: src/docs_inc.c:825
+#: src/docs_inc.c:186
+msgid ""
+"A position is very similar to a network in that it groups multiplexes (or "
+"Transponders) for each satellite you're able to receive. It also allows you "
+"to set certain configuration options, such as where the dish should move to "
+"in order to receive a multiplex."
+msgstr ""
+
+#: src/docs_inc.c:2624 src/docs_inc.c:2656
+msgid ""
+"A slave frontend (can be used to link with a master, mainly used for buggy "
+"drivers or frontends that share an input)."
+msgstr ""
+
+#: src/docs_inc.c:5738 src/docs_inc.c:5910
+msgid "A string"
+msgstr ""
+
+#: src/docs_inc.c:180
+msgid "A tuner can have multiple positional inputs,"
+msgstr ""
+
+#: src/docs_inc.c:578
 msgid "AAC"
 msgstr ""
 
-#: src/docs_inc.c:1723
+#: src/docs_inc.c:1084
 msgid "AC-3, AAC and MP2 audio supported."
 msgstr ""
 
-#: src/docs_inc.c:991 src/docs_inc.c:2402
-msgid "AES constant code word client"
+#: src/docs_inc.c:3151 src/docs_inc.c:3155
+msgid "AES ECB Constant Code Word"
 msgstr ""
 
-#: src/docs_inc.c:3841
+#: src/docs_inc.c:3493
 msgid "API"
 msgstr ""
 
-#: src/docs_inc.c:4069
+#: src/docs_inc.c:3745
 msgid "ATSC PSIP EPG"
 msgstr ""
 
-#: src/docs_inc.c:3893
+#: src/docs_inc.c:3545
 msgid "ATSC SI Tables"
 msgstr ""
 
-#: src/docs_inc.c:537 src/docs_inc.c:549 src/docs_inc.c:2681
+#: src/docs_inc.c:2642 src/docs_inc.c:4281
 msgid "ATSC-C"
 msgstr ""
 
-#: src/docs_inc.c:527 src/docs_inc.c:547 src/docs_inc.c:2705
+#: src/docs_inc.c:2630 src/docs_inc.c:4309
 msgid "ATSC-T"
 msgstr ""
 
-#: src/docs_inc.c:3330
+#: src/docs_inc.c:1442
 msgid "Abort"
 msgstr ""
 
-#: src/docs_inc.c:4401 src/docs_inc.c:4995 src/docs_inc.c:5205
+#: src/docs_inc.c:5220 src/docs_inc.c:5710 src/docs_inc.c:5798
 msgid "Aborted by user"
 msgstr ""
 
-#: src/docs_inc.c:1005 src/docs_inc.c:1019 src/docs_inc.c:1251
-#: src/docs_inc.c:1483
+#: src/docs_inc.c:22 src/docs_inc.c:2074 src/docs_inc.c:2088
+#: src/docs_inc.c:2421
 msgid "About"
 msgstr ""
 
-#: src/docs_inc.c:3332
-msgid "Abruptly stop the selected in-progress recording entries."
+#: src/docs_inc.c:1052 src/docs_inc.c:1694
+msgid "About This Guide"
 msgstr ""
 
-#: src/docs_inc.c:3392
+#: src/docs_inc.c:1054
+msgid "About this guide and where to get help if you're stuck"
+msgstr ""
+
+#: src/docs_inc.c:1444
+msgid "Abruptly stop the selected in-progress recording entry/entries."
+msgstr ""
+
+#: src/docs_inc.c:233
 msgid "Accept icon"
 msgstr ""
 
-#: src/docs_inc.c:4881
+#: src/docs_inc.c:6074
 msgid "Access"
 msgstr ""
 
-#: src/docs_inc.c:3821
+#: src/docs_inc.c:3473
 msgid "Access (ACL)"
 msgstr ""
 
-#: src/docs_inc.c:905 src/docs_inc.c:2277 src/docs_inc.c:2574
-#: src/docs_inc.c:4887 src/docs_inc.c:4967
+#: src/docs_inc.c:3014 src/docs_inc.c:5384 src/docs_inc.c:6080
+#: src/docs_inc.c:6138 src/docs_inc.c:6166
 msgid "Access Entries"
 msgstr ""
 
-#: src/docs_inc.c:1807
+#: src/docs_inc.c:1168
 msgid ""
 "Access to system features (streaming, administration, configurations) can be "
 "configured based on username/password and/or IP address."
 msgstr ""
 
-#: src/docs_inc.c:5116
+#: src/docs_inc.c:4700
 msgid "Action"
 msgstr ""
 
-#: src/docs_inc.c:49
+#: src/docs_inc.c:2952
+msgid "Active subscriptions"
+msgstr ""
+
+#: src/docs_inc.c:1765
 msgid "Actual numbers don't matter, just that it's a number"
 msgstr ""
 
-#: src/docs_inc.c:1940 src/docs_inc.c:2362 src/docs_inc.c:2620
-#: src/docs_inc.c:2998 src/docs_inc.c:3314
+#: src/docs_inc.c:782
+msgid "Adapter example"
+msgstr ""
+
+#: src/docs_inc.c:1290 src/docs_inc.c:2538
 msgid "Add"
 msgstr ""
 
-#: src/docs_inc.c:2634
-msgid "Add a Profile"
-msgstr ""
-
-#: src/docs_inc.c:3316
-msgid "Add a new (one-time-only) recording entry."
-msgstr ""
-
-#: src/docs_inc.c:2364
-msgid "Add a new CA client configuration."
-msgstr ""
-
-#: src/docs_inc.c:2622 src/docs_inc.c:3000
-msgid "Add a new profile."
-msgstr ""
-
-#: src/docs_inc.c:1944
+#: src/docs_inc.c:1294 src/docs_inc.c:2542
 msgid "Add entry"
 msgstr ""
 
-#: src/docs_inc.c:5142
+#: src/docs_inc.c:4726
 msgid ""
 "Add this elementary stream only when no elementary streams are used from "
 "previous rules. It does not match the implicit USE rules which are added "
 "after the user rules."
 msgstr ""
 
-#: src/docs_inc.c:1852
-msgid "Adding an Entry"
+#: src/docs_inc.c:1646
+msgid "Adding, Editing and More"
 msgstr ""
 
-#: src/docs_inc.c:3424
-msgid "Adding an Entry Using Autorec Rules"
+#: src/docs_inc.c:1676
+msgid "Adding/Editing"
 msgstr ""
 
-#: src/docs_inc.c:3408
-msgid "Adding an Entry Using the EPG"
-msgstr ""
-
-#: src/docs_inc.c:3492
-msgid "Adding an Entry/Mux"
-msgstr ""
-
-#: src/docs_inc.c:2740
-msgid "Adding an Entry/Network"
-msgstr ""
-
-#: src/docs_inc.c:2424
-msgid "Adding/Editing a CA Configuration"
-msgstr ""
-
-#: src/docs_inc.c:3012
-msgid "Adding/Editing a Profile"
-msgstr ""
-
-#: src/docs_inc.c:4650
+#: src/docs_inc.c:4950
 msgid "Admin"
 msgstr ""
 
-#: src/docs_inc.c:4311 src/docs_inc.c:4957
+#: src/docs_inc.c:4884
+msgid "Admin enabled/set?"
+msgstr ""
+
+#: src/docs_inc.c:1568 src/docs_inc.c:6106 src/docs_inc.c:6128
 msgid "Advanced"
 msgstr ""
 
-#: src/docs_inc.c:509
+#: src/docs_inc.c:2674
 msgid "Advanced LNB"
 msgstr ""
 
-#: src/docs_inc.c:1881
-msgid ""
-"After a cell is changed, a small red flag or triangle will appear in the top-"
-"left corner to indicate that it has been changed. These changes can now be "
-"kept (_[Save]_ button), or abandoned (_[Undo]_ button)."
+#: src/docs_inc.c:2676
+msgid "Advanced LNB configuration."
 msgstr ""
 
-#: src/docs_inc.c:4389 src/docs_inc.c:4767 src/docs_inc.c:5189
+#: src/docs_inc.c:5336
+msgid "Advanced option specifying a csv of movie modules to use."
+msgstr ""
+
+#: src/docs_inc.c:5334
+msgid "Advanced option specifying a csv of tv modules to use."
+msgstr ""
+
+#: src/docs_inc.c:5690 src/docs_inc.c:5786 src/docs_inc.c:5882
 msgid "Afternoon"
 msgstr ""
 
-#: src/docs_inc.c:4482
+#: src/docs_inc.c:5686 src/docs_inc.c:5694 src/docs_inc.c:5878
+#: src/docs_inc.c:5886
+msgid "Afternoon fast news"
+msgstr ""
+
+#: src/docs_inc.c:312 src/docs_inc.c:1358 src/docs_inc.c:5374
+#: src/docs_inc.c:6152
+msgid "All"
+msgstr ""
+
+#: src/docs_inc.c:5128
 msgid "All (Streaming plus DVR)"
 msgstr ""
 
-#: src/docs_inc.c:5013
+#: src/docs_inc.c:5238
 msgid ""
 "All available tuners failed to tune (this can indicate a signal, driver or "
 "hardware problem)."
 msgstr ""
 
-#: src/docs_inc.c:1817
+#: src/docs_inc.c:1178
 msgid ""
 "All channel data, channel groups/tags, EPG and TV streaming is carried over "
 "a single TCP connection."
 msgstr ""
 
-#: src/docs_inc.c:1335 src/docs_inc.c:1451
+#: src/docs_inc.c:2220 src/docs_inc.c:2370
 msgid "All channels"
 msgstr ""
 
-#: src/docs_inc.c:4604
+#: src/docs_inc.c:5078
 msgid "All lower-case"
 msgstr ""
 
-#: src/docs_inc.c:1835
+#: src/docs_inc.c:1196
 msgid ""
 "All major character encodings in DVB are supported (e.g. for localised EPG "
 "character sets)."
 msgstr ""
 
-#: src/docs_inc.c:1765
+#: src/docs_inc.c:1126
 msgid "All original streams (multiple audio tracks, etc) are recorded."
 msgstr ""
 
-#: src/docs_inc.c:1343
+#: src/docs_inc.c:2228
 msgid "All recordings"
 msgstr ""
 
-#: src/docs_inc.c:1255
+#: src/docs_inc.c:26
 msgid ""
 "All rights reserved, and all implications of using, following, not "
 "following, or in any way even being aware of this documentation are "
@@ -912,65 +1065,68 @@ msgid ""
 "that's nothing to do with us."
 msgstr ""
 
-#: src/docs_inc.c:1793
+#: src/docs_inc.c:1154
 msgid "All settings are stored in human-readable text files."
 msgstr ""
 
-#: src/docs_inc.c:1791
+#: src/docs_inc.c:1152
 msgid ""
 "All setup and configuration is done from the built in web user interface."
 msgstr ""
 
-#: src/docs_inc.c:1787
+#: src/docs_inc.c:1148
 msgid ""
 "All sorting/filtering is then done in C by the main application for speed."
 msgstr ""
 
-#: src/docs_inc.c:1339
+#: src/docs_inc.c:2224
 msgid "All tags, for Enigma2 - tags are converted to labels"
 msgstr ""
 
-#: src/docs_inc.c:1833
+#: src/docs_inc.c:1194
 msgid "All text is encoded in UTF-8 to provide full international support."
 msgstr ""
 
-#: src/docs_inc.c:4484
+#: src/docs_inc.c:308
+msgid "All/Now"
+msgstr ""
+
+#: src/docs_inc.c:5130
 msgid "Allow access to all streaming options (including DVR functionality)."
 msgstr ""
 
-#: src/docs_inc.c:4860
+#: src/docs_inc.c:5644
 msgid "Allow the user to change the interface view level."
 msgstr ""
 
-#: src/docs_inc.c:4628
-msgid ""
-"Allows you to control which parameters are merged. If the _Change "
-"parameters_ flag is turned on and a parameter (permission flags, all types "
-"of profiles, channel tags and ranges) for an entry is not set the parameter "
-"(value, list or range) is cleared (unset). This allows the next matching "
-"entry (if any) in the sequence to set it."
+#: src/docs_inc.c:492
+msgid "Alternative showings"
 msgstr ""
 
-#: src/docs_inc.c:1163
+#: src/docs_inc.c:925
 msgid ""
 "Alternatively, you can run Tvheadend on a server, perhaps on an always-on "
 "system that houses your media, perhaps on a dedicated low-power system - "
 "it's your choice."
 msgstr ""
 
-#: src/docs_inc.c:4230
+#: src/docs_inc.c:6004
 msgid "Always keep the mux regardless of whether it exists or not."
 msgstr ""
 
-#: src/docs_inc.c:4238
+#: src/docs_inc.c:6012
 msgid "Always reject but allow partial match."
 msgstr ""
 
-#: src/docs_inc.c:4234
+#: src/docs_inc.c:6008
 msgid "Always reject."
 msgstr ""
 
-#: src/docs_inc.c:1177
+#: src/docs_inc.c:136
+msgid "An Example TV Adapter Tree"
+msgstr ""
+
+#: src/docs_inc.c:939
 msgid ""
 "An __Internet connection__ is recommended but not essential. You need to "
 "have an accurate clock for EPG timers to work, for example, but this can be "
@@ -978,312 +1134,354 @@ msgid ""
 "`ntp` or similar."
 msgstr ""
 
-#: src/docs_inc.c:2898
+#: src/docs_inc.c:3053
 msgid ""
 "An access entry is said to match if the username and the IP source address "
-"of the requesting peer is within the prefix (_Allowed networks_ ). Wildcard ("
+"of the requesting peer is within the prefix _(Allowed networks)_ , wildcard "
+"(anonymous) accounts will match __ANY__ username."
 msgstr ""
 
-#: src/docs_inc.c:4798
+#: src/docs_inc.c:4448
+msgid "An audio-only profile."
+msgstr ""
+
+#: src/docs_inc.c:5926
 msgid "An example:"
 msgstr ""
 
-#: src/docs_inc.c:1237
+#: src/docs_inc.c:2139
 msgid "And I'm left with these final open questions:"
 msgstr ""
 
-#: src/docs_inc.c:53
+#: src/docs_inc.c:1769
 msgid "And another item."
 msgstr ""
 
-#: src/docs_inc.c:413
+#: src/docs_inc.c:1228
 msgid ""
 "And finally, services are mapped to __channels__ . These are what you and "
 "your client software think in terms of: _\"I'd like to watch BBC One now, "
 "please\"_ ."
 msgstr ""
 
-#: src/docs_inc.c:87
+#: src/docs_inc.c:1803
 msgid ""
 "And if you don't want a header, you can leave it out - but the cells remain "
 "in this theme, so I'd suggest you don't do this as it's ugly:"
 msgstr ""
 
-#: src/docs_inc.c:1135
+#: src/docs_inc.c:1588
 msgid ""
 "And the same drop-down menu also gives you access to a __filter__ function "
 "if defined. The filter does simple pattern-matching on any string you "
 "provide. A small blue flag or triangle will appear in the top-left corner to "
-"indicate that a filter is active."
+"indicate that a filter is active. Filters persist until cleared."
 msgstr ""
 
-#: src/docs_inc.c:1175
+#: src/docs_inc.c:937
 msgid ""
 "And, of course, you'll need one or more __TV tuners__ if you want to receive "
 "regular broadcast television - otherwise, you're limited to IP sources."
 msgstr ""
 
-#: src/docs_inc.c:1823
+#: src/docs_inc.c:1184
 msgid "Android"
 msgstr ""
 
-#: src/docs_inc.c:4654
+#: src/docs_inc.c:4954
 msgid "Anonymize HTSP access"
 msgstr ""
 
-#: src/docs_inc.c:2965
-msgid "Anonymous Access"
-msgstr ""
-
-#: src/docs_inc.c:45
+#: src/docs_inc.c:1761
 msgid "Another item"
 msgstr ""
 
-#: src/docs_inc.c:3279
+#: src/docs_inc.c:702
+msgid "Antenna (also known as an aerial)"
+msgstr ""
+
+#: src/docs_inc.c:3099
 msgid ""
 "Any changes (mapped services, number changes etc) to the channels can be "
 "lost if new changes in the bouquet override them."
 msgstr ""
 
-#: src/docs_inc.c:1007
+#: src/docs_inc.c:2076
 msgid "Appendices"
 msgstr ""
 
-#: src/docs_inc.c:1009
+#: src/docs_inc.c:2078
 msgid "Appendix 1 - URL syntax (Exports)"
 msgstr ""
 
-#: src/docs_inc.c:1011
+#: src/docs_inc.c:2080
 msgid "Appendix 2 - FAQ"
 msgstr ""
 
-#: src/docs_inc.c:1013
+#: src/docs_inc.c:2082
 msgid "Appendix 3 - Command-line Options"
 msgstr ""
 
-#: src/docs_inc.c:1015
+#: src/docs_inc.c:2084
 msgid "Appendix 4 - Updating this documentation"
 msgstr ""
 
-#: src/docs_inc.c:1017
+#: src/docs_inc.c:2086
 msgid "Appendix 5 - Markdown Cribsheet"
 msgstr ""
 
-#: src/docs_inc.c:403
+#: src/docs_inc.c:1218
 msgid "Application/Tvheadend Fundamentals"
 msgstr ""
 
-#: src/docs_inc.c:3721
-msgid "Apply configuration (run-time only)"
+#: src/docs_inc.c:1662
+msgid "Apply"
 msgstr ""
 
-#: src/docs_inc.c:3723
+#: src/docs_inc.c:1506
+msgid "Apply configuration (run time only)"
+msgstr ""
+
+#: src/docs_inc.c:1508
 msgid "Apply the entered debugging settings."
 msgstr ""
 
-#: src/docs_inc.c:373
+#: src/docs_inc.c:5328
+msgid "Argument"
+msgstr ""
+
+#: src/docs_inc.c:890
 msgid "Arranging your channels into groups (channel tags)"
 msgstr ""
 
-#: src/docs_inc.c:1617
+#: src/docs_inc.c:991
 msgid ""
 "As a broad guide, though, you need two main components: a driver, and "
 "firmware."
 msgstr ""
 
-#: src/docs_inc.c:363
+#: src/docs_inc.c:880
 msgid "As required, you may now wish to look into:"
 msgstr ""
 
-#: src/docs_inc.c:199
+#: src/docs_inc.c:1070
 msgid ""
 "As well as being able to record the input, Tvheadend also offers it up to "
 "client applications via HTTP (VLC, MPlayer), HTSP (Kodi, Movian) and SAT>IP "
 "streaming."
 msgstr ""
 
-#: src/docs_inc.c:1821
+#: src/docs_inc.c:1182
 msgid ""
 "As well as the web interface, which is accessible through VPN if required, "
 "third-party clients are available for both"
 msgstr ""
 
-#: src/docs_inc.c:157
-msgid ""
-"As you set things up, consult the on-line (web interface) help as well. "
-"Tvheadend includes copies of many of these pages in the application, which "
-"is easier to find when you're wondering what to do next."
-msgstr ""
-
-#: src/docs_inc.c:3640
+#: src/docs_inc.c:1382
 msgid "Assign Number"
 msgstr ""
 
-#: src/docs_inc.c:5284
+#: src/docs_inc.c:718
 msgid ""
 "Assign predefined muxes to networks. To save you from manually entering "
-"muxes, Tvheadend includes predefined mux lists. Please select a list for "
-"each network below."
+"muxes, Tvheadend includes predefined mux lists. Please select an option from "
+"the list for each network."
 msgstr ""
 
-#: src/docs_inc.c:3642
-msgid ""
-"Assign the lowest available channel number(s) to the selected channel(s)."
-msgstr ""
-
-#: src/docs_inc.c:287
+#: src/docs_inc.c:810
 msgid ""
 "Associate each of your tuners with the correct network through _Parameters -"
 "> Basic Settings_ ."
 msgstr ""
 
-#: src/docs_inc.c:291
+#: src/docs_inc.c:814
 msgid ""
 "At this point, your tuners now know what networks to use: one network can "
 "appear on multiple tuners (many-to-one), and one tuner can have multiple "
 "networks."
 msgstr ""
 
-#: src/docs_inc.c:2219
+#: src/docs_inc.c:1502
 msgid "Attempt to discover more SAT>IP servers on the network."
 msgstr ""
 
-#: src/docs_inc.c:967
+#: src/docs_inc.c:4446
+msgid "Audio Profile"
+msgstr ""
+
+#: src/docs_inc.c:3987
 msgid "Audio Stream Filters"
 msgstr ""
 
-#: src/docs_inc.c:4224
+#: src/docs_inc.c:3593
+msgid "Audio muxer"
+msgstr ""
+
+#: src/docs_inc.c:3989
+msgid "Audio stream filter."
+msgstr ""
+
+#: src/docs_inc.c:4764
+msgid "Authcode only"
+msgstr ""
+
+#: src/docs_inc.c:5998
 msgid "Auto"
 msgstr ""
 
-#: src/docs_inc.c:4534
+#: src/docs_inc.c:6028
 msgid "Auto check disabled"
 msgstr ""
 
-#: src/docs_inc.c:4530
+#: src/docs_inc.c:6024
 msgid "Auto check enabled"
 msgstr ""
 
-#: src/docs_inc.c:889
+#: src/docs_inc.c:280
+msgid "Auto-recording"
+msgstr ""
+
+#: src/docs_inc.c:2740
 msgid "Auto-recording (Autorecs)"
 msgstr ""
 
-#: src/docs_inc.c:3414
-msgid ""
-"Automatically record all upcoming events matching the program's title by "
-"pressing the _[Autorec]_ button."
+#: src/docs_inc.c:278 src/docs_inc.c:502
+msgid "Auto-recordings"
 msgstr ""
 
-#: src/docs_inc.c:755 src/docs_inc.c:3434
+#: src/docs_inc.c:508
 msgid "Autorec"
 msgstr ""
 
-#: src/docs_inc.c:3426
-msgid "Autorec rules allow you to match events using various options."
+#: src/docs_inc.c:1336
+msgid "Autorec/Record Series"
 msgstr ""
 
-#: src/docs_inc.c:749
-msgid "Autorecordings"
+#: src/docs_inc.c:488
+msgid "Autorec:"
 msgstr ""
 
-#: src/docs_inc.c:3833
+#: src/docs_inc.c:3485
 msgid "Avahi"
 msgstr ""
 
-#: src/docs_inc.c:2390
-msgid "Available CA types"
+#: src/docs_inc.c:2453
+msgid "Available CA client types"
 msgstr ""
 
-#: src/docs_inc.c:4373 src/docs_inc.c:4751 src/docs_inc.c:5173
+#: src/docs_inc.c:3353
+msgid "Available debugging subsystems"
+msgstr ""
+
+#: src/docs_inc.c:2823
+msgid "Available network types (with links to their Help page)"
+msgstr ""
+
+#: src/docs_inc.c:4295
+msgid ""
+"Available worldwide but common in Brazil and various other countries "
+"throughout south America."
+msgstr ""
+
+#: src/docs_inc.c:4291
+msgid "Available worldwide."
+msgstr ""
+
+#: src/docs_inc.c:5670 src/docs_inc.c:5770 src/docs_inc.c:5862
 msgid "BBC world"
 msgstr ""
 
-#: src/docs_inc.c:4818
+#: src/docs_inc.c:5946
 msgid "BUSY"
 msgstr ""
 
-#: src/docs_inc.c:897
-msgid "Base"
-msgstr ""
-
-#: src/docs_inc.c:4303 src/docs_inc.c:4850
+#: src/docs_inc.c:5634 src/docs_inc.c:6098
 msgid "Base Config"
 msgstr ""
 
-#: src/docs_inc.c:3877
+#: src/docs_inc.c:2570
+msgid "Base Configuration"
+msgstr ""
+
+#: src/docs_inc.c:3529
 msgid "Base DVB SI Tables (PAT,CAT,PMT,SDT etc.)"
 msgstr ""
 
-#: src/docs_inc.c:1785
+#: src/docs_inc.c:1146
 msgid "Based on extJS, all pages are dynamic and self-refreshing."
 msgstr ""
 
-#: src/docs_inc.c:4367 src/docs_inc.c:4745 src/docs_inc.c:5167
+#: src/docs_inc.c:5664 src/docs_inc.c:5764 src/docs_inc.c:5856
 msgid "Basename of recording"
 msgstr ""
 
-#: src/docs_inc.c:4307 src/docs_inc.c:4953
+#: src/docs_inc.c:1564 src/docs_inc.c:5378 src/docs_inc.c:6102
+#: src/docs_inc.c:6124 src/docs_inc.c:6156
 msgid "Basic"
 msgstr ""
 
-#: src/docs_inc.c:859 src/docs_inc.c:1157
+#: src/docs_inc.c:6160
+msgid "Basic Alternative (No Hash)"
+msgstr ""
+
+#: src/docs_inc.c:907 src/docs_inc.c:919
 msgid "Basic Requirements"
 msgstr ""
 
-#: src/docs_inc.c:2945
-msgid ""
-"Be as limiting as possible especially when making Tvheadend available over "
-"the Internet."
-msgstr ""
-
-#: src/docs_inc.c:2275
-msgid ""
-"Be aware that the username you enter here must match a username/entry in the"
-msgstr ""
-
-#: src/docs_inc.c:4940
+#: src/docs_inc.c:5208
 msgid ""
 "Be sure to check you have enough free tuners available to record all "
 "scheduled recordings if they overlap."
 msgstr ""
 
-#: src/docs_inc.c:385
-msgid "Before You Begin"
+#: src/docs_inc.c:1044 src/docs_inc.c:1200
+msgid "Before you Begin"
 msgstr ""
 
-#: src/docs_inc.c:865
-msgid "Before you begin (concepts)"
+#: src/docs_inc.c:1276
+msgid ""
+"Below is a (VERY) long list of the buttons you'll find in Tvheadend, They're "
+"listed here so you can quickly refer back to them at a later date (and know "
+"where to find them!)."
 msgstr ""
 
-#: src/docs_inc.c:3082
-msgid "Below are some examples:"
-msgstr ""
-
-#: src/docs_inc.c:1089
+#: src/docs_inc.c:1936
 msgid "Bit Error Ratio"
 msgstr ""
 
-#: src/docs_inc.c:4873
+#: src/docs_inc.c:6066
 msgid "Blue"
 msgstr ""
 
-#: src/docs_inc.c:3837
+#: src/docs_inc.c:5540
+msgid "Bones - S02E06"
+msgstr ""
+
+#: src/docs_inc.c:5590
+msgid "Bones/Bones - S05 E11 (episode with guide season/episode information)"
+msgstr ""
+
+#: src/docs_inc.c:5614
+msgid "Bones/Season 5/Bones - S05E11"
+msgstr ""
+
+#: src/docs_inc.c:3489
 msgid "Bonjour"
 msgstr ""
 
-#: src/docs_inc.c:3676 src/docs_inc.c:3688 src/docs_inc.c:3957
+#: src/docs_inc.c:3617
 msgid "Bouquet"
 msgstr ""
 
-#: src/docs_inc.c:355 src/docs_inc.c:929
+#: src/docs_inc.c:2491
 msgid "Bouquets"
 msgstr ""
 
-#: src/docs_inc.c:3228
+#: src/docs_inc.c:3073
 msgid "Bouquets are broadcaster-defined groupings and orders of channels."
 msgstr ""
 
-#: src/docs_inc.c:3236
+#: src/docs_inc.c:3081
 msgid ""
 "Bouquets are usually obtained automatically from the DVB source during the "
 "mux scan period. Note that bouquets may use more muxes and only services "
@@ -1291,585 +1489,768 @@ msgid ""
 "scan when all muxes are discovered (manually using the rescan checkbox)."
 msgstr ""
 
-#: src/docs_inc.c:691
+#: src/docs_inc.c:400
 msgid "Broadcast details icon"
 msgstr ""
 
-#: src/docs_inc.c:765 src/docs_inc.c:795 src/docs_inc.c:819
+#: src/docs_inc.c:518 src/docs_inc.c:548 src/docs_inc.c:572
 msgid "Browser"
 msgstr ""
 
-#: src/docs_inc.c:1659
+#: src/docs_inc.c:67
 msgid "Build Tvheadend as you normally would, see the"
 msgstr ""
 
-#: src/docs_inc.c:1761
+#: src/docs_inc.c:1122
 msgid ""
 "Built in video recorder stores recorded programs as Transport Stream (.ts) "
 "or Matroska (.mkv) files."
 msgstr ""
 
-#: src/docs_inc.c:2584
+#: src/docs_inc.c:4426
 msgid "Built-in"
 msgstr ""
 
-#: src/docs_inc.c:119 src/docs_inc.c:465 src/docs_inc.c:653 src/docs_inc.c:1061
-#: src/docs_inc.c:1509 src/docs_inc.c:1685 src/docs_inc.c:1890
-#: src/docs_inc.c:1928 src/docs_inc.c:1992 src/docs_inc.c:2143
-#: src/docs_inc.c:2176 src/docs_inc.c:2203 src/docs_inc.c:2296
-#: src/docs_inc.c:2321 src/docs_inc.c:2350 src/docs_inc.c:2459
-#: src/docs_inc.c:2500 src/docs_inc.c:2541 src/docs_inc.c:2608
-#: src/docs_inc.c:2732 src/docs_inc.c:2875 src/docs_inc.c:2915
-#: src/docs_inc.c:2986 src/docs_inc.c:3048 src/docs_inc.c:3115
-#: src/docs_inc.c:3140 src/docs_inc.c:3213 src/docs_inc.c:3247
-#: src/docs_inc.c:3310 src/docs_inc.c:3562 src/docs_inc.c:3592
-#: src/docs_inc.c:3717 src/docs_inc.c:4114 src/docs_inc.c:4171
+#: src/docs_inc.c:1278 src/docs_inc.c:2526
 msgid "Button"
 msgstr ""
 
-#: src/docs_inc.c:461 src/docs_inc.c:649 src/docs_inc.c:2172
-#: src/docs_inc.c:2292 src/docs_inc.c:2871 src/docs_inc.c:3111
-#: src/docs_inc.c:3136 src/docs_inc.c:3209 src/docs_inc.c:3558
-#: src/docs_inc.c:4167
+#: src/docs_inc.c:120 src/docs_inc.c:203 src/docs_inc.c:296 src/docs_inc.c:1828
+#: src/docs_inc.c:1912 src/docs_inc.c:1975 src/docs_inc.c:3061
+#: src/docs_inc.c:3117 src/docs_inc.c:3281 src/docs_inc.c:3299
+#: src/docs_inc.c:3317 src/docs_inc.c:3335 src/docs_inc.c:3375
+#: src/docs_inc.c:3799 src/docs_inc.c:3817 src/docs_inc.c:3829
+#: src/docs_inc.c:3841 src/docs_inc.c:3863 src/docs_inc.c:3881
+#: src/docs_inc.c:3939 src/docs_inc.c:4007 src/docs_inc.c:4057
+#: src/docs_inc.c:4079 src/docs_inc.c:4107 src/docs_inc.c:4127
+#: src/docs_inc.c:4147 src/docs_inc.c:4167 src/docs_inc.c:4209
+#: src/docs_inc.c:4239 src/docs_inc.c:4257 src/docs_inc.c:4366
+#: src/docs_inc.c:4404 src/docs_inc.c:4470 src/docs_inc.c:4552
+#: src/docs_inc.c:4572 src/docs_inc.c:4592 src/docs_inc.c:4618
+#: src/docs_inc.c:4672 src/docs_inc.c:4690
 msgid "Buttons"
 msgstr ""
 
-#: src/docs_inc.c:223
+#: src/docs_inc.c:613
 msgid ""
 "By default Tvheadend's _Play_ links are playlists, although not all players "
 "accept them (e.g. Media Player Classic Home Cinema). You can bypass this by "
 "removing the `/play/` path from the url."
 msgstr ""
 
-#: src/docs_inc.c:3973
+#: src/docs_inc.c:4269
+msgid "C (Cable)"
+msgstr ""
+
+#: src/docs_inc.c:3637
 msgid "CA (descrambling) Client"
 msgstr ""
 
-#: src/docs_inc.c:973
+#: src/docs_inc.c:3999
 msgid "CA Stream Filters"
 msgstr ""
 
-#: src/docs_inc.c:985 src/docs_inc.c:2396
-msgid "CAPMT (Linux Network DVBAPI)"
+#: src/docs_inc.c:3139
+msgid "CAPMT (Linux DVBAPI)"
 msgstr ""
 
-#: src/docs_inc.c:3981
+#: src/docs_inc.c:3645
 msgid "CAPMT CA Client"
 msgstr ""
 
-#: src/docs_inc.c:4049
+#: src/docs_inc.c:3135
+msgid "CCCam"
+msgstr ""
+
+#: src/docs_inc.c:3725
 msgid "CI Module"
 msgstr ""
 
-#: src/docs_inc.c:3759 src/docs_inc.c:3761
+#: src/docs_inc.c:3411 src/docs_inc.c:3413
 msgid "CPU"
 msgstr ""
 
-#: src/docs_inc.c:3743 src/docs_inc.c:3745
+#: src/docs_inc.c:3395 src/docs_inc.c:3397
 msgid "CRASH"
 msgstr ""
 
-#: src/docs_inc.c:3977
+#: src/docs_inc.c:3641
 msgid "CSA (descrambling)"
 msgstr ""
 
-#: src/docs_inc.c:3985
+#: src/docs_inc.c:3143
+msgid "CSA CBC Constant Code Word"
+msgstr ""
+
+#: src/docs_inc.c:3649
 msgid "CWC CA Client"
 msgstr ""
 
-#: src/docs_inc.c:531
-msgid "Cable (DVB-C/ATSC-C/ISDB-C)"
+#: src/docs_inc.c:3653
+msgid "CWC CCCam Client"
 msgstr ""
 
-#: src/docs_inc.c:2671
-msgid "Cable TV, delivered via a cable to your house"
+#: src/docs_inc.c:706
+msgid "Cable"
 msgstr ""
 
-#: src/docs_inc.c:191
-msgid "Cable TV, delivered via a cable to your house (DVB-C)"
+#: src/docs_inc.c:4271
+msgid "Cable TV, delivered via a cable to your house."
 msgstr ""
 
-#: src/docs_inc.c:1735
-msgid "Cable signals via DVB-C"
+#: src/docs_inc.c:1096
+msgid "Cable signals via DVB-C."
 msgstr ""
 
-#: src/docs_inc.c:3566
+#: src/docs_inc.c:2576
+msgid ""
+"Caching of channel icons or other images (such as EPG metadata) to be served "
+"from the local webserver. This can be useful for multi-client systems and, "
+"generally, to reduce hits on upstream providers"
+msgstr ""
+
+#: src/docs_inc.c:3193
+msgid "Camd.socket filename / IP Address (TCP mode)"
+msgstr ""
+
+#: src/docs_inc.c:4886
+msgid "Can access configuration tab?"
+msgstr ""
+
+#: src/docs_inc.c:1654
 msgid "Cancel"
 msgstr ""
 
-#: src/docs_inc.c:3568
-msgid "Cancel mapping and close the dialog."
-msgstr ""
-
-#: src/docs_inc.c:1657
+#: src/docs_inc.c:65
 msgid ""
 "Change markdown files in `docs/markdown`, `docs/markdown/inc`, `docs/class`, "
 "`docs/wizard`, etc. Images are placed in `src/webui/static/img/doc/`."
 msgstr ""
 
-#: src/docs_inc.c:4274
+#: src/docs_inc.c:4858
 msgid ""
 "Change nothing and rely on standard (default) system caching to behave as it "
 "normally would."
 msgstr ""
 
-#: src/docs_inc.c:3707
+#: src/docs_inc.c:1668
+msgid "Change the dialog view level to show/hide more advanced options."
+msgstr ""
+
+#: src/docs_inc.c:3369
 msgid ""
 "Changes to any of these settings must be confirmed by pressing the _[Apply "
 "configuration]_ button before taking effect."
 msgstr ""
 
-#: src/docs_inc.c:3945
+#: src/docs_inc.c:2591
+msgid ""
+"Changing some of these settings __may__ cause unexpected results, you have "
+"been warned!\n"
+msgstr ""
+
+#: src/docs_inc.c:3605
 msgid "Channel"
 msgstr ""
 
-#: src/docs_inc.c:923
+#: src/docs_inc.c:4766
+msgid "Channel 'play' streams"
+msgstr ""
+
+#: src/docs_inc.c:2062
 msgid "Channel / EPG"
 msgstr ""
 
-#: src/docs_inc.c:927
+#: src/docs_inc.c:2487
 msgid "Channel Tags"
 msgstr ""
 
-#: src/docs_inc.c:4371 src/docs_inc.c:4749 src/docs_inc.c:5048
-#: src/docs_inc.c:5171
+#: src/docs_inc.c:2485
+msgid "Channel management"
+msgstr ""
+
+#: src/docs_inc.c:5524 src/docs_inc.c:5668 src/docs_inc.c:5768
+#: src/docs_inc.c:5860
 msgid "Channel name"
 msgstr ""
 
-#: src/docs_inc.c:4658
+#: src/docs_inc.c:2286
+msgid "Channel name only"
+msgstr ""
+
+#: src/docs_inc.c:2280
+msgid "Channel number as first key, channel name as second key"
+msgstr ""
+
+#: src/docs_inc.c:4958
 msgid "Channel number range"
 msgstr ""
 
-#: src/docs_inc.c:1399
+#: src/docs_inc.c:2318
 msgid "Channel specified by channel UUID"
 msgstr ""
 
-#: src/docs_inc.c:1395
+#: src/docs_inc.c:2314
 msgid "Channel specified by channel name"
 msgstr ""
 
-#: src/docs_inc.c:1391
+#: src/docs_inc.c:2310
 msgid "Channel specified by channel number"
 msgstr ""
 
-#: src/docs_inc.c:1403
+#: src/docs_inc.c:2322
 msgid "Channel specified by short channel ID"
 msgstr ""
 
-#: src/docs_inc.c:4668 src/docs_inc.c:4674
+#: src/docs_inc.c:2489
+msgid "Channel tagging management"
+msgstr ""
+
+#: src/docs_inc.c:4968 src/docs_inc.c:4974
 msgid "Channel tags"
 msgstr ""
 
-#: src/docs_inc.c:925 src/docs_inc.c:4503 src/docs_inc.c:4592
+#: src/docs_inc.c:2483 src/docs_inc.c:5066 src/docs_inc.c:5102
 msgid "Channels"
 msgstr ""
 
-#: src/docs_inc.c:597
+#: src/docs_inc.c:330
 msgid ""
 "Channels in the drop down are ordered by name and can be filtered (by name) "
 "by typing in the box."
 msgstr ""
 
-#: src/docs_inc.c:4009
+#: src/docs_inc.c:3681
 msgid "Charset"
 msgstr ""
 
-#: src/docs_inc.c:1209
+#: src/docs_inc.c:2111
 msgid ""
 "Check all link from tvh (e.g. there are no help buttons on the 'Stream' tabs)"
 msgstr ""
 
-#: src/docs_inc.c:1203
+#: src/docs_inc.c:2105
 msgid ""
 "Check non-univeral (i.e. item-specific) configuration items (e.g. the IPTV "
 "mux parameters) and make sure they're documented"
 msgstr ""
 
-#: src/docs_inc.c:4517
+#: src/docs_inc.c:457
+msgid ""
+"Choose a specific DVR profile that will apply to the recording or autorec "
+"rule. You can define different profiles in the"
+msgstr ""
+
+#: src/docs_inc.c:5116
 msgid ""
 "Choose this if your picon pack has icons that start with \"1_0_1_xxxx\"."
 msgstr ""
 
-#: src/docs_inc.c:4513
+#: src/docs_inc.c:5112
 msgid ""
 "Choose this if your picon pack uses the standard naming scheme, e.g "
 "\"1_0_19_xxxx\"."
 msgstr ""
 
-#: src/docs_inc.c:4126
+#: src/docs_inc.c:1486
 msgid "Clean image (icon) cache"
 msgstr ""
 
-#: src/docs_inc.c:4128
+#: src/docs_inc.c:1488
 msgid "Clean-up the stored image files (empty cache and re-fetch icons)."
 msgstr ""
 
-#: src/docs_inc.c:659
-msgid "Clears all search filters."
+#: src/docs_inc.c:1512
+msgid "Clear all statistics"
 msgstr ""
 
-#: src/docs_inc.c:487
-msgid "Click on an item to display more information."
+#: src/docs_inc.c:3159
+msgid "Click a type to see its properties (below)."
 msgstr ""
 
-#: src/docs_inc.c:263
+#: src/docs_inc.c:784
 msgid ""
 "Click on each tuner that you want Tvheadend to use, and ensure \"Enabled\" "
 "is checked in the 'Parameters' list"
 msgstr ""
 
-#: src/docs_inc.c:2068
-msgid ""
-"Click on the services you would like to map as channels, once you're done "
-"selecting press the \"Map services\" button and then \"Map selected services"
-"\"."
+#: src/docs_inc.c:4332
+msgid "Click the desired network type (to see all available"
 msgstr ""
 
-#: src/docs_inc.c:2717
-msgid "Click the desired network type (above) to see all available"
+#: src/docs_inc.c:227
+msgid "Click to display detailed information about the selected recording."
 msgstr ""
 
-#: src/docs_inc.c:2116
+#: src/docs_inc.c:2718
+msgid "Click to return the DVR help index"
+msgstr ""
+
+#: src/docs_inc.c:4372
 msgid "Clicking the !"
 msgstr ""
 
-#: src/docs_inc.c:543
-msgid "Client"
+#: src/docs_inc.c:2451 src/docs_inc.c:3121
+msgid "Client Types"
 msgstr ""
 
-#: src/docs_inc.c:683 src/docs_inc.c:3376
+#: src/docs_inc.c:217 src/docs_inc.c:392
 msgid "Clock icon"
 msgstr ""
 
-#: src/docs_inc.c:2370 src/docs_inc.c:2628 src/docs_inc.c:3006
+#: src/docs_inc.c:1424
 msgid "Clone"
 msgstr ""
 
-#: src/docs_inc.c:2372
-msgid "Clone the currently selected configuration."
+#: src/docs_inc.c:1426
+msgid "Clone the currently selected entry."
 msgstr ""
 
-#: src/docs_inc.c:2630 src/docs_inc.c:3008
-msgid "Clone the currently selected profile."
+#: src/docs_inc.c:1656
+msgid "Closes the dialog, discarding all unsaved changes."
 msgstr ""
 
-#: src/docs_inc.c:987 src/docs_inc.c:2398
-msgid "Code word client (newcamd)"
+#: src/docs_inc.c:3131
+msgid "Code Word Client (CWC) / newcamd"
 msgstr ""
 
-#: src/docs_inc.c:5107
+#: src/docs_inc.c:3781
+msgid "Codec"
+msgstr ""
+
+#: src/docs_inc.c:2990
+msgid "Codec Profiles"
+msgstr ""
+
+#: src/docs_inc.c:2992
+msgid "Codec profiles and settings (for use with stream profiles)"
+msgstr ""
+
+#: src/docs_inc.c:4798
 msgid "Combine channels with the same name into a single channel."
 msgstr ""
 
-#: src/docs_inc.c:1027
+#: src/docs_inc.c:4532
+msgid "Combined DVB OTA and XMLTV"
+msgstr ""
+
+#: src/docs_inc.c:3
 msgid "Command-line Options"
 msgstr ""
 
-#: src/docs_inc.c:1201
+#: src/docs_inc.c:5736 src/docs_inc.c:5908
+msgid "Comment"
+msgstr ""
+
+#: src/docs_inc.c:4279 src/docs_inc.c:4307
+msgid "Common in Brazil and various other countries throughout south America."
+msgstr ""
+
+#: src/docs_inc.c:4275 src/docs_inc.c:4303
+msgid "Common in most of Europe."
+msgstr ""
+
+#: src/docs_inc.c:4283
+msgid "Common in north and central America and parts of south Asia."
+msgstr ""
+
+#: src/docs_inc.c:4311
+msgid "Common in north and central America."
+msgstr ""
+
+#: src/docs_inc.c:2103
 msgid ""
 "Complete the content for 4.0 (4.2 can wait) - strip out what isn't stricly "
 "necessary now (we can come back)"
 msgstr ""
 
-#: src/docs_inc.c:983
+#: src/docs_inc.c:2068
 msgid "Conditional Access (CA)"
 msgstr ""
 
-#: src/docs_inc.c:893 src/docs_inc.c:3817
+#: src/docs_inc.c:4001
+msgid "Conditional Access (CA) stream filter."
+msgstr ""
+
+#: src/docs_inc.c:2572
+msgid "Config parameters that affect the core Tvheadend functionality"
+msgstr ""
+
+#: src/docs_inc.c:2054 src/docs_inc.c:3469
 msgid "Configuration"
 msgstr ""
 
-#: src/docs_inc.c:249 src/docs_inc.c:871 src/docs_inc.c:3514
-msgid "Configure Tvheadend"
+#: src/docs_inc.c:459
+msgid "Configuration -"
 msgstr ""
 
-#: src/docs_inc.c:2764
-msgid "Configure Tvheadend."
+#: src/docs_inc.c:1398
+msgid "Configuration -> Channel / EPG -> Channels only."
 msgstr ""
 
-#: src/docs_inc.c:2404
+#: src/docs_inc.c:1366
+msgid ""
+"Configuration -> Channel / EPG -> Channels/Configuration -> DVB Inputs -> "
+"Services only."
+msgstr ""
+
+#: src/docs_inc.c:1404
+msgid "Configuration -> Channel / EPG -> EPG Grabber only."
+msgstr ""
+
+#: src/docs_inc.c:1410
+msgid "Configuration -> Channel / EPG -> EPG Grabber/EPG Grabber Modules only."
+msgstr ""
+
+#: src/docs_inc.c:1434
+msgid "Configuration -> Conditional Access (CAs) only."
+msgstr ""
+
+#: src/docs_inc.c:1428
+msgid ""
+"Configuration -> Conditional Access (CAs)/Configuration -> Stream -> Stream/"
+"Codec Profiles only."
+msgstr ""
+
+#: src/docs_inc.c:1350
+msgid ""
+"Configuration -> DVB Inputs -> Networks/Configuration -> Channel / EPG -> "
+"Bouquets only."
+msgstr ""
+
+#: src/docs_inc.c:1378
+msgid "Configuration -> DVB Inputs -> Services only."
+msgstr ""
+
+#: src/docs_inc.c:1510
+msgid "Configuration -> Debugging -> Configuration only."
+msgstr ""
+
+#: src/docs_inc.c:1484
+msgid "Configuration -> General -> Base only."
+msgstr ""
+
+#: src/docs_inc.c:1490 src/docs_inc.c:1496
+msgid "Configuration -> General -> Image cache only."
+msgstr ""
+
+#: src/docs_inc.c:1504
+msgid "Configuration -> General -> SAT>IP Server only."
+msgstr ""
+
+#: src/docs_inc.c:1416 src/docs_inc.c:1422
+msgid ""
+"Configuration -> Users -> Access entries/Configuration -> Stream -> Stream "
+"filters only."
+msgstr ""
+
+#: src/docs_inc.c:4622
+msgid "Configure Tvheadend as a SAT>IP Server (Basic Guide)"
+msgstr ""
+
+#: src/docs_inc.c:646 src/docs_inc.c:2046
+msgid "Configuring for the First Time"
+msgstr ""
+
+#: src/docs_inc.c:2455 src/docs_inc.c:3161
 msgid "Connection Status"
 msgstr ""
 
-#: src/docs_inc.c:4692
+#: src/docs_inc.c:2956
+msgid "Connection information"
+msgstr ""
+
+#: src/docs_inc.c:4992
 msgid "Connection limit type"
 msgstr ""
 
-#: src/docs_inc.c:4690
+#: src/docs_inc.c:4990
 msgid "Connection limits"
 msgstr ""
 
-#: src/docs_inc.c:1001
+#: src/docs_inc.c:2457
+msgid "Connection status indicators"
+msgstr ""
+
+#: src/docs_inc.c:2954
 msgid "Connections"
 msgstr ""
 
-#: src/docs_inc.c:79
+#: src/docs_inc.c:1795
 msgid "Content from cell 1"
 msgstr ""
 
-#: src/docs_inc.c:81
+#: src/docs_inc.c:1797
 msgid "Content from cell 2"
 msgstr ""
 
-#: src/docs_inc.c:83
+#: src/docs_inc.c:1799
 msgid "Content in the first column"
 msgstr ""
 
-#: src/docs_inc.c:85
+#: src/docs_inc.c:1801
 msgid "Content in the second column"
 msgstr ""
 
-#: src/docs_inc.c:5052
+#: src/docs_inc.c:5528
 msgid "Content type"
 msgstr ""
 
-#: src/docs_inc.c:1275
+#: src/docs_inc.c:80 src/docs_inc.c:258 src/docs_inc.c:648 src/docs_inc.c:903
+#: src/docs_inc.c:1032 src/docs_inc.c:2443 src/docs_inc.c:2471
+#: src/docs_inc.c:2558 src/docs_inc.c:2712 src/docs_inc.c:2791
+#: src/docs_inc.c:2813 src/docs_inc.c:2868 src/docs_inc.c:2888
+#: src/docs_inc.c:2912 src/docs_inc.c:2938 src/docs_inc.c:2974
+#: src/docs_inc.c:3002 src/docs_inc.c:3343 src/docs_inc.c:4187
+#: src/docs_inc.c:4217
+msgid "Contents"
+msgstr ""
+
+#: src/docs_inc.c:46
 msgid "Contributor Licensing Agreement"
 msgstr ""
 
-#: src/docs_inc.c:1273
+#: src/docs_inc.c:44
 msgid "Contributor information"
 msgstr ""
 
-#: src/docs_inc.c:665
+#: src/docs_inc.c:2414
+msgid "Copy this contents to your oscam.srvid2 and start/restart the server."
+msgstr ""
+
+#: src/docs_inc.c:5592
+msgid "Countdown/Countdown (episode without guide season/episode information)"
+msgstr ""
+
+#: src/docs_inc.c:1318
 msgid "Create Autorec"
 msgstr ""
 
-#: src/docs_inc.c:271
+#: src/docs_inc.c:794
 msgid ""
 "Create a network of the appropriate type here. You can have multiple "
 "networks of the same type as necessary, e.g. to have two DVB-T networks "
 "defined, one with HD muxes, one without."
 msgstr ""
 
-#: src/docs_inc.c:4908
+#: src/docs_inc.c:490
+msgid "Create a pseudo-series link using the autorec feature."
+msgstr ""
+
+#: src/docs_inc.c:4828
 msgid "Create a tag based on the channel type and link it to the channel."
 msgstr ""
 
-#: src/docs_inc.c:4904
+#: src/docs_inc.c:4824
 msgid ""
 "Create a tag with the bouquets name and link it to all channels created by "
 "the bouquet."
 msgstr ""
 
-#: src/docs_inc.c:4912
+#: src/docs_inc.c:4832
 msgid ""
 "Create a tag with the channel provider's name and link it to the channel."
 msgstr ""
 
-#: src/docs_inc.c:4916
+#: src/docs_inc.c:4836
 msgid ""
 "Create a tag with the network name and link it to all channels created by "
 "the bouquet."
 msgstr ""
 
-#: src/docs_inc.c:4902
+#: src/docs_inc.c:1338
+msgid ""
+"Create an Auto-record entry matching the current program query. For events "
+"that have series-link information available the"
+msgstr ""
+
+#: src/docs_inc.c:760
+msgid "Create and link a network tag to the mapped channels."
+msgstr ""
+
+#: src/docs_inc.c:756
+msgid "Create and link a provider tag to the mapped channels."
+msgstr ""
+
+#: src/docs_inc.c:4822
 msgid "Create bouquet tag"
 msgstr ""
 
-#: src/docs_inc.c:4914
+#: src/docs_inc.c:4834
 msgid "Create network name tags"
 msgstr ""
 
-#: src/docs_inc.c:4910
+#: src/docs_inc.c:758
+msgid "Create network tags"
+msgstr ""
+
+#: src/docs_inc.c:4830
 msgid "Create provider name tags"
 msgstr ""
 
-#: src/docs_inc.c:1769
+#: src/docs_inc.c:754
+msgid "Create provider tags"
+msgstr ""
+
+#: src/docs_inc.c:1130
 msgid "Create rule sets manually or based on EPG queries."
 msgstr ""
 
-#: src/docs_inc.c:4906
+#: src/docs_inc.c:4826
 msgid "Create type-based tags"
 msgstr ""
 
-#: src/docs_inc.c:667
-msgid ""
-"Creates an auto-recording rule based on the current filter criteria (see "
-"below)."
+#: src/docs_inc.c:1320
+msgid "Creates an auto-recording rule based on the current filter criteria."
 msgstr ""
 
-#: src/docs_inc.c:3825
+#: src/docs_inc.c:3477
 msgid "Cron"
 msgstr ""
 
-#: src/docs_inc.c:5201
+#: src/docs_inc.c:5706
 msgid "Current affairs"
 msgstr ""
 
-#: src/docs_inc.c:3829
+#: src/docs_inc.c:3959
+msgid ""
+"Currently only a limited number of configuration files are shipped and these "
+"are located in the epggrab/eit/scrape directory."
+msgstr ""
+
+#: src/docs_inc.c:2948
+msgid "Currently-active streams"
+msgstr ""
+
+#: src/docs_inc.c:3481
 msgid "DBUS"
 msgstr ""
 
-#: src/docs_inc.c:989 src/docs_inc.c:2400
-msgid "DES constant code word client"
+#: src/docs_inc.c:3789
+msgid "DD-CI"
 msgstr ""
 
-#: src/docs_inc.c:4013
+#: src/docs_inc.c:3147
+msgid "DES NCB Constant Code Word"
+msgstr ""
+
+#: src/docs_inc.c:3685
 msgid "DVB"
 msgstr ""
 
-#: src/docs_inc.c:3989
+#: src/docs_inc.c:3657
 msgid "DVB CAM Client"
 msgstr ""
 
-#: src/docs_inc.c:3881
+#: src/docs_inc.c:3533
 msgid "DVB CSA (descrambling) Tables"
 msgstr ""
 
-#: src/docs_inc.c:3885
+#: src/docs_inc.c:3537
 msgid "DVB EPG Tables"
 msgstr ""
 
-#: src/docs_inc.c:911
+#: src/docs_inc.c:78 src/docs_inc.c:2060 src/docs_inc.c:4091
 msgid "DVB Inputs"
 msgstr ""
 
-#: src/docs_inc.c:453
-msgid "DVB Inputs - TV Adapters"
+#: src/docs_inc.c:4498
+msgid "DVB OTA"
 msgstr ""
 
-#: src/docs_inc.c:3873
+#: src/docs_inc.c:3525
 msgid "DVB SI Tables"
 msgstr ""
 
-#: src/docs_inc.c:3889
+#: src/docs_inc.c:3541
 msgid "DVB Time Tables"
 msgstr ""
 
-#: src/docs_inc.c:1725
+#: src/docs_inc.c:1086
 msgid "DVB subtitles supported."
 msgstr ""
 
-#: src/docs_inc.c:535 src/docs_inc.c:2673
+#: src/docs_inc.c:2638 src/docs_inc.c:4273
 msgid "DVB-C"
 msgstr ""
 
-#: src/docs_inc.c:2687
+#: src/docs_inc.c:4289
 msgid "DVB-S"
 msgstr ""
 
-#: src/docs_inc.c:553
-msgid "DVB-S (Master)"
+#: src/docs_inc.c:2650
+msgid "DVB-S (SAT>IP Master)"
 msgstr ""
 
-#: src/docs_inc.c:555
-msgid "DVB-S (Slave)"
+#: src/docs_inc.c:2654
+msgid "DVB-S (SAT>IP Slave)"
 msgstr ""
 
-#: src/docs_inc.c:551 src/docs_inc.c:2697
+#: src/docs_inc.c:4301
 msgid "DVB-T"
 msgstr ""
 
-#: src/docs_inc.c:525
-msgid "DVB-T/DVB-T2"
-msgstr ""
-
-#: src/docs_inc.c:4490
+#: src/docs_inc.c:5136
 msgid "DVR"
 msgstr ""
 
-#: src/docs_inc.c:2852
-msgid "DVR Entry"
+#: src/docs_inc.c:3665
+msgid "DVR Inotify"
 msgstr ""
 
-#: src/docs_inc.c:4936 src/docs_inc.c:5275
+#: src/docs_inc.c:5204 src/docs_inc.c:5252
 msgid "DVR Profile"
 msgstr ""
 
-#: src/docs_inc.c:4680
+#: src/docs_inc.c:4980
 msgid "DVR configuration profiles"
 msgstr ""
 
-#: src/docs_inc.c:4678
+#: src/docs_inc.c:4978
 msgid "DVR configurations"
 msgstr ""
 
-#: src/docs_inc.c:5246
+#: src/docs_inc.c:5968
 msgid "DVR profile"
 msgstr ""
 
-#: src/docs_inc.c:439
+#: src/docs_inc.c:2898
+msgid "DVR profiles and related settings"
+msgstr ""
+
+#: src/docs_inc.c:1017
 msgid "Debian/Ubuntu installation instructions"
 msgstr ""
 
-#: src/docs_inc.c:1037
+#: src/docs_inc.c:13
 msgid "Debug options"
 msgstr ""
 
-#: src/docs_inc.c:993
+#: src/docs_inc.c:2070
 msgid "Debugging"
 msgstr ""
 
-#: src/docs_inc.c:3650
-msgid "Decrement the selected channel numbers by 1."
-msgstr ""
-
-#: src/docs_inc.c:4299 src/docs_inc.c:4846
+#: src/docs_inc.c:5630 src/docs_inc.c:6094
 msgid "Default"
 msgstr ""
 
-#: src/docs_inc.c:5032
+#: src/docs_inc.c:5500
 msgid "Default format (title, unique number, extension)"
 msgstr ""
 
-#: src/docs_inc.c:1948 src/docs_inc.c:2366 src/docs_inc.c:2471
-#: src/docs_inc.c:2624 src/docs_inc.c:3002
+#: src/docs_inc.c:2546
 msgid "Delete"
 msgstr ""
 
-#: src/docs_inc.c:2368
-msgid "Delete an existing CA client configuration."
-msgstr ""
-
-#: src/docs_inc.c:3004
-msgid "Delete an existing profile."
-msgstr ""
-
-#: src/docs_inc.c:2626
-msgid "Delete the selected entry."
-msgstr ""
-
-#: src/docs_inc.c:1950
+#: src/docs_inc.c:1300 src/docs_inc.c:2548
 msgid "Delete the selected entry/entries."
 msgstr ""
 
-#: src/docs_inc.c:2473
-msgid "Delete the selected grid entries."
-msgstr ""
-
-#: src/docs_inc.c:3334
+#: src/docs_inc.c:1298
 msgid "Delete/Remove"
 msgstr ""
 
-#: src/docs_inc.c:3336
-msgid "Delete/Remove the selected grid entries."
-msgstr ""
-
-#: src/docs_inc.c:2440
-msgid "Deleting a CA Configuration"
-msgstr ""
-
-#: src/docs_inc.c:2658 src/docs_inc.c:3028
-msgid "Deleting a Profile"
-msgstr ""
-
-#: src/docs_inc.c:3530
-msgid ""
-"Deleting a mux will also remove any associated services, including those "
-"mapped to channels. If you have network discovery enabled any previously "
-"deleted muxes found in the NIT during a scan will automatically be re-added."
-msgstr ""
-
-#: src/docs_inc.c:1900
-msgid "Deleting an Entry"
-msgstr ""
-
-#: src/docs_inc.c:3526
-msgid "Deleting an Entry/Mux"
-msgstr ""
-
-#: src/docs_inc.c:3711
+#: src/docs_inc.c:3373
 msgid ""
 "Depending on your distribution, the default command-line configuration is "
 "usually stored in the `/etc/sysconfig` tree or an init script. You may also "
@@ -1877,485 +2258,619 @@ msgid ""
 "parameters."
 msgstr ""
 
-#: src/docs_inc.c:3969
+#: src/docs_inc.c:3629
 msgid "Descrambler"
 msgstr ""
 
-#: src/docs_inc.c:681 src/docs_inc.c:1547 src/docs_inc.c:2410
-#: src/docs_inc.c:3180 src/docs_inc.c:3374 src/docs_inc.c:4199
-#: src/docs_inc.c:4222 src/docs_inc.c:4266 src/docs_inc.c:4297
-#: src/docs_inc.c:4359 src/docs_inc.c:4480 src/docs_inc.c:4509
-#: src/docs_inc.c:4528 src/docs_inc.c:4551 src/docs_inc.c:4598
-#: src/docs_inc.c:4737 src/docs_inc.c:4844 src/docs_inc.c:4871
-#: src/docs_inc.c:4900 src/docs_inc.c:4951 src/docs_inc.c:4993
-#: src/docs_inc.c:5028 src/docs_inc.c:5118 src/docs_inc.c:5159
-#: src/docs_inc.c:5252
+#: src/docs_inc.c:3633
+msgid "Descrambler EMM"
+msgstr ""
+
+#: src/docs_inc.c:82 src/docs_inc.c:146 src/docs_inc.c:215 src/docs_inc.c:260
+#: src/docs_inc.c:390 src/docs_inc.c:442 src/docs_inc.c:650 src/docs_inc.c:905
+#: src/docs_inc.c:1034 src/docs_inc.c:1562 src/docs_inc.c:2009
+#: src/docs_inc.c:2274 src/docs_inc.c:2445 src/docs_inc.c:2473
+#: src/docs_inc.c:2560 src/docs_inc.c:2608 src/docs_inc.c:2714
+#: src/docs_inc.c:2793 src/docs_inc.c:2815 src/docs_inc.c:2870
+#: src/docs_inc.c:2890 src/docs_inc.c:2914 src/docs_inc.c:2940
+#: src/docs_inc.c:2976 src/docs_inc.c:3004 src/docs_inc.c:3125
+#: src/docs_inc.c:3167 src/docs_inc.c:3345 src/docs_inc.c:3901
+#: src/docs_inc.c:3981 src/docs_inc.c:4189 src/docs_inc.c:4219
+#: src/docs_inc.c:4267 src/docs_inc.c:4424 src/docs_inc.c:4702
+#: src/docs_inc.c:4740 src/docs_inc.c:4820 src/docs_inc.c:4850
+#: src/docs_inc.c:5072 src/docs_inc.c:5108 src/docs_inc.c:5126
+#: src/docs_inc.c:5160 src/docs_inc.c:5218 src/docs_inc.c:5300
+#: src/docs_inc.c:5330 src/docs_inc.c:5372 src/docs_inc.c:5444
+#: src/docs_inc.c:5496 src/docs_inc.c:5628 src/docs_inc.c:5656
+#: src/docs_inc.c:5756 src/docs_inc.c:5848 src/docs_inc.c:5974
+#: src/docs_inc.c:5996 src/docs_inc.c:6022 src/docs_inc.c:6064
+#: src/docs_inc.c:6092 src/docs_inc.c:6122 src/docs_inc.c:6150
 msgid "Description"
 msgstr ""
 
-#: src/docs_inc.c:4634
+#: src/docs_inc.c:4934
 msgid "Description/Properties"
 msgstr ""
 
-#: src/docs_inc.c:3267
+#: src/docs_inc.c:1362
+msgid "Detach from bouquet"
+msgstr ""
+
+#: src/docs_inc.c:3087
 msgid "Detaching Channels"
 msgstr ""
 
-#: src/docs_inc.c:3281
+#: src/docs_inc.c:3101
 msgid ""
 "Detaching channels from a bouquet will prevent any further updates provided "
 "by the bouquet, which unfortunately means you will have to manually re-map "
 "when changes to services occur (e.g, mux moves, ceased broadcasting etc)."
 msgstr ""
 
-#: src/docs_inc.c:485
-msgid "Device Configuration"
+#: src/docs_inc.c:88 src/docs_inc.c:124 src/docs_inc.c:2799 src/docs_inc.c:4111
+#: src/docs_inc.c:4131 src/docs_inc.c:4151 src/docs_inc.c:4171
+#: src/docs_inc.c:4556 src/docs_inc.c:4576 src/docs_inc.c:4596
+msgid "Device Types and Configuration"
 msgstr ""
 
-#: src/docs_inc.c:475
-msgid "Device Tree"
-msgstr ""
-
-#: src/docs_inc.c:515
+#: src/docs_inc.c:2686
 msgid "DiSEqC Switch"
 msgstr ""
 
-#: src/docs_inc.c:879 src/docs_inc.c:1759 src/docs_inc.c:3993
+#: src/docs_inc.c:2688
+msgid "DiSEqC Switch configuration."
+msgstr ""
+
+#: src/docs_inc.c:1650
+msgid "Dialog button"
+msgstr ""
+
+#: src/docs_inc.c:197 src/docs_inc.c:1120 src/docs_inc.c:2052
+#: src/docs_inc.c:3661
 msgid "Digital Video Recorder"
 msgstr ""
 
-#: src/docs_inc.c:741 src/docs_inc.c:979
+#: src/docs_inc.c:1478
+msgid "Digital Video Recorder -> Failed Recordings only."
+msgstr ""
+
+#: src/docs_inc.c:1468
+msgid "Digital Video Recorder -> Finished Recordings only."
+msgstr ""
+
+#: src/docs_inc.c:1452 src/docs_inc.c:1458
+msgid "Digital Video Recorder -> Finished/Failed/Removed Recordings only."
+msgstr ""
+
+#: src/docs_inc.c:1440 src/docs_inc.c:1446
+msgid "Digital Video Recorder -> Upcoming / Current Recordings only."
+msgstr ""
+
+#: src/docs_inc.c:464 src/docs_inc.c:2896
 msgid "Digital Video Recorder Profiles"
 msgstr ""
 
-#: src/docs_inc.c:4201
+#: src/docs_inc.c:5446
 msgid "Disable"
 msgstr ""
 
-#: src/docs_inc.c:4536
+#: src/docs_inc.c:6030
 msgid "Disable automatic service checking."
 msgstr ""
 
-#: src/docs_inc.c:4203
+#: src/docs_inc.c:5448
 msgid "Disable mux discovery."
 msgstr ""
 
-#: src/docs_inc.c:5262
+#: src/docs_inc.c:5984
 msgid "Disabled"
 msgstr ""
 
-#: src/docs_inc.c:2215
+#: src/docs_inc.c:1498
 msgid "Discover SAT"
 msgstr ""
 
-#: src/docs_inc.c:4211
+#: src/docs_inc.c:5456
 msgid "Discover new muxes and changes to existing muxes."
 msgstr ""
 
-#: src/docs_inc.c:4207
+#: src/docs_inc.c:5452
 msgid "Discover new muxes only."
 msgstr ""
 
-#: src/docs_inc.c:4045
+#: src/docs_inc.c:106
+msgid "Discovered service(s) management"
+msgstr ""
+
+#: src/docs_inc.c:3721
 msgid "DiseqC"
 msgstr ""
 
-#: src/docs_inc.c:513
+#: src/docs_inc.c:2682
 msgid "DiseqC Rotor"
 msgstr ""
 
-#: src/docs_inc.c:1942
+#: src/docs_inc.c:2684
+msgid "DiseqC rotor configuration."
+msgstr ""
+
+#: src/docs_inc.c:207
+msgid "Display Only Grid Items"
+msgstr ""
+
+#: src/docs_inc.c:1292 src/docs_inc.c:2540
 msgid "Display the"
 msgstr ""
 
-#: src/docs_inc.c:2157
-msgid "Display the first-run set-up wizard."
+#: src/docs_inc.c:1530 src/docs_inc.c:1672
+msgid "Display the help page."
 msgstr ""
 
-#: src/docs_inc.c:125 src/docs_inc.c:671 src/docs_inc.c:1067
-#: src/docs_inc.c:1515 src/docs_inc.c:1691 src/docs_inc.c:2388
-msgid "Display this help page."
+#: src/docs_inc.c:1570 src/docs_inc.c:6108
+msgid "Display the more advanced tabs/items."
 msgstr ""
 
-#: src/docs_inc.c:1129
+#: src/docs_inc.c:1566 src/docs_inc.c:6104
+msgid "Display the most commonly used tabs/items."
+msgstr ""
+
+#: src/docs_inc.c:1538
+msgid "Display/Jump to the next associated item, channel or EPG event."
+msgstr ""
+
+#: src/docs_inc.c:1544
+msgid "Display/Jump to the previous associated item, channel or EPG event."
+msgstr ""
+
+#: src/docs_inc.c:1582
 msgid "Displaying and Manipulating Columns"
 msgstr ""
 
-#: src/docs_inc.c:443
+#: src/docs_inc.c:1021
 msgid ""
 "Do not assume that your distro's package manager will give you the latest "
 "version of Tvheadend - indeed, give you any version at all. Always check."
 msgstr ""
 
-#: src/docs_inc.c:823
+#: src/docs_inc.c:576
 msgid "Dolby Digital (AC3)"
 msgstr ""
 
-#: src/docs_inc.c:4276
+#: src/docs_inc.c:3947
+msgid "Don't forget to set the _EIT time offset_ for your network(s)!"
+msgstr ""
+
+#: src/docs_inc.c:4860
 msgid "Don't keep"
 msgstr ""
 
-#: src/docs_inc.c:5264
+#: src/docs_inc.c:5986
 msgid "Don't use running state (EITp/f) detection."
 msgstr ""
 
-#: src/docs_inc.c:3342
+#: src/docs_inc.c:1448
 msgid "Download"
 msgstr ""
 
-#: src/docs_inc.c:3344
-msgid "Download the recording."
+#: src/docs_inc.c:453
+msgid ""
+"Download a playlist file (XSPF or M3U depending on your startup options); if "
+"your system is configured for it, this will automatically launch an "
+"appropriate player, otherwise you will need to manually open the playlist to "
+"start watching (normally a double-click on the downloaded file)."
 msgstr ""
 
-#: src/docs_inc.c:3444
-msgid "Downloading a Recording"
+#: src/docs_inc.c:1450
+msgid "Download the selected recording."
 msgstr ""
 
-#: src/docs_inc.c:1621
+#: src/docs_inc.c:995
 msgid ""
 "Driver software typically comes either built-in to the operating system (a "
 "clue here is documentation that says _\"supported since kernel 3.16\"_ , for "
 "example) or as an external program that needs to be compiled in (e.g. how "
 "you'd build TBS' or Digital Devices drivers, or perhaps where the driver is "
 "supported in a later version of LinuxTV V4L-DVB than has made it to your "
-"kernel - the giveaway here is _\"compile and install the latest media_build"
-"\"_ )."
+"kernel - the giveaway here is _\"compile and install the latest "
+"media_build\"_ )."
 msgstr ""
 
-#: src/docs_inc.c:3610
-msgid "Drop down menu (see mapping button table below)."
+#: src/docs_inc.c:1518
+msgid "Drop (displayed) connections"
 msgstr ""
 
-#: src/docs_inc.c:3614
-msgid "Drop down menu (see numbering button table below)."
+#: src/docs_inc.c:1520
+msgid "Drop the currently-shown active connections."
 msgstr ""
 
-#: src/docs_inc.c:1998 src/docs_inc.c:2006
-msgid "Drop-down menu (see"
-msgstr ""
-
-#: src/docs_inc.c:5366
+#: src/docs_inc.c:732
 msgid ""
 "During scanning, the number of muxes and services shown below should "
 "increase. If this doesn't happen, check the connection(s) to your device(s).."
 msgstr ""
 
-#: src/docs_inc.c:5238
+#: src/docs_inc.c:5960
 msgid ""
 "EITp/f (Event Information Table present/following) is broadcast alongside "
 "EPG data, it allows broadcasters to tell DVRs/STBs when a program starts, "
 "pauses or finishes."
 msgstr ""
 
-#: src/docs_inc.c:5140
+#: src/docs_inc.c:4724
 msgid "EMPTY"
 msgstr ""
 
-#: src/docs_inc.c:3420
-msgid "EPG"
-msgstr ""
-
-#: src/docs_inc.c:4001
+#: src/docs_inc.c:3673
 msgid "EPG Database"
 msgstr ""
 
-#: src/docs_inc.c:731
-msgid "EPG Detail 1"
-msgstr ""
-
-#: src/docs_inc.c:737
+#: src/docs_inc.c:438
 msgid "EPG Detail 2"
 msgstr ""
 
-#: src/docs_inc.c:933 src/docs_inc.c:4005
+#: src/docs_inc.c:2499 src/docs_inc.c:2880 src/docs_inc.c:3677
+#: src/docs_inc.c:4494
 msgid "EPG Grabber"
 msgstr ""
 
-#: src/docs_inc.c:931
+#: src/docs_inc.c:2495
 msgid "EPG Grabber Channels"
 msgstr ""
 
-#: src/docs_inc.c:935
+#: src/docs_inc.c:2503
 msgid "EPG Grabber Modules"
 msgstr ""
 
-#: src/docs_inc.c:5136
+#: src/docs_inc.c:2497
+msgid "EPG data sources used by channels"
+msgstr ""
+
+#: src/docs_inc.c:2501 src/docs_inc.c:2882
+msgid "EPG grabber configuration"
+msgstr ""
+
+#: src/docs_inc.c:2505
+msgid "EPG grabber module management"
+msgstr ""
+
+#: src/docs_inc.c:264
+msgid "EPG overview"
+msgstr ""
+
+#: src/docs_inc.c:272
+msgid "EPG tab items"
+msgstr ""
+
+#: src/docs_inc.c:4720
 msgid "EXCLUSIVE"
 msgstr ""
 
-#: src/docs_inc.c:65
+#: src/docs_inc.c:1781
 msgid "Each numbered (ordered) list will restart from 1."
 msgstr ""
 
-#: src/docs_inc.c:3062
+#: src/docs_inc.c:4013
 msgid "Each rule is executed in sequence (as displayed in the grid)."
 msgstr ""
 
-#: src/docs_inc.c:1125
-msgid ""
-"Each tab is then typically laid out with a menu bar across the top that "
-"provides access to Add/Save/Edit-type functions, and a grid like a "
-"spreadsheet below that. The grid items are frequently editable."
+#: src/docs_inc.c:1260
+msgid "Each tab is then laid out with a"
 msgstr ""
 
-#: src/docs_inc.c:1789
+#: src/docs_inc.c:1150
 msgid "Easy to Configure and Administer"
 msgstr ""
 
-#: src/docs_inc.c:1952 src/docs_inc.c:2475 src/docs_inc.c:3338
+#: src/docs_inc.c:1302 src/docs_inc.c:2550
 msgid "Edit"
 msgstr ""
 
-#: src/docs_inc.c:2648
-msgid "Edit a Profile"
-msgstr ""
-
-#: src/docs_inc.c:1954
+#: src/docs_inc.c:1304 src/docs_inc.c:2552
 msgid "Edit the selected entries."
 msgstr ""
 
-#: src/docs_inc.c:2477 src/docs_inc.c:3340
-msgid "Edit the selected grid entries."
+#: src/docs_inc.c:1682
+msgid "Editing (in the Grid)"
 msgstr ""
 
-#: src/docs_inc.c:1141
-msgid "Editing Fields"
-msgstr ""
-
-#: src/docs_inc.c:1869
-msgid "Editing an Entry"
-msgstr ""
-
-#: src/docs_inc.c:1873
-msgid "Editing in the Grid"
-msgstr ""
-
-#: src/docs_inc.c:565 src/docs_inc.c:877 src/docs_inc.c:1773
-#: src/docs_inc.c:3997
+#: src/docs_inc.c:256 src/docs_inc.c:1134 src/docs_inc.c:2050
 msgid "Electronic Program Guide"
 msgstr ""
 
-#: src/docs_inc.c:3961
+#: src/docs_inc.c:1310 src/docs_inc.c:1316 src/docs_inc.c:1322
+msgid "Electronic Program Guide only."
+msgstr ""
+
+#: src/docs_inc.c:1328 src/docs_inc.c:1334 src/docs_inc.c:1344
+msgid "Electronic Program Guide/Broadcast details only."
+msgstr ""
+
+#: src/docs_inc.c:3669
+msgid "Electronic Programme Guide"
+msgstr ""
+
+#: src/docs_inc.c:3621
 msgid "Elementary Stream Filter"
 msgstr ""
 
-#: src/docs_inc.c:3066
+#: src/docs_inc.c:2996
+msgid "Elementary stream filtering"
+msgstr ""
+
+#: src/docs_inc.c:4017
 msgid ""
 "Elementary streams not marked IGNORE, USE or EXCLUSIVE will not be filtered "
 "out."
 msgstr ""
 
-#: src/docs_inc.c:2955
-msgid "Emergency/Backdoor Access"
+#: src/docs_inc.c:4742
+msgid "Enable"
 msgstr ""
 
-#: src/docs_inc.c:4532
+#: src/docs_inc.c:6026
 msgid "Enable automatic service checking."
 msgstr ""
 
-#: src/docs_inc.c:5260
+#: src/docs_inc.c:4744
+msgid "Enable persistent authentication."
+msgstr ""
+
+#: src/docs_inc.c:5982
 msgid "Enable running state (EITp/f) detection."
 msgstr ""
 
-#: src/docs_inc.c:5258
+#: src/docs_inc.c:5980
 msgid "Enabled"
 msgstr ""
 
-#: src/docs_inc.c:1323
+#: src/docs_inc.c:2208
 msgid "Enigma2"
 msgstr ""
 
-#: src/docs_inc.c:5345
-msgid ""
-"Enter the access control details to secure your system. The first part of "
-"this covers the network details for address-based access to the system; for "
-"example, 192.168.1.0/24 to allow local access only to 192.168.1.x clients, "
-"or 0.0.0.0/0 or empty value for access from any system."
-msgstr ""
-
-#: src/docs_inc.c:2913
-msgid ""
-"Entries are checked in order (when logging in, etc), the following functions "
-"allows you to change the ordering:"
-msgstr ""
-
-#: src/docs_inc.c:3368
-msgid "Entry Overview"
-msgstr ""
-
-#: src/docs_inc.c:4399 src/docs_inc.c:5203
+#: src/docs_inc.c:5708 src/docs_inc.c:5796
 msgid "Error message"
 msgstr ""
 
-#: src/docs_inc.c:723
+#: src/docs_inc.c:5618
+msgid ""
+"Even with correct guide information, external scrapers can retrieve "
+"incorrect results. A famous example being the detective tv series \"Castle\" "
+"is often incorrectly retrieved as a much earlier tv show about castles."
+msgstr ""
+
+#: src/docs_inc.c:5324
+msgid ""
+"Even with these details, fanart grabbers can sometimes return incorrect "
+"results."
+msgstr ""
+
+#: src/docs_inc.c:274 src/docs_inc.c:432
 msgid "Event Details and Recording"
 msgstr ""
 
-#: src/docs_inc.c:5044
+#: src/docs_inc.c:5520
 msgid "Event episode name"
 msgstr ""
 
-#: src/docs_inc.c:5036
+#: src/docs_inc.c:5512
 msgid "Event subtitle name"
 msgstr ""
 
-#: src/docs_inc.c:5040
+#: src/docs_inc.c:5508
+msgid "Event subtitle name or summary text"
+msgstr ""
+
+#: src/docs_inc.c:5516
+msgid "Event summary text"
+msgstr ""
+
+#: src/docs_inc.c:5504
 msgid "Event title name"
 msgstr ""
 
-#: src/docs_inc.c:2267 src/docs_inc.c:2842 src/docs_inc.c:2929
-#: src/docs_inc.c:3166 src/docs_inc.c:3257 src/docs_inc.c:3662
-#: src/docs_inc.c:5030
+#: src/docs_inc.c:4758 src/docs_inc.c:5498
 msgid "Example"
 msgstr ""
 
-#: src/docs_inc.c:621
+#: src/docs_inc.c:354
 msgid "Example Purpose"
 msgstr ""
 
-#: src/docs_inc.c:4361 src/docs_inc.c:4739 src/docs_inc.c:5161
+#: src/docs_inc.c:639
+msgid "Example for apache (--http_root=/my/tvh/server):"
+msgstr ""
+
+#: src/docs_inc.c:637
+msgid "Example for nginx (--http_root /my/tvh/server):"
+msgstr ""
+
+#: src/docs_inc.c:5658 src/docs_inc.c:5758 src/docs_inc.c:5850
 msgid "Example value"
 msgstr ""
 
-#: src/docs_inc.c:4619
+#: src/docs_inc.c:5464
+msgid "Example:"
+msgstr ""
+
+#: src/docs_inc.c:5092
 msgid "Example: `file:///home/hts/picons`"
 msgstr ""
 
-#: src/docs_inc.c:4456
+#: src/docs_inc.c:5052
 #, c-format
 msgid "Example: `file:///tmp/icons/%C.png` or `http://example.com/%c.png`"
 msgstr ""
 
-#: src/docs_inc.c:695 src/docs_inc.c:3388
+#: src/docs_inc.c:5576
+msgid "Examples are:"
+msgstr ""
+
+#: src/docs_inc.c:5610
+msgid "Examples for `$3Q` are:"
+msgstr ""
+
+#: src/docs_inc.c:5604
+msgid "Examples for `$3q` are:"
+msgstr ""
+
+#: src/docs_inc.c:229 src/docs_inc.c:404
 msgid "Exclamation icon"
 msgstr ""
 
-#: src/docs_inc.c:4670
+#: src/docs_inc.c:4970
 msgid "Exclude channel tags"
 msgstr ""
 
-#: src/docs_inc.c:1235
+#: src/docs_inc.c:2137
 msgid ""
 "Expand a bit on command-line options and give some examples of common usage"
 msgstr ""
 
-#: src/docs_inc.c:4315 src/docs_inc.c:4961
+#: src/docs_inc.c:1572 src/docs_inc.c:6110 src/docs_inc.c:6132
 msgid "Expert"
 msgstr ""
 
-#: src/docs_inc.c:1295 src/docs_inc.c:1375 src/docs_inc.c:1415
+#: src/docs_inc.c:2164 src/docs_inc.c:2260 src/docs_inc.c:2334
+#: src/docs_inc.c:2398
 msgid "Explanation"
 msgstr ""
 
-#: src/docs_inc.c:1597
+#: src/docs_inc.c:971
 msgid ""
 "External HDHomeRun tuners that send MPEG-TS streams over a LAN connection"
 msgstr ""
 
-#: src/docs_inc.c:943
+#: src/docs_inc.c:3931
 msgid "External PyEPG"
 msgstr ""
 
-#: src/docs_inc.c:1595
+#: src/docs_inc.c:969
 msgid "External SAT>IP tuners that send MPEG-TS streams over a LAN connection"
 msgstr ""
 
-#: src/docs_inc.c:1591
+#: src/docs_inc.c:965
 msgid "External USB tuners that plug in"
 msgstr ""
 
-#: src/docs_inc.c:945
+#: src/docs_inc.c:3915
 msgid "External XMLTV"
 msgstr ""
 
-#: src/docs_inc.c:215
-msgid "FAQ: Frequently-asked Questions"
-msgstr ""
-
-#: src/docs_inc.c:885 src/docs_inc.c:3354
-msgid "Failed Recordings"
-msgstr ""
-
-#: src/docs_inc.c:3905
-msgid "Fastscan DVB"
-msgstr ""
-
-#: src/docs_inc.c:861
-msgid "Features"
-msgstr ""
-
-#: src/docs_inc.c:1717
-msgid "Features of Tvheadend"
-msgstr ""
-
-#: src/docs_inc.c:4999
-msgid "File missing"
-msgstr ""
-
-#: src/docs_inc.c:5060
-msgid "Filename extension (from the active stream muxer"
-msgstr ""
-
-#: src/docs_inc.c:3781
-msgid "Filesystem monitor"
-msgstr ""
-
-#: src/docs_inc.c:583
-msgid "Filter"
-msgstr ""
-
-#: src/docs_inc.c:3060
-msgid "Filter Basics"
-msgstr ""
-
-#: src/docs_inc.c:619
-msgid "Filter Range"
-msgstr ""
-
-#: src/docs_inc.c:593
-msgid "Filter channel..."
+#: src/docs_inc.c:5298
+msgid "Extra Arguments"
 msgstr ""
 
 #: src/docs_inc.c:605
+msgid "FAQ: Frequently-asked Questions"
+msgstr ""
+
+#: src/docs_inc.c:4450
+msgid "FFMPEG"
+msgstr ""
+
+#: src/docs_inc.c:1464 src/docs_inc.c:2732
+msgid "Failed Recordings"
+msgstr ""
+
+#: src/docs_inc.c:5322
+msgid ""
+"Fanart grabbers only work correctly if your scrapper provides high quality "
+"information. In particular, they require season and episode details for "
+"series, and year details for movies."
+msgstr ""
+
+#: src/docs_inc.c:3557
+msgid "Fastscan DVB"
+msgstr ""
+
+#: src/docs_inc.c:1040 src/docs_inc.c:1066 src/docs_inc.c:1078
+msgid "Features"
+msgstr ""
+
+#: src/docs_inc.c:5224
+msgid "File missing"
+msgstr ""
+
+#: src/docs_inc.c:5556
+msgid "Filename extension (from the active stream muxer"
+msgstr ""
+
+#: src/docs_inc.c:3433
+msgid "Filesystem monitor"
+msgstr ""
+
+#: src/docs_inc.c:304
+msgid "Filter"
+msgstr ""
+
+#: src/docs_inc.c:4011
+msgid "Filter Basics"
+msgstr ""
+
+#: src/docs_inc.c:352
+msgid "Filter Range"
+msgstr ""
+
+#: src/docs_inc.c:310
+msgid "Filter between showing all events ("
+msgstr ""
+
+#: src/docs_inc.c:326
+msgid "Filter channel..."
+msgstr ""
+
+#: src/docs_inc.c:338
 msgid "Filter content type..."
 msgstr ""
 
-#: src/docs_inc.c:611
+#: src/docs_inc.c:344
 msgid "Filter duration..."
 msgstr ""
 
-#: src/docs_inc.c:599
+#: src/docs_inc.c:332
 msgid "Filter tag..."
 msgstr ""
 
-#: src/docs_inc.c:579
+#: src/docs_inc.c:3979
+msgid "Filter type"
+msgstr ""
+
+#: src/docs_inc.c:266 src/docs_inc.c:300
 msgid "Filtering (or searching)"
 msgstr ""
 
-#: src/docs_inc.c:3084
+#: src/docs_inc.c:4031
 msgid "Filtering out a Stream"
 msgstr ""
 
-#: src/docs_inc.c:883 src/docs_inc.c:3362
+#: src/docs_inc.c:268
+msgid "Filtering the EPG"
+msgstr ""
+
+#: src/docs_inc.c:444
+msgid "Find info from ... drop-down"
+msgstr ""
+
+#: src/docs_inc.c:1474 src/docs_inc.c:2728
 msgid "Finished Recordings"
 msgstr ""
 
-#: src/docs_inc.c:75
+#: src/docs_inc.c:1791
 msgid "First Header"
 msgstr ""
 
-#: src/docs_inc.c:43
+#: src/docs_inc.c:1759
 msgid "First ordered list item"
 msgstr ""
 
-#: src/docs_inc.c:1599
+#: src/docs_inc.c:973
 msgid ""
 "Follow the appropriate installation instructions and, if relevant, the setup "
 "instruction (e.g. for SAT>IP, which are effectively small, standalone "
 "computers)."
 msgstr ""
 
-#: src/docs_inc.c:437
+#: src/docs_inc.c:1015
 msgid ""
 "Follow the instructions that are specific to your Linux distribution (Ubuntu/"
 "Debian/Mint, Arch, Fedora...). This will typically be PPA-and-dpkg for "
@@ -2363,38 +2878,57 @@ msgid ""
 "source."
 msgstr ""
 
-#: src/docs_inc.c:5074
+#: src/docs_inc.c:5570
 msgid ""
 "For $t and $s format strings, you may also limit the number of output "
 "characters using $99-t format string where 99 means the limit. As you can "
 "see, the delimiter can be also applied."
 msgstr ""
 
-#: src/docs_inc.c:727
-msgid ""
-"For EPG providers that supply series link information there will also be a "
-"_[Record series]_ button that will record all entries in the series."
+#: src/docs_inc.c:3137
+msgid "For CCCam connections."
 msgstr ""
 
-#: src/docs_inc.c:5445
+#: src/docs_inc.c:3153
+msgid "For Constant Code Word connections (AES/ECB variant)"
+msgstr ""
+
+#: src/docs_inc.c:3157
+msgid "For Constant Code Word connections (AES128/ECB variant)"
+msgstr ""
+
+#: src/docs_inc.c:3145
+msgid "For Constant Code Word connections (CSA/CBC variant)"
+msgstr ""
+
+#: src/docs_inc.c:3149
+msgid "For Constant Code Word connections (DES/NCB variant)"
+msgstr ""
+
+#: src/docs_inc.c:3141
+msgid "For DVBAPI connections"
+msgstr ""
+
+#: src/docs_inc.c:4396
+msgid ""
+"For a password to apply to an account, the username entered must match a "
+"username in the _Access Entries_ tab and only password entries that are "
+"enabled will apply."
+msgstr ""
+
+#: src/docs_inc.c:714
 msgid ""
 "For devices with multiple tuners (e.g. either cable or terrestrial), be "
 "aware that many only allow you to use one tuner at a time. Selecting more "
 "than one tuner per device can thus result in unexpected behavior."
 msgstr ""
 
-#: src/docs_inc.c:733
-msgid ""
-"For events without any series link information, an _[Autorec]_ button will "
-"be provided to create a pseudo-series link using the autorec feature."
-msgstr ""
-
-#: src/docs_inc.c:19
+#: src/docs_inc.c:1735
 msgid ""
 "For example to include the passwd items you'd enter something like this:"
 msgstr ""
 
-#: src/docs_inc.c:4934
+#: src/docs_inc.c:5202
 msgid ""
 "For example, if a program is to start at 13:00 and you set a padding of 5 "
 "minutes, it will start recording at 12:54:30 (including a warm-up time of 30 "
@@ -2402,60 +2936,50 @@ msgid ""
 "the padding set in the"
 msgstr ""
 
-#: src/docs_inc.c:4630
-msgid ""
-"For example, say you have a wildcard account with the theme set to Gray, and "
-"an admin account with the Blue theme. Unchecking the theme checkbox for the "
-"admin user would mean that the theme from the last matching entry (which in "
-"this case would be the wildcard account) applies instead."
+#: src/docs_inc.c:3263
+msgid "For example.."
 msgstr ""
 
-#: src/docs_inc.c:2947
-msgid ""
-"For extra security always enter (a comma-separated list of) network "
-"prefix(es) (_Allowed networks_ )."
-msgstr ""
-
-#: src/docs_inc.c:3418
-msgid ""
-"For full instructions on how to search and record using the EPG take a look "
-"at the"
-msgstr ""
-
-#: src/docs_inc.c:2762
-msgid "For more detailed information on networks and how to set them up, see"
-msgstr ""
-
-#: src/docs_inc.c:1269
+#: src/docs_inc.c:40
 msgid ""
 "For more information regarding the project, licensing and contributions, "
 "please see:"
 msgstr ""
 
-#: src/docs_inc.c:3074
+#: src/docs_inc.c:2706
+msgid "For more information, click on a type."
+msgstr ""
+
+#: src/docs_inc.c:3133
+msgid "For newcamd or CWC."
+msgstr ""
+
+#: src/docs_inc.c:3129
+msgid "For use with devices that have a CAM module."
+msgstr ""
+
+#: src/docs_inc.c:4025
 msgid ""
 "For visual verification of filtering, there is the service info dialog in the"
 msgstr ""
 
-#: src/docs_inc.c:2736 src/docs_inc.c:3251
+#: src/docs_inc.c:1346
 msgid "Force Scan"
 msgstr ""
 
-#: src/docs_inc.c:2774
+#: src/docs_inc.c:2825 src/docs_inc.c:4338
 msgid "Force Scanning"
 msgstr ""
 
-#: src/docs_inc.c:2738
-msgid ""
-"Force a new scan (i.e. scan all muxes for services) for the selected "
-"networks."
-msgstr ""
-
-#: src/docs_inc.c:2555
+#: src/docs_inc.c:1402
 msgid "Force an immediate tune to the OTA EPG mux(es) to request EPG updates."
 msgstr ""
 
-#: src/docs_inc.c:2778
+#: src/docs_inc.c:2827
+msgid "Force scanning a network"
+msgstr ""
+
+#: src/docs_inc.c:4340
 msgid ""
 "Force scanning can take some time. You may continue to use Tvheadend while a "
 "scan is in progress, but doing so will increase the time needed for it to "
@@ -2464,341 +2988,372 @@ msgid ""
 "on each."
 msgstr ""
 
-#: src/docs_inc.c:4357 src/docs_inc.c:4735 src/docs_inc.c:5026
-#: src/docs_inc.c:5157
+#: src/docs_inc.c:1348
+msgid "Forces a scan on the selected network(s) or bouquet(s)."
+msgstr ""
+
+#: src/docs_inc.c:5494 src/docs_inc.c:5654 src/docs_inc.c:5754
+#: src/docs_inc.c:5846
 msgid "Format"
 msgstr ""
 
-#: src/docs_inc.c:4328
+#: src/docs_inc.c:5264
 msgid "Format Result"
 msgstr ""
 
-#: src/docs_inc.c:491 src/docs_inc.c:523 src/docs_inc.c:533 src/docs_inc.c:545
-msgid "Frontend"
+#: src/docs_inc.c:5400
+msgid "Frequently changing path component(s) in URL"
 msgstr ""
 
-#: src/docs_inc.c:4363 src/docs_inc.c:4741 src/docs_inc.c:5163
+#: src/docs_inc.c:2610
+msgid "Frontends"
+msgstr ""
+
+#: src/docs_inc.c:5660 src/docs_inc.c:5760 src/docs_inc.c:5852
 msgid "Full path to recording"
 msgstr ""
 
-#: src/docs_inc.c:1813
+#: src/docs_inc.c:1174
 msgid "Fully-Integrated with Mainstream Media Players"
 msgstr ""
 
-#: src/docs_inc.c:121 src/docs_inc.c:467 src/docs_inc.c:585 src/docs_inc.c:655
-#: src/docs_inc.c:1063 src/docs_inc.c:1511 src/docs_inc.c:1687
-#: src/docs_inc.c:1930 src/docs_inc.c:1994 src/docs_inc.c:2014
-#: src/docs_inc.c:2026 src/docs_inc.c:2145 src/docs_inc.c:2178
-#: src/docs_inc.c:2205 src/docs_inc.c:2298 src/docs_inc.c:2323
-#: src/docs_inc.c:2352 src/docs_inc.c:2461 src/docs_inc.c:2502
-#: src/docs_inc.c:2543 src/docs_inc.c:2610 src/docs_inc.c:2734
-#: src/docs_inc.c:2877 src/docs_inc.c:2917 src/docs_inc.c:2988
-#: src/docs_inc.c:3050 src/docs_inc.c:3117 src/docs_inc.c:3142
-#: src/docs_inc.c:3215 src/docs_inc.c:3249 src/docs_inc.c:3312
-#: src/docs_inc.c:3564 src/docs_inc.c:3594 src/docs_inc.c:3618
-#: src/docs_inc.c:3638 src/docs_inc.c:3719 src/docs_inc.c:4116
-#: src/docs_inc.c:4173 src/docs_inc.c:4438 src/docs_inc.c:5085
+#: src/docs_inc.c:306 src/docs_inc.c:1280 src/docs_inc.c:2528
+#: src/docs_inc.c:4776 src/docs_inc.c:5036
 msgid "Function"
 msgstr ""
 
-#: src/docs_inc.c:1267
+#: src/docs_inc.c:38
 msgid "Further Information"
 msgstr ""
 
-#: src/docs_inc.c:1263
+#: src/docs_inc.c:34
 msgid "GPLv3"
 msgstr ""
 
-#: src/docs_inc.c:875 src/docs_inc.c:895
+#: src/docs_inc.c:2056
 msgid "General"
 msgstr ""
 
-#: src/docs_inc.c:1115
-msgid "General Overview of Web Interface"
+#: src/docs_inc.c:4468
+msgid "General avlib profile."
 msgstr ""
 
-#: src/docs_inc.c:4610
+#: src/docs_inc.c:1618
+msgid ""
+"General paging functions `|< < > >|` allow you to quickly move between data "
+"sets."
+msgstr ""
+
+#: src/docs_inc.c:5084
 msgid "Generate lower-case filenames using picon formatting."
 msgstr ""
 
-#: src/docs_inc.c:4606
+#: src/docs_inc.c:5080
 msgid "Generate lower-case filenames."
 msgstr ""
 
-#: src/docs_inc.c:1207
-msgid "Generate new webUI help pages and push them to the tvheadend repo"
+#: src/docs_inc.c:2109
+msgid "Generate new webUI help pages and push them to the Tvheadend repo"
 msgstr ""
 
-#: src/docs_inc.c:1031
+#: src/docs_inc.c:7
 msgid "Generic options"
 msgstr ""
 
-#: src/docs_inc.c:863
+#: src/docs_inc.c:2040
 msgid "Getting Started"
 msgstr ""
 
-#: src/docs_inc.c:13
+#: src/docs_inc.c:1050
+msgid "Getting to grips with the interface"
+msgstr ""
+
+#: src/docs_inc.c:654
+msgid "Getting to know the first-time-user wizard"
+msgstr ""
+
+#: src/docs_inc.c:1729
 msgid "GitHub mastering markdown"
 msgstr ""
 
-#: src/docs_inc.c:3917
+#: src/docs_inc.c:5534
+msgid "Gladiator (2000)"
+msgstr ""
+
+#: src/docs_inc.c:5588
+msgid "Gladiator (2000) (movie)"
+msgstr ""
+
+#: src/docs_inc.c:5612
+msgid "Gladiator (2000)/Gladiator (2000)"
+msgstr ""
+
+#: src/docs_inc.c:3573
 msgid "Global Headers"
 msgstr ""
 
-#: src/docs_inc.c:3753
-msgid "Global timer"
-msgstr ""
-
-#: src/docs_inc.c:303
+#: src/docs_inc.c:826
 msgid "Good sources of transmitter/mux information include:"
 msgstr ""
 
-#: src/docs_inc.c:775 src/docs_inc.c:803 src/docs_inc.c:829
+#: src/docs_inc.c:528 src/docs_inc.c:556 src/docs_inc.c:582
 msgid "Google Chrome"
 msgstr ""
 
-#: src/docs_inc.c:3328
-msgid "Gracefully stop the selected in-progress recording entries."
+#: src/docs_inc.c:5290
+msgid ""
+"Grabbers frequently require additional options such as \"api keys\", which "
+"are generated by registering at the appropriate site."
 msgstr ""
 
-#: src/docs_inc.c:4877
+#: src/docs_inc.c:1438
+msgid "Gracefully stop the selected in-progress recording entry/entries."
+msgstr ""
+
+#: src/docs_inc.c:6070
 msgid "Gray"
 msgstr ""
 
-#: src/docs_inc.c:673 src/docs_inc.c:1069 src/docs_inc.c:1517
-#: src/docs_inc.c:1693
-msgid "Grid Items"
+#: src/docs_inc.c:1576
+msgid "Grids"
 msgstr ""
 
-#: src/docs_inc.c:799
+#: src/docs_inc.c:552
 msgid "H.264"
 msgstr ""
 
-#: src/docs_inc.c:1721
+#: src/docs_inc.c:1082
 msgid "H.265 (HEVC), H.264 (MPEG-4 AVC) and MPEG2 video supported."
 msgstr ""
 
-#: src/docs_inc.c:4421 src/docs_inc.c:5225
+#: src/docs_inc.c:5730 src/docs_inc.c:5818
 msgid "H264,AC3,TELETEXT"
 msgstr ""
 
-#: src/docs_inc.c:1231
+#: src/docs_inc.c:2133
 msgid "HD Homerun setup"
 msgstr ""
 
-#: src/docs_inc.c:3925
+#: src/docs_inc.c:3581
 msgid "HEVC - H.265"
 msgstr ""
 
-#: src/docs_inc.c:1749
+#: src/docs_inc.c:1110
 msgid "HTSP (Home TV Streaming Protocol)."
 msgstr ""
 
-#: src/docs_inc.c:3865
+#: src/docs_inc.c:3517
 msgid "HTSP Answer"
 msgstr ""
 
-#: src/docs_inc.c:951 src/docs_inc.c:2586
+#: src/docs_inc.c:4430
 msgid "HTSP Profile"
 msgstr ""
 
-#: src/docs_inc.c:3861
+#: src/docs_inc.c:3513
 msgid "HTSP Request"
 msgstr ""
 
-#: src/docs_inc.c:3853
+#: src/docs_inc.c:3505
 msgid "HTSP Server"
 msgstr ""
 
-#: src/docs_inc.c:3857
+#: src/docs_inc.c:3509
 msgid "HTSP Subscription"
 msgstr ""
 
-#: src/docs_inc.c:3849
+#: src/docs_inc.c:3501
 msgid "HTTP Client"
 msgstr ""
 
-#: src/docs_inc.c:3845
+#: src/docs_inc.c:3497
 msgid "HTTP Server"
 msgstr ""
 
-#: src/docs_inc.c:1751
+#: src/docs_inc.c:4760
+msgid "HTTP authentication (digest/plain)"
+msgstr ""
+
+#: src/docs_inc.c:1112
 msgid "HTTP streaming."
 msgstr ""
 
-#: src/docs_inc.c:389
+#: src/docs_inc.c:1204
 msgid "Hardware/Software Fundamentals"
 msgstr ""
 
-#: src/docs_inc.c:123 src/docs_inc.c:669 src/docs_inc.c:1065
-#: src/docs_inc.c:1513 src/docs_inc.c:1689 src/docs_inc.c:2386
+#: src/docs_inc.c:1528 src/docs_inc.c:1670
 msgid "Help"
 msgstr ""
 
-#: src/docs_inc.c:3090
+#: src/docs_inc.c:5396
+msgid "Here are some examples:-"
+msgstr ""
+
+#: src/docs_inc.c:138
+msgid ""
+"Here is an example of a device tree - yours will follow the same layout, but "
+"this is just to give you an idea as to what all the bits mean."
+msgstr ""
+
+#: src/docs_inc.c:4037
 msgid ""
 "Here we're removing the Bulgarian language audio from the input (first "
 "rule). However, if Bulgarian is the only language available add it back in "
 "as a last resort (second rule)."
 msgstr ""
 
-#: src/docs_inc.c:1902
-msgid ""
-"Highlight (select) the desired entries in the grid, then press the "
-"_[Delete]_ button on the menu bar."
+#: src/docs_inc.c:686
+msgid "Here you enter the access control details to secure your system."
 msgstr ""
 
-#: src/docs_inc.c:1875
-msgid "Highlight (select) the desired entry and then..:"
+#: src/docs_inc.c:740
+msgid "Here you map all discovered services to channels.."
 msgstr ""
 
-#: src/docs_inc.c:2442 src/docs_inc.c:2660 src/docs_inc.c:3030
-msgid ""
-"Highlight (select) the desired entry from the grid, then press the "
-"_[Delete]_ button from the menu bar."
-msgstr ""
-
-#: src/docs_inc.c:3446
-msgid ""
-"Highlight (select) the desired entry, then press the _[Download]_ button on "
-"the menu bar."
-msgstr ""
-
-#: src/docs_inc.c:1892
-msgid ""
-"Highlight (select) the entries in the grid that you'd like to edit, then "
-"click the _[Edit]_ button from the menu bar, the edit dialog should now be "
-"displayed. Note that when editing multiple entries there is an additional "
-"check box before each setting, ticking it will apply that setting to all "
-"selected entries. After you've finished editing an entry you can save your "
-"pending changes using the _[Save]_ button (closing the dialog), save your "
-"changes and continue making further adjustments by pressing the _[Apply]_ "
-"button, or cancel any unsaved changes (and close the dialog) by pressing the "
-"_[Cancel]_ button."
-msgstr ""
-
-#: src/docs_inc.c:2776
-msgid ""
-"Highlight (select) the network(s) you would like to force scan, and then "
-"press the \"Force Scan\" button from the menu bar."
-msgstr ""
-
-#: src/docs_inc.c:2249
+#: src/docs_inc.c:4646
 msgid ""
 "Hopefully (and if everything went to plan) your client should have now "
 "detected Tvheadend as a SAT>IP server. If not, restart or force it to "
 "perform a service discovery."
 msgstr ""
 
-#: src/docs_inc.c:1179
+#: src/docs_inc.c:941
 msgid "How Lightweight?"
 msgstr ""
 
-#: src/docs_inc.c:1181
+#: src/docs_inc.c:943
 msgid "How about light enough to run on a travel router? Take a look at this"
 msgstr ""
 
-#: src/docs_inc.c:1241
+#: src/docs_inc.c:2143
 msgid ""
 "How deep do we want to (need to) get into setting up tuners - that's a "
 "constant source of woe for people?"
 msgstr ""
 
-#: src/docs_inc.c:2223
-msgid "How to Configure Tvheadend as a SAT"
-msgstr ""
-
-#: src/docs_inc.c:1223
+#: src/docs_inc.c:2125
 msgid "How to compile/install on _insert your distro here_"
 msgstr ""
 
-#: src/docs_inc.c:1215
+#: src/docs_inc.c:2117
 msgid "How to configure a recording"
 msgstr ""
 
-#: src/docs_inc.c:1221
+#: src/docs_inc.c:2922
+msgid "How to display service information"
+msgstr ""
+
+#: src/docs_inc.c:2123
 msgid "How to set up a multi-profile installation (access)"
 msgstr ""
 
-#: src/docs_inc.c:1219
+#: src/docs_inc.c:2121
 msgid ""
-"How to set up conditional access (\"Conditional Access System Configuration"
-"\")"
+"How to set up conditional access (\"Conditional Access System "
+"Configuration\")"
 msgstr ""
 
-#: src/docs_inc.c:1217
+#: src/docs_inc.c:2119
 msgid "How to watch Live TV"
 msgstr ""
 
-#: src/docs_inc.c:4820 src/docs_inc.c:4822
+#: src/docs_inc.c:1580
+msgid ""
+"However, some item-specific configuration items are then only available "
+"through the _Add_ and _Edit_ dialog boxes. For example, the main network "
+"configuration tab grid covers parameters common to DVB-S, -T, -C and IPTV "
+"networks, but specific things such as FEC rolloff or mux URL are then only "
+"in the dialogs for networks that need these values."
+msgstr ""
+
+#: src/docs_inc.c:5948 src/docs_inc.c:5950
 msgid "IDLE"
 msgstr ""
 
-#: src/docs_inc.c:5144
+#: src/docs_inc.c:4728
 msgid "IGNORE"
 msgstr ""
 
-#: src/docs_inc.c:909
-msgid "IP Address Block List"
+#: src/docs_inc.c:3022
+msgid "IP Blocking Records"
 msgstr ""
 
-#: src/docs_inc.c:2197
+#: src/docs_inc.c:4612
 msgid "IP Config tab'"
 msgstr ""
 
-#: src/docs_inc.c:2225
-msgid "IP Server (Basic Guide)"
+#: src/docs_inc.c:3024
+msgid "IP address block list."
 msgstr ""
 
-#: src/docs_inc.c:2217
+#: src/docs_inc.c:3191
+msgid ""
+"IP and IPTV. If you run your OSCam server on the same machine as TVHeadend, "
+"set"
+msgstr ""
+
+#: src/docs_inc.c:3219
+msgid "IP and IPTV. The following lines are required in"
+msgstr ""
+
+#: src/docs_inc.c:1500
 msgid "IP servers"
 msgstr ""
 
-#: src/docs_inc.c:2711 src/docs_inc.c:4033
+#: src/docs_inc.c:3705 src/docs_inc.c:4313 src/docs_inc.c:4317
 msgid "IPTV"
 msgstr ""
 
-#: src/docs_inc.c:2709
-msgid "IPTV - TV over the Internet via your broadband connection"
-msgstr ""
-
-#: src/docs_inc.c:2713
+#: src/docs_inc.c:4321
 msgid "IPTV Automatic Network"
 msgstr ""
 
-#: src/docs_inc.c:4037
+#: src/docs_inc.c:4327
+msgid "IPTV Automatic Network - Don't Probe Services"
+msgstr ""
+
+#: src/docs_inc.c:3709
 msgid "IPTV PCR"
 msgstr ""
 
-#: src/docs_inc.c:5311 src/docs_inc.c:5389
+#: src/docs_inc.c:3713
+msgid "IPTV Subcription"
+msgstr ""
+
+#: src/docs_inc.c:4323
+msgid "IPTV using a playlist as the source -"
+msgstr ""
+
+#: src/docs_inc.c:6186 src/docs_inc.c:6210
 msgid "IRC"
 msgstr ""
 
-#: src/docs_inc.c:539 src/docs_inc.c:2677
+#: src/docs_inc.c:2646 src/docs_inc.c:4277
 msgid "ISDB-C"
 msgstr ""
 
-#: src/docs_inc.c:2691
+#: src/docs_inc.c:4293
 msgid "ISDB-S"
 msgstr ""
 
-#: src/docs_inc.c:529 src/docs_inc.c:2701
+#: src/docs_inc.c:2634 src/docs_inc.c:4305
 msgid "ISDB-T"
 msgstr ""
 
-#: src/docs_inc.c:5064
+#: src/docs_inc.c:5560
 msgid "ISO 8601 date format"
 msgstr ""
 
-#: src/docs_inc.c:679 src/docs_inc.c:2408 src/docs_inc.c:3372
+#: src/docs_inc.c:213 src/docs_inc.c:388 src/docs_inc.c:3165
 msgid "Icon"
 msgstr ""
 
-#: src/docs_inc.c:3604
-msgid "Icon URL"
+#: src/docs_inc.c:1532
+msgid "Icon-only buttons"
 msgstr ""
 
-#: src/docs_inc.c:297
+#: src/docs_inc.c:820
 msgid ""
 "Ideally, this is where you'll see a list of the pre-populated muxes as "
 "created when you set up your initial network. However, should there be any "
@@ -2809,57 +3364,70 @@ msgid ""
 "muxes over time."
 msgstr ""
 
-#: src/docs_inc.c:1553
+#: src/docs_inc.c:2015
 msgid "Idle"
 msgstr ""
 
-#: src/docs_inc.c:1801
+#: src/docs_inc.c:1162
 msgid "Idle scanning for automatic detection of muxes and services."
 msgstr ""
 
-#: src/docs_inc.c:3064
+#: src/docs_inc.c:4015
 msgid ""
 "If a rule removes a stream, it will not be available to other rules unless "
 "explicitly added back in (by another rule)."
 msgstr ""
 
-#: src/docs_inc.c:265
+#: src/docs_inc.c:786
 msgid ""
 "If anything is obviously wrong at this point, you probably have a driver/"
 "firmware error which you'll need to resolve before going any further."
 msgstr ""
 
-#: src/docs_inc.c:5443
+#: src/docs_inc.c:3961
 msgid ""
-"If using IPTV, the playlist you enter must contain valid links to streams "
-"using codecs supported by Tvheadend."
+"If the \"EIT: DVB Grabber\" is used then typically you would enter the "
+"configuration file (such as \"uk\") and enable relevant tickboxes to enable "
+"the additional scraping."
 msgstr ""
 
-#: src/docs_inc.c:1243
+#: src/docs_inc.c:3963
+msgid ""
+"If the scraper configuration is not enabled then the default behaviour means "
+"broadcast information such as summary information will still be retrieved."
+msgstr ""
+
+#: src/docs_inc.c:712
+msgid ""
+"If using IPTV, the playlist you enter must contain valid links to streams "
+"using codecs/containers supported by Tvheadend."
+msgstr ""
+
+#: src/docs_inc.c:2145
 msgid ""
 "If we do all the above, do we need the FAQ pages? Check existing manual/guide"
 msgstr ""
 
-#: src/docs_inc.c:5410
+#: src/docs_inc.c:678
 msgid ""
 "If you cannot see your preferred language in the language list and would "
 "like to help translate Tvheadend see"
 msgstr ""
 
-#: src/docs_inc.c:725
+#: src/docs_inc.c:434
 msgid ""
 "If you click on a single event, a popup will display detailed information "
-"about the event. It also allows you to schedule the event for recording by "
-"clicking on the _[Record program]_ button."
+"about the event. It also allows you to schedule the event for recording, "
+"find alternative events and more."
 msgstr ""
 
-#: src/docs_inc.c:5381
+#: src/docs_inc.c:6178
 msgid ""
 "If you confirm this dialog, the default administrator account will be "
 "removed. Please then the use credentials you defined thru this wizard."
 msgstr ""
 
-#: src/docs_inc.c:299
+#: src/docs_inc.c:822
 msgid ""
 "If you do need to add something manually, you'll need to search the Internet "
 "for details of the appropriate transmitter and settings: satellites tend not "
@@ -2868,82 +3436,57 @@ msgid ""
 "transmitter you're listening to."
 msgstr ""
 
-#: src/docs_inc.c:3275
+#: src/docs_inc.c:3095
 msgid ""
 "If you do not detach channel(s) before mapping additional services the "
 "following changes can occur.."
 msgstr ""
 
-#: src/docs_inc.c:2602
+#: src/docs_inc.c:5292
 msgid ""
-"If you do not have a build of Tvheadend with transcoding enabled some of the "
-"above profiles (and their associated Help pages) will not be available."
+"If you do not register and provide the api keys then the fanart grabber will "
+"fail."
 msgstr ""
 
-#: src/docs_inc.c:5416
-msgid ""
-"If you don't enter a preferred language, US English will be used as a "
-"default."
-msgstr ""
-
-#: src/docs_inc.c:5370
+#: src/docs_inc.c:736
 msgid ""
 "If you don't see any signal information at all, but the number of muxes or "
 "services is increasing anyway, the driver used by your device isn't "
-"supplying signal information to Tvheadend. In most cases this isn't an "
-"issue.."
+"supplying signal information to Tvheadend. In most cases this isn't an issue "
+"and can be ignored."
 msgstr ""
 
-#: src/docs_inc.c:159
+#: src/docs_inc.c:1704
 msgid "If you get really stuck, there's the"
 msgstr ""
 
-#: src/docs_inc.c:4465
+#: src/docs_inc.c:6234
+msgid ""
+"If you get stuck at any point and need a little more information, press "
+"[Help]."
+msgstr ""
+
+#: src/docs_inc.c:5832
 msgid ""
 "If you have _Network Discovery_ enabled, an out-of-date mux list isn't "
 "usually an issue provided that one of the muxes in the list scans "
 "successfully and has a"
 msgstr ""
 
-#: src/docs_inc.c:2094
+#: src/docs_inc.c:4534
 msgid ""
-"If you have a lot of services you may want to use filtering to limit the "
-"number of grid entries. You can do this by hovering your mouse over the "
-"_Service name_ column, a down arrow ▾ should now be visible, clicking the "
-"arrow will then display a list of options, move your mouse down to \"Filters"
-"\" and a text box should then appear, click on it and enter the desired "
-"service's name."
+"If you have multiple EPG sources for different groups of channels, it is "
+"possible to map the ratings from those multiple sources to produce a single "
+"unified rating system. This can be done by adjusting the 'display age' and "
+"'display label' of the various sources until they are matched to your "
+"requirements."
 msgstr ""
 
-#: src/docs_inc.c:3670
-msgid "If you have a lot of services you may want to use the"
-msgstr ""
-
-#: src/docs_inc.c:5355
-msgid ""
-"If you plan on accessing Tvheadend over the Internet, make sure you use "
-"strong credentials and ___do not allow anonymous access at all_ __ ."
-msgstr ""
-
-#: src/docs_inc.c:5305 src/docs_inc.c:5383
+#: src/docs_inc.c:6180 src/docs_inc.c:6204
 msgid "If you require further help, check out"
 msgstr ""
 
-#: src/docs_inc.c:739
-msgid ""
-"If you schedule any kind of recording from this point, you can choose a "
-"specific DVR profile that will apply to the recording or autorec rule. This "
-"will normally show as _(default)_ , but you can define different profiles in "
-"the __Configuration -> Recording ->"
-msgstr ""
-
-#: src/docs_inc.c:2518
-msgid ""
-"If you use more than one grabber, be sure to give a higher priority to the "
-"grabber that provides you with richer data."
-msgstr ""
-
-#: src/docs_inc.c:761
+#: src/docs_inc.c:514
 msgid ""
 "If you want to watch live TV in the web UI, the _[Watch TV]_ button will pop "
 "up a HTML5 video player, where you can select the channel to watch and a "
@@ -2952,38 +3495,14 @@ msgid ""
 "support certain formats and codecs."
 msgstr ""
 
-#: src/docs_inc.c:3168
-msgid ""
-"If you wanted to record any programs matching \"BBC News\" on BBC One you "
-"would enter something like this into the add entry dialog:"
-msgstr ""
-
-#: src/docs_inc.c:5330
-msgid ""
-"If you would like Tvheadend to do this for you, check the 'Map all services' "
-"option below, but be aware that this will also map encrypted services you "
-"may not have access to."
-msgstr ""
-
-#: src/docs_inc.c:2967
-msgid ""
-"If you would like to allow anonymous access to your Tvheadend server you may "
-"set-up a wildcard account, you can do this by creating a new user and "
-"entering an asterisk `*` in the username field."
-msgstr ""
-
-#: src/docs_inc.c:353
-msgid "If you would like to use bouquets see"
-msgstr ""
-
-#: src/docs_inc.c:3094
+#: src/docs_inc.c:4041
 msgid ""
 "If you'd like to ignore unknown elementary streams, add a rule to the end of "
 "grid with the _ANY_ (not defined) comparison(s) and the action set to "
 "_IGNORE_ ."
 msgstr ""
 
-#: src/docs_inc.c:3269
+#: src/docs_inc.c:3089
 msgid ""
 "If you're mapping another service to a channel created by a bouquet you must "
 "first detach the channel to prevent unexpected changes, you can do this by "
@@ -2992,67 +3511,75 @@ msgid ""
 "button."
 msgstr ""
 
-#: src/docs_inc.c:229
+#: src/docs_inc.c:619
 msgid ""
 "If you're not seeing any service names at all this may indicate an issue "
 "with your hardware and/or configuration."
 msgstr ""
 
-#: src/docs_inc.c:3512
-msgid ""
-"If you're not sure what to enter here, take a look at the \"If Necessary, "
-"Manually Add Muxes\" section on the"
-msgstr ""
-
-#: src/docs_inc.c:5290
+#: src/docs_inc.c:722
 msgid ""
 "If you're unsure as to which list(s) to select you may want to look online "
 "for details about the various television reception choices available in your "
 "area."
 msgstr ""
 
-#: src/docs_inc.c:5146
+#: src/docs_inc.c:2773
+msgid ""
+"If you're unsure as to why a scheduled recording failed, check the status "
+"column. Take a look at the _status_ property"
+msgstr ""
+
+#: src/docs_inc.c:4730
 msgid ""
 "Ignore this elementary stream. This stream is not used. Another successfully "
 "compared rule with different action may override it."
 msgstr ""
 
-#: src/docs_inc.c:3092
+#: src/docs_inc.c:4039
 msgid "Ignoring Unknown Streams"
 msgstr ""
 
-#: src/docs_inc.c:899 src/docs_inc.c:3869
+#: src/docs_inc.c:2574 src/docs_inc.c:3521
 msgid "Image Cache"
 msgstr ""
 
-#: src/docs_inc.c:1605
+#: src/docs_inc.c:979
 msgid ""
 "In addition, even USB3 doesn't have the greatest practical bandwidth per "
 "bus. That means you're probably asking for problems if you have four DVB-S2 "
 "dongles on the same USB connection to the motherboard."
 msgstr ""
 
-#: src/docs_inc.c:7
+#: src/docs_inc.c:1723
 msgid ""
 "In general, __keep it simple__ , especially if you're contributing to the "
 "pages that get carried over into the web help. The simpler the formatting, "
 "the cleaner the conversion, the less tidying up there is afterwards."
 msgstr ""
 
-#: src/docs_inc.c:5328
+#: src/docs_inc.c:742
 msgid ""
 "In order for your frontend client(s) (such as Kodi, Movian, and similar) to "
 "see/play channels, you must first map discovered services to channels."
 msgstr ""
 
-#: src/docs_inc.c:581
+#: src/docs_inc.c:6252
+msgid ""
+"In order for your frontend client(s) (such as Kodi, Movian, and similar) to "
+"see/play channels, you must first map discovered services to channels. If "
+"you would like Tvheadend to do this for you, check the 'Map all services' "
+"option below."
+msgstr ""
+
+#: src/docs_inc.c:302
 msgid ""
 "In the EPG top tool bar you can access five input fields. These are used to "
 "filter/search for events. The form uses implicit AND between the input "
 "fields. This means that all filters must match for an event to be displayed."
 msgstr ""
 
-#: src/docs_inc.c:2233
+#: src/docs_inc.c:4630
 msgid ""
 "In the _Exported tuners_ section, enter the number of tuners (per delivery "
 "system) that you'd like to export. This setting lets the client know how "
@@ -3061,14 +3588,13 @@ msgid ""
 "failures, e.g. \"No free tuner\"."
 msgstr ""
 
-#: src/docs_inc.c:3668
+#: src/docs_inc.c:2785
 msgid ""
-"In the above example image, we're creating a channel called Channel 4 and "
-"mapping it to the service of the same name. You can name a channel whatever "
-"you like, it doesn't have to match the service it's linking to."
+"In the _Upcoming / Current Recordings_ tab, duplicates are shown with a line-"
+"through."
 msgstr ""
 
-#: src/docs_inc.c:4824
+#: src/docs_inc.c:5952
 msgid ""
 "In the above table _Tuner A_ is busy so Tvheadend will have to use the next "
 "available idle tuner which in this example is _Tuner B_ and _Tuner C_ but "
@@ -3077,465 +3603,584 @@ msgid ""
 "will use the first available idle tuner."
 msgstr ""
 
-#: src/docs_inc.c:5103
+#: src/docs_inc.c:5376 src/docs_inc.c:6154
+msgid "Include all information."
+msgstr ""
+
+#: src/docs_inc.c:4794
 msgid "Include channels even if the linked service is flagged as encrypted."
 msgstr ""
 
-#: src/docs_inc.c:5089
+#: src/docs_inc.c:4780
 msgid "Include channels with no channel number."
 msgstr ""
 
-#: src/docs_inc.c:5093
+#: src/docs_inc.c:4784
 msgid "Include channels with no name."
 msgstr ""
 
-#: src/docs_inc.c:5099
+#: src/docs_inc.c:4790
 msgid "Include radio channels."
 msgstr ""
 
-#: src/docs_inc.c:15
+#: src/docs_inc.c:1731
 msgid "Including Documentation/Items"
 msgstr ""
 
-#: src/docs_inc.c:3646
-msgid "Increment the selected channel number(s) by 1."
-msgstr ""
-
-#: src/docs_inc.c:261
+#: src/docs_inc.c:778
 msgid ""
 "Individual tuners are then the next level down (e.g. `DiBcom 7000PC : DVB-T "
 "#0`)"
 msgstr ""
 
-#: src/docs_inc.c:3384
+#: src/docs_inc.c:225
 msgid "Information icon"
 msgstr ""
 
-#: src/docs_inc.c:1795
+#: src/docs_inc.c:1156
 msgid "Initial setup can be done by choosing one of the pre-defined"
 msgstr ""
 
-#: src/docs_inc.c:1729
+#: src/docs_inc.c:1090
 msgid "Input Sources"
 msgstr ""
 
-#: src/docs_inc.c:433 src/docs_inc.c:869
+#: src/docs_inc.c:915 src/docs_inc.c:1011
 msgid "Install Tvheadend"
 msgstr ""
 
-#: src/docs_inc.c:1575
+#: src/docs_inc.c:911 src/docs_inc.c:949
 msgid "Install Your Tuners"
 msgstr ""
 
-#: src/docs_inc.c:867
-msgid "Install hardware"
+#: src/docs_inc.c:901 src/docs_inc.c:2044
+msgid "Installation"
 msgstr ""
 
-#: src/docs_inc.c:1655
+#: src/docs_inc.c:913
+msgid "Installing and setting up your hardware"
+msgstr ""
+
+#: src/docs_inc.c:63
 msgid "Instructions For Built-in Help"
 msgstr ""
 
-#: src/docs_inc.c:441
+#: src/docs_inc.c:1019
 msgid "Instructions on how to build from source"
 msgstr ""
 
-#: src/docs_inc.c:313
+#: src/docs_inc.c:836
 msgid "Interactive EU DVB-T map"
 msgstr ""
 
-#: src/docs_inc.c:1593
+#: src/docs_inc.c:967
 msgid "Internal (e.g. PCI) tuners that go inside the computer chassis"
 msgstr ""
 
-#: src/docs_inc.c:939
+#: src/docs_inc.c:3923
 msgid "Internal PyEPG"
 msgstr ""
 
-#: src/docs_inc.c:941
+#: src/docs_inc.c:3907
 msgid "Internal XMLTV"
 msgstr ""
 
-#: src/docs_inc.c:1831
+#: src/docs_inc.c:1192
 msgid "Internationalisation"
 msgstr ""
 
-#: src/docs_inc.c:197
-msgid ""
-"Internet and LAN feeds, such as IPTV, SAT>IP, HDHomeRun and a general-"
-"purpose MPEG-TS `pipe://`"
+#: src/docs_inc.c:708
+msgid "Internet m3u playlist"
 msgstr ""
 
-#: src/docs_inc.c:855
+#: src/docs_inc.c:132 src/docs_inc.c:670 src/docs_inc.c:1030
+#: src/docs_inc.c:2042 src/docs_inc.c:2433
 msgid "Introduction"
 msgstr ""
 
-#: src/docs_inc.c:5240
+#: src/docs_inc.c:5962
 msgid ""
 "It is recommended that you only enable this option if you're absolutely sure "
 "the flags are sent correctly and on time. Incorrect EITp/f flags can result "
 "in failed/broken recordings. You can set this option per"
 msgstr ""
 
-#: src/docs_inc.c:189
-msgid "It supports input from:"
+#: src/docs_inc.c:1064
+msgid ""
+"It supports input from a number of sources such as DVB-T, DVB-S and more, see"
 msgstr ""
 
-#: src/docs_inc.c:1161
+#: src/docs_inc.c:923
 msgid ""
 "It's perfectly possible to install and run Tvheadend as a single-seat "
 "installation, with the software running on the same system as any client "
 "software (e.g. Kodi), with all files stored locally."
 msgstr ""
 
-#: src/docs_inc.c:127
+#: src/docs_inc.c:382 src/docs_inc.c:1832 src/docs_inc.c:1883
+#: src/docs_inc.c:1916 src/docs_inc.c:1979
 msgid "Items"
 msgstr ""
 
-#: src/docs_inc.c:4228
+#: src/docs_inc.c:270
+msgid "Items (grid items)"
+msgstr ""
+
+#: src/docs_inc.c:2481 src/docs_inc.c:2722 src/docs_inc.c:2805
+#: src/docs_inc.c:2878 src/docs_inc.c:2930 src/docs_inc.c:2984
+#: src/docs_inc.c:4197 src/docs_inc.c:4227
+msgid "Items and Properties"
+msgstr ""
+
+#: src/docs_inc.c:2835
+msgid "Items and properties"
+msgstr ""
+
+#: src/docs_inc.c:2463 src/docs_inc.c:2465 src/docs_inc.c:2479
+#: src/docs_inc.c:2566 src/docs_inc.c:2720 src/docs_inc.c:2803
+#: src/docs_inc.c:2833 src/docs_inc.c:2876 src/docs_inc.c:2904
+#: src/docs_inc.c:2928 src/docs_inc.c:2966 src/docs_inc.c:2968
+#: src/docs_inc.c:2982 src/docs_inc.c:3010 src/docs_inc.c:3355
+#: src/docs_inc.c:3357 src/docs_inc.c:4195 src/docs_inc.c:4225
+msgid "Items/Properties"
+msgstr ""
+
+#: src/docs_inc.c:4920
+msgid "John doe (Another entry)."
+msgstr ""
+
+#: src/docs_inc.c:4908
+msgid "John doe."
+msgstr ""
+
+#: src/docs_inc.c:6002
 msgid "Keep"
 msgstr ""
 
-#: src/docs_inc.c:4226
+#: src/docs_inc.c:6000
 msgid "Keep the mux if it doesn't already exist."
 msgstr ""
 
-#: src/docs_inc.c:305
+#: src/docs_inc.c:5304 src/docs_inc.c:5312
+msgid "Key from"
+msgstr ""
+
+#: src/docs_inc.c:828
 msgid "KingofSat"
 msgstr ""
 
-#: src/docs_inc.c:165
-msgid "Kiwi IRC"
+#: src/docs_inc.c:1098
+msgid "LAN/IPTV signals such as IPTV, SAT>IP, HDHomeRun."
 msgstr ""
 
-#: src/docs_inc.c:1737
-msgid "LAN/IPTV signals such as IPTV, SAT>IP, HDHomeRun"
-msgstr ""
-
-#: src/docs_inc.c:4700 src/docs_inc.c:4702
+#: src/docs_inc.c:5000 src/docs_inc.c:5002
 msgid "Language"
 msgstr ""
 
-#: src/docs_inc.c:663
-msgid "Launches Live TV via HTML5 video (see below)."
+#: src/docs_inc.c:5320
+msgid "Languages to use for searching for episode."
 msgstr ""
 
-#: src/docs_inc.c:1631
+#: src/docs_inc.c:1314
+msgid "Launches Live TV via HTML5 video."
+msgstr ""
+
+#: src/docs_inc.c:6226
+msgid ""
+"Let's start by configuring the basic language settings. Please select the "
+"default user interface and EPG language(s)."
+msgstr ""
+
+#: src/docs_inc.c:1005
 msgid "LibreELEC"
 msgstr ""
 
-#: src/docs_inc.c:1259
+#: src/docs_inc.c:30
 msgid "Licensing"
 msgstr ""
 
-#: src/docs_inc.c:4492
+#: src/docs_inc.c:5138
 msgid "Limit access to DVR functionality only."
 msgstr ""
 
-#: src/docs_inc.c:4488
+#: src/docs_inc.c:5134
 msgid "Limit access to streaming only (no DVR functionality)."
 msgstr ""
 
-#: src/docs_inc.c:4696
+#: src/docs_inc.c:4996
 msgid "Limit connections"
 msgstr ""
 
-#: src/docs_inc.c:4041
+#: src/docs_inc.c:6162
+msgid ""
+"Limited information for low memory devices that don't correctly process tv "
+"channel names."
+msgstr ""
+
+#: src/docs_inc.c:5380 src/docs_inc.c:6158
+msgid "Limited information for low memory devices."
+msgstr ""
+
+#: src/docs_inc.c:5466
+msgid "Line"
+msgstr ""
+
+#: src/docs_inc.c:3127
+msgid "Linux DVB CAM Client"
+msgstr ""
+
+#: src/docs_inc.c:3717
 msgid "LinuxDVB Input"
 msgstr ""
 
-#: src/docs_inc.c:1613
+#: src/docs_inc.c:987
 msgid "LinuxTV wiki device library"
 msgstr ""
 
-#: src/docs_inc.c:2394
-msgid "List of types"
+#: src/docs_inc.c:1042
+msgid "List of features"
 msgstr ""
 
-#: src/docs_inc.c:37
+#: src/docs_inc.c:494
+msgid "List/Find alternative showings (exact matches) of this event."
+msgstr ""
+
+#: src/docs_inc.c:498
+msgid "List/Find related EPG events."
+msgstr ""
+
+#: src/docs_inc.c:3197
+msgid "Listen / Connect port"
+msgstr ""
+
+#: src/docs_inc.c:1753
 msgid "Lists"
 msgstr ""
 
-#: src/docs_inc.c:1747
+#: src/docs_inc.c:2742
+msgid ""
+"Lists all EPG-driven recording rules. Events matched (by an auto-record "
+"rule) will be added to the"
+msgstr ""
+
+#: src/docs_inc.c:2730
+msgid ""
+"Lists all completed recording entries. Entries shown here have reached the "
+"end of the scheduled (or EITp/f defined) recording time."
+msgstr ""
+
+#: src/docs_inc.c:2734
+msgid ""
+"Lists all failed recording entries. Entries shown here have failed to record "
+"due to one (or more) errors that occurred during the recording."
+msgstr ""
+
+#: src/docs_inc.c:2738
+msgid ""
+"Lists all recording entries that have missing file(s). Entries shown here "
+"link to file(s) that Tvheadend cannot locate (files which have been "
+"externally (re)moved)."
+msgstr ""
+
+#: src/docs_inc.c:2750
+msgid ""
+"Lists all time-driven recording rules. Events matched (by a timer rule) will "
+"be added to the"
+msgstr ""
+
+#: src/docs_inc.c:2726
+msgid ""
+"Lists current and upcoming recording entries. Entries shown here are either "
+"currently recording or are soon-to-be recorded."
+msgstr ""
+
+#: src/docs_inc.c:1620
+msgid ""
+"Lists the number of current and maximum (per page) rows displayed, followed "
+"by the total number of items available."
+msgstr ""
+
+#: src/docs_inc.c:5510 src/docs_inc.c:5518
+msgid "Live Tennis Broadcast from Wimbledon"
+msgstr ""
+
+#: src/docs_inc.c:1108
 msgid "Local or remote disk, via the built-in digital video recorder."
 msgstr ""
 
-#: src/docs_inc.c:3785
+#: src/docs_inc.c:3437
 msgid "Locking"
 msgstr ""
 
-#: src/docs_inc.c:637
+#: src/docs_inc.c:370
 msgid "Longer programs, e.g. films"
 msgstr ""
 
-#: src/docs_inc.c:317
+#: src/docs_inc.c:840
 msgid "Lyngsat"
 msgstr ""
 
-#: src/docs_inc.c:1319
+#: src/docs_inc.c:2204
 msgid "M3U"
 msgstr ""
 
-#: src/docs_inc.c:1327
+#: src/docs_inc.c:2212
 msgid "M3U using SAT>IP extensions"
 msgstr ""
 
-#: src/docs_inc.c:961 src/docs_inc.c:2598
+#: src/docs_inc.c:4464
+msgid "MP4 profile."
+msgstr ""
+
+#: src/docs_inc.c:4462
 msgid "MP4/libav Profile"
 msgstr ""
 
-#: src/docs_inc.c:769
+#: src/docs_inc.c:522
 msgid "MPEG-PS"
 msgstr ""
 
-#: src/docs_inc.c:767 src/docs_inc.c:4017
+#: src/docs_inc.c:520 src/docs_inc.c:3689
 msgid "MPEG-TS"
 msgstr ""
 
-#: src/docs_inc.c:4097
+#: src/docs_inc.c:3773
 msgid "MPEG-TS File"
 msgstr ""
 
-#: src/docs_inc.c:3909
+#: src/docs_inc.c:3777
+msgid "MPEG-TS Input Debug"
+msgstr ""
+
+#: src/docs_inc.c:3565
 msgid "MPEG-TS Parser"
 msgstr ""
 
-#: src/docs_inc.c:953 src/docs_inc.c:2588
+#: src/docs_inc.c:4434
 msgid "MPEG-TS Pass-thru Profile"
 msgstr ""
 
-#: src/docs_inc.c:957 src/docs_inc.c:2594
+#: src/docs_inc.c:4438
+msgid "MPEG-TS Spawn"
+msgstr ""
+
+#: src/docs_inc.c:4436
+msgid ""
+"MPEG-TS pass-thru, this is a simple profile that just passes on the data "
+"received, can be configured to remove unneeded data packets."
+msgstr ""
+
+#: src/docs_inc.c:4456
+msgid "MPEG-TS profile."
+msgstr ""
+
+#: src/docs_inc.c:4454
 msgid "MPEG-TS/libav Profile"
 msgstr ""
 
-#: src/docs_inc.c:821
+#: src/docs_inc.c:574
 msgid "MPEG2 Audio"
 msgstr ""
 
-#: src/docs_inc.c:797
+#: src/docs_inc.c:550
 msgid "MPEG2 Video"
 msgstr ""
 
-#: src/docs_inc.c:3749
+#: src/docs_inc.c:3401
 msgid "Main"
 msgstr ""
 
-#: src/docs_inc.c:2004 src/docs_inc.c:2008
+#: src/docs_inc.c:1368
 msgid "Maintenance"
 msgstr ""
 
-#: src/docs_inc.c:2024
-msgid "Maintenance Button"
+#: src/docs_inc.c:2771
+msgid ""
+"Make sure you have enough tuners free to record (and watch) multiple "
+"services, insufficient tuners may result in missed recordings. However, "
+"depending on the tuner, most are able to receive a full multiplex, so you "
+"usually only need one per frequency/mux. You can quickly check if your tuner "
+"supports \"full mux receive\" by going to the _Muxes_ tab and playing a freq/"
+"mux in something like VLC."
 msgstr ""
 
-#: src/docs_inc.c:3400
-msgid "Manual Recording Entry Example"
+#: src/docs_inc.c:4319
+msgid "Manual IPTV input."
 msgstr ""
 
-#: src/docs_inc.c:1625
+#: src/docs_inc.c:656 src/docs_inc.c:770
+msgid "Manual Set-up"
+msgstr ""
+
+#: src/docs_inc.c:999
 msgid ""
 "Many Linux distros include a package for the most common devices (e.g. "
 "_linux-firmwares_ under Ubuntu or _firmware-linux-nonfree_ under Debian). If "
 "this isn't sufficient, a good source of firmware files are the"
 msgstr ""
 
-#: src/docs_inc.c:5336
+#: src/docs_inc.c:2437
+msgid ""
+"Many of the buttons have tool-tips giving you a hint as to their function. "
+"If you don't see any, you may need to enable them in __Configuration -> "
+"General -> Base__ ."
+msgstr ""
+
+#: src/docs_inc.c:762
 msgid ""
 "Many providers include undesirable services - Teleshopping, Adult "
 "Entertainment, etc; using the 'Map all services' will include these."
 msgstr ""
 
-#: src/docs_inc.c:351
+#: src/docs_inc.c:696
 msgid ""
-"Many service providers use bouquets for channel management and just like a "
-"standard set-top box Tvheadend can use these to automatically manage and "
-"keep your channels up-to-date."
+"Many tuners are able to receive different signal types, If you receive your "
+"channels through an.."
 msgstr ""
 
-#: src/docs_inc.c:5431
-msgid "Many tuners are able to receive different signal types.."
-msgstr ""
-
-#: src/docs_inc.c:1623
+#: src/docs_inc.c:997
 msgid ""
 "Many tuners then also require __firmware__ - normally, a binary file that's "
 "been extracted from the proprietary drivers used by Windows."
 msgstr ""
 
-#: src/docs_inc.c:3622
-msgid "Map"
-msgstr ""
-
-#: src/docs_inc.c:1996 src/docs_inc.c:2000 src/docs_inc.c:3570
-#: src/docs_inc.c:3608
+#: src/docs_inc.c:1352
 msgid "Map Services"
 msgstr ""
 
-#: src/docs_inc.c:2012
-msgid "Map Services Button"
+#: src/docs_inc.c:752
+msgid ""
+"Map all available services, including encrypted, data services and radio."
 msgstr ""
 
-#: src/docs_inc.c:3630
-msgid "Map all available"
-msgstr ""
-
-#: src/docs_inc.c:2022
-msgid "Map all available services as channels."
-msgstr ""
-
-#: src/docs_inc.c:5326
-msgid "Map all discovered services to channels."
-msgstr ""
-
-#: src/docs_inc.c:2020 src/docs_inc.c:3628
+#: src/docs_inc.c:750
 msgid "Map all services"
 msgstr ""
 
-#: src/docs_inc.c:5101
+#: src/docs_inc.c:4792
 msgid "Map encrypted services"
 msgstr ""
 
-#: src/docs_inc.c:5095
+#: src/docs_inc.c:4786
 msgid "Map radio channels"
 msgstr ""
 
-#: src/docs_inc.c:2016
-msgid "Map selected services"
-msgstr ""
-
-#: src/docs_inc.c:3620 src/docs_inc.c:3672
-msgid "Map services"
-msgstr ""
-
-#: src/docs_inc.c:111 src/docs_inc.c:2058 src/docs_inc.c:2076
+#: src/docs_inc.c:1879
 msgid "Map services to channels"
 msgstr ""
 
-#: src/docs_inc.c:2018
-msgid "Map the highlighted services within the grid."
-msgstr ""
-
-#: src/docs_inc.c:3572
-msgid "Map the services."
-msgstr ""
-
-#: src/docs_inc.c:5091
+#: src/docs_inc.c:4782
 msgid "Map unnamed channels"
 msgstr ""
 
-#: src/docs_inc.c:5087
+#: src/docs_inc.c:4778
 msgid "Map zero-numbered channels"
 msgstr ""
 
-#: src/docs_inc.c:2048
-msgid "Mapping All"
-msgstr ""
-
-#: src/docs_inc.c:3616
-msgid "Mapping Button"
-msgstr ""
-
-#: src/docs_inc.c:2066
-msgid "Mapping Selected"
-msgstr ""
-
-#: src/docs_inc.c:2040
-msgid "Mapping Services to Channels"
-msgstr ""
-
-#: src/docs_inc.c:2088
-msgid "Mapping/Removing a Service to/from an Existing Channel"
-msgstr ""
-
-#: src/docs_inc.c:11
+#: src/docs_inc.c:1727
 msgid "Markdown basics:"
 msgstr ""
 
-#: src/docs_inc.c:3
+#: src/docs_inc.c:1719
 msgid "Markdown/Formatting Crib Sheet"
 msgstr ""
 
-#: src/docs_inc.c:493
-msgid "Master"
+#: src/docs_inc.c:2614
+msgid "Master (DVB-S)"
 msgstr ""
 
-#: src/docs_inc.c:495
+#: src/docs_inc.c:2618
 msgid "Master (ISDB-S)"
 msgstr ""
 
-#: src/docs_inc.c:3183
-msgid "Matches \"BBC News\" exactly."
+#: src/docs_inc.c:2626
+msgid "Master DVB-T"
 msgstr ""
 
-#: src/docs_inc.c:3186
-msgid "Matches \"Regular Show\" and (if it exists) \"New: Regular Show\"."
-msgstr ""
-
-#: src/docs_inc.c:3188
-msgid "Matching events will be added to the _"
-msgstr ""
-
-#: src/docs_inc.c:771
+#: src/docs_inc.c:524
 msgid "Matroska"
 msgstr ""
 
-#: src/docs_inc.c:955 src/docs_inc.c:2590
+#: src/docs_inc.c:4442
 msgid "Matroska Profile"
 msgstr ""
 
-#: src/docs_inc.c:3937
+#: src/docs_inc.c:3597
 msgid "Matroska muxer"
 msgstr ""
 
-#: src/docs_inc.c:959 src/docs_inc.c:2596
+#: src/docs_inc.c:4460
+msgid "Matroska profile."
+msgstr ""
+
+#: src/docs_inc.c:4458
 msgid "Matroska/libav Profile"
 msgstr ""
 
-#: src/docs_inc.c:4664
+#: src/docs_inc.c:4964
 msgid "Maximal channel number"
 msgstr ""
 
-#: src/docs_inc.c:633
+#: src/docs_inc.c:5468
+msgid "Meaning"
+msgstr ""
+
+#: src/docs_inc.c:366
 msgid "Medium-length programs, e.g. documentaries"
 msgstr ""
 
-#: src/docs_inc.c:115 src/docs_inc.c:575 src/docs_inc.c:1057
-#: src/docs_inc.c:1505 src/docs_inc.c:1681 src/docs_inc.c:1924
-#: src/docs_inc.c:2139 src/docs_inc.c:2199 src/docs_inc.c:2317
-#: src/docs_inc.c:2346 src/docs_inc.c:2455 src/docs_inc.c:2496
-#: src/docs_inc.c:2537 src/docs_inc.c:2604 src/docs_inc.c:2982
-#: src/docs_inc.c:3306 src/docs_inc.c:3713 src/docs_inc.c:4110
+#: src/docs_inc.c:2522
 msgid "Menu Bar/Buttons"
 msgstr ""
 
-#: src/docs_inc.c:5105
+#: src/docs_inc.c:1648
+msgid ""
+"Menu bar buttons that display dialogs - certainly in the case of the Add and "
+"Edit buttons - show a dialog that share's a layout and buttons, these are "
+"explained in the table below."
+msgstr ""
+
+#: src/docs_inc.c:1270
+msgid "Menu bar/Panel Buttons"
+msgstr ""
+
+#: src/docs_inc.c:4796 src/docs_inc.c:4804
 msgid "Merge same name"
 msgstr ""
 
-#: src/docs_inc.c:4660
+#: src/docs_inc.c:4756
+msgid "Method"
+msgstr ""
+
+#: src/docs_inc.c:4960
 msgid "Minimal channel number"
 msgstr ""
 
-#: src/docs_inc.c:4538
+#: src/docs_inc.c:6032
 msgid "Missing In PAT/SDT"
 msgstr ""
 
-#: src/docs_inc.c:2032
-msgid "Missing in PAT/SDT"
-msgstr ""
-
-#: src/docs_inc.c:39
+#: src/docs_inc.c:1755
 msgid "Mixed lists don't work without further python extensions. Be careful."
 msgstr ""
 
-#: src/docs_inc.c:1819
+#: src/docs_inc.c:1180
 msgid "Mobile/Remote Client Support"
 msgstr ""
 
-#: src/docs_inc.c:3757
-msgid "Monitonic timer"
+#: src/docs_inc.c:3183
+msgid "Mode"
 msgstr ""
 
-#: src/docs_inc.c:609
+#: src/docs_inc.c:5296
+msgid "Module"
+msgstr ""
+
+#: src/docs_inc.c:5294
+msgid "Modules that are supplied with Tvheadend are listed below."
+msgstr ""
+
+#: src/docs_inc.c:342
 msgid ""
 "Most DVB networks classify their events into content groups. This field "
 "allows you to filter based on content type (e.g. “Sports” or “Game Show”). "
@@ -3543,114 +4188,101 @@ msgid ""
 "typing to filter the entries if you have a long list to choose from."
 msgstr ""
 
-#: src/docs_inc.c:1127
+#: src/docs_inc.c:1578
 msgid ""
 "Most configuration items - certainly the ones that are common to all types "
-"of item covered by that tab - are in this grid. However, some item-specific "
-"configuration items are then only available through the _Add_ and _Edit_ "
-"dialog boxes. For example, the main network configuration tab grid covers "
-"parameters common to DVB-S, -T, -C and IPTV networks, but specific things "
-"such as FEC rolloff or mux URL are then only in the dialogs for networks "
-"that need these values."
+"of item covered by that tab - are in this grid."
 msgstr ""
 
-#: src/docs_inc.c:1149
-msgid ""
-"Most rows are multi-selectable, so you can carry out certain actions on more "
-"than one entry at the same time. So, for example, you can select multiple "
-"items by using ctrl+click on each entry or click, shift+click to select a "
-"range."
-msgstr ""
-
-#: src/docs_inc.c:2378 src/docs_inc.c:2923 src/docs_inc.c:3056
+#: src/docs_inc.c:1418
 msgid "Move Down"
 msgstr ""
 
-#: src/docs_inc.c:2374 src/docs_inc.c:2919 src/docs_inc.c:3052
+#: src/docs_inc.c:1412
 msgid "Move Up"
 msgstr ""
 
-#: src/docs_inc.c:2380
-msgid "Move the selected CA client configuration down in the list."
+#: src/docs_inc.c:1420
+msgid "Move the selected entry down in the list."
 msgstr ""
 
-#: src/docs_inc.c:2376
-msgid "Move the selected CA client configuration up in the list."
+#: src/docs_inc.c:1414
+msgid "Move the selected entry up in the list."
 msgstr ""
 
-#: src/docs_inc.c:2925 src/docs_inc.c:3058
-msgid "Move the selected entry down the grid."
+#: src/docs_inc.c:1462
+msgid "Move the selected recording entries to"
 msgstr ""
 
-#: src/docs_inc.c:2921 src/docs_inc.c:3054
-msgid "Move the selected entry up the grid."
-msgstr ""
-
-#: src/docs_inc.c:3352 src/docs_inc.c:3360
+#: src/docs_inc.c:1472
 msgid "Move the selected recording entries to the"
 msgstr ""
 
-#: src/docs_inc.c:3350
+#: src/docs_inc.c:1460
 msgid "Move to failed"
 msgstr ""
 
-#: src/docs_inc.c:3358
+#: src/docs_inc.c:1470
 msgid "Move to finished"
 msgstr ""
 
-#: src/docs_inc.c:1815
+#: src/docs_inc.c:1176
 msgid "Movian and Kodi are the main targets."
 msgstr ""
 
-#: src/docs_inc.c:5054
+#: src/docs_inc.c:5530
 msgid "Movie : Science fiction"
 msgstr ""
 
-#: src/docs_inc.c:785 src/docs_inc.c:811 src/docs_inc.c:839
+#: src/docs_inc.c:538 src/docs_inc.c:564 src/docs_inc.c:592
 msgid "Mozilla Firefox"
 msgstr ""
 
-#: src/docs_inc.c:1805
+#: src/docs_inc.c:1166
 msgid "Multi-User Support"
 msgstr ""
 
-#: src/docs_inc.c:1771
+#: src/docs_inc.c:1686
+msgid "Multi-select"
+msgstr ""
+
+#: src/docs_inc.c:1132
 msgid ""
 "Multiple DVR profiles that support different target directories, post-"
 "processing options, filtering options, etc."
 msgstr ""
 
-#: src/docs_inc.c:1763
+#: src/docs_inc.c:1124
 msgid "Multiple simultaneous recordings are supported."
 msgstr ""
 
-#: src/docs_inc.c:4021
+#: src/docs_inc.c:3693
 msgid "Mux Scheduler"
 msgstr ""
 
-#: src/docs_inc.c:921
+#: src/docs_inc.c:108
 msgid "Mux Schedulers"
 msgstr ""
 
-#: src/docs_inc.c:4141
+#: src/docs_inc.c:4233
 msgid ""
 "Mux Schedulers enable Tvheadend to automatically play channels. This is "
 "useful to get EPG, services or access rights updates."
 msgstr ""
 
-#: src/docs_inc.c:1411
+#: src/docs_inc.c:2330
 msgid "Mux specified by mux UUID"
 msgstr ""
 
-#: src/docs_inc.c:3929
+#: src/docs_inc.c:3585
 msgid "Muxer"
 msgstr ""
 
-#: src/docs_inc.c:917
+#: src/docs_inc.c:100
 msgid "Muxes"
 msgstr ""
 
-#: src/docs_inc.c:3483
+#: src/docs_inc.c:4203
 msgid ""
 "Muxes are locations at which services can be found. On traditional networks "
 "(DVB-C, -T and -S), these are carrier signals on which the individual "
@@ -3659,7 +4291,7 @@ msgid ""
 "in effect."
 msgstr ""
 
-#: src/docs_inc.c:411
+#: src/docs_inc.c:1226
 msgid ""
 "Muxes then carry __services__ . These are the individual streams of data. "
 "They can be TV or radio programmes, they can provide data services such as "
@@ -3667,37 +4299,37 @@ msgid ""
 "up IPTV services."
 msgstr ""
 
-#: src/docs_inc.c:5120
+#: src/docs_inc.c:4704
 msgid "NONE"
 msgstr ""
 
-#: src/docs_inc.c:3733
-msgid "Name"
-msgstr ""
-
-#: src/docs_inc.c:4467
+#: src/docs_inc.c:5834
 msgid "Network Information Table (NIT)"
 msgstr ""
 
-#: src/docs_inc.c:2669
-msgid "Network Types"
-msgstr ""
-
-#: src/docs_inc.c:281
+#: src/docs_inc.c:804
 msgid ""
 "Network discovery (enabled by default) increases the likelihood of receiving "
 "all available muxes and services."
 msgstr ""
 
-#: src/docs_inc.c:915
+#: src/docs_inc.c:4265
+msgid "Network type"
+msgstr ""
+
+#: src/docs_inc.c:2821 src/docs_inc.c:4261
+msgid "Network types"
+msgstr ""
+
+#: src/docs_inc.c:96
 msgid "Networks"
 msgstr ""
 
-#: src/docs_inc.c:5292
-msgid "Networks already configured will not be shown below."
+#: src/docs_inc.c:724
+msgid "Networks already configured will not be shown."
 msgstr ""
 
-#: src/docs_inc.c:409
+#: src/docs_inc.c:1224
 msgid ""
 "Networks then have __muxes__ . These are the carrier frequencies that exist "
 "on the old analogue channels that are used to transmit multiple digital "
@@ -3705,55 +4337,73 @@ msgid ""
 "together, hence the name _mux_ ."
 msgstr ""
 
-#: src/docs_inc.c:4209
+#: src/docs_inc.c:5454
 msgid "New muxes + changed muxes"
 msgstr ""
 
-#: src/docs_inc.c:4205
+#: src/docs_inc.c:5450
 msgid "New muxes only"
 msgstr ""
 
-#: src/docs_inc.c:3520
-msgid "Newly added muxes are automatically set to the _PEND_ state."
-msgstr ""
-
-#: src/docs_inc.c:4385 src/docs_inc.c:4763 src/docs_inc.c:5185
+#: src/docs_inc.c:5682 src/docs_inc.c:5782 src/docs_inc.c:5874
 msgid "News"
 msgstr ""
 
-#: src/docs_inc.c:4397 src/docs_inc.c:4775 src/docs_inc.c:5197
+#: src/docs_inc.c:5702 src/docs_inc.c:5794 src/docs_inc.c:5894
 msgid "News and stories…"
 msgstr ""
 
-#: src/docs_inc.c:4369 src/docs_inc.c:4747 src/docs_inc.c:5169
+#: src/docs_inc.c:5666 src/docs_inc.c:5766 src/docs_inc.c:5858
 msgid "News.mkv"
 msgstr ""
 
-#: src/docs_inc.c:4854
+#: src/docs_inc.c:5638
 msgid "No"
 msgstr ""
 
-#: src/docs_inc.c:5122
+#: src/docs_inc.c:4706
 msgid "No action, may be used for the logging and a comparison verification."
 msgstr ""
 
-#: src/docs_inc.c:5009
+#: src/docs_inc.c:5234
 msgid "No free tuners - usually in-use by other subscription(s)."
 msgstr ""
 
-#: src/docs_inc.c:4600
+#: src/docs_inc.c:5074
 msgid "No scheme"
 msgstr ""
 
-#: src/docs_inc.c:5011
+#: src/docs_inc.c:5236
 msgid "No tuners are enabled and/or have no network assigned."
 msgstr ""
 
-#: src/docs_inc.c:3793
+#: src/docs_inc.c:5412
+msgid "No, because we're ignoring the last component"
+msgstr ""
+
+#: src/docs_inc.c:5430
+msgid "No, because we're ignoring the last two components"
+msgstr ""
+
+#: src/docs_inc.c:4914
+msgid "No, this is because the above entry \"Change parameters\" rights"
+msgstr ""
+
+#: src/docs_inc.c:4926
+msgid ""
+"No, this is because the even though above entry \"Change parameters\" rights"
+msgstr ""
+
+#: src/docs_inc.c:4892 src/docs_inc.c:4894 src/docs_inc.c:4898
+#: src/docs_inc.c:4924
+msgid "No."
+msgstr ""
+
+#: src/docs_inc.c:3445
 msgid "Node subsystem"
 msgstr ""
 
-#: src/docs_inc.c:1131
+#: src/docs_inc.c:1584
 msgid ""
 "Not all columns are necessarily visible. If you hover your mouse over a "
 "column heading, you'll see a down arrow - click here, and a drop-down menu "
@@ -3761,48 +4411,18 @@ msgid ""
 "not__ ."
 msgstr ""
 
-#: src/docs_inc.c:5418
-msgid ""
-"Not selecting the correct EPG language can result in garbled EPG text; if "
-"this happens, don't panic, as you can easily change it later."
-msgstr ""
-
-#: src/docs_inc.c:5254
+#: src/docs_inc.c:5976
 msgid "Not set"
 msgstr ""
 
-#: src/docs_inc.c:3686
-msgid ""
-"Note that editing a channel created by a bouquet can have unexpected "
-"results, please see _Detaching Channels_ on the"
-msgstr ""
-
-#: src/docs_inc.c:2245
+#: src/docs_inc.c:4642
 msgid ""
 "Note that if you use a similar number for multiple networks, the first "
 "matched network containing the mux with the requested parameters will win "
 "(also applies to unknown muxes)."
 msgstr ""
 
-#: src/docs_inc.c:3709
-msgid ""
-"Note that settings are not saved to a storage. Any change is available only "
-"while Tvheadend is running, and will be lost on a restart. To change the "
-"default behaviour permanently, use command line options such as `-l,` `–"
-"debug`, `–trace`."
-msgstr ""
-
-#: src/docs_inc.c:3263
-msgid "Note that the URL must begin with `file://` or `http(s)://`."
-msgstr ""
-
-#: src/docs_inc.c:3398
-msgid ""
-"Note that the _[Add]_ functionality is only available in the _Upcoming/"
-"Current Recordings_ tab."
-msgstr ""
-
-#: src/docs_inc.c:1970
+#: src/docs_inc.c:2858
 msgid ""
 "Note that the links don't link to the actual stream but to a playlist for "
 "use with media players such as VLC, If you'd prefer to receive the raw "
@@ -3810,659 +4430,886 @@ msgid ""
 "see"
 msgstr ""
 
-#: src/docs_inc.c:2850
-msgid "Note that when you create a rule/entry it will also generate a"
-msgstr ""
-
-#: src/docs_inc.c:645
+#: src/docs_inc.c:378
 msgid ""
 "Note that you don’t have to press a ‘Search’ button: the grid immediately "
 "updates itself as you change the filters."
 msgstr ""
 
-#: src/docs_inc.c:235
+#: src/docs_inc.c:1598
+msgid ""
+"Note, a cookie is used to remember your column/filtering preferences; "
+"Clearing your cookies will reset the interface to default."
+msgstr ""
+
+#: src/docs_inc.c:3261
+msgid ""
+"Note, because of how markdown generates tables, the OSCam variables "
+"`highlighted` above must be on separate lines in your config file."
+msgstr ""
+
+#: src/docs_inc.c:4348
+msgid ""
+"Note, the above two settings are only visible with the view level set to "
+"Expert."
+msgstr ""
+
+#: src/docs_inc.c:243
+msgid ""
+"Note, the links don't point to a stream but to an m3u playlist, for use with "
+"media players such as VLC. If you'd prefer to receive the raw stream "
+"instead, you can do so by removing the `/play/` path from the URL - see"
+msgstr ""
+
+#: src/docs_inc.c:788
+msgid ""
+"Note, there may be additional levels shown related to various other "
+"settings, e.g. satellite positions for SAT>IP tuners and so on - these are "
+"more advanced options that most will not need to use so can be ignored "
+"(generally)."
+msgstr ""
+
+#: src/docs_inc.c:1674
+msgid ""
+"Note, when using Save/Apply, certain fields must differ otherwise existing "
+"entries __may__ be overwritten."
+msgstr ""
+
+#: src/docs_inc.c:5342 src/docs_inc.c:5348 src/docs_inc.c:5354
+msgid ""
+"Note, you may have to disable this option for certain languages/charsets - "
+"Hebrew, etc."
+msgstr ""
+
+#: src/docs_inc.c:5054
+msgid ""
+"Note: The `file://` URLs are deescaped back when used, so `%20` means space "
+"for the filename for example."
+msgstr ""
+
+#: src/docs_inc.c:625
 msgid ""
 "Note: The above path only applies to Debian/Ubuntu systems others may differ."
 msgstr ""
 
-#: src/docs_inc.c:3508
-msgid ""
-"Note: You only really need to add muxes if the pre-defined list didn't work, "
-"e.g. because of out-of-date data as broadcasters re-arrange their services "
-"or because automatic detection (network discovery) hasn't successfully found "
-"all the muxes over time."
-msgstr ""
-
-#: src/docs_inc.c:2514
+#: src/docs_inc.c:2587 src/docs_inc.c:3185 src/docs_inc.c:3367
+#: src/docs_inc.c:3943
 msgid "Notes"
 msgstr ""
 
-#: src/docs_inc.c:5427
-msgid ""
-"Now let's get your tuners configured. Go ahead and select a network for each "
-"of the tuners you would like to use. if you do not assign a network to a "
-"tuner it will __not__ be used."
+#: src/docs_inc.c:2769
+msgid "Notes About the DVR"
 msgstr ""
 
-#: src/docs_inc.c:3648
+#: src/docs_inc.c:3047
+msgid "Notes on Access Entries"
+msgstr ""
+
+#: src/docs_inc.c:4073
+msgid "Notes on IP Blocking"
+msgstr ""
+
+#: src/docs_inc.c:4394
+msgid "Notes on Passwords"
+msgstr ""
+
+#: src/docs_inc.c:316
+msgid "Now"
+msgstr ""
+
+#: src/docs_inc.c:6274
+msgid ""
+"Now let's get your tuners configured. Go ahead and select a network for each "
+"of the tuners you would like to use. If you don't assign a network to a "
+"tuner it __won't__ be used."
+msgstr ""
+
+#: src/docs_inc.c:1390
 msgid "Number Down"
 msgstr ""
 
-#: src/docs_inc.c:3612
+#: src/docs_inc.c:1380
 msgid "Number Operations"
 msgstr ""
 
-#: src/docs_inc.c:3644
+#: src/docs_inc.c:1386
 msgid "Number Up"
 msgstr ""
 
-#: src/docs_inc.c:4415 src/docs_inc.c:5219
+#: src/docs_inc.c:144
+msgid "Number in Image / Text"
+msgstr ""
+
+#: src/docs_inc.c:5402
+msgid "Number of components to ignore"
+msgstr ""
+
+#: src/docs_inc.c:5724 src/docs_inc.c:5812
 msgid "Number of data errors during recording"
 msgstr ""
 
-#: src/docs_inc.c:4411 src/docs_inc.c:5215
+#: src/docs_inc.c:5720 src/docs_inc.c:5808
 msgid "Number of errors during recording"
 msgstr ""
 
-#: src/docs_inc.c:3636
-msgid "Numbering Button"
-msgstr ""
-
-#: src/docs_inc.c:5128
+#: src/docs_inc.c:4712
 msgid "ONE"
 msgstr ""
 
-#: src/docs_inc.c:937
-msgid "OTA Module"
+#: src/docs_inc.c:3233
+msgid "OSCam (rev >= 9095)"
 msgstr ""
 
-#: src/docs_inc.c:1205
+#: src/docs_inc.c:2459 src/docs_inc.c:2461 src/docs_inc.c:3181
+msgid "OSCam Modes"
+msgstr ""
+
+#: src/docs_inc.c:3215 src/docs_inc.c:3229
+msgid "OSCam TCP (rev >= 9574)"
+msgstr ""
+
+#: src/docs_inc.c:3187 src/docs_inc.c:3211
+msgid "OSCam net protocol (rev >= 10389)"
+msgstr ""
+
+#: src/docs_inc.c:3207
+msgid "OSCam new pc-nodmx (rev >= 10389)"
+msgstr ""
+
+#: src/docs_inc.c:3225
+msgid "OSCam pc-nodmx (rev >= 9756)"
+msgstr ""
+
+#: src/docs_inc.c:3949
+msgid "OTA Scrapper"
+msgstr ""
+
+#: src/docs_inc.c:2107
 msgid ""
 "Obviously, fill in the minor gaps as highlighted in the document: buttons, "
 "descriptions, etc."
 msgstr ""
 
-#: src/docs_inc.c:63
+#: src/docs_inc.c:1779
 msgid "Oh, and"
 msgstr ""
 
-#: src/docs_inc.c:259
+#: src/docs_inc.c:3237 src/docs_inc.c:3241 src/docs_inc.c:3245
+msgid "Older OSCam"
+msgstr ""
+
+#: src/docs_inc.c:776
 msgid ""
 "On this tab, you'll see a tree structure, with the Linux device list at the "
 "top level (e.g. `/dev/dvb/adapter0`)"
 msgstr ""
 
-#: src/docs_inc.c:339
+#: src/docs_inc.c:862
 msgid ""
 "Once scanning for services is complete, you need to map the services to "
 "channels so your client can actually request them (i.e. so you can watch or "
 "record)."
 msgstr ""
 
-#: src/docs_inc.c:2754
-msgid ""
-"Once you're happy with what you've entered into the dialog you can save the "
-"network using the _[Save]_ button (closing the dialog), save your pending "
-"changes and continue making further adjustments by pressing the _[Apply]_ "
-"button, or cancel any unsaved changes (and close the dialog) by pressing the "
-"_[Cancel]_ button."
-msgstr ""
-
-#: src/docs_inc.c:2758
-msgid ""
-"Once you've created a network (and added muxes) you must assign it to an "
-"__enabled__ adapter."
-msgstr ""
-
-#: src/docs_inc.c:2961
-msgid ""
-"Once you've created this file you must restart Tvheadend for it to take "
-"affect. Note that for security the superuser account is not listed in the "
-"access entries grid."
-msgstr ""
-
-#: src/docs_inc.c:2642
-msgid ""
-"Once you've selected a type you can then enter/select the desired options "
-"from the resultant _Add_ dialog."
-msgstr ""
-
-#: src/docs_inc.c:1371
+#: src/docs_inc.c:2256
 msgid "One DVR record specified by short DVR ID"
 msgstr ""
 
-#: src/docs_inc.c:1351 src/docs_inc.c:1459
+#: src/docs_inc.c:2236 src/docs_inc.c:2378
 msgid "One channel specified by channel name"
 msgstr ""
 
-#: src/docs_inc.c:1347 src/docs_inc.c:1455
+#: src/docs_inc.c:2232 src/docs_inc.c:2374
 msgid "One channel specified by channel number"
 msgstr ""
 
-#: src/docs_inc.c:1355 src/docs_inc.c:1463
+#: src/docs_inc.c:2240 src/docs_inc.c:2382
 msgid "One channel specified by short channel ID"
 msgstr ""
 
-#: src/docs_inc.c:4925
+#: src/docs_inc.c:5362
 msgid ""
 "Only OTA EIT and PSIP (ATSC) grabbers are enabled by default. Also note that "
 "__EPG data isn't merged__ , so be sure to give the highest priority to the "
 "grabber that provides you with the best data available."
 msgstr ""
 
-#: src/docs_inc.c:2516
+#: src/docs_inc.c:3945
 msgid ""
 "Only OTA EIT and PSIP (ATSC) grabbers are enabled by default. If you're "
 "missing EPG data, make sure to enable the correct grabber(s) for your "
-"location/provider."
+"location/provider. If you use more than one grabber, be sure to give a "
+"higher priority to the grabber that provides you with richer data."
 msgstr ""
 
-#: src/docs_inc.c:601
+#: src/docs_inc.c:334
 msgid ""
 "Only display events from channels which are included in the selected tag."
 msgstr ""
 
-#: src/docs_inc.c:595
+#: src/docs_inc.c:328
 msgid "Only display events from the selected channel."
 msgstr ""
 
-#: src/docs_inc.c:613
+#: src/docs_inc.c:346
 msgid ""
 "Only display events that fall between the given minimum and maximum "
 "durations."
 msgstr ""
 
-#: src/docs_inc.c:607
+#: src/docs_inc.c:340
 msgid "Only display events that match the given content type tag."
 msgstr ""
 
-#: src/docs_inc.c:589
+#: src/docs_inc.c:322
 msgid "Only display events that match the given title."
 msgstr ""
 
-#: src/docs_inc.c:1627
+#: src/docs_inc.c:1001
 msgid "OpenElec"
 msgstr ""
 
-#: src/docs_inc.c:4073
+#: src/docs_inc.c:3749
 msgid "OpenTV EPG"
 msgstr ""
 
-#: src/docs_inc.c:1293 src/docs_inc.c:1373 src/docs_inc.c:1413
-#: src/docs_inc.c:4197 src/docs_inc.c:4220 src/docs_inc.c:4295
-#: src/docs_inc.c:4478 src/docs_inc.c:4526 src/docs_inc.c:4549
-#: src/docs_inc.c:4632 src/docs_inc.c:4842 src/docs_inc.c:4869
-#: src/docs_inc.c:4898 src/docs_inc.c:4949 src/docs_inc.c:5083
+#: src/docs_inc.c:746 src/docs_inc.c:2162 src/docs_inc.c:2258
+#: src/docs_inc.c:2332 src/docs_inc.c:2396 src/docs_inc.c:4738
+#: src/docs_inc.c:4774 src/docs_inc.c:4818 src/docs_inc.c:4932
+#: src/docs_inc.c:5124 src/docs_inc.c:5158 src/docs_inc.c:5370
+#: src/docs_inc.c:5442 src/docs_inc.c:5626 src/docs_inc.c:5994
+#: src/docs_inc.c:6020 src/docs_inc.c:6062 src/docs_inc.c:6090
+#: src/docs_inc.c:6120 src/docs_inc.c:6148
 msgid "Option"
 msgstr ""
 
-#: src/docs_inc.c:59
+#: src/docs_inc.c:5326
+msgid ""
+"Optional extra arguments can be supplied to alter behaviour. Notable "
+"arguments are below:"
+msgstr ""
+
+#: src/docs_inc.c:1775
 msgid "Or minuses"
 msgstr ""
 
-#: src/docs_inc.c:61
+#: src/docs_inc.c:1777
 msgid "Or pluses"
 msgstr ""
 
-#: src/docs_inc.c:51
+#: src/docs_inc.c:1767
 msgid "Ordered sub-list"
 msgstr ""
 
-#: src/docs_inc.c:975
+#: src/docs_inc.c:4003
 msgid "Other Stream Filters"
 msgstr ""
 
-#: src/docs_inc.c:1745
+#: src/docs_inc.c:4005
+msgid "Other stream filter."
+msgstr ""
+
+#: src/docs_inc.c:1106
 msgid "Output Targets"
 msgstr ""
 
-#: src/docs_inc.c:1427
+#: src/docs_inc.c:3903
+msgid "Over-the-air (OTA)"
+msgstr ""
+
+#: src/docs_inc.c:4299
+msgid ""
+"Over-the-air broadcasts received through a traditional television aerial/"
+"antenna."
+msgstr ""
+
+#: src/docs_inc.c:2346
 msgid ""
 "Override queue size in bytes (default value is 1500000 for channel/service, "
 "10000000 for mux)"
 msgstr ""
 
-#: src/docs_inc.c:1379
+#: src/docs_inc.c:2264
 msgid ""
 "Override streaming profile, otherwise the default profile for the user is "
 "used."
 msgstr ""
 
-#: src/docs_inc.c:1423
+#: src/docs_inc.c:2342
 msgid "Override subscription weight"
 msgstr ""
 
-#: src/docs_inc.c:857
+#: src/docs_inc.c:84 src/docs_inc.c:112 src/docs_inc.c:262 src/docs_inc.c:286
+#: src/docs_inc.c:1036 src/docs_inc.c:1056 src/docs_inc.c:1818
+#: src/docs_inc.c:1867 src/docs_inc.c:1902 src/docs_inc.c:1965
+#: src/docs_inc.c:2447 src/docs_inc.c:2475 src/docs_inc.c:2562
+#: src/docs_inc.c:2598 src/docs_inc.c:2716 src/docs_inc.c:2761
+#: src/docs_inc.c:2795 src/docs_inc.c:2817 src/docs_inc.c:2872
+#: src/docs_inc.c:2892 src/docs_inc.c:2916 src/docs_inc.c:2942
+#: src/docs_inc.c:2978 src/docs_inc.c:3006 src/docs_inc.c:3031
+#: src/docs_inc.c:3071 src/docs_inc.c:3109 src/docs_inc.c:3271
+#: src/docs_inc.c:3291 src/docs_inc.c:3309 src/docs_inc.c:3347
+#: src/docs_inc.c:3359 src/docs_inc.c:3809 src/docs_inc.c:3851
+#: src/docs_inc.c:3873 src/docs_inc.c:3891 src/docs_inc.c:3971
+#: src/docs_inc.c:4101 src/docs_inc.c:4121 src/docs_inc.c:4141
+#: src/docs_inc.c:4161 src/docs_inc.c:4191 src/docs_inc.c:4201
+#: src/docs_inc.c:4221 src/docs_inc.c:4231 src/docs_inc.c:4249
+#: src/docs_inc.c:4356 src/docs_inc.c:4414 src/docs_inc.c:4480
+#: src/docs_inc.c:4546 src/docs_inc.c:4566 src/docs_inc.c:4586
+#: src/docs_inc.c:4654 src/docs_inc.c:4682
 msgid "Overview"
 msgstr ""
 
-#: src/docs_inc.c:179
+#: src/docs_inc.c:1038
 msgid "Overview of Tvheadend"
 msgstr ""
 
-#: src/docs_inc.c:4375 src/docs_inc.c:4753 src/docs_inc.c:5175
+#: src/docs_inc.c:2564 src/docs_inc.c:2894
+msgid "Overview of the tab"
+msgstr ""
+
+#: src/docs_inc.c:5672 src/docs_inc.c:5772 src/docs_inc.c:5864
 msgid "Owner of this recording"
 msgstr ""
 
-#: src/docs_inc.c:1093
+#: src/docs_inc.c:3561
+msgid "PCR Clocks"
+msgstr ""
+
+#: src/docs_inc.c:3259
+msgid ""
+"PRELOAD / wrapper hack active. TVH listens on the local specified UDP port "
+"(standard is 9000) for the code words. Only onechannel can be decoded at a "
+"time."
+msgstr ""
+
+#: src/docs_inc.c:3249
+msgid ""
+"PRELOAD / wrapper hack. TVH listens on a range of UDP ports starting with "
+"the specified port number (standard port range starts with 9000). The "
+"following lines are required in"
+msgstr ""
+
+#: src/docs_inc.c:1940
 msgid "Packet Error Ratio"
 msgstr ""
 
-#: src/docs_inc.c:1121
+#: src/docs_inc.c:1248
 msgid "Page Structure"
 msgstr ""
 
-#: src/docs_inc.c:25
+#: src/docs_inc.c:1610
+msgid "Paging Toolbar"
+msgstr ""
+
+#: src/docs_inc.c:1741
 msgid "Paragraphs Versus Definition Lists"
 msgstr ""
 
-#: src/docs_inc.c:3933
-msgid "Pass-thru muxer"
+#: src/docs_inc.c:3589
+msgid "Pass-through muxer"
 msgstr ""
 
-#: src/docs_inc.c:3897
+#: src/docs_inc.c:3549
 msgid "Passthrough Muxer SI Tables"
 msgstr ""
 
-#: src/docs_inc.c:907 src/docs_inc.c:2939
+#: src/docs_inc.c:3020
+msgid "Password management."
+msgstr ""
+
+#: src/docs_inc.c:3018
 msgid "Passwords"
 msgstr ""
 
-#: src/docs_inc.c:5250
+#: src/docs_inc.c:5972
 msgid "Per Channel Option"
 msgstr ""
 
-#: src/docs_inc.c:1159
+#: src/docs_inc.c:921
 msgid "Physical Architecture"
 msgstr ""
 
-#: src/docs_inc.c:4436
+#: src/docs_inc.c:4440
+msgid ""
+"Pipe stream out to script/binary for transcoding. Spawned script/binary must "
+"pipe the output back in as MPEG-TS."
+msgstr ""
+
+#: src/docs_inc.c:5034
 msgid "Placeholder"
 msgstr ""
 
-#: src/docs_inc.c:1229
+#: src/docs_inc.c:2131
 msgid "Platform differences - Ubuntu, Fedora, Red Hat, Arch, Android..."
 msgstr ""
 
-#: src/docs_inc.c:1227
+#: src/docs_inc.c:2129
 msgid ""
 "Platform differences - what you need to transcode, or what you can expect "
 "from Android vs GNU/Linux"
 msgstr ""
 
-#: src/docs_inc.c:1962
+#: src/docs_inc.c:448 src/docs_inc.c:1324
+msgid "Play"
+msgstr ""
+
+#: src/docs_inc.c:239
+msgid "Play icon"
+msgstr ""
+
+#: src/docs_inc.c:1326
+msgid "Play the program."
+msgstr ""
+
+#: src/docs_inc.c:2850
 msgid "Playing a Stream/File"
 msgstr ""
 
-#: src/docs_inc.c:1331 src/docs_inc.c:1447
+#: src/docs_inc.c:2216 src/docs_inc.c:2366
 msgid "Playlist contents"
 msgstr ""
 
-#: src/docs_inc.c:1315
+#: src/docs_inc.c:2184 src/docs_inc.c:2200
 msgid "Playlist type"
 msgstr ""
 
-#: src/docs_inc.c:1299
+#: src/docs_inc.c:2168
 msgid "Playlist type, can be"
 msgstr ""
 
-#: src/docs_inc.c:1285
+#: src/docs_inc.c:4325
+msgid "Please read"
+msgstr ""
+
+#: src/docs_inc.c:2154
 msgid "Please, add `http://IP:Port` to complete the URL."
 msgstr ""
 
-#: src/docs_inc.c:3769
+#: src/docs_inc.c:3421
 msgid "Poll multiplexer"
 msgstr ""
 
-#: src/docs_inc.c:1743
+#: src/docs_inc.c:1104
 msgid ""
 "Powerful many-to-many channel:service:tuner mapping that allows you to "
 "select channels irrespective of the underlying carrier (for channels that "
 "broadcast on multiple sources)."
 msgstr ""
 
-#: src/docs_inc.c:2050
-msgid "Press the _[Map services]_ button and then _[Map all services]_ ."
-msgstr ""
-
-#: src/docs_inc.c:3506
+#: src/docs_inc.c:6264
 msgid ""
-"Pressing the _[Save]_ button (at the bottom of the dialog) will commit your "
-"changes and close the dialog, pressing the _[Apply]_ button will commit your "
-"changes but won't close the dialog, pressing the _[Cancel]_ button closes "
-"the dialog - any unsaved changes will be lost."
+"Pre-defined lists are not always up-to-date, this generally isn't a problem "
+"provided that one of the muxes in list is active, and contains network "
+"information."
 msgstr ""
 
-#: src/docs_inc.c:4856
+#: src/docs_inc.c:5640
 msgid ""
 "Prevent the user from changing their view level and hide the view level drop-"
 "dowm from the interface."
 msgstr ""
 
-#: src/docs_inc.c:4808
+#: src/docs_inc.c:2431
+msgid ""
+"Previous versions of this documentation had buttons tables everywhere, to "
+"make the buttons - and their function/description - easier to find, they've "
+"all been moved to a single table in the"
+msgstr ""
+
+#: src/docs_inc.c:5936
 msgid "Priority"
 msgstr ""
 
-#: src/docs_inc.c:5199
+#: src/docs_inc.c:5704
 msgid "Program content type"
 msgstr ""
 
-#: src/docs_inc.c:4395 src/docs_inc.c:4773 src/docs_inc.c:5195
+#: src/docs_inc.c:5700 src/docs_inc.c:5792 src/docs_inc.c:5892
 msgid "Program description"
 msgstr ""
 
-#: src/docs_inc.c:4391 src/docs_inc.c:4769 src/docs_inc.c:5191
+#: src/docs_inc.c:5696 src/docs_inc.c:5788 src/docs_inc.c:5888
 msgid "Program episode"
 msgstr ""
 
-#: src/docs_inc.c:4387 src/docs_inc.c:4765 src/docs_inc.c:5187
+#: src/docs_inc.c:276
+msgid "Program event details and recording"
+msgstr ""
+
+#: src/docs_inc.c:5688 src/docs_inc.c:5784 src/docs_inc.c:5880
 msgid "Program subtitle"
 msgstr ""
 
-#: src/docs_inc.c:4383 src/docs_inc.c:4761 src/docs_inc.c:5183
+#: src/docs_inc.c:5684 src/docs_inc.c:5876
+msgid "Program subtitle or summary"
+msgstr ""
+
+#: src/docs_inc.c:5692 src/docs_inc.c:5884
+msgid "Program summary"
+msgstr ""
+
+#: src/docs_inc.c:5680 src/docs_inc.c:5780 src/docs_inc.c:5872
 msgid "Program title"
 msgstr ""
 
-#: src/docs_inc.c:1271
+#: src/docs_inc.c:42
 msgid "Project website"
 msgstr ""
 
-#: src/docs_inc.c:149
-msgid "Purpose"
+#: src/docs_inc.c:5332
+msgid "Provide extra level of debugging information"
 msgstr ""
 
-#: src/docs_inc.c:4077
+#: src/docs_inc.c:2493
+msgid "Provider-based channel grouping and ordering"
+msgstr ""
+
+#: src/docs_inc.c:3927 src/docs_inc.c:3935
+msgid "PyEPG"
+msgstr ""
+
+#: src/docs_inc.c:3753
 msgid "PyEPG Import"
 msgstr ""
 
-#: src/docs_inc.c:217
+#: src/docs_inc.c:633
+msgid "Q: Access Tvheadend through HTTP proxy"
+msgstr ""
+
+#: src/docs_inc.c:607
 msgid "Q: How do I get a playlist for all my channels?"
 msgstr ""
 
-#: src/docs_inc.c:231
+#: src/docs_inc.c:621
 msgid "Q: I get a blank page when trying to view the web interface!"
 msgstr ""
 
-#: src/docs_inc.c:225
+#: src/docs_inc.c:615
 msgid ""
 "Q: Tvheadend has scanned for services but some rows in the Service Name "
 "column are blank, is that normal?"
 msgstr ""
 
-#: src/docs_inc.c:221
+#: src/docs_inc.c:611
 msgid "Q: Why am I getting a playlist when trying to view/stream a channel?"
 msgstr ""
 
-#: src/docs_inc.c:237
+#: src/docs_inc.c:627
 msgid "Q: Why can't I see my tuners in Tvheadend's interface?"
 msgstr ""
 
-#: src/docs_inc.c:3805
+#: src/docs_inc.c:446
+msgid ""
+"Query an online service for more information on an event. Opens in new "
+"window."
+msgstr ""
+
+#: src/docs_inc.c:3409
+msgid "Queue profiling"
+msgstr ""
+
+#: src/docs_inc.c:3457
 msgid "RTSP Protocol"
 msgstr ""
 
-#: src/docs_inc.c:4130
+#: src/docs_inc.c:2507
+msgid "Rating Labels Module"
+msgstr ""
+
+#: src/docs_inc.c:2509
+msgid "Rating Labels management"
+msgstr ""
+
+#: src/docs_inc.c:4490
+msgid ""
+"Rating labels can be sourced from the OTA EPG grabber or from the XMLTV "
+"grabber."
+msgstr ""
+
+#: src/docs_inc.c:4524
+msgid ""
+"Ratings from XMLTV contain the rating label text, but not the recommended "
+"age."
+msgstr ""
+
+#: src/docs_inc.c:4500
+msgid ""
+"Ratings from the OTA EPG do not contain rating text like 'PG', instead, a "
+"combination of country code and age is transmitted, eg: AUS + 8. It is the "
+"responsibility of the receiver unit to decode this combination and determine "
+"the rating text to display."
+msgstr ""
+
+#: src/docs_inc.c:1492
 msgid "Re-fetch images"
 msgstr ""
 
-#: src/docs_inc.c:3346
+#: src/docs_inc.c:1454
 msgid "Re-record"
 msgstr ""
 
-#: src/docs_inc.c:3448
-msgid "Re-recording an Entry/Re-schedule a Recording"
-msgstr ""
-
-#: src/docs_inc.c:4132
+#: src/docs_inc.c:1494
 msgid "Re-refresh image cache (reload images from upstream providers)."
 msgstr ""
 
-#: src/docs_inc.c:2557
+#: src/docs_inc.c:1406
 msgid "Re-run Internal EPG Grabbers"
 msgstr ""
 
-#: src/docs_inc.c:2559
-msgid "Re-run all enabled"
+#: src/docs_inc.c:1408
+msgid "Re-run all enabled internal grabbers."
 msgstr ""
 
-#: src/docs_inc.c:3348
+#: src/docs_inc.c:1456
 msgid "Re-schedule the selected entry/recording if possible."
 msgstr ""
 
-#: src/docs_inc.c:4567
+#: src/docs_inc.c:468 src/docs_inc.c:1330
+msgid "Record"
+msgstr ""
+
+#: src/docs_inc.c:475 src/docs_inc.c:1340
+msgid "Record Series"
+msgstr ""
+
+#: src/docs_inc.c:484
+msgid "Record Series:"
+msgstr ""
+
+#: src/docs_inc.c:5180
 msgid "Record a matching event only if the description is different."
 msgstr ""
 
-#: src/docs_inc.c:4559
+#: src/docs_inc.c:5172
 msgid "Record a matching event only if the episode number is different."
 msgstr ""
 
-#: src/docs_inc.c:4563
+#: src/docs_inc.c:5176
 msgid "Record a matching event only if the subtitle is different."
 msgstr ""
 
-#: src/docs_inc.c:4553
+#: src/docs_inc.c:5162
 msgid "Record all"
 msgstr ""
 
-#: src/docs_inc.c:4555
+#: src/docs_inc.c:5164
 msgid "Record all matching events."
 msgstr ""
 
-#: src/docs_inc.c:3416
-msgid ""
-"Record all upcoming series episodes by pressing the _[Record series]_ "
-"button. __This replaces the _[Autorec]_ button when series link information "
-"is available.__"
+#: src/docs_inc.c:5166
+msgid "Record if EPG/XMLTV indicates it is a unique programme"
 msgstr ""
 
-#: src/docs_inc.c:3430
-msgid "Record events that broadcast between certain times or days of the week."
-msgstr ""
-
-#: src/docs_inc.c:3428
-msgid ""
-"Record events using regular expressions, they can be as simple or as "
-"powerful as you like."
-msgstr ""
-
-#: src/docs_inc.c:4565
+#: src/docs_inc.c:5178
 msgid "Record if different description"
 msgstr ""
 
-#: src/docs_inc.c:4557
+#: src/docs_inc.c:5170
 msgid "Record if different episode number"
 msgstr ""
 
-#: src/docs_inc.c:4561
+#: src/docs_inc.c:5174
 msgid "Record if different subtitle"
 msgstr ""
 
-#: src/docs_inc.c:4577
+#: src/docs_inc.c:5190
 msgid "Record once per day"
 msgstr ""
 
-#: src/docs_inc.c:4569
+#: src/docs_inc.c:5182
 msgid "Record once per month"
 msgstr ""
 
-#: src/docs_inc.c:4573
+#: src/docs_inc.c:5186
 msgid "Record once per week"
 msgstr ""
 
-#: src/docs_inc.c:3412
-msgid "Record the event once by pressing the _[Record program]_ button."
+#: src/docs_inc.c:5168
+msgid ""
+"Record only if no other timer or recording has the same EPG data including "
+"event ID."
 msgstr ""
 
-#: src/docs_inc.c:4579
+#: src/docs_inc.c:473
+msgid "Record the displayed event."
+msgstr ""
+
+#: src/docs_inc.c:5192
 msgid "Record the first matching event once a day."
 msgstr ""
 
-#: src/docs_inc.c:4575
+#: src/docs_inc.c:5188
 msgid "Record the first matching event once a week."
 msgstr ""
 
-#: src/docs_inc.c:4571
+#: src/docs_inc.c:5184
 msgid "Record the first matching event once per month."
 msgstr ""
 
-#: src/docs_inc.c:977
-msgid "Recording"
+#: src/docs_inc.c:1332
+msgid "Record the program/event."
 msgstr ""
 
-#: src/docs_inc.c:687 src/docs_inc.c:3380
+#: src/docs_inc.c:2066
+msgid "Recording (Profiles/Timeshift)"
+msgstr ""
+
+#: src/docs_inc.c:461
+msgid "Recording -"
+msgstr ""
+
+#: src/docs_inc.c:221 src/docs_inc.c:396
 msgid "Recording icon"
 msgstr ""
 
-#: src/docs_inc.c:9
+#: src/docs_inc.c:223
+msgid "Recording of the program is active and underway (current)."
+msgstr ""
+
+#: src/docs_inc.c:1725
 msgid "References"
 msgstr ""
 
-#: src/docs_inc.c:3178
-msgid "Regex"
-msgstr ""
-
-#: src/docs_inc.c:3176
-msgid "Regular expressions examples:"
-msgstr ""
-
-#: src/docs_inc.c:4232
+#: src/docs_inc.c:6006
 msgid "Reject"
 msgstr ""
 
-#: src/docs_inc.c:4236
+#: src/docs_inc.c:6010
 msgid "Reject exact match"
 msgstr ""
 
-#: src/docs_inc.c:425
+#: src/docs_inc.c:496
+msgid "Related events"
+msgstr ""
+
+#: src/docs_inc.c:1240
 msgid "Relationship Between Tuners, Neworks, Muxes, Services and Channels"
 msgstr ""
 
-#: src/docs_inc.c:2436 src/docs_inc.c:2654
-msgid ""
-"Remember to _[Save]_ your changes before selecting another config from "
-"within the grid."
-msgstr ""
-
-#: src/docs_inc.c:3024
-msgid ""
-"Remember to _[Save]_ your changes before selecting another profile from "
-"within the grid."
-msgstr ""
-
-#: src/docs_inc.c:2937
-msgid "Remember to also add a password entry in the _"
-msgstr ""
-
-#: src/docs_inc.c:2038
-msgid "Remove all services not seen for 7+ days."
-msgstr ""
-
-#: src/docs_inc.c:2036
+#: src/docs_inc.c:1374
 msgid "Remove all unseen services"
 msgstr ""
 
-#: src/docs_inc.c:2030
-msgid "Remove services marked as"
+#: src/docs_inc.c:4810
+msgid "Remove common suffixes, e.g., HD/UHD."
 msgstr ""
 
-#: src/docs_inc.c:2028
+#: src/docs_inc.c:1370
 msgid "Remove unseen services (PAT/SDT) (7 days+)"
 msgstr ""
 
-#: src/docs_inc.c:887
+#: src/docs_inc.c:2736
 msgid "Removed Recordings"
 msgstr ""
 
-#: src/docs_inc.c:2592
-msgid "Requires Tvheadend to be built with transcoding/ffmpeg enabled."
-msgstr ""
-
-#: src/docs_inc.c:1811
+#: src/docs_inc.c:1172
 msgid "Requires a card server (newcamd and capmt protocol is supported)."
 msgstr ""
 
-#: src/docs_inc.c:3253
-msgid "Rescan the selected mux for changes to the bouquet."
+#: src/docs_inc.c:4746
+msgid "Reset"
 msgstr ""
 
-#: src/docs_inc.c:657
+#: src/docs_inc.c:1306
 msgid "Reset All"
 msgstr ""
 
-#: src/docs_inc.c:3596
-msgid "Reset Icon"
+#: src/docs_inc.c:1514
+msgid "Reset all stream statistics, e.g. BER, PER etc.."
 msgstr ""
 
-#: src/docs_inc.c:3598
-msgid "Reset the selected channel(s)"
+#: src/docs_inc.c:1308
+msgid "Reset/clear all filters."
 msgstr ""
 
-#: src/docs_inc.c:1779
+#: src/docs_inc.c:1140
 msgid "Results can be scheduled for recording with a single click."
 msgstr ""
 
-#: src/docs_inc.c:1443
+#: src/docs_inc.c:2362
 msgid ""
 "Return the XMLTV EPG export. By default (if the rest of path is ommitted), "
 "an redirection answer will be sent where /channels remainder is used."
 msgstr ""
 
-#: src/docs_inc.c:1311
+#: src/docs_inc.c:2180
 msgid ""
 "Return the m3u playlist in Enigma2 format. By default (if the rest of path "
 "is ommitted), an redirection answer will be sent where /channels remainder "
 "is used."
 msgstr ""
 
-#: src/docs_inc.c:1289
+#: src/docs_inc.c:2158
 msgid ""
 "Return the playlist in _xspf_ or _m3u_ format. If the agent is in the list "
 "of direct agents (like wget/curl/vlc), the stream is returned instead."
 msgstr ""
 
-#: src/docs_inc.c:2384
-msgid "Reveal/Hide any stored CA client passwords."
+#: src/docs_inc.c:2837 src/docs_inc.c:2932 src/docs_inc.c:4199
+#: src/docs_inc.c:4229
+msgid "Return to DVB Inputs"
 msgstr ""
 
-#: src/docs_inc.c:3324
-msgid "Revert all changes made to the grid entries since the last save."
+#: src/docs_inc.c:2807
+msgid "Return to TV Adapters overview"
 msgstr ""
 
-#: src/docs_inc.c:2213
-msgid "Revert all changes since last save."
+#: src/docs_inc.c:4263
+msgid "Return to the index"
 msgstr ""
 
-#: src/docs_inc.c:1938 src/docs_inc.c:2469 src/docs_inc.c:2510
-#: src/docs_inc.c:2551 src/docs_inc.c:4124
+#: src/docs_inc.c:1432
+msgid "Reveal/Hide password fields."
+msgstr ""
+
+#: src/docs_inc.c:1288 src/docs_inc.c:2536
 msgid "Revert any changes made since the last save."
 msgstr ""
 
-#: src/docs_inc.c:2331
-msgid "Revert the changes made since last save."
+#: src/docs_inc.c:4748
+msgid "Revoke the code and generate a new one."
 msgstr ""
 
-#: src/docs_inc.c:1781
+#: src/docs_inc.c:1142
 msgid "Rich Browser-Driven Interface"
 msgstr ""
 
-#: src/docs_inc.c:1775
+#: src/docs_inc.c:1136
 msgid "Rich EPG support, with data from DVB/OTA, XMLTV (scheduled and socket)."
 msgstr ""
 
-#: src/docs_inc.c:4636
+#: src/docs_inc.c:4936
 msgid "Rights"
 msgstr ""
 
-#: src/docs_inc.c:517
+#: src/docs_inc.c:2690
 msgid "Rotor (GOTOX)"
 msgstr ""
 
-#: src/docs_inc.c:519
+#: src/docs_inc.c:2692
+msgid "Rotor (GOTOX) configuration."
+msgstr ""
+
+#: src/docs_inc.c:2694
 msgid "Rotor (USALS)"
 msgstr ""
 
-#: src/docs_inc.c:3068
+#: src/docs_inc.c:2696
+msgid "Rotor (USALS) configuration."
+msgstr ""
+
+#: src/docs_inc.c:1688
+msgid ""
+"Rows (in the grid) are multi-selectable, so you can carry out certain "
+"actions on more than one entry at a time. So, for example, you can select "
+"multiple items by using ctrl+click, shift+click to select a range, or ctrl+a "
+"to select all. When dealing with multiple entries, an additional check-box "
+"will be shown before each field in the dialog, remember to tick this check-"
+"box so that the changes are applied to all (selected) entries."
+msgstr ""
+
+#: src/docs_inc.c:4019
 msgid ""
 "Rules with fields not defined (or set to _ANY_ ) will apply to ALL "
 "elementary streams. For example, not defining/selecting _ANY_ for the "
@@ -4470,159 +5317,172 @@ msgid ""
 "filtered out by another rule."
 msgstr ""
 
-#: src/docs_inc.c:1549
+#: src/docs_inc.c:2011
 msgid "Running"
 msgstr ""
 
-#: src/docs_inc.c:5046
+#: src/docs_inc.c:6230
+msgid ""
+"Running this wizard on existing configurations is NOT a good idea as it may "
+"lead to confusion, misconfiguration and unexpected features! ;)"
+msgstr ""
+
+#: src/docs_inc.c:4285
+msgid "S (Satellite)"
+msgstr ""
+
+#: src/docs_inc.c:5522
 msgid "S02-E06"
 msgstr ""
 
-#: src/docs_inc.c:4393 src/docs_inc.c:4771 src/docs_inc.c:5193
+#: src/docs_inc.c:5698 src/docs_inc.c:5790 src/docs_inc.c:5890
 msgid "S02.E07"
 msgstr ""
 
-#: src/docs_inc.c:541
-msgid "SAT>IP (DVB-T/ATSC-T/ATSC-C/DVB-S)"
-msgstr ""
-
-#: src/docs_inc.c:4057
+#: src/docs_inc.c:2698 src/docs_inc.c:3733
 msgid "SAT>IP Client"
 msgstr ""
 
-#: src/docs_inc.c:901 src/docs_inc.c:4061
+#: src/docs_inc.c:2702 src/docs_inc.c:2704
+msgid "SAT>IP Satellite Configuration"
+msgstr ""
+
+#: src/docs_inc.c:2578 src/docs_inc.c:3737
 msgid "SAT>IP Server"
 msgstr ""
 
-#: src/docs_inc.c:3901
+#: src/docs_inc.c:3553
 msgid "SAT>IP Server SI Tables"
 msgstr ""
 
-#: src/docs_inc.c:2191
+#: src/docs_inc.c:2580
 msgid ""
-"SAT>IP Server is something like DVB network tuner. Tvheadend can forward "
-"mpegts input streams including on-the-fly descrambling to SAT>IP clients."
+"SAT>IP Server is like a DVB network tuner. Tvheadend can forward mpegts "
+"input streams (including on-the-fly descrambling) to SAT>IP clients"
 msgstr ""
 
-#: src/docs_inc.c:1753
+#: src/docs_inc.c:2700
+msgid "SAT>IP client configuration."
+msgstr ""
+
+#: src/docs_inc.c:1114
 msgid "SAT>IP server (including on-the-fly descrambling)."
 msgstr ""
 
-#: src/docs_inc.c:1719
+#: src/docs_inc.c:1080
 msgid "SDTV and HDTV support"
 msgstr ""
 
-#: src/docs_inc.c:3735 src/docs_inc.c:3737
+#: src/docs_inc.c:3387 src/docs_inc.c:3389
 msgid "START"
 msgstr ""
 
-#: src/docs_inc.c:3739 src/docs_inc.c:3741
+#: src/docs_inc.c:3391 src/docs_inc.c:3393
 msgid "STOP"
 msgstr ""
 
-#: src/docs_inc.c:489
-msgid "Satellite (DVB-S/ISDB-S)"
+#: src/docs_inc.c:5056
+msgid ""
+"Safety note: For the channel name, the first dot characters (possible hidden "
+"files or special directories) are replaced with the underscore character. "
+"The possible directory delimiters (slash) and the special character "
+"backslash are replaced with the minus character."
 msgstr ""
 
-#: src/docs_inc.c:499 src/docs_inc.c:557
+#: src/docs_inc.c:2658
 msgid "Satellite Configuration"
 msgstr ""
 
-#: src/docs_inc.c:507
-msgid "Satellite Configuration (Advanced)"
+#: src/docs_inc.c:704
+msgid "Satellite dish"
 msgstr ""
 
-#: src/docs_inc.c:1731
-msgid "Satellite signals via DVB-S and DVB-S2"
+#: src/docs_inc.c:1092
+msgid "Satellite signals via DVB-S and DVB-S2."
 msgstr ""
 
-#: src/docs_inc.c:2685
-msgid "Satellite, any signal coming in via a dish"
+#: src/docs_inc.c:4287
+msgid "Satellite, any signal coming in via a dish."
 msgstr ""
 
-#: src/docs_inc.c:193
-msgid "Satellite, so any signal coming in via a dish (DVB-S and DVB-S2)"
-msgstr ""
-
-#: src/docs_inc.c:469 src/docs_inc.c:1932 src/docs_inc.c:2147
-#: src/docs_inc.c:2180 src/docs_inc.c:2207 src/docs_inc.c:2300
-#: src/docs_inc.c:2325 src/docs_inc.c:2354 src/docs_inc.c:2463
-#: src/docs_inc.c:2504 src/docs_inc.c:2545 src/docs_inc.c:2612
-#: src/docs_inc.c:2879 src/docs_inc.c:2990 src/docs_inc.c:3119
-#: src/docs_inc.c:3144 src/docs_inc.c:3217 src/docs_inc.c:3318
-#: src/docs_inc.c:4118 src/docs_inc.c:4175
+#: src/docs_inc.c:1282 src/docs_inc.c:1658 src/docs_inc.c:2530
 msgid "Save"
 msgstr ""
 
-#: src/docs_inc.c:2209
-msgid "Save all changes."
-msgstr ""
-
-#: src/docs_inc.c:2356
-msgid "Save any changes made to the CA client configuration."
-msgstr ""
-
-#: src/docs_inc.c:2465
-msgid "Save any changes made to the grid."
-msgstr ""
-
-#: src/docs_inc.c:1934
+#: src/docs_inc.c:2532
 msgid "Save any changes made to the grid/entries."
 msgstr ""
 
-#: src/docs_inc.c:2614
-msgid "Save any changes made to the selected configuration."
+#: src/docs_inc.c:1284
+msgid "Save any changes made to the grid/entries/panel."
 msgstr ""
 
-#: src/docs_inc.c:2992
-msgid "Save any changes made to the selected profile."
+#: src/docs_inc.c:1660
+msgid "Saves (or add a new entry) & closes the dialog."
 msgstr ""
 
-#: src/docs_inc.c:2506 src/docs_inc.c:2547 src/docs_inc.c:4120
-msgid "Save any changes made to the tab."
+#: src/docs_inc.c:1664
+msgid ""
+"Saves pending changes but doesn't close the dialog, so you can more entries "
+"without having to fill in the fields again."
 msgstr ""
 
-#: src/docs_inc.c:3320
-msgid "Save changes made to the grid entries."
-msgstr ""
-
-#: src/docs_inc.c:471 src/docs_inc.c:2149 src/docs_inc.c:2182
-#: src/docs_inc.c:2302 src/docs_inc.c:2327 src/docs_inc.c:2881
-#: src/docs_inc.c:3121 src/docs_inc.c:3146 src/docs_inc.c:3219
-#: src/docs_inc.c:4177
-msgid "Save the current configuration."
-msgstr ""
-
-#: src/docs_inc.c:4093
+#: src/docs_inc.c:3769
 msgid "Scanfile"
 msgstr ""
 
-#: src/docs_inc.c:4264 src/docs_inc.c:4507 src/docs_inc.c:4596
+#: src/docs_inc.c:4848 src/docs_inc.c:5070 src/docs_inc.c:5106
 msgid "Scheme"
 msgstr ""
 
-#: src/docs_inc.c:587
+#: src/docs_inc.c:2272
+msgid "Scope"
+msgstr ""
+
+#: src/docs_inc.c:5532
+msgid "Scraper friendly (see below)"
+msgstr ""
+
+#: src/docs_inc.c:5542
+msgid "Scraper friendly with directories (see below)"
+msgstr ""
+
+#: src/docs_inc.c:5486
+msgid "Search for 'content_descriptor' in the standards document."
+msgstr ""
+
+#: src/docs_inc.c:5484
+msgid ""
+"Search the ETSI web site for the latest version of the 'ETSI EN 300 468' "
+"standard."
+msgstr ""
+
+#: src/docs_inc.c:320
 msgid "Search title..."
 msgstr ""
 
-#: src/docs_inc.c:1777
+#: src/docs_inc.c:1138
 msgid "Searchable and filterable from the web user interface."
 msgstr ""
 
-#: src/docs_inc.c:77
+#: src/docs_inc.c:1793
 msgid "Second Header"
 msgstr ""
 
-#: src/docs_inc.c:341 src/docs_inc.c:2790 src/docs_inc.c:3432
-#: src/docs_inc.c:3552 src/docs_inc.c:4980
+#: src/docs_inc.c:864 src/docs_inc.c:4089 src/docs_inc.c:4666
+#: src/docs_inc.c:5148
 msgid "See"
 msgstr ""
 
-#: src/docs_inc.c:5005
+#: src/docs_inc.c:5230
 msgid "See below."
 msgstr ""
 
-#: src/docs_inc.c:5288
+#: src/docs_inc.c:5482
+msgid "See:"
+msgstr ""
+
+#: src/docs_inc.c:720
 msgid ""
 "Select the closest transmitter if using an antenna (T); if using cable (C), "
 "select your provider; if using satellite (S), the orbital position of the "
@@ -4630,127 +5490,198 @@ msgid ""
 "your playlist."
 msgstr ""
 
-#: src/docs_inc.c:5294
+#: src/docs_inc.c:1354
+msgid "Selected"
+msgstr ""
+
+#: src/docs_inc.c:726
 msgid "Selecting the wrong list may cause the scan (on the next page) to fail."
 msgstr ""
 
-#: src/docs_inc.c:1003
-msgid "Server Mapper"
+#: src/docs_inc.c:486
+msgid "Series link, Record all EPG-defined episodes in the series/season."
 msgstr ""
 
-#: src/docs_inc.c:1035
+#: src/docs_inc.c:11
 msgid "Server connectivity"
 msgstr ""
 
-#: src/docs_inc.c:3941
+#: src/docs_inc.c:3601
 msgid "Service"
 msgstr ""
 
-#: src/docs_inc.c:2114
+#: src/docs_inc.c:4370
 msgid "Service Information"
 msgstr ""
 
-#: src/docs_inc.c:99 src/docs_inc.c:2062 src/docs_inc.c:2080
-#: src/docs_inc.c:3544 src/docs_inc.c:3953
+#: src/docs_inc.c:1863 src/docs_inc.c:2962 src/docs_inc.c:3613
+#: src/docs_inc.c:4658
 msgid "Service Mapper"
 msgstr ""
 
-#: src/docs_inc.c:1033
+#: src/docs_inc.c:2924 src/docs_inc.c:2958
+msgid "Service Mapper Dialog"
+msgstr ""
+
+#: src/docs_inc.c:2829 src/docs_inc.c:4342
+msgid "Service Probing (IPTV only)"
+msgstr ""
+
+#: src/docs_inc.c:9
 msgid "Service configuration"
 msgstr ""
 
-#: src/docs_inc.c:4608
+#: src/docs_inc.c:2920
+msgid "Service information"
+msgstr ""
+
+#: src/docs_inc.c:2960
+msgid "Service mapping dialog"
+msgstr ""
+
+#: src/docs_inc.c:2926
+msgid "Service mapping option(s) dialog"
+msgstr ""
+
+#: src/docs_inc.c:2964
+msgid "Service mapping status"
+msgstr ""
+
+#: src/docs_inc.c:5082
 msgid "Service name picons"
 msgstr ""
 
-#: src/docs_inc.c:1407
+#: src/docs_inc.c:2831
+msgid "Service probing information (IPTV only)"
+msgstr ""
+
+#: src/docs_inc.c:2326
 msgid "Service specified by service UUID"
 msgstr ""
 
-#: src/docs_inc.c:343 src/docs_inc.c:919 src/docs_inc.c:3076
-#: src/docs_inc.c:3554
+#: src/docs_inc.c:104 src/docs_inc.c:866 src/docs_inc.c:4027
+#: src/docs_inc.c:4668
 msgid "Services"
 msgstr ""
 
-#: src/docs_inc.c:1981
+#: src/docs_inc.c:4358
 msgid ""
 "Services are automatically pulled from muxes and can be mapped to Channels."
 msgstr ""
 
-#: src/docs_inc.c:1225
+#: src/docs_inc.c:658
+msgid "Set-up Tvheadend manually"
+msgstr ""
+
+#: src/docs_inc.c:5394
+msgid ""
+"Setting a number here forces tvheadend to ignore frequently-changing path "
+"components when deciding if a URL is new or not - starting from the end of "
+"the URL.."
+msgstr ""
+
+#: src/docs_inc.c:2127
 msgid "Setting up SAT>IP - as a client, as a server"
 msgstr ""
 
-#: src/docs_inc.c:2890
+#: src/docs_inc.c:3033
 msgid ""
 "Setting up access control is an important initial step as __the system is "
 "initially wide open__ ."
 msgstr ""
 
-#: src/docs_inc.c:377
+#: src/docs_inc.c:894
 msgid ""
 "Setting up access control rules for different client types/permission levels"
 msgstr ""
 
-#: src/docs_inc.c:367
+#: src/docs_inc.c:884
 msgid "Setting up channel icons"
 msgstr ""
 
-#: src/docs_inc.c:365
+#: src/docs_inc.c:882
 msgid ""
 "Setting up different EPGs (inc. localised character sets and timing offsets)"
 msgstr ""
 
-#: src/docs_inc.c:369
+#: src/docs_inc.c:886
 msgid "Setting up recording profiles"
 msgstr ""
 
-#: src/docs_inc.c:375
+#: src/docs_inc.c:892
 msgid "Setting up softcams for descrambling"
 msgstr ""
 
-#: src/docs_inc.c:371
+#: src/docs_inc.c:888
 msgid "Setting up streaming profiles (including transcoding)"
 msgstr ""
 
-#: src/docs_inc.c:3813
+#: src/docs_inc.c:3465
 msgid "Settings"
 msgstr ""
 
-#: src/docs_inc.c:629
+#: src/docs_inc.c:3371
+msgid ""
+"Settings are not saved to a storage. Any change is available only while "
+"Tvheadend is running, and will be lost on a restart. To change the default "
+"behaviour permanently, use command line options such as `-l,` `–debug`, `–"
+"trace`."
+msgstr ""
+
+#: src/docs_inc.c:3385
+msgid "Short Description"
+msgstr ""
+
+#: src/docs_inc.c:362
 msgid "Short programs, e.g. daily soap operas"
 msgstr ""
 
-#: src/docs_inc.c:751
+#: src/docs_inc.c:504
 msgid ""
 "Should you wish to record all events matching a specific query (to record "
 "your favourite show every week, for example) you can press the _[Create "
 "AutoRec]_ button in the top toolbar."
 msgstr ""
 
-#: src/docs_inc.c:4309 src/docs_inc.c:4955
+#: src/docs_inc.c:1574 src/docs_inc.c:6112
+msgid "Show all tabs/items."
+msgstr ""
+
+#: src/docs_inc.c:6126
 msgid "Show basic settings/information."
 msgstr ""
 
-#: src/docs_inc.c:4313 src/docs_inc.c:4959
+#: src/docs_inc.c:6130
 msgid "Show more advanced settings/information."
 msgstr ""
 
-#: src/docs_inc.c:4317 src/docs_inc.c:4963
+#: src/docs_inc.c:6134
 msgid "Show the expert (All) settings/information."
 msgstr ""
 
-#: src/docs_inc.c:2382
+#: src/docs_inc.c:1430
 msgid "Show/Hide Passwords"
 msgstr ""
 
-#: src/docs_inc.c:1611
+#: src/docs_inc.c:1526
+msgid "Show/Hide more advanced options."
+msgstr ""
+
+#: src/docs_inc.c:698
+msgid "Signal type"
+msgstr ""
+
+#: src/docs_inc.c:3209 src/docs_inc.c:3227
+msgid "Similar to"
+msgstr ""
+
+#: src/docs_inc.c:985
 msgid ""
 "Similar to the above, Tvheadend can do nothing if your tuners aren't working "
 "properly. A good place to check how to set up your tuners is the"
 msgstr ""
 
-#: src/docs_inc.c:417
+#: src/docs_inc.c:1232
 msgid ""
 "Simply, because 'BBC One' might exist in many different places... it might "
 "have regional variations on multiple frequencies (so different services on "
@@ -4760,15 +5691,15 @@ msgid ""
 "terrestrial tuner)."
 msgstr ""
 
-#: src/docs_inc.c:5050
+#: src/docs_inc.c:5526
 msgid "SkySport"
 msgstr ""
 
-#: src/docs_inc.c:497
-msgid "Slave"
+#: src/docs_inc.c:2622
+msgid "Slave (DVB-S/ISDB-S)"
 msgstr ""
 
-#: src/docs_inc.c:643
+#: src/docs_inc.c:376
 msgid ""
 "So, if you only want to see Movies from your available HD channels, you "
 "would select ‘HDTV’ in the _[Filter tag…]_ field, and select ‘Movie / Drama’ "
@@ -4777,211 +5708,253 @@ msgid ""
 "‘01:30:01 to 03:00:00’ in the _[Filter duration…]_ field."
 msgstr ""
 
-#: src/docs_inc.c:1809
+#: src/docs_inc.c:1170
 msgid "Software-Based CSA Descrambling"
 msgstr ""
 
-#: src/docs_inc.c:5
+#: src/docs_inc.c:3951
+msgid "Some OTA EIT grabber mechanisms support additional scraping options."
+msgstr ""
+
+#: src/docs_inc.c:1721
 msgid ""
 "Some notable items about how formatting is used on this particular site."
 msgstr ""
 
-#: src/docs_inc.c:3518
+#: src/docs_inc.c:1546
 msgid ""
-"Some tuners (or drivers) require more tuning parameters than others so be "
-"sure to enter as many tuning parameters as possible."
+"Some of these buttons are only displayed in selected tabs/panels (noted in "
+"bold underneath). For items not listed above, refer to the associated Help "
+"page."
 msgstr ""
 
-#: src/docs_inc.c:3777
+#: src/docs_inc.c:2268 src/docs_inc.c:2270
+msgid "Sorting method"
+msgstr ""
+
+#: src/docs_inc.c:4538
+msgid ""
+"Sources can also be kept seperated by ensuring that a DVB OTA rating does "
+"not have an 'authority' that matches any XMLTV sources and that an XMLTV "
+"rating does not have an 'age' or 'country' that matches a DVB OTA source, "
+"only a 'display age'."
+msgstr ""
+
+#: src/docs_inc.c:3429
 msgid "Spawn"
 msgstr ""
 
-#: src/docs_inc.c:5038
-msgid "Sport"
+#: src/docs_inc.c:1600
+msgid "Split panels"
 msgstr ""
 
-#: src/docs_inc.c:4511
+#: src/docs_inc.c:5110
 msgid "Standard"
 msgstr ""
 
-#: src/docs_inc.c:4403 src/docs_inc.c:4777 src/docs_inc.c:5207
+#: src/docs_inc.c:1482
+msgid "Start the wizard."
+msgstr ""
+
+#: src/docs_inc.c:5712 src/docs_inc.c:5800 src/docs_inc.c:5896
 msgid "Start time stamp of recording, UNIX epoch"
 msgstr ""
 
-#: src/docs_inc.c:2155
+#: src/docs_inc.c:1480
 msgid "Start wizard"
 msgstr ""
 
-#: src/docs_inc.c:1545
+#: src/docs_inc.c:2007
 msgid "State"
 msgstr ""
 
-#: src/docs_inc.c:995 src/docs_inc.c:4816 src/docs_inc.c:4991
+#: src/docs_inc.c:2072 src/docs_inc.c:5216 src/docs_inc.c:5944
 msgid "Status"
 msgstr ""
 
-#: src/docs_inc.c:1671
+#: src/docs_inc.c:1814
 msgid "Status - Connections"
 msgstr ""
 
-#: src/docs_inc.c:1047
+#: src/docs_inc.c:1898
 msgid "Status - Stream"
 msgstr ""
 
-#: src/docs_inc.c:1495
+#: src/docs_inc.c:1961
 msgid "Status - Subscriptions"
 msgstr ""
 
-#: src/docs_inc.c:35
+#: src/docs_inc.c:1522
+msgid "Status -> Connections only."
+msgstr ""
+
+#: src/docs_inc.c:1516
+msgid "Status -> Stream only."
+msgstr ""
+
+#: src/docs_inc.c:1751
 msgid ""
 "Stick to paragraph formatting unless and until you have a need for "
 "definition lists."
 msgstr ""
 
-#: src/docs_inc.c:3326
+#: src/docs_inc.c:1436
 msgid "Stop"
 msgstr ""
 
-#: src/docs_inc.c:4407 src/docs_inc.c:4781 src/docs_inc.c:5211
+#: src/docs_inc.c:5716 src/docs_inc.c:5804 src/docs_inc.c:5900
 msgid "Stop time stamp of recording, UNIX epoch"
 msgstr ""
 
-#: src/docs_inc.c:947 src/docs_inc.c:997
+#: src/docs_inc.c:2064 src/docs_inc.c:2946
 msgid "Stream"
 msgstr ""
 
-#: src/docs_inc.c:949 src/docs_inc.c:4249
+#: src/docs_inc.c:2994
+msgid "Stream Filters"
+msgstr ""
+
+#: src/docs_inc.c:2986 src/docs_inc.c:6052
 msgid "Stream Profiles"
 msgstr ""
 
-#: src/docs_inc.c:2572
+#: src/docs_inc.c:4416
 msgid ""
 "Stream Profiles are the settings for output formats. These are used for Live "
-"TV streaming and recordings. The profiles are assigned through the"
+"TV streaming and recordings. The profiles can be assigned through Access "
+"Entries, DVR Profiles or as parameter for HTTP Streaming."
 msgstr ""
 
-#: src/docs_inc.c:1387
+#: src/docs_inc.c:2306
 msgid "Stream for"
 msgstr ""
 
-#: src/docs_inc.c:4486 src/docs_inc.c:4638
+#: src/docs_inc.c:2988
+msgid "Stream profile types and profile settings"
+msgstr ""
+
+#: src/docs_inc.c:4938 src/docs_inc.c:5132
 msgid "Streaming"
 msgstr ""
 
-#: src/docs_inc.c:3965
+#: src/docs_inc.c:3625
 msgid "Streaming Profile"
 msgstr ""
 
-#: src/docs_inc.c:4833
+#: src/docs_inc.c:6042
 msgid ""
 "Streaming priority is like the _Priority_ setting (above) but only applies "
 "when streaming over HTTP or HTSP. If no streaming priority value is set (0) "
 "the _Priority_ value is used instead."
 msgstr ""
 
-#: src/docs_inc.c:4684 src/docs_inc.c:4686
+#: src/docs_inc.c:4984 src/docs_inc.c:4986
 msgid "Streaming profiles"
 msgstr ""
 
-#: src/docs_inc.c:4419 src/docs_inc.c:5223
+#: src/docs_inc.c:5728 src/docs_inc.c:5816
 msgid "Streams (comma separated)"
 msgstr ""
 
-#: src/docs_inc.c:1767
+#: src/docs_inc.c:1128
 msgid ""
 "Streams can be selected and filtered positively or negatively as required."
 msgstr ""
 
-#: src/docs_inc.c:4326
+#: src/docs_inc.c:5262
 msgid "String"
 msgstr ""
 
-#: src/docs_inc.c:1757
+#: src/docs_inc.c:1118
 msgid ""
 "Subject to your system's capabilities, support for on-the-fly transcoding "
 "for both live and recorded streams in various formats."
 msgstr ""
 
-#: src/docs_inc.c:3949
+#: src/docs_inc.c:3609
 msgid "Subscription"
 msgstr ""
 
-#: src/docs_inc.c:999
+#: src/docs_inc.c:2950
 msgid "Subscriptions"
 msgstr ""
 
-#: src/docs_inc.c:3731
+#: src/docs_inc.c:3383
 msgid "Subsystem"
 msgstr ""
 
-#: src/docs_inc.c:3727
+#: src/docs_inc.c:3351 src/docs_inc.c:3379
 msgid "Subsystems"
 msgstr ""
 
-#: src/docs_inc.c:971
+#: src/docs_inc.c:3995
 msgid "Subtitle Stream Filters"
 msgstr ""
 
-#: src/docs_inc.c:1803
+#: src/docs_inc.c:3997
+msgid "Subtitle stream filter."
+msgstr ""
+
+#: src/docs_inc.c:1164
 msgid ""
 "Support for broadcaster (primarily DVB-S) bouquets for easy channel mapping."
 msgstr ""
 
-#: src/docs_inc.c:1741
+#: src/docs_inc.c:1102
 msgid ""
 "Support for multiple adapters of any mix, with each adapter able to receive "
 "simultaneously all programmes on the current mux."
 msgstr ""
 
-#: src/docs_inc.c:817
+#: src/docs_inc.c:570
 msgid "Supported audio codecs"
 msgstr ""
 
-#: src/docs_inc.c:4355 src/docs_inc.c:4733 src/docs_inc.c:5155
+#: src/docs_inc.c:5652 src/docs_inc.c:5752 src/docs_inc.c:5844
 msgid "Supported format strings:"
 msgstr ""
 
-#: src/docs_inc.c:763
+#: src/docs_inc.c:516
 msgid "Supported formats (containers)"
 msgstr ""
 
-#: src/docs_inc.c:793
+#: src/docs_inc.c:546
 msgid "Supported video codecs"
 msgstr ""
 
-#: src/docs_inc.c:3652
+#: src/docs_inc.c:1394
 msgid "Swap Numbers"
 msgstr ""
 
-#: src/docs_inc.c:3654
-msgid "Swap the numbers of the"
-msgstr ""
-
-#: src/docs_inc.c:4280
+#: src/docs_inc.c:4864
 msgid "Sync"
 msgstr ""
 
-#: src/docs_inc.c:4284
+#: src/docs_inc.c:4868
 msgid "Sync + Don't keep"
 msgstr ""
 
-#: src/docs_inc.c:4272
+#: src/docs_inc.c:4856
 msgid "System"
 msgstr ""
 
-#: src/docs_inc.c:1167
+#: src/docs_inc.c:929
 msgid "System Requirements"
 msgstr ""
 
-#: src/docs_inc.c:3801
+#: src/docs_inc.c:4297
+msgid "T (Terrestrial)"
+msgstr ""
+
+#: src/docs_inc.c:3453
 msgid "TCP Protocol"
 msgstr ""
 
-#: src/docs_inc.c:5130
+#: src/docs_inc.c:4714
 msgid "TIME"
 msgstr ""
 
-#: src/docs_inc.c:5134
+#: src/docs_inc.c:4718
 msgid ""
 "TIME action was matched, the new AC3 elementary stream will not be added if "
 "the language for new AC3 elementary stream is ‘eng’. Note that the second "
@@ -4990,66 +5963,94 @@ msgid ""
 "CA is not already used."
 msgstr ""
 
-#: src/docs_inc.c:3911
+#: src/docs_inc.c:3567
 msgid "TS"
 msgstr ""
 
-#: src/docs_inc.c:913 src/docs_inc.c:2792
+#: src/docs_inc.c:92 src/docs_inc.c:128
 msgid "TV Adapters"
 msgstr ""
 
-#: src/docs_inc.c:4065
+#: src/docs_inc.c:4315
+msgid "TV over the Internet via your broadband connection."
+msgstr ""
+
+#: src/docs_inc.c:3741
 msgid "TVHDHomeRun Client"
 msgstr ""
 
-#: src/docs_inc.c:1313
+#: src/docs_inc.c:2182 src/docs_inc.c:2198
 msgid "TYPE"
 msgstr ""
 
-#: src/docs_inc.c:3046
-msgid "Tab specific functions:"
+#: src/docs_inc.c:86 src/docs_inc.c:2449 src/docs_inc.c:2477
+#: src/docs_inc.c:2797 src/docs_inc.c:2819 src/docs_inc.c:2874
+#: src/docs_inc.c:2918 src/docs_inc.c:2944 src/docs_inc.c:2980
+#: src/docs_inc.c:3008 src/docs_inc.c:3349 src/docs_inc.c:4193
+#: src/docs_inc.c:4223
+msgid "Tab overview"
 msgstr ""
 
-#: src/docs_inc.c:853
+#: src/docs_inc.c:2568 src/docs_inc.c:2906 src/docs_inc.c:3012
+msgid "Tab specific items and properties"
+msgstr ""
+
+#: src/docs_inc.c:2038
 msgid "Table of Contents"
 msgstr ""
 
-#: src/docs_inc.c:67
+#: src/docs_inc.c:90 src/docs_inc.c:2801
+msgid "Table of device types and their respective configuration options"
+msgstr ""
+
+#: src/docs_inc.c:1783
 msgid "Tables"
 msgstr ""
 
-#: src/docs_inc.c:69
+#: src/docs_inc.c:1785
 msgid "Tables can be constructed as follows."
 msgstr ""
 
-#: src/docs_inc.c:1359 src/docs_inc.c:1467
+#: src/docs_inc.c:2292
+msgid "Tag index as first key, tag name as second key"
+msgstr ""
+
+#: src/docs_inc.c:2298
+msgid "Tag name only"
+msgstr ""
+
+#: src/docs_inc.c:2244 src/docs_inc.c:2386
 msgid "Tagged channels specified by UUID or tag name"
 msgstr ""
 
-#: src/docs_inc.c:1367 src/docs_inc.c:1475
+#: src/docs_inc.c:2252 src/docs_inc.c:2394
 msgid "Tagged channels specified by short tag ID"
 msgstr ""
 
-#: src/docs_inc.c:1363 src/docs_inc.c:1471
+#: src/docs_inc.c:2248 src/docs_inc.c:2390
 msgid "Tagged channels specified by tag name"
 msgstr ""
 
-#: src/docs_inc.c:603
+#: src/docs_inc.c:336
 msgid ""
 "Tags are used for grouping channels together - such as ‘Radio’ or ‘HDTV’ - "
 "and are configured by the administrator. You can start typing a tag name to "
 "filter the list."
 msgstr ""
 
-#: src/docs_inc.c:969
+#: src/docs_inc.c:3991
 msgid "Teletext Stream Filters"
 msgstr ""
 
-#: src/docs_inc.c:1727
+#: src/docs_inc.c:3993
+msgid "Teletext stream filter."
+msgstr ""
+
+#: src/docs_inc.c:1088
 msgid "Teletext subtitles supported."
 msgstr ""
 
-#: src/docs_inc.c:4278
+#: src/docs_inc.c:4862
 msgid ""
 "Tell the system that you’re not expecting to re-use the data soon, so don’t "
 "keep it in cache. The data will still be buffered for writing. Useful e.g. "
@@ -5057,7 +6058,7 @@ msgid ""
 "while recording, so data can be discarded now and read back from disc later)."
 msgstr ""
 
-#: src/docs_inc.c:4282
+#: src/docs_inc.c:4866
 msgid ""
 "Tell the system to write the data immediately. This doesn’t affect whether "
 "or not it’s cached. Useful e.g. if you’ve a particular problem with data "
@@ -5065,64 +6066,63 @@ msgid ""
 "problems)."
 msgstr ""
 
-#: src/docs_inc.c:5042
+#: src/docs_inc.c:5514
+msgid "Tennis"
+msgstr ""
+
+#: src/docs_inc.c:5506
 msgid "Tennis - Wimbledon"
 msgstr ""
 
-#: src/docs_inc.c:5034
+#: src/docs_inc.c:5502
 msgid "Tennis - Wimbledon-1.mkv"
 msgstr ""
 
-#: src/docs_inc.c:521
-msgid "Terrestrial (DVB-T/ATSC-T/ISDB-T)"
+#: src/docs_inc.c:1094
+msgid "Terrestrial/Over-the-Air signals via DVB-T, DVB-T2 and ATSC."
 msgstr ""
 
-#: src/docs_inc.c:2695
-msgid ""
-"Terrestrial, over-the-air broadcasts received through a traditional "
-"television aerial"
-msgstr ""
-
-#: src/docs_inc.c:195
-msgid ""
-"Terrestrial, so over-the-air broadcasts received through a traditional "
-"television aerial (DVB-T and DVB-T2 in much of the world, ATSC in north and "
-"central America)"
-msgstr ""
-
-#: src/docs_inc.c:1733
-msgid "Terrestrial/Over-the-Air signals via DVB-T, DVB-T2 and ATSC"
-msgstr ""
-
-#: src/docs_inc.c:1557
+#: src/docs_inc.c:2019
 msgid "Testing"
 msgstr ""
 
-#: src/docs_inc.c:1039
+#: src/docs_inc.c:15
 msgid "Testing options"
 msgstr ""
 
-#: src/docs_inc.c:5315 src/docs_inc.c:5393
+#: src/docs_inc.c:6190 src/docs_inc.c:6214
 msgid "Thank you for using Tvheadend (and don't forget to"
 msgstr ""
 
-#: src/docs_inc.c:361
+#: src/docs_inc.c:878
 msgid ""
 "That's it - you're done. You should now have a working basic Tvheadend "
 "installation with channels mapped and ready for use!"
 msgstr ""
 
-#: src/docs_inc.c:109 src/docs_inc.c:2056 src/docs_inc.c:2074
+#: src/docs_inc.c:1877
 msgid "The"
 msgstr ""
 
-#: src/docs_inc.c:569
+#: src/docs_inc.c:290
 msgid ""
 "The EPG tab displays a filterable grid containing all events, sorted based "
 "on start time."
 msgstr ""
 
-#: src/docs_inc.c:405
+#: src/docs_inc.c:4432
+msgid ""
+"The HTSP profile, generally used with HTSP clients such as Kodi and Movian."
+msgstr ""
+
+#: src/docs_inc.c:3953
+msgid ""
+"The OTA broadcast data often does not have specific dedicated fields to "
+"describe the programme season, episode, etc. Sometimes this information is "
+"included in the programme summary."
+msgstr ""
+
+#: src/docs_inc.c:1220
 msgid ""
 "The Tvheadend software then sets up a series of configuration elements, and "
 "the way in which these interact determines how a TV signal ends up in front "
@@ -5132,30 +6132,54 @@ msgid ""
 "on multiple tuners."
 msgstr ""
 
-#: src/docs_inc.c:1649
+#: src/docs_inc.c:57
 msgid "The User Guide in"
 msgstr ""
 
-#: src/docs_inc.c:4590
+#: src/docs_inc.c:1626
+msgid ""
+"The _Auto refresh_ check-box allows the interface to automatically refresh "
+"the rows for you, every 30 seconds."
+msgstr ""
+
+#: src/docs_inc.c:2783
+msgid ""
+"The _Auto-recording (Autorecs)_ tab offers many powerful features, regular "
+"expressions for title, synopsis and description event matching, duplicate "
+"episode handling, time-frame based rules and much more!"
+msgstr ""
+
+#: src/docs_inc.c:4878
+msgid ""
+"The _Change parameters_ flag allows you to control which parameters "
+"(permission flags, all types of profiles, channel tags and ranges) are "
+"combined when multiple entries match a username/login. When the change "
+"parameter flag is enabled (checked) for a parameter that isn't set, the next "
+"matching entry (if any) in the sequence can set it."
+msgstr ""
+
+#: src/docs_inc.c:5064
 msgid ""
 "The _Channel icon path_ (above) must be set to generate the filenames. Also "
 "note that changing the scheme will not update existing icons, you must use "
 "the _[Reset Icons]_ button in the"
 msgstr ""
 
-#: src/docs_inc.c:3370
+#: src/docs_inc.c:1622
 msgid ""
-"The _Details_ column gives a quick overview as to the status of each entry:"
+"The _Per page_ drop-down allows you to control how many rows are displayed "
+"within the grid. By default, this is set to 50, increasing the number of "
+"rows displayed may affect performance."
 msgstr ""
 
-#: src/docs_inc.c:4501
+#: src/docs_inc.c:5100
 msgid ""
 "The _Picon path_ (above) must be set to generate the filenames. Also note "
 "that changing the scheme will not update existing icons, you must use the "
 "_[Reset Icons]_ button in the"
 msgstr ""
 
-#: src/docs_inc.c:2243
+#: src/docs_inc.c:4640
 msgid ""
 "The _SAT>IP source number_ is matched through the “src” parameter requested "
 "by the SAT>IP client. Usually (and by default) this value is 1. For "
@@ -5164,13 +6188,19 @@ msgid ""
 "DiseqC BB."
 msgstr ""
 
-#: src/docs_inc.c:1619
+#: src/docs_inc.c:1550
+msgid ""
+"The _View level_ drop-down/button - next to the Help button - displays/hides "
+"the more advanced features. By default it is set to Basic. Note, depending on"
+msgstr ""
+
+#: src/docs_inc.c:993
 msgid ""
 "The __driver__ is the piece of software that, as far as the operating system "
 "is concerned, controls the tuner hardware."
 msgstr ""
 
-#: src/docs_inc.c:407
+#: src/docs_inc.c:1222
 msgid ""
 "The __network__ is the software definition of your carrier network. Broadly, "
 "it lays out what sort of network it is (such as DVB-T or DVB-S2), how it "
@@ -5178,94 +6208,120 @@ msgid ""
 "are used by tuners so the hardware knows where to look for a signal."
 msgstr ""
 
-#: src/docs_inc.c:4724
+#: src/docs_inc.c:5594
+msgid ""
+"The `$Q` and `$q` formats also have two numeric modifiers to select variant "
+"formats and can be used as `$1Q`, `$2Q`, `3Q`, `$1q`, `$2q`, and `$3q`."
+msgstr ""
+
+#: src/docs_inc.c:5586
+msgid ""
+"The `$Q` format is similar to `$q` but does not use genre sub-directories. "
+"Sub-directories are still created for tvshow episodes. Examples are below "
+"based on different information in the EPG:"
+msgstr ""
+
+#: src/docs_inc.c:5574
+msgid ""
+"The `$q` format will create sub-directories `tvmovies` and `tvshows` based "
+"on the genre in the guide data. For tvshows a second-level directory based "
+"on the title of the show is created."
+msgstr ""
+
+#: src/docs_inc.c:5024
 msgid ""
 "The above table displays the _Change parameters_ option name and the fields "
 "that it applies to, as shown in add/edit dialog(s)."
 msgstr ""
 
-#: src/docs_inc.c:455
-msgid "The adapters and tuners are listed and edited in a tree."
+#: src/docs_inc.c:130
+msgid ""
+"The adapter tree lists the available frontends, LNB configuration and so on "
+"related to your device(s) in sections. Clicking on these sections will "
+"display available parameters and device information. Bold sections and a "
+"green dot indicate that it's enabled. A red dot indicates that it's "
+"disabled. Please see the"
 msgstr ""
 
-#: src/docs_inc.c:5001
+#: src/docs_inc.c:5226
 msgid "The associated file(s) cannot be found on disk."
 msgstr ""
 
-#: src/docs_inc.c:1487
+#: src/docs_inc.c:2425
 msgid ""
 "The build arguments/options used during compilation can be seen by clicking "
 "the _Toggle details_ link (only visible to users with admin rights)."
 msgstr ""
 
-#: src/docs_inc.c:4454
-msgid "The channel name (URL encoded ASCII)"
-msgstr ""
-
-#: src/docs_inc.c:2414
+#: src/docs_inc.c:3171
 msgid "The client is connected."
 msgstr ""
 
-#: src/docs_inc.c:2422
+#: src/docs_inc.c:3179
 msgid "The client is disabled."
 msgstr ""
 
-#: src/docs_inc.c:203
+#: src/docs_inc.c:1072
 msgid "The code is hosted at"
 msgstr ""
 
-#: src/docs_inc.c:273
+#: src/docs_inc.c:1644
+msgid ""
+"The cog (or gear) `⚙` icon allows you to enable/disable a more verbose "
+"output."
+msgstr ""
+
+#: src/docs_inc.c:5744 src/docs_inc.c:5824 src/docs_inc.c:5916
+msgid ""
+"The command is executed as-is, without a shell. To redirect command output "
+"or chain commands, wrap the command in a shell, e.g."
+msgstr ""
+
+#: src/docs_inc.c:796
 msgid ""
 "The creation process allows you to select from a series of pre-defined mux "
 "lists for common DVB sources. These are available"
 msgstr ""
 
-#: src/docs_inc.c:4332
+#: src/docs_inc.c:5268
 msgid "The date in ISO-format (e.g. 2015-02-28)."
 msgstr ""
 
-#: src/docs_inc.c:4340
+#: src/docs_inc.c:5276
 msgid "The date, formatted according to your locale settings."
 msgstr ""
 
-#: src/docs_inc.c:4247
+#: src/docs_inc.c:6050
 msgid "The default profile and priorities can be changed in the"
 msgstr ""
 
-#: src/docs_inc.c:477
-msgid ""
-"The device tree lists the available frontends, LNB configuration and so on "
-"related to your device(s) in sections. Clicking on these sections will "
-"display available parameters and device information."
-msgstr ""
-
-#: src/docs_inc.c:1647
+#: src/docs_inc.c:55
 msgid ""
 "The documentation is written in markdown, and then converted for direct "
-"inclusion to tvheadend binary. The markdown processor in tvheadend binary "
+"inclusion to tvheadend binary. The markdown processor in Tvheadend binary "
 "adds other information from the internal class system."
 msgstr ""
 
-#: src/docs_inc.c:1783
+#: src/docs_inc.c:1144
 msgid "The entire application is loaded into the browser."
 msgstr ""
 
-#: src/docs_inc.c:1261
+#: src/docs_inc.c:32
 msgid "The entire project is currently licensed using"
 msgstr ""
 
-#: src/docs_inc.c:4342
+#: src/docs_inc.c:5278
 msgid "The escape-codes use the"
 msgstr ""
 
-#: src/docs_inc.c:3238
+#: src/docs_inc.c:3083
 msgid ""
 "The fastscan bouquets are pre-defined in the configuration tree. These "
 "bouquets must be manually enabled to let Tvheadend to subscribe and listen "
 "to the specific MPEG-TS PIDs."
 msgstr ""
 
-#: src/docs_inc.c:591
+#: src/docs_inc.c:324
 msgid ""
 "The filter uses case-insensitive regular expressions. If you don’t know what "
 "a regular expression is, this simply means that you can type just parts of "
@@ -5274,87 +6330,108 @@ msgid ""
 "subtitle, summary and description."
 msgstr ""
 
-#: src/docs_inc.c:651
-msgid "The following buttons are also available:"
-msgstr ""
-
-#: src/docs_inc.c:2174 src/docs_inc.c:2294 src/docs_inc.c:2873
-#: src/docs_inc.c:3113 src/docs_inc.c:3138 src/docs_inc.c:3211
-#: src/docs_inc.c:4169
-msgid "The following buttons are available:"
-msgstr ""
-
-#: src/docs_inc.c:2392
+#: src/docs_inc.c:676
 msgid ""
-"The following configuration parameters are used, depending on the type of CA "
-"access:"
+"The first part of the wizard is where you select the basic language "
+"settings, if you don't enter a preferred language, US English will be used "
+"as a default. Not selecting the correct EPG language can result in garbled "
+"EPG text; if this happens, don't panic, as you can easily change it later."
 msgstr ""
 
-#: src/docs_inc.c:421
+#: src/docs_inc.c:6242
+msgid ""
+"The first part of this covers the network details for address-based access "
+"to the system; for example, 192.168.1.0/24 to allow local access only to "
+"192.168.1.x clients, or 0.0.0.0/0 or empty value for access from any system."
+msgstr ""
+
+#: src/docs_inc.c:688
+msgid ""
+"The first part of this covers the network details for address-based access "
+"to the system; for example, 192.168.1.0/24 to allow local access only to "
+"192.168.1.x clients, or 0.0.0.0/0 or empty value for access from any system. "
+"This works alongside the second part, which is a familiar username/password "
+"combination, so provide these for both an administrator and regular (day-to-"
+"day) user."
+msgstr ""
+
+#: src/docs_inc.c:1236
 msgid ""
 "The following diagram explains the relationship between these components:"
 msgstr ""
 
-#: src/docs_inc.c:3308
-msgid "The following functions are available (tab dependant):"
-msgstr ""
-
-#: src/docs_inc.c:117 src/docs_inc.c:463 src/docs_inc.c:577 src/docs_inc.c:1059
-#: src/docs_inc.c:1507 src/docs_inc.c:1683 src/docs_inc.c:1926
-#: src/docs_inc.c:2141 src/docs_inc.c:2201 src/docs_inc.c:2319
-#: src/docs_inc.c:2348 src/docs_inc.c:2457 src/docs_inc.c:2498
-#: src/docs_inc.c:2539 src/docs_inc.c:2606 src/docs_inc.c:2984
-#: src/docs_inc.c:3560 src/docs_inc.c:3715 src/docs_inc.c:4112
+#: src/docs_inc.c:2524
 msgid "The following functions are available:"
 msgstr ""
 
-#: src/docs_inc.c:1211
+#: src/docs_inc.c:209
+msgid "The following items are display only - they are not part of the entry."
+msgstr ""
+
+#: src/docs_inc.c:2113
 msgid ""
 "The following major content items/chapters are then missing - based on most "
 "FAQs on the forum:"
 msgstr ""
 
-#: src/docs_inc.c:3729
+#: src/docs_inc.c:3381
 msgid ""
-"The following options can be passed to tvheadend to provide detailed "
+"The following options can be passed to Tvheadend to provide detailed "
 "debugging information while the application is running."
 msgstr ""
 
-#: src/docs_inc.c:4434
+#: src/docs_inc.c:5032
 msgid "The following placeholders are available:"
 msgstr ""
 
-#: src/docs_inc.c:1990 src/docs_inc.c:2730 src/docs_inc.c:3245
-msgid "The following tab specific buttons are available:"
+#: src/docs_inc.c:4452
+msgid ""
+"The following profiles (and their help docs) require Tvheadend to be built "
+"with transcoding/ffmpeg enabled."
 msgstr ""
 
-#: src/docs_inc.c:3590
-msgid "The following tab specific functions are available:"
+#: src/docs_inc.c:5572
+msgid ""
+"The format strings `$q` and `$Q` generate filenames that are suitable for "
+"many external scrapers. They rely on correct schedule data that correctly "
+"identifies episodes and genres. If your guide data incorrectly identifies "
+"movies as shows then the filenames will be incorrect and show could be "
+"identifies as movies or vice-versa. Any xmltv guide data should contain the "
+"category \"movie\" for movies."
 msgstr ""
 
-#: src/docs_inc.c:5072
+#: src/docs_inc.c:5568
 #, c-format
 msgid ""
-"The format strings `$t`,`$s`,`%e`,`$c` also have delimiter variants such as `"
-"$ t` (space after the dollar character), `$-t`, `$_t`, `$.t`, `$,t`, `$;t`. "
+"The format strings `$t`,`$s`,`%e`,`$c` also have delimiter variants such as "
+"`$ t` (space after the dollar character), `$-t`, `$_t`, `$.t`, `$,t`, `$;t`. "
 "In these cases, the delimiter is applied only when the substituted string is "
 "not empty."
 msgstr ""
 
-#: src/docs_inc.c:2406
+#: src/docs_inc.c:3163
 msgid ""
-"The icon next to each entry within the grid indicates the client's "
-"connection status."
+"The icon next to each entry within the grid indicates the clients connection "
+"status."
 msgstr ""
 
-#: src/docs_inc.c:1123
+#: src/docs_inc.c:1602
+msgid ""
+"The interface also makes use of split panels, examples being the _TV "
+"Adapters_ and _EPG Grabber Modules_ tabs. On the left, you'll see a list of "
+"items (or a tree as shown in the screenshot below), clicking on any of the "
+"items will display a parameter panel (on the right)."
+msgstr ""
+
+#: src/docs_inc.c:1250
 msgid ""
 "The interface is made up of nested tabs, so similar functions are grouped "
 "together (e.g. all configuration items at the top level, then all "
-"configuration items for a particular topic are below that)."
+"configuration items for a particular topic are below that). Be aware that "
+"not all tabs are shown by default, some are hidden depending on the current"
 msgstr ""
 
-#: src/docs_inc.c:3277
+#: src/docs_inc.c:3097
 msgid ""
 "The last mapped service's values will override the channel values set by the "
 "bouquet, e,g, if service \"MyTV\" with channel number 155 gets mapped to the "
@@ -5362,41 +6439,139 @@ msgid ""
 "channel number 155."
 msgstr ""
 
-#: src/docs_inc.c:1103
+#: src/docs_inc.c:1950
 msgid "The level of a desired signal to the level of background noise"
 msgstr ""
 
-#: src/docs_inc.c:675 src/docs_inc.c:1071 src/docs_inc.c:1519
-#: src/docs_inc.c:1695
+#: src/docs_inc.c:1630
+msgid ""
+"The log contains information relating to the status of Tvheadend such as "
+"who's accessing it, what client they're using, and so on. it's mainly used "
+"for debugging (please see the debugging section for more), it can be used as "
+"a quick \"is-it-working\" overview too."
+msgstr ""
+
+#: src/docs_inc.c:1638
+msgid ""
+"The log will remain open for a few moments at a time, if you want to keep it "
+"open (or to close it), press the chevron `▲` (up) or `▼` (down) arrows."
+msgstr ""
+
+#: src/docs_inc.c:384
 msgid "The main grid items have the following functions:"
 msgstr ""
 
-#: src/docs_inc.c:3542
+#: src/docs_inc.c:4656
 msgid ""
 "The map services to channels dialog allows you to control which services are "
 "mapped. The options selected here get passed to the"
 msgstr ""
 
-#: src/docs_inc.c:71
+#: src/docs_inc.c:1787
 msgid "The markup code:"
 msgstr ""
 
-#: src/docs_inc.c:241
+#: src/docs_inc.c:2644
+msgid "The master ATSC-C frontend (most ATSC-C tuners use this type)."
+msgstr ""
+
+#: src/docs_inc.c:2632
+msgid "The master ATSC-T frontend (most ATSC-T tuners use this type)."
+msgstr ""
+
+#: src/docs_inc.c:2640
+msgid "The master DVB-C/C2 frontend (most DVB-C tuners use this type)."
+msgstr ""
+
+#: src/docs_inc.c:2616
+msgid "The master DVB-S/S2 frontend (most DVB-S tuners use this type)."
+msgstr ""
+
+#: src/docs_inc.c:2628
+msgid "The master DVB-T/T2 frontend (most DVB-T tuners use this type)."
+msgstr ""
+
+#: src/docs_inc.c:2648
+msgid "The master ISDB-C frontend (most ISDB-C tuners use this type)."
+msgstr ""
+
+#: src/docs_inc.c:2620
+msgid "The master ISDB-S/S2 frontend."
+msgstr ""
+
+#: src/docs_inc.c:2636
+msgid "The master ISDB-T frontend (most ISDB-T tuners use this type)."
+msgstr ""
+
+#: src/docs_inc.c:2652
+msgid ""
+"The master SAT>IP DVB-S/S2 frontend (most SAT>IP DVB-S tuners use this type)."
+msgstr ""
+
+#: src/docs_inc.c:5596
+msgid ""
+"The number 1 variant forces the recording to be formatted as a movie, "
+"ignoring the genre from the schedule."
+msgstr ""
+
+#: src/docs_inc.c:5602
+msgid ""
+"The number 3 variants (`$3Q` and `$3q`) is an alternative directory layout "
+"that can be used if your guide data has accurate programme information. It "
+"will put movies in separate directories for each movie and tvshows in "
+"separate per-season directories."
+msgstr ""
+
+#: src/docs_inc.c:631
 msgid ""
 "The other major cause of this issue is when you're running Tvheadend as a "
 "user who doesn't have sufficient access to the tuners, such as not being a "
 "member of the _video_ group."
 msgstr ""
 
-#: src/docs_inc.c:4997
+#: src/docs_inc.c:2589
+msgid ""
+"The out-of-the-box default settings should suit most set-ups, you should "
+"rarely need to change the them."
+msgstr ""
+
+#: src/docs_inc.c:1612
+msgid ""
+"The paging toolbar - at the bottom of most grids - offers many useful tools."
+msgstr ""
+
+#: src/docs_inc.c:3055
+msgid ""
+"The permission flags, streaming profiles, DVR config profiles, channel tags, "
+"and channel number ranges are combined (for all matching access entries). "
+"You can control which parameters are merged, see _Change parameters_"
+msgstr ""
+
+#: src/docs_inc.c:231
+msgid "The program failed to record."
+msgstr ""
+
+#: src/docs_inc.c:219
+msgid "The program is scheduled (upcoming)."
+msgstr ""
+
+#: src/docs_inc.c:235
+msgid "The program recorded successfully."
+msgstr ""
+
+#: src/docs_inc.c:5222
 msgid "The recording was interrupted by the user."
 msgstr ""
 
-#: src/docs_inc.c:1291
+#: src/docs_inc.c:1624
+msgid "The refresh icon allows you to refresh the currently-displayed rows."
+msgstr ""
+
+#: src/docs_inc.c:2160
 msgid "The remain part can be any URL starting with /stream ."
 msgstr ""
 
-#: src/docs_inc.c:1133
+#: src/docs_inc.c:1586
 msgid ""
 "The same drop-down menu gives you access to a __sort__ function if defined "
 "(it doesn't always make sense to have a sortable column for some "
@@ -5404,104 +6579,130 @@ msgid ""
 "header; reverse the sort order by clicking again."
 msgstr ""
 
-#: src/docs_inc.c:4540
+#: src/docs_inc.c:4536
+msgid ""
+"The same rating label can be used for both DVB OTA and XMLTV EPG sources. "
+"Because DVB OTA is matched on Country+Age and XMLTV is matched on "
+"Authority+Label, a rating label that contains all 4 of these values will be "
+"selected and the 'display age' and 'display label' will be used for both EPG "
+"sources."
+msgstr ""
+
+#: src/docs_inc.c:3955
+msgid ""
+"The scraper configuration files contains regular expressions to scrape "
+"additional information from the broadcast information. For example the "
+"broadcast summary may include the text '(S10 E5)' and the configuration file "
+"will extract this."
+msgstr ""
+
+#: src/docs_inc.c:6034
 msgid "The service is no longer available on this mux."
 msgstr ""
 
-#: src/docs_inc.c:5368
+#: src/docs_inc.c:734
 msgid ""
 "The status tab (behind this wizard) will display signal information. If you "
 "notice a lot of errors or the signal strength appears low then this usually "
-"indicates a physical issue with your antenna, satellite dish or cable.."
+"indicates a physical issue with your antenna, satellite dish, cable or "
+"network.."
 msgstr ""
 
-#: src/docs_inc.c:1551
+#: src/docs_inc.c:2013
 msgid "The subscription is active - the stream is being sent."
 msgstr ""
 
-#: src/docs_inc.c:1555
+#: src/docs_inc.c:2017
 msgid "The subscription is idling, waiting for the subscriber."
 msgstr ""
 
-#: src/docs_inc.c:5068
+#: src/docs_inc.c:5564
 msgid "The time in 24-hour notation"
 msgstr ""
 
-#: src/docs_inc.c:4336
+#: src/docs_inc.c:5272
 msgid "The time in 24h HH:MM format (e.g. 19:45)."
 msgstr ""
 
-#: src/docs_inc.c:4442
+#: src/docs_inc.c:2781
 msgid ""
-"The transliterated channel name in ASCII (safe characters, no spaces, etc. - "
-"so"
+"The time-based \"Timers\" tab allows you to schedule multiple recordings "
+"based on time and/or day."
 msgstr ""
 
-#: src/docs_inc.c:4796
+#: src/docs_inc.c:5046
+msgid "The transliterated channel name in URL encoded ASCII"
+msgstr ""
+
+#: src/docs_inc.c:5040
+msgid ""
+"The transliterated channel name in URL encoded ASCII with safe characters "
+"only -"
+msgstr ""
+
+#: src/docs_inc.c:5924
 msgid ""
 "The tuner (or network if using IPTV) with the highest priority value will be "
 "used out of preference. If the tuner is busy the next available with the "
 "highest priority value will be used."
 msgstr ""
 
-#: src/docs_inc.c:5015
+#: src/docs_inc.c:5240
 msgid "The underlying service for the channel is no longer available."
 msgstr ""
 
-#: src/docs_inc.c:4712 src/docs_inc.c:4714
+#: src/docs_inc.c:666
+msgid ""
+"The wizard helps you get up and running fast, if you don't see the wizard on "
+"the initial run, or would like to use it, you can do so by pressing the "
+"__Start wizard__ button in __Configuration -> General -> Base__ ."
+msgstr ""
+
+#: src/docs_inc.c:6232
+msgid ""
+"The wizard will restart and reload the interface in your chosen language, "
+"unfortunately not all translations are available/complete."
+msgstr ""
+
+#: src/docs_inc.c:5012 src/docs_inc.c:5014
 msgid "Theme"
 msgstr ""
 
-#: src/docs_inc.c:3500
-msgid "Then enter the mux information:"
-msgstr ""
-
-#: src/docs_inc.c:2748
-msgid ""
-"Then using the resultant dialog enter/select the desired network options."
-msgstr ""
-
-#: src/docs_inc.c:2042
-msgid ""
-"There are a number of methods to mapping available services, mapping uses "
-"the following dialog."
-msgstr ""
-
-#: src/docs_inc.c:387
+#: src/docs_inc.c:1202
 msgid ""
 "There are some basic concepts that will make life much easier if you "
 "understand them from the outset."
 msgstr ""
 
-#: src/docs_inc.c:1119
+#: src/docs_inc.c:1246
 msgid ""
 "There are some basic navigation concepts that will help you get around and "
 "make the best of it."
 msgstr ""
 
-#: src/docs_inc.c:1871
-msgid "There are two methods for editing an entry."
-msgstr ""
-
-#: src/docs_inc.c:2760
-msgid ""
-"There is a 5-10 minute delay before a scan starts, this is so you can make "
-"changes if needed (this does not apply to IPTV networks)."
-msgstr ""
-
-#: src/docs_inc.c:1579
+#: src/docs_inc.c:953
 msgid "There is a discussion about supported hardware on"
 msgstr ""
 
-#: src/docs_inc.c:2418
+#: src/docs_inc.c:3175
 msgid "There was an error."
 msgstr ""
 
-#: src/docs_inc.c:1197
+#: src/docs_inc.c:2099
 msgid "These are not part of the final product, obviously!"
 msgstr ""
 
-#: src/docs_inc.c:33
+#: src/docs_inc.c:4428
+msgid "These profiles are always available."
+msgstr ""
+
+#: src/docs_inc.c:5600
+msgid ""
+"These variants can be useful to work-around bad schedule data that gives "
+"incorrect genres for programmes."
+msgstr ""
+
+#: src/docs_inc.c:1749
 msgid ""
 "They may render the same here, but note the extra leading spaces in the "
 "second example: this means that they will convert differently for use in the "
@@ -5509,36 +6710,36 @@ msgid ""
 "place unless you handle the dl/dt/dd formatting in Tvheadend's CSS."
 msgstr ""
 
-#: src/docs_inc.c:1199
+#: src/docs_inc.c:2101
 msgid ""
 "They're just some of the areas I'm aware of that we need to close off before "
 "release"
 msgstr ""
 
-#: src/docs_inc.c:1193
+#: src/docs_inc.c:2095
 msgid "Things To Do on This Guide..."
 msgstr ""
 
-#: src/docs_inc.c:1383
+#: src/docs_inc.c:2302
 msgid ""
 "This URL scheme is used for streaming. The stream contents depends on the "
 "streaming profile. It might be MPEG-TS, Matroska or MP4."
 msgstr ""
 
-#: src/docs_inc.c:615
+#: src/docs_inc.c:348
 msgid ""
 "This allows you to filter for or against, say, a daily broadcast and a "
 "weekly omnibus edition of a program, or only look for short news bulletins "
 "and not the 24-hour rolling broadcasts."
 msgstr ""
 
-#: src/docs_inc.c:2229
+#: src/docs_inc.c:4626
 msgid ""
 "This can be anything you like, it is recommended that you use 9983 (to avoid "
 "permission issues). Entering zero (0) in this field will disable the server."
 msgstr ""
 
-#: src/docs_inc.c:289
+#: src/docs_inc.c:812
 msgid ""
 "This can be as simple or as complex as necessary. You may simply have, for "
 "example, a single DVB-S2 network defined and then associate this with all "
@@ -5549,7 +6750,7 @@ msgid ""
 "tuner."
 msgstr ""
 
-#: src/docs_inc.c:4617
+#: src/docs_inc.c:5090
 msgid ""
 "This can be named however you wish, as either a local (file://) or remote "
 "(http://) location - however, remember that it’s pointing to a directory as "
@@ -5557,44 +6758,30 @@ msgid ""
 "frequency, orbital position (required), etc."
 msgstr ""
 
-#: src/docs_inc.c:151
+#: src/docs_inc.c:4754
 msgid ""
-"This document is intended to give you a high-level overview of how to set up "
-"Tvheadend for the first time. It does not aim to provide a complete "
-"description of every step or answer every question: more details are "
-"available on the tvheadend"
+"This code may be used instead of/along side the password to access playlists/"
+"streams."
 msgstr ""
 
-#: src/docs_inc.c:1253
+#: src/docs_inc.c:24
 msgid "This documentation forms part of the Tvheadend project."
 msgstr ""
 
-#: src/docs_inc.c:1645
-msgid "This information was last updated on 11 May 2016."
+#: src/docs_inc.c:1696
+msgid ""
+"This guide is intended to give you a high-level overview of how to set up "
+"and use Tvheadend. It does not aim to provide a complete description of "
+"every step or answer every question: more details are available on the "
+"Tvheadend"
 msgstr ""
 
-#: src/docs_inc.c:103 src/docs_inc.c:1051 src/docs_inc.c:1499
-#: src/docs_inc.c:1675
+#: src/docs_inc.c:1822 src/docs_inc.c:1871 src/docs_inc.c:1906
+#: src/docs_inc.c:1969
 msgid "This is a read-only tab; nothing is configurable."
 msgstr ""
 
-#: src/docs_inc.c:2931
-msgid "This is an example of a limited user entry."
-msgstr ""
-
-#: src/docs_inc.c:3402
-msgid "This is an example of a one-time recording entry."
-msgstr ""
-
-#: src/docs_inc.c:2844
-msgid "This is an example of a one-time timer-based recording entry."
-msgstr ""
-
-#: src/docs_inc.c:2269
-msgid "This is an example of a password entry."
-msgstr ""
-
-#: src/docs_inc.c:5273
+#: src/docs_inc.c:5250
 msgid ""
 "This is extremely useful for those programs you think/know will overrun. Any "
 "value selected here will keep a tuner busy for longer, so be sure to check "
@@ -5602,7 +6789,7 @@ msgid ""
 "overlap. Setting the padding per channel will override the padding set in the"
 msgstr ""
 
-#: src/docs_inc.c:239
+#: src/docs_inc.c:629
 msgid ""
 "This is normally because they're not installed properly. Check syslog/dmesg "
 "(e.g. `dmesg | grep dvb`) and see that you have startup messages that "
@@ -5611,13 +6798,13 @@ msgid ""
 "communicate with the tuner) have been created correctly."
 msgstr ""
 
-#: src/docs_inc.c:1587
+#: src/docs_inc.c:961
 msgid ""
 "This is obviously a core requirement that's outside of the scope of this "
 "guide."
 msgstr ""
 
-#: src/docs_inc.c:1607
+#: src/docs_inc.c:981
 msgid ""
 "This is particularly true of systems such as the Raspberry Pi which share "
 "USB bandwidth with the Ethernet port. Don't be surprised if this kind of "
@@ -5625,13 +6812,13 @@ msgid ""
 "especially on high-bandwidth (e.g. HD) streams."
 msgstr ""
 
-#: src/docs_inc.c:2788
+#: src/docs_inc.c:4087
 msgid ""
 "This is the list of available parameters for the linuxdvb frontend. It is "
 "used as a base for other frontends."
 msgstr ""
 
-#: src/docs_inc.c:331
+#: src/docs_inc.c:854
 msgid ""
 "This is where the services will appear as your tuners tune to the muxes "
 "based on the network you told them to look on. Again, remember what's "
@@ -5642,60 +6829,71 @@ msgid ""
 "subtitle stream(s) and language(s), and so on."
 msgstr ""
 
-#: src/docs_inc.c:1485
+#: src/docs_inc.c:3247
+msgid ""
+"This mode uses named pipe (/tmp/camd.socket). If selected, connection will "
+"be made directly to OSCam without using the LD"
+msgstr ""
+
+#: src/docs_inc.c:3235
+msgid "This mode uses named pipe (/tmp/camd.socket). The difference between"
+msgstr ""
+
+#: src/docs_inc.c:3257
+msgid "This mode uses named pipe (/tmp/camd.socket). With the LD"
+msgstr ""
+
+#: src/docs_inc.c:2423
 msgid ""
 "This page displays general information about the current Tvheadend version."
 msgstr ""
 
-#: src/docs_inc.c:4165
+#: src/docs_inc.c:4568
 msgid ""
 "This panel displays all available SAT>IP DVB-T/DVB-S/DVB-C/ATSC-T/ATSC-C "
 "frontend parameters."
 msgstr ""
 
-#: src/docs_inc.c:3105
+#: src/docs_inc.c:4548
 msgid "This panel displays all available SAT>IP client parameters."
 msgstr ""
 
-#: src/docs_inc.c:2865
+#: src/docs_inc.c:4103
 msgid ""
 "This panel lists all the available Cable (DVB-C/C2/ISDB-C/ATSC-C) frontend "
 "parameters."
 msgstr ""
 
-#: src/docs_inc.c:2166
+#: src/docs_inc.c:4143
 msgid ""
 "This panel lists all the available Terrestrial (DVB-T/T2/ISDB-T/ATSC-T) "
 "frontend parameters."
 msgstr ""
 
-#: src/docs_inc.c:2290 src/docs_inc.c:3207
+#: src/docs_inc.c:4163 src/docs_inc.c:4588
 msgid ""
 "This panel lists all the available satellite (DVB-S/ISDB-S) configuration "
 "parameters."
 msgstr ""
 
-#: src/docs_inc.c:3130
+#: src/docs_inc.c:4123
 msgid ""
 "This panel lists all the available satellite (DVB-S/ISDB-S) frontend "
 "parameters."
 msgstr ""
 
-#: src/docs_inc.c:251
+#: src/docs_inc.c:3957
 msgid ""
-"This section gives a high-level overview of the steps needed to get "
-"Tvheadend up and running. For more detailed information, please consult the "
-"rest of this guide - much of it is arranged in the same order as the tabs on "
-"the Tvheadend interface so you know where to look."
+"This scraping option does not access or retrieve details from the Internet."
 msgstr ""
 
-#: src/docs_inc.c:435
+#: src/docs_inc.c:1013
 msgid ""
 "This section tells you how to get hold of the software in the first place, "
 "and how to get it onto your system."
 msgstr ""
 
-#: src/docs_inc.c:1577
+#: src/docs_inc.c:951
 msgid ""
 "This section will give you some basic ideas on how to get your tuner working "
 "with your operating system. However, it's clearly way beyond the scope of "
@@ -5704,47 +6902,32 @@ msgid ""
 "before you hand over any money."
 msgstr ""
 
-#: src/docs_inc.c:4885 src/docs_inc.c:4965
+#: src/docs_inc.c:5382 src/docs_inc.c:6078 src/docs_inc.c:6136
+#: src/docs_inc.c:6164
 msgid "This setting can be overridden on a per-user basis, see"
 msgstr ""
 
-#: src/docs_inc.c:2801
-msgid ""
-"This tab allows to configure blocked IP ranges. Users within these ranges "
-"are not allowed to login (use any Tvheadend service)."
-msgstr ""
-
-#: src/docs_inc.c:3037
+#: src/docs_inc.c:3973
 msgid ""
 "This tab allows you to define rules that filter and order various elementary "
 "streams."
 msgstr ""
 
-#: src/docs_inc.c:3155
-msgid "This tab controls EPG-driven recording rules."
+#: src/docs_inc.c:3311
+msgid ""
+"This tab allows you to manage the codec settings used by stream profiles."
 msgstr ""
 
-#: src/docs_inc.c:2831
-msgid "This tab controls timer-driven recording rules."
-msgstr ""
-
-#: src/docs_inc.c:2449
+#: src/docs_inc.c:3875
 msgid "This tab displays EPG data used by channels."
 msgstr ""
 
-#: src/docs_inc.c:4186
+#: src/docs_inc.c:4179
 msgid ""
 "This tab displays various memory usage information useful for debugging."
 msgstr ""
 
-#: src/docs_inc.c:2256
-msgid ""
-"This tab is the second part of Tvheadend's access control mechanism. It is "
-"where you set and maintain all user passwords (e.g. for streaming or DVR "
-"access)."
-msgstr ""
-
-#: src/docs_inc.c:3459
+#: src/docs_inc.c:3293
 msgid ""
 "This tab is used to configure channel tags. Tags are used to define a set of "
 "channels - to group them, to aid searches, and similar. Tags are not "
@@ -5752,17 +6935,17 @@ msgid ""
 "Kodi and are a requirement for using Tvheadend with Movian."
 msgstr ""
 
-#: src/docs_inc.c:2976
+#: src/docs_inc.c:3811
 msgid ""
 "This tab is used to configure operation of the Digital Video Recorder. It is "
 "not used for scheduling or administration of individual recordings."
 msgstr ""
 
-#: src/docs_inc.c:2527
+#: src/docs_inc.c:3853
 msgid "This tab is used to configure the Electronic Program Guide (EPG)"
 msgstr ""
 
-#: src/docs_inc.c:2490
+#: src/docs_inc.c:3893
 msgid ""
 "This tab is used to configure the Electronic Program Guide (EPG) grabber "
 "modules. Tvheadend supports a variety of different EPG grabbing mechanisms. "
@@ -5770,323 +6953,313 @@ msgid ""
 "specific grabber implementations."
 msgstr ""
 
-#: src/docs_inc.c:2311
+#: src/docs_inc.c:4684
 msgid "This tab is used to configure timeshift properties."
 msgstr ""
 
-#: src/docs_inc.c:3701
-msgid "This tab is used to configure various debugging options in tvheadend."
+#: src/docs_inc.c:3361
+msgid "This tab is used to configure various debugging options in Tvheadend."
 msgstr ""
 
-#: src/docs_inc.c:3292
+#: src/docs_inc.c:2600
+msgid ""
+"This tab is where you configure many of the server features of Tvheadend."
+msgstr ""
+
+#: src/docs_inc.c:114
+msgid ""
+"This tab is where you configure/manage your adapters/input, networks, muxes "
+"and services."
+msgstr ""
+
+#: src/docs_inc.c:2763
 msgid ""
 "This tab is where you manage your recordings. Each entry is moved between "
 "the _Upcoming / Current Recordings_ , _Finished Recordings_ and _Failed "
-"Recordings_ sub-tabs depending on its status."
+"Recordings_ sub-tabs depending on status."
 msgstr ""
 
-#: src/docs_inc.c:3581
+#: src/docs_inc.c:3273
 msgid "This tab lists all defined channels."
 msgstr ""
 
-#: src/docs_inc.c:1673
+#: src/docs_inc.c:4482
+msgid "This tab lists all defined parental rating labels."
+msgstr ""
+
+#: src/docs_inc.c:1820
 msgid "This tab shows information about all active connections."
 msgstr ""
 
-#: src/docs_inc.c:1497
+#: src/docs_inc.c:1967
 msgid "This tab shows information about all active subscriptions to Tvheadend."
 msgstr ""
 
-#: src/docs_inc.c:1049
+#: src/docs_inc.c:1904
 msgid "This tab shows information about all currently-open streams."
 msgstr ""
 
-#: src/docs_inc.c:101
+#: src/docs_inc.c:1869
 msgid "This tab shows information about current service mapping activity."
 msgstr ""
 
-#: src/docs_inc.c:2133
-msgid ""
-"This tabs allow configuration of several general parameters that affect the "
-"core Tvheadend functionality."
+#: src/docs_inc.c:3909 src/docs_inc.c:3925
+msgid "This type of grabber executes an internal (local)"
 msgstr ""
 
-#: src/docs_inc.c:3174
-msgid ""
-"This uses a regular expression (regex) to match the program title \"BBC News"
-"\" exactly, otherwise event titles containing the phrase would also match, e."
-"g \"BBC News at One\" and \"BBC News at Six\" etc."
+#: src/docs_inc.c:3905
+msgid "This type of grabber pulls EPG data directly from the broadcast signal."
 msgstr ""
 
-#: src/docs_inc.c:233
+#: src/docs_inc.c:3917 src/docs_inc.c:3933
+msgid "This type of grabber reads EPG data from a socket pushed to it using an"
+msgstr ""
+
+#: src/docs_inc.c:623
 msgid ""
 "This usually happens when Tvheadend is installed incorrectly. As a start, "
 "make sure that the web interface path `/usr/share/tvheadend/src/webui/static/"
 "` exists and isn't empty."
 msgstr ""
 
-#: src/docs_inc.c:4104
+#: src/docs_inc.c:6228
 msgid ""
-"This will cache any channel icons or other images (such as EPG metadata) to "
-"be served from the local webserver. This can be useful for multi-client "
-"systems and, generally, to reduce hits on upstream providers."
+"This wizard is optional, and can be cancelled at any time, but recommended "
+"for new users."
 msgstr ""
 
-#: src/docs_inc.c:5347
+#: src/docs_inc.c:6244
 msgid ""
 "This works alongside the second part, which is a familiar username/password "
 "combination, so provide these for both an administrator and regular (day-to-"
 "day) user."
 msgstr ""
 
-#: src/docs_inc.c:3765
+#: src/docs_inc.c:3417
 msgid "Thread"
 msgstr ""
 
-#: src/docs_inc.c:3773
+#: src/docs_inc.c:4808
+msgid "Tidy channel name"
+msgstr ""
+
+#: src/docs_inc.c:3425
 msgid "Time"
 msgstr ""
 
-#: src/docs_inc.c:3921
+#: src/docs_inc.c:3577
 msgid "Time Stamp Fix"
 msgstr ""
 
-#: src/docs_inc.c:5003
+#: src/docs_inc.c:5228
 msgid "Time missed"
 msgstr ""
 
-#: src/docs_inc.c:5007
+#: src/docs_inc.c:5232
 msgid "Time missed can be caused by one (or more) of the following:"
 msgstr ""
 
-#: src/docs_inc.c:891
+#: src/docs_inc.c:3405
+msgid "Time profiling"
+msgstr ""
+
+#: src/docs_inc.c:2748
 msgid "Time-based Recording (Timers)"
 msgstr ""
 
-#: src/docs_inc.c:2835
-msgid "Timer Tab"
-msgstr ""
-
-#: src/docs_inc.c:2848
-msgid "Timer add example"
-msgstr ""
-
-#: src/docs_inc.c:981 src/docs_inc.c:4089
+#: src/docs_inc.c:2900 src/docs_inc.c:3765
 msgid "Timeshift"
 msgstr ""
 
-#: src/docs_inc.c:3494
-msgid ""
-"To add a mux press the _[Add]_ button from the menu bar and select the "
-"network you want to add the mux to:"
+#: src/docs_inc.c:2902
+msgid "Timeshift settings"
 msgstr ""
 
-#: src/docs_inc.c:1147
+#: src/docs_inc.c:1678
 msgid ""
-"To add a new entry, press the _Add_ button. The new (empty) entry will be "
-"created on the server but will not be saved and will not necessarily be "
-"enabled. You can now change all the cells to the desired values, check the "
-"‘enable’ box if applicable and then press _Save_ to activate the new entry."
+"To add an entry, click the _Add_ button - you should see a dialog - you can "
+"now fill in the desired/required fields. The entry can then be saved "
+"(_Create/Save_ button), applied (_Apply_ button), or abandoned (_Cancel_ "
+"button). Note, you may need to make a pre-selection, for example, to pick a "
+"network, a network type, or tuner."
 msgstr ""
 
-#: src/docs_inc.c:1854
-msgid ""
-"To add an entry click the _[Add]_ button from the menu bar, the add dialog "
-"should now be displayed. Once you've filled in the required/desired fields "
-"you can then press _[Save]_ to add the entry, _[Apply]_ to commit and "
-"continue editing or _[Cancel]_ to abort (losing any unsaved changes)."
-msgstr ""
-
-#: src/docs_inc.c:5353
+#: src/docs_inc.c:692
 msgid ""
 "To allow anonymous access for any account (administrative or regular user) "
-"enter an asterisk (*) in the username and password fields. ___It is not_ __ "
-"recommended that you allow anonymous access to the admin account."
+"enter an asterisk `*` in the username and password fields. It is not "
+"recommended that you allow anonymous access to the admin account. If you "
+"plan on accessing Tvheadend over the Internet, make sure you use strong "
+"credentials and do not allow anonymous access at all."
 msgstr ""
 
-#: src/docs_inc.c:1145 src/docs_inc.c:1879
-msgid "To change a check box or radio button, click once."
-msgstr ""
-
-#: src/docs_inc.c:747
+#: src/docs_inc.c:500
 msgid ""
 "To close the popup, just click on the [X] window button. The popup isn’t "
 "modal, so you don’t have to close it before doing something else, and you "
 "can open as many detailed information popups as you want."
 msgstr ""
 
-#: src/docs_inc.c:2742
+#: src/docs_inc.c:4346
 msgid ""
-"To create a network click the _[Add]_ button from the menu bar and then "
-"select the required network type:"
+"To create services without probing, _Service ID_ must be set (usually to 1) "
+"and the _Scan after creation_ check box un-ticked."
 msgstr ""
 
-#: src/docs_inc.c:2426
+#: src/docs_inc.c:1684
 msgid ""
-"To create a new CA configuration press the _[Add]_ button from the menu bar, "
-"you will then be asked to select a client type. Once you've selected a type "
-"you can then enter/select the desired options from the resultant _Add_ "
-"dialog."
-msgstr ""
-
-#: src/docs_inc.c:3014
-msgid ""
-"To create a new profile press the _[Add]_ button from the menu bar, a new "
-"entry \"! New config\" will be added to the grid, click on that entry to "
-"configure it - don't forget to save!"
-msgstr ""
-
-#: src/docs_inc.c:2636
-msgid ""
-"To create a new profile press the _[Add]_ button from the menu bar, you will "
-"then be asked to select a profile type."
-msgstr ""
-
-#: src/docs_inc.c:2959
-msgid ""
-"To create a superuser account you must have access to your Tvheadend "
-"configuration directory (most commonly `$HOME/.hts/tvheadend`) and be able "
-"to create a plain-text file named `superuser` with the following (JSON "
-"formatted) content:"
-msgstr ""
-
-#: src/docs_inc.c:3528
-msgid ""
-"To delete a mux highlight (select) the desired muxes from within the grid, "
-"and press the _[Delete]_ button from the menu bar."
-msgstr ""
-
-#: src/docs_inc.c:1877
-msgid "To edit a cell, double click on it."
-msgstr ""
-
-#: src/docs_inc.c:1143
-msgid ""
-"To edit a cell, double click on it. After a cell is changed, a small red "
+"To edit a single entry, double click on the desired field/cell. It should "
+"now be editable. Once you've made your changes you can then save (_Save_ "
+"button), or abandon (_Undo_ button). After a cell is changed, a small red "
 "flag or triangle will appear in the top-left corner to indicate that it has "
-"been changed. These changes can now be kept (_Save_ button), or abandoned "
-"(_Undo_ button)."
+"been changed. To change a check box or radio button, click once."
 msgstr ""
 
-#: src/docs_inc.c:2432 src/docs_inc.c:3020
+#: src/docs_inc.c:1680
 msgid ""
-"To edit an existing configuration, click on it from within the grid, the "
-"_Parameters_ panel should then appear on the right hand side."
+"To edit/delete etc, select the entry (or entries - see multi-select below) "
+"and press the desired button."
 msgstr ""
 
-#: src/docs_inc.c:2650
-msgid ""
-"To edit an existing profile, click on it from within the grid, the "
-"_Parameters_ panel should then appear on the right hand side."
-msgstr ""
-
-#: src/docs_inc.c:21
+#: src/docs_inc.c:1737
 msgid "To include class documentation you'd use:"
 msgstr ""
 
-#: src/docs_inc.c:23
+#: src/docs_inc.c:1739
 msgid "To include multi-use docs (placed in the `docs/markdown/inc/` folder:"
 msgstr ""
 
-#: src/docs_inc.c:3234
+#: src/docs_inc.c:1632
+msgid "To open the log click the bar at the very bottom of the interface.."
+msgstr ""
+
+#: src/docs_inc.c:6262
+msgid ""
+"To save you from manually entering muxes, Tvheadend includes predefined mux "
+"lists. Please select an option from the list for each network."
+msgstr ""
+
+#: src/docs_inc.c:3079
 msgid ""
 "To use bouquets, ensure to add and scan all available muxes using the "
 "predefined muxes or manual configuration."
 msgstr ""
 
-#: src/docs_inc.c:4425 src/docs_inc.c:4787 src/docs_inc.c:5229
+#: src/docs_inc.c:5742 src/docs_inc.c:5822
 msgid ""
-"To use special characters (e.g. spaces), either put the string in quotes or "
-"escape the individual characters."
+"To use special characters (e.g. spaces), either put the string in double "
+"quotes or escape the individual characters."
 msgstr ""
 
-#: src/docs_inc.c:4029
+#: src/docs_inc.c:5914
+msgid ""
+"To use special characters (e.g. spaces), either put the string in double "
+"quotes or escape the individual characters:"
+msgstr ""
+
+#: src/docs_inc.c:440
+msgid "Toolbar item"
+msgstr ""
+
+#: src/docs_inc.c:3701
 msgid "Transcode"
 msgstr ""
 
-#: src/docs_inc.c:963 src/docs_inc.c:2600
+#: src/docs_inc.c:4466
 msgid "Transcode Profile"
 msgstr ""
 
-#: src/docs_inc.c:1213
+#: src/docs_inc.c:2115
 msgid ""
 "Transcoding (updated for 4.2, so needs to be tagged properly and reversed as "
 "applicable to 4.0)"
 msgstr ""
 
-#: src/docs_inc.c:1755
+#: src/docs_inc.c:1116
 msgid "Transcoding Support"
 msgstr ""
 
-#: src/docs_inc.c:3913
+#: src/docs_inc.c:5472
+msgid ""
+"Translate decimal 192 (0xC0 = Australian-specific 'comedy') to decimal 20 "
+"(0x14 = ETSI standard 'comedy')."
+msgstr ""
+
+#: src/docs_inc.c:5476
+msgid ""
+"Translate decimal 208 (0xD0 = Australian-specific 'drama') to decimal 16 "
+"(0x10 = ETSI standard 'movie/drama (general)')."
+msgstr ""
+
+#: src/docs_inc.c:5480
+msgid ""
+"Translate decimal 224 (0xE0 = Australian-specific 'documentary') to decimal "
+"35 (0x23 = ETSI standard 'documentary')."
+msgstr ""
+
+#: src/docs_inc.c:3569
 msgid "Transport Stream"
 msgstr ""
 
-#: src/docs_inc.c:2553
+#: src/docs_inc.c:5404
+msgid "Treated as new if changed?"
+msgstr ""
+
+#: src/docs_inc.c:1400
 msgid "Trigger OTA EPG Grabber"
 msgstr ""
 
-#: src/docs_inc.c:4800
+#: src/docs_inc.c:5928
 msgid "Tuner"
 msgstr ""
 
-#: src/docs_inc.c:4802
+#: src/docs_inc.c:5930
 msgid "Tuner A"
 msgstr ""
 
-#: src/docs_inc.c:4804
+#: src/docs_inc.c:5932
 msgid "Tuner B"
 msgstr ""
 
-#: src/docs_inc.c:4806
+#: src/docs_inc.c:5934
 msgid "Tuner C"
 msgstr ""
 
-#: src/docs_inc.c:5441
-msgid "Tuners already in use will not appear below."
+#: src/docs_inc.c:710
+msgid "Tuners already in use will not appear."
 msgstr ""
 
-#: src/docs_inc.c:143
-msgid "Tvheadend 4.2 User Guide"
-msgstr ""
-
-#: src/docs_inc.c:147
-msgid "Tvheadend Logo"
-msgstr ""
-
-#: src/docs_inc.c:219
+#: src/docs_inc.c:609
 msgid ""
 "Tvheadend can generate a playlist of all your mapped services (channels). "
 "You can download it from the webui at `http://IP:Port/playlist`, e.g. "
 "`http://192.168.0.2:9981/playlist`."
 msgstr ""
 
-#: src/docs_inc.c:567
+#: src/docs_inc.c:288
 msgid ""
 "Tvheadend has a built-in Electronic Program Guide. The EPG is an in-memory "
 "database populated with all the information about events received from the "
 "DVB networks over-the-air or from external grabbers such as XMLTV."
 msgstr ""
 
-#: src/docs_inc.c:2957
+#: src/docs_inc.c:1702
 msgid ""
-"Tvheadend includes functionality that allows you to regain access to your "
-"Tvheadend instance in case of emergency or if you find yourself locked out, "
-"this is known as a superuser account. On some systems you may been asked to "
-"enter a superuser username and password during installation."
+"Tvheadend includes copies of many of these pages in the application, which "
+"is easier to find when you're wondering what to do next."
 msgstr ""
 
-#: src/docs_inc.c:187
+#: src/docs_inc.c:1062
 msgid "Tvheadend interface"
 msgstr ""
 
-#: src/docs_inc.c:183
+#: src/docs_inc.c:1058
 msgid ""
 "Tvheadend is a lightweight, easily-configured, general-purpose TV/video "
 "streaming server and recorder (PVR/DVR) for GNU/Linux, FreeBSD and Android."
 msgstr ""
 
-#: src/docs_inc.c:1173
+#: src/docs_inc.c:935
 msgid ""
 "Tvheadend is intended to be lightweight, so it will run on a NAS or similar "
 "__low-powered CPU__ . Note that the exception here is transcoding: if you "
@@ -6098,80 +7271,108 @@ msgid ""
 "will any serious file serving."
 msgstr ""
 
-#: src/docs_inc.c:5362
+#: src/docs_inc.c:6282
 msgid ""
 "Tvheadend is now scanning for available services. Please wait until the scan "
 "completes.."
 msgstr ""
 
-#: src/docs_inc.c:1117
+#: src/docs_inc.c:1244
 msgid "Tvheadend is operated primarily through a tabbed web interface."
 msgstr ""
 
-#: src/docs_inc.c:1559
+#: src/docs_inc.c:2021
 msgid ""
 "Tvheadend is testing the requested stream to see if it's available - if a "
 "subscription stays in this state too long it may indicate a signal issue."
 msgstr ""
 
-#: src/docs_inc.c:2340
+#: src/docs_inc.c:1628
+msgid "Tvheadend log"
+msgstr ""
+
+#: src/docs_inc.c:730
+msgid ""
+"Tvheadend should now be scanning for available services. Please wait until "
+"the scan completes."
+msgstr ""
+
+#: src/docs_inc.c:3111
 msgid ""
 "Tvheadend supports connecting to card clients via the cwc (newcamd) and "
 "capmt (linux network dvbapi) protocols for so-called 'softcam' descrambling."
 msgstr ""
 
-#: src/docs_inc.c:2892
+#: src/docs_inc.c:5288
 msgid ""
-"Tvheadend verifies access by scanning through all enabled access control "
-"entries in sequence, from the top of the list to the bottom. The permission "
-"flags, streaming profiles, DVR config profiles, channel tags, and channel "
-"number ranges are combined for all matching access entries. You can control "
-"which parameters are merged (on a per-entry basis), see _Change parameters_"
+"Tvheadend supports multiple different fanart grabbers/providers, and can be "
+"extended with third-party grabbers."
 msgstr ""
 
-#: src/docs_inc.c:5017
+#: src/docs_inc.c:3051
+msgid ""
+"Tvheadend verifies access by scanning through all enabled access control "
+"entries in sequence, from the top of the list to the bottom. The order of "
+"entries is __extremely__ important! It's recommended that you put wildcard "
+"(anonymous) accounts at top and all others (with special permissions) at the "
+"bottom."
+msgstr ""
+
+#: src/docs_inc.c:5242
 msgid ""
 "Tvheadend wasn't running or crashed when a scheduled event/entry was to "
 "start."
 msgstr ""
 
-#: src/docs_inc.c:3522
+#: src/docs_inc.c:4344
 msgid ""
-"Tvheadend won't scan the newly added mux instantly, it can take up to 10 "
-"minutes to begin an initial scan."
+"Tvheadend will by default probe each playlist entry for service information. "
+"Some service providers do not allow such probing & will deny (or rate limit) "
+"access, leading to scan failures."
 msgstr ""
 
-#: src/docs_inc.c:5307 src/docs_inc.c:5385
+#: src/docs_inc.c:6182 src/docs_inc.c:6206
 msgid "Tvheadend.org"
 msgstr ""
 
-#: src/docs_inc.c:2582
-msgid "Types"
+#: src/docs_inc.c:2606 src/docs_inc.c:3123 src/docs_inc.c:3899
+#: src/docs_inc.c:4422
+msgid "Type"
 msgstr ""
 
-#: src/docs_inc.c:1635
+#: src/docs_inc.c:5616
+msgid ""
+"Typically the `$q` and `$Q` formats would be combined with other modifiers "
+"to generate a complete filename such as `$q$n.$x`."
+msgstr ""
+
+#: src/docs_inc.c:1009
 msgid ""
 "Typically, download the binary file and install it into `/lib/firmware`, "
 "owned by `root:root`, permissions `rw-r--r--` (0644)"
 msgstr ""
 
-#: src/docs_inc.c:3809
+#: src/docs_inc.c:3461
 msgid "UPnP Protocol"
 msgstr ""
 
-#: src/docs_inc.c:3797
+#: src/docs_inc.c:3449
 msgid "URL"
 msgstr ""
 
-#: src/docs_inc.c:1972
+#: src/docs_inc.c:245 src/docs_inc.c:2860
 msgid "URL Syntax"
 msgstr ""
 
-#: src/docs_inc.c:1283
+#: src/docs_inc.c:5398
+msgid "URL in playlist"
+msgstr ""
+
+#: src/docs_inc.c:2152
 msgid "URL syntax"
 msgstr ""
 
-#: src/docs_inc.c:1603
+#: src/docs_inc.c:977
 msgid ""
 "USB tuners are cheap, work well and are frequently well-matched to "
 "physically-smaller builds (e.g. HTPCs) which simply don't have the internal "
@@ -6179,123 +7380,134 @@ msgid ""
 "powered hub to work properly."
 msgstr ""
 
-#: src/docs_inc.c:5124
+#: src/docs_inc.c:4708
 msgid "USE"
 msgstr ""
 
-#: src/docs_inc.c:3070
+#: src/docs_inc.c:4021
 msgid ""
 "USE / EMPTY rules have precedence against IGNORE (if the stream is already "
 "selected - it cannot be ignored)."
 msgstr ""
 
-#: src/docs_inc.c:3789
+#: src/docs_inc.c:5050
+msgid "UTF-8 encoded URL"
+msgstr ""
+
+#: src/docs_inc.c:3441
 msgid "UUID"
 msgstr ""
 
-#: src/docs_inc.c:1936 src/docs_inc.c:2151 src/docs_inc.c:2211
-#: src/docs_inc.c:2329 src/docs_inc.c:2358 src/docs_inc.c:2467
-#: src/docs_inc.c:2508 src/docs_inc.c:2549 src/docs_inc.c:2616
-#: src/docs_inc.c:2994 src/docs_inc.c:3322 src/docs_inc.c:4122
+#: src/docs_inc.c:1286 src/docs_inc.c:2534
 msgid "Undo"
 msgstr ""
 
-#: src/docs_inc.c:2360
-msgid ""
-"Undo any changes made to the CA client configuration since the last save."
-msgstr ""
-
-#: src/docs_inc.c:2618
-msgid ""
-"Undo any changes made to the selected configuration since the last save."
-msgstr ""
-
-#: src/docs_inc.c:2996
-msgid "Undo any changes made to the selected profile since the last save."
-msgstr ""
-
-#: src/docs_inc.c:2153
-msgid "Undo changes since the last save."
-msgstr ""
-
-#: src/docs_inc.c:4053
+#: src/docs_inc.c:3729
 msgid "Unicable (EN50494)"
 msgstr ""
 
-#: src/docs_inc.c:511
+#: src/docs_inc.c:2678
 msgid "Unicable EN50494 (experimental)"
 msgstr ""
 
-#: src/docs_inc.c:5056
+#: src/docs_inc.c:2680
+msgid "Unicable LNB configuration."
+msgstr ""
+
+#: src/docs_inc.c:5732 src/docs_inc.c:5904
+msgid "Unique ID of recording"
+msgstr ""
+
+#: src/docs_inc.c:5552
 msgid "Unique number added when the file already exists"
 msgstr ""
 
-#: src/docs_inc.c:501
+#: src/docs_inc.c:2662
 msgid "Universal LNB"
 msgstr ""
 
-#: src/docs_inc.c:4268
+#: src/docs_inc.c:2664
+msgid "Universal LNB - most DVB-S tuners."
+msgstr ""
+
+#: src/docs_inc.c:4852
 msgid "Unknown"
 msgstr ""
 
-#: src/docs_inc.c:57
+#: src/docs_inc.c:1773
 msgid "Unordered list can use asterisks"
 msgstr ""
 
-#: src/docs_inc.c:47
+#: src/docs_inc.c:1763
 msgid "Unordered sub-list."
 msgstr ""
 
-#: src/docs_inc.c:881
+#: src/docs_inc.c:2724 src/docs_inc.c:2744 src/docs_inc.c:2752
 msgid "Upcoming / Current Recordings"
 msgstr ""
 
-#: src/docs_inc.c:3190
-msgid "Upcoming/Current Recordings"
-msgstr ""
-
-#: src/docs_inc.c:1643
+#: src/docs_inc.c:53
 msgid "Updating the Documentation"
 msgstr ""
 
-#: src/docs_inc.c:1029
+#: src/docs_inc.c:5
 msgid "Usage: `tvheadend [OPTIONS]`"
 msgstr ""
 
-#: src/docs_inc.c:5256
+#: src/docs_inc.c:2402
+msgid "Use"
+msgstr ""
+
+#: src/docs_inc.c:635
+msgid ""
+"Use '--http_root' directive to specify the alternative http webroot (initial "
+"path prefix). The proxy server _MUST_ pass this webroot path in the HTTP "
+"request, otherwise an access to the Tvheadend server will end with the "
+"endless redirect loop."
+msgstr ""
+
+#: src/docs_inc.c:5978
 msgid "Use DVR profile setting."
 msgstr ""
 
-#: src/docs_inc.c:5138
+#: src/docs_inc.c:4800
+msgid "Use fuzzy mapping if merging same name"
+msgstr ""
+
+#: src/docs_inc.c:4802
+msgid "Use fuzzy name comparison when mapping - used with"
+msgstr ""
+
+#: src/docs_inc.c:4722
 msgid ""
 "Use only this elementary stream. No other elementary streams will be used."
 msgstr ""
 
-#: src/docs_inc.c:4602
+#: src/docs_inc.c:5076
 msgid "Use service name \"as is\" to generate the filename."
 msgstr ""
 
-#: src/docs_inc.c:4848
+#: src/docs_inc.c:5632
 msgid "Use the \"Persistent user interface level\" value as set in"
 msgstr ""
 
-#: src/docs_inc.c:4875
+#: src/docs_inc.c:6068
 msgid "Use the (default) blue theme."
 msgstr ""
 
-#: src/docs_inc.c:4301
+#: src/docs_inc.c:6096
 msgid "Use the default view level value as set in"
 msgstr ""
 
-#: src/docs_inc.c:4879
+#: src/docs_inc.c:6072
 msgid "Use the gray theme."
 msgstr ""
 
-#: src/docs_inc.c:4883
+#: src/docs_inc.c:6076
 msgid "Use the high contrast accessibility theme."
 msgstr ""
 
-#: src/docs_inc.c:5132
+#: src/docs_inc.c:4716
 msgid ""
 "Use this elementary stream only one time per service type (like video, "
 "audio, subtitles) and language. The first sucessfully compared rule wins. "
@@ -6303,128 +7515,180 @@ msgid ""
 "language and another rule with the ONE"
 msgstr ""
 
-#: src/docs_inc.c:5126
+#: src/docs_inc.c:4710
 msgid "Use this elementary stream."
 msgstr ""
 
-#: src/docs_inc.c:3600
-msgid "User Icon"
+#: src/docs_inc.c:5462
+msgid ""
+"Use this setting to translate broadcaster-specific, country-specific or "
+"other customised genre tags into tags recognised by tvheadend."
 msgstr ""
 
-#: src/docs_inc.c:4718 src/docs_inc.c:4720
+#: src/docs_inc.c:700
+msgid "Use tuners with .. in the name"
+msgstr ""
+
+#: src/docs_inc.c:1046
+msgid "Useful information you'll need to know before using Tvheadend"
+msgstr ""
+
+#: src/docs_inc.c:3016
+msgid "User account management."
+msgstr ""
+
+#: src/docs_inc.c:5018 src/docs_inc.c:5020
 msgid "User interface level"
 msgstr ""
 
-#: src/docs_inc.c:903
+#: src/docs_inc.c:4880
+msgid "Username/Entry (matched in sequence)"
+msgstr ""
+
+#: src/docs_inc.c:2058
 msgid "Users"
 msgstr ""
 
-#: src/docs_inc.c:1886
-msgid "Using the"
+#: src/docs_inc.c:1048 src/docs_inc.c:1242
+msgid "Using the Interface"
 msgstr ""
 
-#: src/docs_inc.c:3410
-msgid ""
-"Using the Electronic Program Guide search functionality, find the program/"
-"event you would like to record. Click on it, then using the broadcast "
-"details dialog you can:"
+#: src/docs_inc.c:652 src/docs_inc.c:660
+msgid "Using the Wizard"
 msgstr ""
 
-#: src/docs_inc.c:801
+#: src/docs_inc.c:3785
+msgid "VA-API"
+msgstr ""
+
+#: src/docs_inc.c:554
 msgid "VP8"
 msgstr ""
 
-#: src/docs_inc.c:641
+#: src/docs_inc.c:374
 msgid "Very long programs, e.g. major sporting events"
 msgstr ""
 
-#: src/docs_inc.c:625
+#: src/docs_inc.c:358
 msgid "Very short news bulletins, children's programs, etc."
 msgstr ""
 
-#: src/docs_inc.c:965
+#: src/docs_inc.c:3983
 msgid "Video Stream Filters"
 msgstr ""
 
-#: src/docs_inc.c:4646
+#: src/docs_inc.c:4946
 msgid "Video recorder"
 msgstr ""
 
-#: src/docs_inc.c:3072
+#: src/docs_inc.c:3985
+msgid "Video stream filter."
+msgstr ""
+
+#: src/docs_inc.c:1524 src/docs_inc.c:1548 src/docs_inc.c:1666
+msgid "View Level"
+msgstr ""
+
+#: src/docs_inc.c:1560
+msgid "View level"
+msgstr ""
+
+#: src/docs_inc.c:4023
 msgid "Visual Verification of Filtering"
 msgstr ""
 
-#: src/docs_inc.c:827
+#: src/docs_inc.c:580
 msgid "Vorbis"
 msgstr ""
 
-#: src/docs_inc.c:1329 src/docs_inc.c:1385 src/docs_inc.c:1445
+#: src/docs_inc.c:2214 src/docs_inc.c:2304 src/docs_inc.c:2364
 msgid "WHAT"
 msgstr ""
 
-#: src/docs_inc.c:4262
+#: src/docs_inc.c:4846
 msgid ""
 "Warning, setting an incorrect scheme can lead to crashes. If you're unsure "
 "select _System_ ."
 msgstr ""
 
-#: src/docs_inc.c:661 src/docs_inc.c:759
+#: src/docs_inc.c:1312
 msgid "Watch TV"
 msgstr ""
 
-#: src/docs_inc.c:27
+#: src/docs_inc.c:1743
 msgid "Watch this one - indentation is key."
 msgstr ""
 
-#: src/docs_inc.c:1239
+#: src/docs_inc.c:512
+msgid "Watching TV"
+msgstr ""
+
+#: src/docs_inc.c:282
+msgid "Watching TV and Browser Codec Support"
+msgstr ""
+
+#: src/docs_inc.c:284
+msgid "Watching TV and browser codec support"
+msgstr ""
+
+#: src/docs_inc.c:2141
 msgid ""
 "We need the webUI pages documented (as they are). How much should they be "
 "the how-tos, and how much should these be separate?"
 msgstr ""
 
-#: src/docs_inc.c:91
+#: src/docs_inc.c:1807
 msgid ""
 "We're using default heading/cell justification, so it's consistent "
 "throughout."
 msgstr ""
 
-#: src/docs_inc.c:873
+#: src/docs_inc.c:2048
 msgid "Web Interface Guide"
 msgstr ""
 
-#: src/docs_inc.c:4085
+#: src/docs_inc.c:3761
 msgid "Web User Interface"
 msgstr ""
 
-#: src/docs_inc.c:4642
+#: src/docs_inc.c:4942
 msgid "Web interface"
 msgstr ""
 
-#: src/docs_inc.c:1837
+#: src/docs_inc.c:1198
 msgid "Web interface internationalization"
 msgstr ""
 
-#: src/docs_inc.c:4706 src/docs_inc.c:4708
+#: src/docs_inc.c:5006 src/docs_inc.c:5008
 msgid "Web interface language"
 msgstr ""
 
-#: src/docs_inc.c:773
+#: src/docs_inc.c:526
 msgid "WebM"
 msgstr ""
 
-#: src/docs_inc.c:181
-msgid "Welcome to Tvheadend!"
+#: src/docs_inc.c:748 src/docs_inc.c:1652
+msgid "What it does"
 msgstr ""
 
-#: src/docs_inc.c:5404
+#: src/docs_inc.c:909
+msgid "What's needed to run Tvheadend"
+msgstr ""
+
+#: src/docs_inc.c:4526
 msgid ""
-"Welcome to Tvheadend, your TV streaming server and video recorder. This "
-"wizard will help you get up and running fast. Let's start by configuring the "
-"basic language settings. Please select the default user interface and EPG "
-"language(s)."
+"When a new rating is encountered from an XMLTV EPG source, a placeholder "
+"label similar to the DVB ones is created and you will need to add the "
+"country code and the ages."
 msgstr ""
 
-#: src/docs_inc.c:279
+#: src/docs_inc.c:4508
+msgid ""
+"When a placeholder label is in use, the programme details in the EPG will "
+"show this placeholder entry rather than the expected value."
+msgstr ""
+
+#: src/docs_inc.c:802
 msgid ""
 "When creating a DVB-S network, be sure to set the orbital position of the "
 "satellite to which your dish is pointing, as some satellites provide "
@@ -6432,14 +7696,26 @@ msgid ""
 "be able to receive."
 msgstr ""
 
-#: src/docs_inc.c:419
+#: src/docs_inc.c:1608
+msgid ""
+"When making changes (in the parameter panel) be sure to save __before__ "
+"clicking on another item in the list."
+msgstr ""
+
+#: src/docs_inc.c:4502
+msgid ""
+"When the rating labels module encounters a new country and age combination, "
+"it will create a placeholder entry in the rating labels table as follows:"
+msgstr ""
+
+#: src/docs_inc.c:1234
 msgid ""
 "When you select the channel you want to watch or record, Tvheadend can then "
 "map a path through all those variables to ask a particular tuner to go and "
 "get the signal for you."
 msgstr ""
 
-#: src/docs_inc.c:4260
+#: src/docs_inc.c:4844
 msgid ""
 "Whenever you read or write data to the filesystems, the information is kept "
 "(cached) in memory for a while. This means that regularly-accessed files are "
@@ -6449,7 +7725,7 @@ msgid ""
 "be written in one go."
 msgstr ""
 
-#: src/docs_inc.c:445
+#: src/docs_inc.c:1023
 msgid ""
 "Where a pre-built package exists, this will usually get you the last "
 "official stable version. However, more advanced users may be interested in "
@@ -6457,7 +7733,37 @@ msgid ""
 "version."
 msgstr ""
 
-#: src/docs_inc.c:1165
+#: src/docs_inc.c:917
+msgid "Where to get Tvheadend and how-to install it"
+msgstr ""
+
+#: src/docs_inc.c:94
+msgid "Where you configure adapters"
+msgstr ""
+
+#: src/docs_inc.c:102
+msgid "Where you configure multiplexes"
+msgstr ""
+
+#: src/docs_inc.c:110
+msgid ""
+"Where you configure mux schedulers - schedule Tvheadend to tune to a "
+"specific mux to receive different types of data, EMMs, EIT etc"
+msgstr ""
+
+#: src/docs_inc.c:98
+msgid "Where you configure networks"
+msgstr ""
+
+#: src/docs_inc.c:2612
+msgid "Where you configure the frontend, whether or not it's enabled etc."
+msgstr ""
+
+#: src/docs_inc.c:2660
+msgid "Where you configure various settings related to your DVB-S tuners."
+msgstr ""
+
+#: src/docs_inc.c:927
 msgid ""
 "Where you have aerial/coax connections might influence your choice - unless "
 "you use SAT>IP or have some other way to transport your TV signal over a "
@@ -6465,7 +7771,13 @@ msgid ""
 "your tuners."
 msgstr ""
 
-#: src/docs_inc.c:1169
+#: src/docs_inc.c:5598
+msgid ""
+"Whereas the number 2 variant forces the recording to be formatted as a tv "
+"series."
+msgstr ""
+
+#: src/docs_inc.c:931
 msgid ""
 "Wherever you install it, Tvheadend primarily runs on __Linux__ - pre-built "
 "binaries are available for most Debian-based distributions (Debian itself, "
@@ -6474,124 +7786,166 @@ msgid ""
 "Android (which uses the Linux kernel)."
 msgstr ""
 
-#: src/docs_inc.c:201
-msgid ""
-"While supported in previous versions, analogue video (V4L) is no longer "
-"supported directly. If you still need this, or need to input signals from "
-"video cameras or other non-broadcast sources, use `pipe://`."
-msgstr ""
-
-#: src/docs_inc.c:4379 src/docs_inc.c:4757 src/docs_inc.c:5179
+#: src/docs_inc.c:5676 src/docs_inc.c:5776 src/docs_inc.c:5868
 msgid "Who created this recording"
 msgstr ""
 
-#: src/docs_inc.c:415
-msgid "Why The Complexity?"
+#: src/docs_inc.c:1230
+msgid "Why the Complexity?"
 msgstr ""
 
-#: src/docs_inc.c:4982
+#: src/docs_inc.c:5150
 msgid "Wikipedia for a detailed look into Cron."
 msgstr ""
 
-#: src/docs_inc.c:73
+#: src/docs_inc.c:3049
+msgid ""
+"Wildcard (anonymous) accounts (that require no username or password) can be "
+"created by entering an asterisk `*` in the username/password field. These "
+"accounts are matched using the network prefix _(Allowed networks)_ , acting "
+"similar to a username."
+msgstr ""
+
+#: src/docs_inc.c:4402
+msgid ""
+"Wildcard (anonymous) accounts don't actually need a password, but it's "
+"recommended you add one anyway (enter an asterisk `*`)."
+msgstr ""
+
+#: src/docs_inc.c:1789
 msgid "Will generate:"
 msgstr ""
 
-#: src/docs_inc.c:1195
+#: src/docs_inc.c:664
+msgid "Wizard"
+msgstr ""
+
+#: src/docs_inc.c:2097
 msgid "Work-in-progress notes"
 msgstr ""
 
-#: src/docs_inc.c:4081
+#: src/docs_inc.c:3255
+msgid "Wrapper (capmt_ca.so)"
+msgstr ""
+
+#: src/docs_inc.c:3911 src/docs_inc.c:3919 src/docs_inc.c:4522
+msgid "XMLTV"
+msgstr ""
+
+#: src/docs_inc.c:3757
 msgid "XMLTV EPG Import"
 msgstr ""
 
-#: src/docs_inc.c:4858
+#: src/docs_inc.c:5642
 msgid "Yes"
 msgstr ""
 
-#: src/docs_inc.c:227
+#: src/docs_inc.c:5408
+msgid "Yes, because no components are ignored."
+msgstr ""
+
+#: src/docs_inc.c:5420
+msgid "Yes, but only if the second-from-last component"
+msgstr ""
+
+#: src/docs_inc.c:617
 msgid ""
 "Yes, not all services are given a name by providers. These services are "
 "usually hidden for a reason and are often used for things such as encrypted "
 "guide data for set-top boxes, interactive services, and so on."
 msgstr ""
 
-#: src/docs_inc.c:5301 src/docs_inc.c:5377
-msgid "You are now finished."
+#: src/docs_inc.c:4902
+msgid "Yes, this is because the above entry \"Change parameters\" rights"
 msgstr ""
 
-#: src/docs_inc.c:1589
+#: src/docs_inc.c:4890 src/docs_inc.c:4900 src/docs_inc.c:4910
+#: src/docs_inc.c:4912 src/docs_inc.c:4922
+msgid "Yes."
+msgstr ""
+
+#: src/docs_inc.c:4514
+msgid ""
+"You are required to manually edit this placeholder entry in order to provide "
+"the appropriate rating text to display. The correct text can be found by "
+"searching for the specific programme in another EPG source or by obtaining "
+"the classification guidelines in the location (country) in question. This "
+"only needs to be done once for each label, all other programmes with that "
+"label will be automatically adjusted."
+msgstr ""
+
+#: src/docs_inc.c:963
 msgid "You basically have the choice of:"
 msgstr ""
 
-#: src/docs_inc.c:253
-msgid ""
-"You can also consult the in-application help text, which mirrors this guide "
-"to a very great extent."
-msgstr ""
-
-#: src/docs_inc.c:321
+#: src/docs_inc.c:844
 msgid "You can also use"
 msgstr ""
 
-#: src/docs_inc.c:753
+#: src/docs_inc.c:506
 msgid "You can change or delete the autorec rules in the __"
 msgstr ""
 
-#: src/docs_inc.c:647
+#: src/docs_inc.c:380
 msgid ""
 "You can clear an individual filter by simply deleting its contents, or by "
 "selecting _‘(Clear filter)’_ as appropriate on all except the title filter. "
 "If you want to clear all filters, just press the _[Reset All]_ button."
 msgstr ""
 
-#: src/docs_inc.c:2438 src/docs_inc.c:2656
-msgid "You can clone an existing config by clicking the _[Clone]_ button."
+#: src/docs_inc.c:4077 src/docs_inc.c:4400
+msgid "You can enter whatever you like in the comment field."
 msgstr ""
 
-#: src/docs_inc.c:3026
-msgid "You can clone an existing profile by clicking the _[Clone]_ button."
-msgstr ""
-
-#: src/docs_inc.c:2949
+#: src/docs_inc.c:4398
 msgid ""
-"You can have multiple entries using the same username with varying rights, "
-"allowing you to enable / disable each as needed. Note, matching (enabled) "
-"accounts will have permissions combined."
+"You can have multiple passwords matching a single _Access Entry_ if you wish."
 msgstr ""
 
-#: src/docs_inc.c:17
+#: src/docs_inc.c:1733
 msgid ""
 "You can include documentation/items in other markdown files by using the "
 "tvh_class_doc, tvh_include and tvh_class_items tags."
 msgstr ""
 
-#: src/docs_inc.c:2090
+#: src/docs_inc.c:3279
 msgid ""
-"You can map/remove a service to/from an existing channel by doing the "
-"following:"
+"You can play a stream by clicking the play icon. This will automatically "
+"launch an appropriate player, otherwise you will need to manually open the "
+"playlist to start watching (normally a double-click on the downloaded file). "
+"Note, the links don't link to the actual stream but to a playlist for use "
+"with media players such as VLC, If you'd prefer to receive the raw stream "
+"instead, you can do so by removing the /play/ path from the URL - see URL "
+"Syntax for more info."
 msgstr ""
 
-#: src/docs_inc.c:1964
+#: src/docs_inc.c:2852
 msgid "You can play a stream/file by clicking the play icon !"
 msgstr ""
 
-#: src/docs_inc.c:3450
+#: src/docs_inc.c:4616
 msgid ""
-"You can re-schedule an entry by pressing the _[Re-record]_ button on the "
-"menu bar."
+"You can put a custom M3U playlist (which will be advertised to clients) in "
+"your Tvheadend configuration directory - filename _satip.m3u_ ."
 msgstr ""
 
-#: src/docs_inc.c:55
+#: src/docs_inc.c:2779
+msgid ""
+"You can schedule a one-time only recording by pressing the [Add] button from "
+"the menu bar in the _Upcoming / Current Recordings_ tab. You must enter a "
+"title, a start (and an end) time, and pick a channel."
+msgstr ""
+
+#: src/docs_inc.c:1771
 msgid "You can't have have properly indented paragraphs within list items."
 msgstr ""
 
-#: src/docs_inc.c:4978
+#: src/docs_inc.c:5146
 msgid ""
 "You cannot use non-standard predefined scheduling definitions for this field."
 msgstr ""
 
-#: src/docs_inc.c:5351
+#: src/docs_inc.c:690
 msgid ""
 "You may enter a comma-separated list of network prefixes (IPv4/IPv6). If you "
 "were asked to enter a username and password during installation, we'd "
@@ -6599,37 +7953,33 @@ msgid ""
 "unexpected behavior, incorrect permissions etc."
 msgstr ""
 
-#: src/docs_inc.c:5303 src/docs_inc.c:5379
+#: src/docs_inc.c:6176 src/docs_inc.c:6202
 msgid ""
 "You may further customize your settings by editing channel numbers, etc."
 msgstr ""
 
-#: src/docs_inc.c:3240
+#: src/docs_inc.c:3085
 msgid "You may import your own bouquet using enigma2 (.tv) formatted files."
 msgstr ""
 
-#: src/docs_inc.c:5338
+#: src/docs_inc.c:764
 msgid ""
 "You may need to enable specific EPG grabbers to receive OTA EPG data, See "
 "the _EPG Grabber Modules_ Help doc for details."
 msgstr ""
 
-#: src/docs_inc.c:2237
+#: src/docs_inc.c:4634
 msgid "You must enter a _SAT>IP source number_ for all the"
 msgstr ""
 
-#: src/docs_inc.c:745
+#: src/docs_inc.c:4075
 msgid ""
-"You will also see _[Search IMDB]_ and _[TheTVDB]_ buttons to look for the "
-"program by name on imdb.com/thetvdb.com, and a _[Play program]_ button to "
-"watch a program that’s already in progress. This second button downloads a "
-"playlist file (XSPF or M3U depending on your startup options); if your "
-"system is configured for it, this will automatically launch an appropriate "
-"player, otherwise you will need to manually open the playlist to start "
-"watching (normally a double-click on the downloaded file)."
+"You must enter a network prefix to block. For example, to block just "
+"`192.168.6.66` enter `192.168.6.66/32` or to block the all addresses in the "
+"`192.168.6` range, enter `192.168.6.0/24`."
 msgstr ""
 
-#: src/docs_inc.c:1171
+#: src/docs_inc.c:933
 msgid ""
 "You will only need __c. 30MB disk space__ for the application and associated "
 "files, and maybe anything up to __1GB__ for your configuration - depending "
@@ -6639,123 +7989,107 @@ msgid ""
 "about 1GB, while high bitrate HD H.264 will easily consume 5GB+ per hour."
 msgstr ""
 
-#: src/docs_inc.c:1888
-msgid "[Edit]"
-msgstr ""
-
-#: src/docs_inc.c:2941
-msgid "_ tab - not required for wildcard accounts."
-msgstr ""
-
-#: src/docs_inc.c:3192
+#: src/docs_inc.c:768
 msgid ""
-"_ tab. __Note that if your rule matches any in-progress events they will "
-"automatically start being recorded.__"
+"You've now finished the wizard, at this point you should be able to view "
+"your channels and make further changes; If not, please take a look at the "
+"manual set-up below."
 msgstr ""
 
-#: src/docs_inc.c:4423 src/docs_inc.c:4785 src/docs_inc.c:5227
+#: src/docs_inc.c:482
+msgid "[Autorec]"
+msgstr ""
+
+#: src/docs_inc.c:150
+msgid "[Panasonic MN88472] #0"
+msgstr ""
+
+#: src/docs_inc.c:451
+msgid "[Play]"
+msgstr ""
+
+#: src/docs_inc.c:478
+msgid "[Record Series]"
+msgstr ""
+
+#: src/docs_inc.c:471
+msgid "[Record]"
+msgstr ""
+
+#: src/docs_inc.c:3201 src/docs_inc.c:3221 src/docs_inc.c:3251
+msgid "[dvbapi]"
+msgstr ""
+
+#: src/docs_inc.c:5740 src/docs_inc.c:5820 src/docs_inc.c:5912
 msgid "_Example usage_"
 msgstr ""
 
-#: src/docs_inc.c:4581
+#: src/docs_inc.c:5194
 msgid ""
 "_Local_ only checks for duplicates created by the same autorec rule, _All_ "
 "checks all the DVR logs for duplicates."
 msgstr ""
 
-#: src/docs_inc.c:2904
-msgid ""
-"_The order of entries is __extremely__ important!_ It's recommended that you "
-"put the wildcard (asterisk `*`) accounts at top and all other accounts (with "
-"special permissions) at the bottom."
-msgstr ""
-
-#: src/docs_inc.c:617
+#: src/docs_inc.c:350
 msgid ""
 "_Title_ , _Channel_ , _Tag_ and _Content Type_ are dependent on your "
 "configuration and on what your broadcaster sends. Options for the _Duration_ "
 "are as follows:"
 msgstr ""
 
-#: src/docs_inc.c:1077
+#: src/docs_inc.c:1922
 msgid "__ : Clear all \"Uncorrected Blocks\", \"BER\", etc stats."
 msgstr ""
 
-#: src/docs_inc.c:1701
+#: src/docs_inc.c:1838
 msgid ""
 "__ : Forcefully kill the connection. Note that many applications such as "
 "Kodi will automatically reconnect when a connection is dropped."
 msgstr ""
 
-#: src/docs_inc.c:743
-msgid ""
-"__ tab. This allows you to set, for example, more post- broadcast padding "
-"for a channel that always runs late, or perhaps define a different post-"
-"processing command to strip adverts out on a commercial channel."
-msgstr ""
-
-#: src/docs_inc.c:757
+#: src/docs_inc.c:510
 msgid ""
 "__ tab. Use that editor if you temporarily want to disable an autorecording "
 "or make adjustments to the channel, tag, or similar."
 msgstr ""
 
-#: src/docs_inc.c:2092
-msgid "__1)__ Find the desired service from within the services grid."
-msgstr ""
-
-#: src/docs_inc.c:2227
-msgid "__1. Define the RTSP Port__"
-msgstr ""
-
-#: src/docs_inc.c:2102
-msgid ""
-"__2)__ Double click on the channel field, a drop down listing of all defined "
-"channels will appear, check/uncheck the check box next to the channel you'd "
-"like to associate/disassociate the service with."
-msgstr ""
-
-#: src/docs_inc.c:2231
-msgid "__2. Export the Tuners__"
-msgstr ""
-
-#: src/docs_inc.c:2108
-msgid "__3)__ Press the _[Save]_ button from the menu bar, and you're done!"
-msgstr ""
-
-#: src/docs_inc.c:2235
-msgid "__3. Export Your Networks__"
-msgstr ""
-
-#: src/docs_inc.c:2247
-msgid "__4. Configure Your Client__"
-msgstr ""
-
-#: src/docs_inc.c:135
+#: src/docs_inc.c:1891
 msgid "__Active__ : Progress bar indicating mapping status."
 msgstr ""
 
-#: src/docs_inc.c:719
+#: src/docs_inc.c:428
 msgid "__Age__ : Age rating of the program."
 msgstr ""
 
-#: src/docs_inc.c:1087
+#: src/docs_inc.c:6260
+msgid "__Assign Predefined Muxes to Networks__"
+msgstr ""
+
+#: src/docs_inc.c:1934
 msgid "__BER__ :"
 msgstr ""
 
-#: src/docs_inc.c:1085
+#: src/docs_inc.c:1932
 msgid "__Bandwidth__ : Total stream input bandwidth."
 msgstr ""
 
-#: src/docs_inc.c:1697
+#: src/docs_inc.c:870
+msgid ""
+"__Bouquets__ : Many service providers - mostly those using satellite - use "
+"bouquets for channel management and just like a standard set-top box "
+"Tvheadend can use these to automatically manage and keep your channels up-to-"
+"date. If you would like to use bouquets see"
+msgstr ""
+
+#: src/docs_inc.c:1834
 msgid "__Cancel Icon !"
 msgstr ""
 
-#: src/docs_inc.c:1529
+#: src/docs_inc.c:1989
 msgid "__Channel__ : The name of the"
 msgstr ""
 
-#: src/docs_inc.c:715
+#: src/docs_inc.c:424
 msgid ""
 "__Channel__ : The name of the broadcasting channel. _You can automatically "
 "set a filter to the value of this field by clicking on it (e.g. click on "
@@ -6763,7 +8097,35 @@ msgid ""
 "programs from that channel)._"
 msgstr ""
 
-#: src/docs_inc.c:721
+#: src/docs_inc.c:1842
+msgid "__Client Address__ : The IP address of the client device."
+msgstr ""
+
+#: src/docs_inc.c:1846
+msgid "__Client Data Ports__ : The data port(s) used by the client device."
+msgstr ""
+
+#: src/docs_inc.c:1844
+msgid "__Client Port__ : The port of the client device."
+msgstr ""
+
+#: src/docs_inc.c:818
+msgid "__Configuration -> DVB Inputs -> Muxes__"
+msgstr ""
+
+#: src/docs_inc.c:792
+msgid "__Configuration -> DVB Inputs -> Networks__"
+msgstr ""
+
+#: src/docs_inc.c:852 src/docs_inc.c:860
+msgid "__Configuration -> DVB Inputs -> Services__"
+msgstr ""
+
+#: src/docs_inc.c:774 src/docs_inc.c:808
+msgid "__Configuration -> DVB Inputs -> TV Adapters__"
+msgstr ""
+
+#: src/docs_inc.c:430
 msgid ""
 "__Content Type__ : Any content/genre information as provided by the EPG "
 "provider. _You can automatically set a filter to the value of this field by "
@@ -6771,69 +8133,59 @@ msgid ""
 "whole grid to only show programs of the same type)._"
 msgstr ""
 
-#: src/docs_inc.c:1099
+#: src/docs_inc.c:1946
 msgid ""
 "__Continuity Errors__ : Continuity Count Error. Number of stream errors, a "
 "high value here can indicate a signal problem."
 msgstr ""
 
-#: src/docs_inc.c:1904
-msgid "__Deleting can't be undone. You will be prompted to confirm. __"
-msgstr ""
-
-#: src/docs_inc.c:1561
+#: src/docs_inc.c:2025
 msgid "__Descramble__ : The CAID used to descramble the stream."
 msgstr ""
 
-#: src/docs_inc.c:677
+#: src/docs_inc.c:386
 msgid ""
 "__Details__ : Displays the current status of a recording event for this "
 "program if one applies:"
 msgstr ""
 
-#: src/docs_inc.c:711
+#: src/docs_inc.c:211
+msgid "__Details__ : Gives a quick overview as to the status of each entry:"
+msgstr ""
+
+#: src/docs_inc.c:420
 msgid ""
 "__Duration__ : The scheduled duration (i.e. start time to end time) of the "
 "program."
 msgstr ""
 
-#: src/docs_inc.c:709
+#: src/docs_inc.c:418
 msgid "__End Time__ : The scheduled end time of the program."
 msgstr ""
 
-#: src/docs_inc.c:705
+#: src/docs_inc.c:6240
+msgid "__Enter Access Control Details to Secure Your System__"
+msgstr ""
+
+#: src/docs_inc.c:414
 msgid "__Episode__ : Episode number, if given by your EPG provider."
 msgstr ""
 
-#: src/docs_inc.c:1563
+#: src/docs_inc.c:2027
 msgid "__Errors__ : Number of errors occurred sending the stream."
 msgstr ""
 
-#: src/docs_inc.c:1307
+#: src/docs_inc.c:2176
 msgid ""
 "__Example:__ `http://127.0.0.1:9981/play/stream/channelname/Life?"
 "playlist=xspf`"
 msgstr ""
 
-#: src/docs_inc.c:3298
-msgid ""
-"__Failed Recordings__ : This sub-tab lists all failed recording entries. "
-"Entries shown here have failed to record due to one (or more) errors that "
-"occurred during the recording."
-msgstr ""
-
-#: src/docs_inc.c:133
+#: src/docs_inc.c:1889
 msgid "__Failed__ : Number of services that failed to be mapped."
 msgstr ""
 
-#: src/docs_inc.c:3296
-msgid ""
-"__Finished Recordings__ : This sub-tab lists all completed recording "
-"entries. Entries shown here have reached the end of the scheduled (or EITp/f "
-"defined) recording time."
-msgstr ""
-
-#: src/docs_inc.c:401
+#: src/docs_inc.c:1216
 msgid ""
 "__Firmware__ is a small piece of binary microcode that your system driver "
 "sends to the tuner upon initialisation. This is the cause of more problems "
@@ -6841,238 +8193,199 @@ msgid ""
 "thing to check along with kernel support for your hardware."
 msgstr ""
 
-#: src/docs_inc.c:1523
+#: src/docs_inc.c:1983
 msgid "__Hostname__ : Hostname/IP address using the subscription."
 msgstr ""
 
-#: src/docs_inc.c:1521
+#: src/docs_inc.c:1981
 msgid "__ID__ : Subscription ID."
 msgstr ""
 
-#: src/docs_inc.c:1705
-msgid "__IP Address__ : The IP address of the device."
-msgstr ""
-
-#: src/docs_inc.c:5435
+#: src/docs_inc.c:6266
 msgid ""
-"__If you receive your channels through a satellite dish__ then you would "
-"select the network under the tuners with DVB-S/S2 in the name."
+"__If you don't see any options below, you need to go back and assign a "
+"network type to a tuner.__"
 msgstr ""
 
-#: src/docs_inc.c:5433
-msgid ""
-"__If you receive your channels through an antenna (also known as an "
-"aerial)__ then you would select the network under the tuners with DVB-T/ATSC-"
-"T/ISDB-T in the name."
+#: src/docs_inc.c:668
+msgid "__If you haven't already don't so__ , please take a look at the"
 msgstr ""
 
-#: src/docs_inc.c:5437
-msgid ""
-"__If you receive your channels via cable__ then you would select the network "
-"under the tuners with DVB-C/ATSC-C/ISDB-C in the name."
-msgstr ""
-
-#: src/docs_inc.c:131
+#: src/docs_inc.c:1887
 msgid "__Ignored__ : Number of services ignored."
 msgstr ""
 
-#: src/docs_inc.c:1079
+#: src/docs_inc.c:1924
 msgid "__Input__ : Device used to receive the stream."
 msgstr ""
 
-#: src/docs_inc.c:1565
+#: src/docs_inc.c:2029
 msgid "__Input__ : The input data rate in kb/s."
 msgstr ""
 
-#: src/docs_inc.c:4188
+#: src/docs_inc.c:4181
 msgid "__It does not have any user configurable options.__"
 msgstr ""
 
-#: src/docs_inc.c:129
+#: src/docs_inc.c:6250
+msgid "__Map Services to Channels__"
+msgstr ""
+
+#: src/docs_inc.c:1885
 msgid "__Mapped__ : Number of services mapped."
 msgstr ""
 
-#: src/docs_inc.c:393
+#: src/docs_inc.c:4520
+msgid ""
+"__NOTE:__ In the example, the age provided by DVB is '10', whereas the age "
+"displayed is '13'. This is because the DVB standard subtracts 3 from some "
+"recommended ages before transmission meaning that the receiver must add 3 to "
+"the number received. When creating a placeholder label, this module will "
+"automatically add 3 where appropriate."
+msgstr ""
+
+#: src/docs_inc.c:4492
+msgid ""
+"__NOTE:__ Rating labels are not enabled by default and must be enabled in the"
+msgstr ""
+
+#: src/docs_inc.c:1208
 msgid "__Network tuners__ are small (usually"
 msgstr ""
 
-#: src/docs_inc.c:301
+#: src/docs_inc.c:824
 msgid ""
 "__Note__ : Some tuners (or drivers) require more tuning parameters than "
 "others so __be sure to enter as many tuning parameters as possible__ ."
 msgstr ""
 
-#: src/docs_inc.c:3452
-msgid ""
-"__Note__ : Your EPG data must have another matching event to be able to re-"
-"schedule the entry."
-msgstr ""
-
-#: src/docs_inc.c:2756 src/docs_inc.c:5286 src/docs_inc.c:5334
-#: src/docs_inc.c:5349 src/docs_inc.c:5364 src/docs_inc.c:5408
-#: src/docs_inc.c:5439
-msgid "__Notes__ :"
-msgstr ""
-
-#: src/docs_inc.c:713
+#: src/docs_inc.c:422
 msgid ""
 "__Number__ : The channel number of the broadcasting channel, if defined."
 msgstr ""
 
-#: src/docs_inc.c:1567
+#: src/docs_inc.c:2031
 msgid "__Output__ : The output data rate in kb/s."
 msgstr ""
 
-#: src/docs_inc.c:1091
+#: src/docs_inc.c:1938
 msgid "__PER__ :"
 msgstr ""
 
-#: src/docs_inc.c:1535
+#: src/docs_inc.c:2023
+msgid ""
+"__PID list__ : Input source Program Identification (PIDs) numbers in use by "
+"the subscription."
+msgstr ""
+
+#: src/docs_inc.c:1930
+msgid ""
+"__PID list__ : Input source Program Identification (PIDs) numbers in use."
+msgstr ""
+
+#: src/docs_inc.c:237
+msgid "__Play__ / !"
+msgstr ""
+
+#: src/docs_inc.c:1997
 msgid "__Profile__ : The name of the"
 msgstr ""
 
-#: src/docs_inc.c:699
+#: src/docs_inc.c:408
 msgid ""
 "__Progress__ : A bar graph display of how far through a program we currently "
 "are."
 msgstr ""
 
-#: src/docs_inc.c:1137
+#: src/docs_inc.c:1856
+msgid ""
+"__Proxy Address__ : The IP address of the proxy the client is connecting "
+"through (if known)."
+msgstr ""
+
+#: src/docs_inc.c:1590
 msgid "__Re-arrange__ the columns by simply dragging he header to a new spot."
 msgstr ""
 
-#: src/docs_inc.c:1139
+#: src/docs_inc.c:1592
 msgid ""
 "__Re-size__ the columns by dragging the very edges of the column header as "
 "required."
 msgstr ""
 
-#: src/docs_inc.c:3300
-msgid ""
-"__Removed Recordings__ : This sub-tab lists all recording entries that have "
-"missing file(s). Entries shown here link to file(s) that Tvheadend cannot "
-"locate (files which have been externally removed)."
-msgstr ""
-
-#: src/docs_inc.c:1101
+#: src/docs_inc.c:1948
 msgid "__SNR__ : Signal (To) Noise Ratio."
 msgstr ""
 
-#: src/docs_inc.c:5429
-msgid "__Selecting the Right Network__ :"
+#: src/docs_inc.c:6280
+msgid "__Scanning__"
 msgstr ""
 
-#: src/docs_inc.c:1107
+#: src/docs_inc.c:1854
+msgid ""
+"__Server Address__ : The address used to connect to the server. This is "
+"usually the IP of your device running Tvheadend."
+msgstr ""
+
+#: src/docs_inc.c:1995
+msgid "__Service__ : The service used by the subscription."
+msgstr ""
+
+#: src/docs_inc.c:1954
 msgid ""
 "__Signal Strength__ : The signal strength as reported by the device, note "
 "that not all devices supply correct signal information, the value here can "
 "sometimes be ambiguous"
 msgstr ""
 
-#: src/docs_inc.c:717
+#: src/docs_inc.c:426
 msgid "__Stars__ : Rating (in stars) of the program."
 msgstr ""
 
-#: src/docs_inc.c:707
+#: src/docs_inc.c:416
 msgid "__Start Time__ : The scheduled start time of the program."
 msgstr ""
 
-#: src/docs_inc.c:1541
+#: src/docs_inc.c:2003
 msgid "__Start__ : The date (and time) the subscription was started."
 msgstr ""
 
-#: src/docs_inc.c:1709
+#: src/docs_inc.c:1850
 msgid "__Started__ : Date the connection started - YYYY-MM-DD HH:MM:SS."
 msgstr ""
 
-#: src/docs_inc.c:1543
+#: src/docs_inc.c:2005
 msgid "__State__ : The status of the subscription"
 msgstr ""
 
-#: src/docs_inc.c:1081
+#: src/docs_inc.c:1852
+msgid "__Streaming__ : The number of active streams."
+msgstr ""
+
+#: src/docs_inc.c:1926
 msgid "__Sub No__ : Number of subscriptions using the stream."
 msgstr ""
 
-#: src/docs_inc.c:703
+#: src/docs_inc.c:412
 msgid ""
 "__Subtitle__ : The subtitle of the program, if gien by your EPG provider. "
 "Note that some (notably, UK) providers use this for a program synopsis "
 "instead of a true subtitle."
 msgstr ""
 
-#: src/docs_inc.c:1073
+#: src/docs_inc.c:1918
 msgid "__Sweep/Clean Icon !"
 msgstr ""
 
-#: src/docs_inc.c:5420
-msgid ""
-"__The interface will reload in your chosen language (if the translation is "
-"available).__"
-msgstr ""
-
-#: src/docs_inc.c:31
+#: src/docs_inc.c:1747
 msgid "__This is definition list formatting__ : with a subsequent explanation"
 msgstr ""
 
-#: src/docs_inc.c:29
+#: src/docs_inc.c:1745
 msgid "__This is paragraph formatting__ : with a subsequent explanation"
 msgstr ""
 
-#: src/docs_inc.c:5406
-msgid ""
-"__This wizard should only be run on initial setup. Please cancel it if "
-"you're not willing to touch the current configuration, as continuing in such "
-"cases can lead to misconfiguration and not all changes made thru this wizard "
-"will take effect.__"
-msgstr ""
-
-#: src/docs_inc.c:2086
-msgid ""
-"__Tip__ : By default Tvheadend will only show a small selection of available "
-"services - you can increase this by using the paging selector at the bottom "
-"right of the page."
-msgstr ""
-
-#: src/docs_inc.c:2520
-msgid ""
-"__Tip__ : Don't forget to set the _EIT time offset_ for your network(s)."
-msgstr ""
-
-#: src/docs_inc.c:1906
-msgid ""
-"__Tip__ : Rather than deleting an entry, you can disable it instead by "
-"unchecking the \"Enabled\" check box (if available)."
-msgstr ""
-
-#: src/docs_inc.c:2100
-msgid ""
-"__Tip__ : Remember to remove the filter when you're finished (uncheck the "
-"check box next to the \"Filters\" option)."
-msgstr ""
-
-#: src/docs_inc.c:483
-msgid "__Tip__ : Remember to save your changes _before_ switching panels."
-msgstr ""
-
-#: src/docs_inc.c:2963
-msgid ""
-"__Tip__ : Remember to set the correct permissions so that Tvheadend is able "
-"to read the superuser file."
-msgstr ""
-
-#: src/docs_inc.c:2816
-msgid ""
-"__Tip__ : You can enter a comma-separated list of network prefixes, if "
-"you're unsure as to what to enter in the _Network prefix_ field take a look "
-"at"
-msgstr ""
-
-#: src/docs_inc.c:2434 src/docs_inc.c:2652 src/docs_inc.c:2943
-#: src/docs_inc.c:3022 src/docs_inc.c:3510
-msgid "__Tips__ :"
-msgstr ""
-
-#: src/docs_inc.c:701
+#: src/docs_inc.c:410
 msgid ""
 "__Title__ : The title of the program. _You can automatically set a filter to "
 "the value of this field by clicking on it (e.g. click on 'Daily News' will "
@@ -7080,14 +8393,14 @@ msgid ""
 "name)._"
 msgstr ""
 
-#: src/docs_inc.c:1527
+#: src/docs_inc.c:1987
 msgid ""
 "__Title__ : Title of the application using the subscription - you will "
 "sometimes see \"epggrab\" here, this is an internal subscription used by "
-"tvheadend to grab EPG data."
+"Tvheadend to grab EPG data."
 msgstr ""
 
-#: src/docs_inc.c:1097
+#: src/docs_inc.c:1944
 msgid ""
 "__Transport Errors__ : Number of transport streams errors. A fast increasing "
 "value here can indicate signal issues. Device drivers can sometimes send "
@@ -7096,125 +8409,106 @@ msgid ""
 "worry about."
 msgstr ""
 
-#: src/docs_inc.c:349
-msgid ""
-"__Tvheadend web interface: _Configuration -> Channel / EPG -> Bouquets_ __"
+#: src/docs_inc.c:6272
+msgid "__Tuner and Network__"
 msgstr ""
 
-#: src/docs_inc.c:295
-msgid "__Tvheadend web interface: _Configuration -> DVB Inputs -> Muxes_ __"
-msgstr ""
-
-#: src/docs_inc.c:269
-msgid "__Tvheadend web interface: _Configuration -> DVB Inputs -> Networks_ __"
-msgstr ""
-
-#: src/docs_inc.c:329 src/docs_inc.c:337
-msgid "__Tvheadend web interface: _Configuration -> DVB Inputs -> Services_ __"
-msgstr ""
-
-#: src/docs_inc.c:257 src/docs_inc.c:285
-msgid ""
-"__Tvheadend web interface: _Configuration -> DVB Inputs -> TV Adapters_ __"
-msgstr ""
-
-#: src/docs_inc.c:1703
+#: src/docs_inc.c:1840
 msgid "__Type__ : Connection type - HTSP or HTTP."
 msgstr ""
 
-#: src/docs_inc.c:1095
+#: src/docs_inc.c:1942
 msgid ""
 "__Uncorrected Blocks__ : Number of uncorrected blocks. A value higher than 0 "
 "can indicate a weak signal or interference, note that some devices can send "
 "a false value."
 msgstr ""
 
-#: src/docs_inc.c:3294
+#: src/docs_inc.c:1848
 msgid ""
-"__Upcoming / Current Recordings__ : This sub-tab lists current and upcoming "
-"recording entries. Entries shown here are either currently recording or are "
-"soon-to-be recorded."
-msgstr ""
-
-#: src/docs_inc.c:1707
-msgid ""
-"__Username__ : The username used to access tvheadend (a blank cell indicates "
+"__Username__ : The username used to access Tvheadend (a blank cell indicates "
 "no username was supplied)."
 msgstr ""
 
-#: src/docs_inc.c:1525
+#: src/docs_inc.c:1985
 msgid ""
 "__Username__ : Username using the subscription - a blank cell indicates the "
 "subscriber didn't supply a username."
 msgstr ""
 
-#: src/docs_inc.c:1916
+#: src/docs_inc.c:2515
 msgid ""
 "__View Level__ | Change the interface view level to show/hide more advanced "
 "options.\n"
 "__Help__ | Display this help page."
 msgstr ""
 
-#: src/docs_inc.c:2969
-msgid ""
-"__WARNING__ : Permissions given to a wildcard account apply to __all__ "
-"accounts."
-msgstr ""
-
-#: src/docs_inc.c:1083
+#: src/docs_inc.c:1928
 msgid "__Weight__ : Stream weighting."
 msgstr ""
 
-#: src/docs_inc.c:5332
+#: src/docs_inc.c:6224
+msgid "__Welcome to Tvheadend, Your TV Streaming Server and Video Recorder__"
+msgstr ""
+
+#: src/docs_inc.c:6174 src/docs_inc.c:6200
+msgid "__You are now Finished__"
+msgstr ""
+
+#: src/docs_inc.c:744
 msgid ""
-"__You may omit this step (do not check 'Map all services') and map services "
+"__You can omit this step (do not check 'Map all services') and map services "
 "to channels manually.__"
 msgstr ""
 
-#: src/docs_inc.c:3819
+#: src/docs_inc.c:6254
+msgid ""
+"__You can skip this step (do not check 'Map all services') and map services "
+"to channels manually.__"
+msgstr ""
+
+#: src/docs_inc.c:3471
 msgid "access"
 msgstr ""
 
-#: src/docs_inc.c:1629 src/docs_inc.c:1825 src/docs_inc.c:4652
-#: src/docs_inc.c:4662 src/docs_inc.c:4672 src/docs_inc.c:4694
+#: src/docs_inc.c:1003 src/docs_inc.c:1186 src/docs_inc.c:4952
+#: src/docs_inc.c:4962 src/docs_inc.c:4972 src/docs_inc.c:4994
 msgid "and"
 msgstr ""
 
-#: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+#: src/docs_inc.c:1708
+msgid ""
+"and IRC (_#hts_ on _Libera_ ). If you don't have a client installed you can "
+"use the"
 msgstr ""
 
-#: src/docs_inc.c:2900
-msgid "anonymous"
-msgstr ""
-
-#: src/docs_inc.c:3839
+#: src/docs_inc.c:3491
 msgid "api"
 msgstr ""
 
-#: src/docs_inc.c:171
-msgid "are good web clients if you don't already have an IRC client installed."
-msgstr ""
-
-#: src/docs_inc.c:395
+#: src/docs_inc.c:1210
 msgid "arm"
 msgstr ""
 
-#: src/docs_inc.c:3634
-msgid "as channels"
+#: src/docs_inc.c:3591
+msgid "audioes"
 msgstr ""
 
-#: src/docs_inc.c:3831
+#: src/docs_inc.c:2194
+msgid "auth"
+msgstr ""
+
+#: src/docs_inc.c:3483
 msgid "avahi"
 msgstr ""
 
-#: src/docs_inc.c:4469
+#: src/docs_inc.c:5836
 msgid ""
 "available. Tvheadend will parse the NIT then the add newly discovered muxes "
 "automatically."
 msgstr ""
 
-#: src/docs_inc.c:397
+#: src/docs_inc.c:1212
 msgid ""
 "based) computers that you connect to your network via Ethernet or Wifi, they "
 "often have a large number of tuners and are controlled via a web interface "
@@ -7222,761 +8516,993 @@ msgid ""
 "HDHomeRun protocols."
 msgstr ""
 
-#: src/docs_inc.c:2894
+#: src/docs_inc.c:672
+msgid "before continuing with the wizard, as it contains lots of useful info!"
+msgstr ""
+
+#: src/docs_inc.c:2775 src/docs_inc.c:3057
 msgid "below"
 msgstr ""
 
-#: src/docs_inc.c:3835
+#: src/docs_inc.c:4329
+msgid "below for important information!"
+msgstr ""
+
+#: src/docs_inc.c:3487
 msgid "bonjour"
 msgstr ""
 
-#: src/docs_inc.c:3955
+#: src/docs_inc.c:3615
 msgid "bouquet"
 msgstr ""
 
-#: src/docs_inc.c:2002 src/docs_inc.c:2010
-msgid "button table below)."
+#: src/docs_inc.c:1342
+msgid "button will be shown instead."
 msgstr ""
 
-#: src/docs_inc.c:3971
+#: src/docs_inc.c:3635
 msgid "caclient"
 msgstr ""
 
-#: src/docs_inc.c:2531
+#: src/docs_inc.c:3857
 msgid "capabilities."
 msgstr ""
 
-#: src/docs_inc.c:3979
+#: src/docs_inc.c:3643
 msgid "capmt"
 msgstr ""
 
-#: src/docs_inc.c:1397 src/docs_inc.c:1531 src/docs_inc.c:3943
-#: src/docs_inc.c:5242
+#: src/docs_inc.c:3651
+msgid "cccam"
+msgstr ""
+
+#: src/docs_inc.c:5422
+msgid "changes. We're ignoring the last component"
+msgstr ""
+
+#: src/docs_inc.c:1991 src/docs_inc.c:2278 src/docs_inc.c:2284
+#: src/docs_inc.c:2316 src/docs_inc.c:3603 src/docs_inc.c:5964
 msgid "channel"
 msgstr ""
 
-#: src/docs_inc.c:1353 src/docs_inc.c:1401 src/docs_inc.c:1461
+#: src/docs_inc.c:2238 src/docs_inc.c:2320 src/docs_inc.c:2380
 msgid "channelid"
 msgstr ""
 
-#: src/docs_inc.c:1349 src/docs_inc.c:1393 src/docs_inc.c:1457
+#: src/docs_inc.c:2234 src/docs_inc.c:2312 src/docs_inc.c:2376
 msgid "channelname"
 msgstr ""
 
-#: src/docs_inc.c:1345 src/docs_inc.c:1389 src/docs_inc.c:1453
+#: src/docs_inc.c:2230 src/docs_inc.c:2308 src/docs_inc.c:2372
 msgid "channelnumber"
 msgstr ""
 
-#: src/docs_inc.c:1333 src/docs_inc.c:1449
+#: src/docs_inc.c:2218 src/docs_inc.c:2368
 msgid "channels"
 msgstr ""
 
-#: src/docs_inc.c:4007
+#: src/docs_inc.c:3679
 msgid "charset"
 msgstr ""
 
-#: src/docs_inc.c:693
+#: src/docs_inc.c:4906
+msgid "checked and this user has admin rights."
+msgstr ""
+
+#: src/docs_inc.c:4918
+msgid "checked even though this user has admin rights."
+msgstr ""
+
+#: src/docs_inc.c:4930
+msgid "checked this user has no admin rights."
+msgstr ""
+
+#: src/docs_inc.c:402
 msgid "click to call up more detailed information about an event"
 msgstr ""
 
-#: src/docs_inc.c:3386
-msgid "click to display detailed information about the selected recording"
+#: src/docs_inc.c:3779
+msgid "codec"
 msgstr ""
 
-#: src/docs_inc.c:3815
+#: src/docs_inc.c:3467
 msgid "config"
 msgstr ""
 
-#: src/docs_inc.c:3823
+#: src/docs_inc.c:1552
+msgid "configuration"
+msgstr ""
+
+#: src/docs_inc.c:3475
 msgid "cron"
 msgstr ""
 
-#: src/docs_inc.c:3975
+#: src/docs_inc.c:3639
 msgid "csa"
 msgstr ""
 
-#: src/docs_inc.c:3983
+#: src/docs_inc.c:3647
 msgid "cwc"
 msgstr ""
 
-#: src/docs_inc.c:3827
+#: src/docs_inc.c:3479
 msgid "dbus"
 msgstr ""
 
-#: src/docs_inc.c:1429
+#: src/docs_inc.c:3787
+msgid "ddci"
+msgstr ""
+
+#: src/docs_inc.c:2188
+msgid "default - HTTP authentication"
+msgstr ""
+
+#: src/docs_inc.c:2348
 msgid "descramble"
 msgstr ""
 
-#: src/docs_inc.c:3967
+#: src/docs_inc.c:3627
 msgid "descrambler"
 msgstr ""
 
-#: src/docs_inc.c:1661
+#: src/docs_inc.c:3631
+msgid "descrambler-emm"
+msgstr ""
+
+#: src/docs_inc.c:69
 msgid "development page"
 msgstr ""
 
-#: src/docs_inc.c:113
+#: src/docs_inc.c:1881
 msgid "dialog determines how services are mapped."
 msgstr ""
 
-#: src/docs_inc.c:2078
-msgid ""
-"dialog will now be displayed with the __selected__ services checked - feel "
-"free to make changes. Once you're happy with the selection press the \"Map "
-"services\" button, you will then be taken to the"
-msgstr ""
-
-#: src/docs_inc.c:1946
+#: src/docs_inc.c:1296 src/docs_inc.c:2544
 msgid "dialog."
 msgstr ""
 
-#: src/docs_inc.c:4043
+#: src/docs_inc.c:3719
 msgid "diseqc"
 msgstr ""
 
-#: src/docs_inc.c:1651
+#: src/docs_inc.c:2408
+msgid "display-name"
+msgstr ""
+
+#: src/docs_inc.c:59
 msgid "documentatation repository"
 msgstr ""
 
-#: src/docs_inc.c:5317 src/docs_inc.c:5395
+#: src/docs_inc.c:6192 src/docs_inc.c:6216
 msgid "donate"
 msgstr ""
 
-#: src/docs_inc.c:4011
+#: src/docs_inc.c:3683
 msgid "dvb"
 msgstr ""
 
-#: src/docs_inc.c:3987
+#: src/docs_inc.c:3655
 msgid "dvbcam"
 msgstr ""
 
-#: src/docs_inc.c:323
+#: src/docs_inc.c:846
 msgid "dvbscan"
 msgstr ""
 
-#: src/docs_inc.c:3991
+#: src/docs_inc.c:3659
 msgid "dvr"
 msgstr ""
 
-#: src/docs_inc.c:1369
+#: src/docs_inc.c:3663
+msgid "dvr-inotify"
+msgstr ""
+
+#: src/docs_inc.c:2254
 msgid "dvrid"
 msgstr ""
 
-#: src/docs_inc.c:1321
+#: src/docs_inc.c:2206
 msgid "e2"
 msgstr ""
 
-#: src/docs_inc.c:1433
+#: src/docs_inc.c:2352
 msgid "emm"
 msgstr ""
 
-#: src/docs_inc.c:1317
+#: src/docs_inc.c:2186 src/docs_inc.c:2202
 msgid "empty"
 msgstr ""
 
-#: src/docs_inc.c:4047
+#: src/docs_inc.c:3723
 msgid "en50221"
 msgstr ""
 
-#: src/docs_inc.c:4051
+#: src/docs_inc.c:3727
 msgid "en50494"
 msgstr ""
 
-#: src/docs_inc.c:3995
+#: src/docs_inc.c:3667
 msgid "epg"
 msgstr ""
 
-#: src/docs_inc.c:3999
+#: src/docs_inc.c:3671
 msgid "epgdb"
 msgstr ""
 
-#: src/docs_inc.c:4003
+#: src/docs_inc.c:3675
 msgid "epggrab"
 msgstr ""
 
-#: src/docs_inc.c:3959
+#: src/docs_inc.c:3619
 msgid "esfilter"
 msgstr ""
 
-#: src/docs_inc.c:1183
+#: src/docs_inc.c:945
 msgid "example"
 msgstr ""
 
-#: src/docs_inc.c:3903
+#: src/docs_inc.c:3555
 msgid "fastscan"
 msgstr ""
 
-#: src/docs_inc.c:1653
+#: src/docs_inc.c:61
 msgid ""
 "fetches the markdown files using the build-in web server and use them as "
 "source for mkdocs."
 msgstr ""
 
-#: src/docs_inc.c:1633
+#: src/docs_inc.c:3195
+msgid "field to 127.0.0.1 and"
+msgstr ""
+
+#: src/docs_inc.c:1007
 msgid "firmware repositories on Github."
 msgstr ""
 
-#: src/docs_inc.c:2034
-msgid "for 7+ days."
-msgstr ""
-
-#: src/docs_inc.c:311
+#: src/docs_inc.c:834
 msgid "for UK DVB-T transmitters"
 msgstr ""
 
-#: src/docs_inc.c:345
+#: src/docs_inc.c:868
 msgid "for a detailed look into service mapping."
 msgstr ""
 
-#: src/docs_inc.c:307
+#: src/docs_inc.c:1068
+msgid "for a full list."
+msgstr ""
+
+#: src/docs_inc.c:2777
+msgid "for a list of possible reasons."
+msgstr ""
+
+#: src/docs_inc.c:830
 msgid "for all European satellite information"
 msgstr ""
 
-#: src/docs_inc.c:1663 src/docs_inc.c:2896
+#: src/docs_inc.c:71
 msgid "for details."
 msgstr ""
 
-#: src/docs_inc.c:3556
+#: src/docs_inc.c:4670
 msgid "for more details on service mapping."
 msgstr ""
 
-#: src/docs_inc.c:1974
+#: src/docs_inc.c:247 src/docs_inc.c:2862
 msgid "for more info."
 msgstr ""
 
-#: src/docs_inc.c:3436
-msgid "for more information."
-msgstr ""
-
-#: src/docs_inc.c:315
+#: src/docs_inc.c:838
 msgid "for primarily central and northern Europe"
 msgstr ""
 
-#: src/docs_inc.c:319
+#: src/docs_inc.c:842
 msgid "for worldwide satellite information."
 msgstr ""
 
-#: src/docs_inc.c:4515
+#: src/docs_inc.c:5114
 msgid "force service type to 1"
 msgstr ""
 
-#: src/docs_inc.c:4346
+#: src/docs_inc.c:5282
 msgid "format."
 msgstr ""
 
-#: src/docs_inc.c:161
+#: src/docs_inc.c:1706
 msgid "forum"
 msgstr ""
 
-#: src/docs_inc.c:1185
+#: src/docs_inc.c:947
 msgid "from one of our users..."
 msgstr ""
 
-#: src/docs_inc.c:3779
+#: src/docs_inc.c:3431
 msgid "fsmonitor"
 msgstr ""
 
-#: src/docs_inc.c:3674
-msgid "functions or a"
-msgstr ""
-
-#: src/docs_inc.c:205
+#: src/docs_inc.c:1074
 msgid "github"
 msgstr ""
 
-#: src/docs_inc.c:3915
+#: src/docs_inc.c:3571
 msgid "globalheaders"
 msgstr ""
 
-#: src/docs_inc.c:2561
-msgid "grabbers"
+#: src/docs_inc.c:3913
+msgid "grabber script & parses the output."
 msgstr ""
 
-#: src/docs_inc.c:2529
-msgid "grabbing"
+#: src/docs_inc.c:3929
+msgid "grabber script & parses the output. This isn't widely used!"
 msgstr ""
 
-#: src/docs_inc.c:3751
-msgid "gtimer"
+#: src/docs_inc.c:3921
+msgid "grabber script."
 msgstr ""
 
-#: src/docs_inc.c:275 src/docs_inc.c:5412
-msgid "here"
-msgstr ""
-
-#: src/docs_inc.c:3923
-msgid "hevc"
-msgstr ""
-
-#: src/docs_inc.c:3851
-msgid "htsp"
-msgstr ""
-
-#: src/docs_inc.c:3863
-msgid "htsp-ans"
-msgstr ""
-
-#: src/docs_inc.c:3859
-msgid "htsp-req"
+#: src/docs_inc.c:3937
+msgid "grabber script. This isn't widely used!"
 msgstr ""
 
 #: src/docs_inc.c:3855
+msgid "grabbing"
+msgstr ""
+
+#: src/docs_inc.c:1266
+msgid "grid"
+msgstr ""
+
+#: src/docs_inc.c:680 src/docs_inc.c:798 src/docs_inc.c:872
+msgid "here"
+msgstr ""
+
+#: src/docs_inc.c:3579
+msgid "hevc"
+msgstr ""
+
+#: src/docs_inc.c:3503
+msgid "htsp"
+msgstr ""
+
+#: src/docs_inc.c:3515
+msgid "htsp-ans"
+msgstr ""
+
+#: src/docs_inc.c:3511
+msgid "htsp-req"
+msgstr ""
+
+#: src/docs_inc.c:3507
 msgid "htsp-sub"
 msgstr ""
 
-#: src/docs_inc.c:3843
+#: src/docs_inc.c:3495
 msgid "http"
 msgstr ""
 
-#: src/docs_inc.c:3847
+#: src/docs_inc.c:3499
 msgid "httpc"
 msgstr ""
 
-#: src/docs_inc.c:1827
+#: src/docs_inc.c:1188
 msgid "iOS"
 msgstr ""
 
-#: src/docs_inc.c:3791
+#: src/docs_inc.c:3443
 msgid "idnode"
 msgstr ""
 
-#: src/docs_inc.c:3867
+#: src/docs_inc.c:2288
+msgid "idxname"
+msgstr ""
+
+#: src/docs_inc.c:3519
 msgid "imagecache"
 msgstr ""
 
-#: src/docs_inc.c:2120
+#: src/docs_inc.c:152
+msgid "indicates the location (or path) of the device."
+msgstr ""
+
+#: src/docs_inc.c:182
+msgid "indicates the tuner (in this case"
+msgstr ""
+
+#: src/docs_inc.c:4376
 msgid "information icon will display service details."
 msgstr ""
 
-#: src/docs_inc.c:4031
+#: src/docs_inc.c:3703
 msgid "iptv"
 msgstr ""
 
-#: src/docs_inc.c:4035
+#: src/docs_inc.c:3707
 msgid "iptv-pcr"
 msgstr ""
 
-#: src/docs_inc.c:4023
+#: src/docs_inc.c:3711
+msgid "iptv-sub"
+msgstr ""
+
+#: src/docs_inc.c:4904 src/docs_inc.c:4928
+msgid "is"
+msgstr ""
+
+#: src/docs_inc.c:174
+msgid "is a unique ID."
+msgstr ""
+
+#: src/docs_inc.c:172
+msgid "is the RTSP server listening port."
+msgstr ""
+
+#: src/docs_inc.c:170
+msgid "is the SAT>IP server name."
+msgstr ""
+
+#: src/docs_inc.c:156
+msgid "is the adapter number (also used in the path)."
+msgstr ""
+
+#: src/docs_inc.c:162
+msgid "is the adapter number."
+msgstr ""
+
+#: src/docs_inc.c:160
+msgid "is the chipset name."
+msgstr ""
+
+#: src/docs_inc.c:164
+msgid "is the delivery system."
+msgstr ""
+
+#: src/docs_inc.c:154
+msgid "is the demodulation chipset name given to it by the kernel driver."
+msgstr ""
+
+#: src/docs_inc.c:166
+msgid "is the frontend number. A tuner can have many frontends!"
+msgstr ""
+
+#: src/docs_inc.c:190
+msgid "is the listening port."
+msgstr ""
+
+#: src/docs_inc.c:176 src/docs_inc.c:188
+msgid "is the server's IP address."
+msgstr ""
+
+#: src/docs_inc.c:4916
+msgid "isn't"
+msgstr ""
+
+#: src/docs_inc.c:4334
+msgid "items"
+msgstr ""
+
+#: src/docs_inc.c:2400 src/docs_inc.c:2404
+msgid "lcn"
+msgstr ""
+
+#: src/docs_inc.c:3695
 msgid "libav"
 msgstr ""
 
-#: src/docs_inc.c:4025
+#: src/docs_inc.c:3697
 msgid "libav / ffmpeg"
 msgstr ""
 
-#: src/docs_inc.c:4039
+#: src/docs_inc.c:1268
+msgid ""
+"like a spreadsheet, a panel, or a list of (grouped) settings/options below "
+"that."
+msgstr ""
+
+#: src/docs_inc.c:3715
 msgid "linuxdvb"
 msgstr ""
 
-#: src/docs_inc.c:1797
+#: src/docs_inc.c:1158
 msgid "linuxtv"
 msgstr ""
 
-#: src/docs_inc.c:3783
+#: src/docs_inc.c:3435
 msgid "lock"
 msgstr ""
 
-#: src/docs_inc.c:1305
+#: src/docs_inc.c:2174
 msgid "m3u"
 msgstr ""
 
-#: src/docs_inc.c:3747
+#: src/docs_inc.c:3399
 msgid "main"
 msgstr ""
 
-#: src/docs_inc.c:3935 src/docs_inc.c:5062
+#: src/docs_inc.c:1262
+msgid "menu bar"
+msgstr ""
+
+#: src/docs_inc.c:3595 src/docs_inc.c:5558
 msgid "mkv"
 msgstr ""
 
-#: src/docs_inc.c:4015
+#: src/docs_inc.c:3239
+msgid ""
+"mode is that no UDP connections are required. All communication is processed "
+"through the named pipe(/tmp/camd.socket). The configuration for OSCam is "
+"same as the previous"
+msgstr ""
+
+#: src/docs_inc.c:3231
+msgid ""
+"mode, but a named pipe(/tmp/camd.socket) connection is used instead of the "
+"TCP connection."
+msgstr ""
+
+#: src/docs_inc.c:3213
+msgid ""
+"mode, but a namedpipe (/tmp/camd.socket) connection is used instead of the "
+"TCP connection."
+msgstr ""
+
+#: src/docs_inc.c:3243
+msgid "mode."
+msgstr ""
+
+#: src/docs_inc.c:4496
+msgid "module under 'General Settings'."
+msgstr ""
+
+#: src/docs_inc.c:3687
 msgid "mpegts"
 msgstr ""
 
-#: src/docs_inc.c:3755
-msgid "mtimer"
-msgstr ""
-
-#: src/docs_inc.c:1409
+#: src/docs_inc.c:2328
 msgid "mux"
 msgstr ""
 
-#: src/docs_inc.c:3927
+#: src/docs_inc.c:3583
 msgid "muxer"
 msgstr ""
 
-#: src/docs_inc.c:4019
+#: src/docs_inc.c:3691
 msgid "muxsched"
 msgstr ""
 
-#: src/docs_inc.c:2239
+#: src/docs_inc.c:2282 src/docs_inc.c:2294
+msgid "name"
+msgstr ""
+
+#: src/docs_inc.c:4636
 msgid "networks"
 msgstr ""
 
-#: src/docs_inc.c:1799
+#: src/docs_inc.c:1160
 msgid "networks or manually configured."
 msgstr ""
 
-#: src/docs_inc.c:777 src/docs_inc.c:779 src/docs_inc.c:787 src/docs_inc.c:789
-#: src/docs_inc.c:805 src/docs_inc.c:813 src/docs_inc.c:831 src/docs_inc.c:833
-#: src/docs_inc.c:841 src/docs_inc.c:843
+#: src/docs_inc.c:530 src/docs_inc.c:532 src/docs_inc.c:540 src/docs_inc.c:542
+#: src/docs_inc.c:558 src/docs_inc.c:566 src/docs_inc.c:584 src/docs_inc.c:586
+#: src/docs_inc.c:594 src/docs_inc.c:596
 msgid "no"
 msgstr ""
 
-#: src/docs_inc.c:4071
+#: src/docs_inc.c:2276
+msgid "numname"
+msgstr ""
+
+#: src/docs_inc.c:3747
 msgid "opentv"
 msgstr ""
 
-#: src/docs_inc.c:1303
+#: src/docs_inc.c:2172 src/docs_inc.c:4762
 msgid "or"
 msgstr ""
 
-#: src/docs_inc.c:167
-msgid "or Freenode's"
-msgstr ""
-
-#: src/docs_inc.c:5309 src/docs_inc.c:5387
+#: src/docs_inc.c:6184 src/docs_inc.c:6208
 msgid "or chat to us on"
 msgstr ""
 
-#: src/docs_inc.c:5244
+#: src/docs_inc.c:5966
 msgid "or per"
 msgstr ""
 
-#: src/docs_inc.c:3690
-msgid "page for info."
-msgstr ""
-
-#: src/docs_inc.c:3422 src/docs_inc.c:3516
-msgid "page."
-msgstr ""
-
-#: src/docs_inc.c:2719
-msgid "parameters"
-msgstr ""
-
-#: src/docs_inc.c:3907
+#: src/docs_inc.c:3563
 msgid "parser"
 msgstr ""
 
-#: src/docs_inc.c:3931
+#: src/docs_inc.c:3587
 msgid "pass"
 msgstr ""
 
-#: src/docs_inc.c:1437
+#: src/docs_inc.c:3559
+msgid "pcr"
+msgstr ""
+
+#: src/docs_inc.c:2196
+msgid "pernament code which must be enabled in the password table"
+msgstr ""
+
+#: src/docs_inc.c:2356
 msgid "pids"
 msgstr ""
 
-#: src/docs_inc.c:1297
+#: src/docs_inc.c:2166
 msgid "playlist"
 msgstr ""
 
-#: src/docs_inc.c:1377 src/docs_inc.c:1417 src/docs_inc.c:1537
-#: src/docs_inc.c:3963
+#: src/docs_inc.c:1999 src/docs_inc.c:2262 src/docs_inc.c:2336
+#: src/docs_inc.c:3623
 msgid "profile"
 msgstr ""
 
-#: src/docs_inc.c:4067
+#: src/docs_inc.c:3743
 msgid "psip"
 msgstr ""
 
-#: src/docs_inc.c:4075
+#: src/docs_inc.c:3751
 msgid "pyepg"
 msgstr ""
 
-#: src/docs_inc.c:1425
+#: src/docs_inc.c:3407
+msgid "qprof"
+msgstr ""
+
+#: src/docs_inc.c:2344
 msgid "qsize"
 msgstr ""
 
-#: src/docs_inc.c:3382
-msgid "recording of the program is active and underway (current)"
-msgstr ""
-
-#: src/docs_inc.c:1341
+#: src/docs_inc.c:2226
 msgid "recordings"
 msgstr ""
 
-#: src/docs_inc.c:3803
+#: src/docs_inc.c:3455
 msgid "rtsp"
 msgstr ""
 
-#: src/docs_inc.c:1325 src/docs_inc.c:4055
+#: src/docs_inc.c:2210 src/docs_inc.c:3731
 msgid "satip"
 msgstr ""
 
-#: src/docs_inc.c:4059
+#: src/docs_inc.c:3735
 msgid "satips"
 msgstr ""
 
-#: src/docs_inc.c:4091
+#: src/docs_inc.c:3767
 msgid "scanfile"
 msgstr ""
 
-#: src/docs_inc.c:3658
-msgid "selected channels."
+#: src/docs_inc.c:3203 src/docs_inc.c:3223 src/docs_inc.c:3253
+msgid "section of oscam.conf:"
 msgstr ""
 
-#: src/docs_inc.c:1405 src/docs_inc.c:3939
+#: src/docs_inc.c:2324 src/docs_inc.c:3599
 msgid "service"
 msgstr ""
 
-#: src/docs_inc.c:3951
+#: src/docs_inc.c:3611
 msgid "service-mapper"
 msgstr ""
 
-#: src/docs_inc.c:3624 src/docs_inc.c:3632
-msgid "services"
-msgstr ""
-
-#: src/docs_inc.c:3811
+#: src/docs_inc.c:3463
 msgid "settings"
 msgstr ""
 
-#: src/docs_inc.c:3775
+#: src/docs_inc.c:2266
+msgid "sort"
+msgstr ""
+
+#: src/docs_inc.c:3427
 msgid "spawn"
 msgstr ""
 
-#: src/docs_inc.c:4344
+#: src/docs_inc.c:5280
 msgid "strftime"
 msgstr ""
 
-#: src/docs_inc.c:3947
+#: src/docs_inc.c:3607
 msgid "subscription"
 msgstr ""
 
-#: src/docs_inc.c:2279
-msgid ""
-"tab for it to apply. You may have multiple password entries for the same "
-"username if you wish."
+#: src/docs_inc.c:2746 src/docs_inc.c:2754
+msgid "tab - including those currently broadcasting."
 msgstr ""
 
-#: src/docs_inc.c:4505 src/docs_inc.c:4594
+#: src/docs_inc.c:5068 src/docs_inc.c:5104
 msgid "tab to re-generate them."
 msgstr ""
 
-#: src/docs_inc.c:3546
+#: src/docs_inc.c:4660
 msgid "tab when you press the _[Map services]_ button."
 msgstr ""
 
-#: src/docs_inc.c:2064 src/docs_inc.c:2082
-msgid "tab which will begin mapping the selected services to channels."
-msgstr ""
-
-#: src/docs_inc.c:3356 src/docs_inc.c:3364
-msgid "tab."
-msgstr ""
-
-#: src/docs_inc.c:4251
+#: src/docs_inc.c:6054
 msgid ""
 "tab. Note, when streaming using the HTSP Protocol e.g. Kodi (via pvr.hts) or "
 "Movian the HTSP profile will always be used."
 msgstr ""
 
-#: src/docs_inc.c:3078
+#: src/docs_inc.c:466
+msgid ""
+"tab. This allows you to set, for example, more post-broadcast padding for a "
+"channel that always runs late, or perhaps define a different post-processing "
+"command to strip adverts out on a commercial channel."
+msgstr ""
+
+#: src/docs_inc.c:4029
 msgid ""
 "tab. This dialog shows the received PIDs and filtered PIDs in one window."
 msgstr ""
 
-#: src/docs_inc.c:1357 src/docs_inc.c:1465
+#: src/docs_inc.c:2242 src/docs_inc.c:2290 src/docs_inc.c:2296
+#: src/docs_inc.c:2384
 msgid "tag"
 msgstr ""
 
-#: src/docs_inc.c:1365 src/docs_inc.c:1473
+#: src/docs_inc.c:2406
+msgid "tag instead"
+msgstr ""
+
+#: src/docs_inc.c:2250 src/docs_inc.c:2392
 msgid "tagid"
 msgstr ""
 
-#: src/docs_inc.c:1361 src/docs_inc.c:1469
+#: src/docs_inc.c:2246 src/docs_inc.c:2388
 msgid "tagname"
 msgstr ""
 
-#: src/docs_inc.c:1337
+#: src/docs_inc.c:2222
 msgid "tags"
 msgstr ""
 
-#: src/docs_inc.c:3871
+#: src/docs_inc.c:3523
 msgid "tbl"
 msgstr ""
 
-#: src/docs_inc.c:3891
+#: src/docs_inc.c:3543
 msgid "tbl-atsc"
 msgstr ""
 
-#: src/docs_inc.c:3875
+#: src/docs_inc.c:3527
 msgid "tbl-base"
 msgstr ""
 
-#: src/docs_inc.c:3879
+#: src/docs_inc.c:3531
 msgid "tbl-csa"
 msgstr ""
 
-#: src/docs_inc.c:3883
+#: src/docs_inc.c:3535
 msgid "tbl-eit"
 msgstr ""
 
-#: src/docs_inc.c:3895
+#: src/docs_inc.c:3547
 msgid "tbl-pass"
 msgstr ""
 
-#: src/docs_inc.c:3899
+#: src/docs_inc.c:3551
 msgid "tbl-satip"
 msgstr ""
 
-#: src/docs_inc.c:3887
+#: src/docs_inc.c:3539
 msgid "tbl-time"
 msgstr ""
 
-#: src/docs_inc.c:3799
+#: src/docs_inc.c:3451
 msgid "tcp"
 msgstr ""
 
-#: src/docs_inc.c:1581
+#: src/docs_inc.c:2192
+msgid "temporary ticket valid for 5 minutes"
+msgstr ""
+
+#: src/docs_inc.c:1264
+msgid "that provides access to Add/Save/Edit-type functions, and a"
+msgstr ""
+
+#: src/docs_inc.c:955
 msgid "the Tvheadend forums"
 msgstr ""
 
-#: src/docs_inc.c:697 src/docs_inc.c:3390
+#: src/docs_inc.c:406
 msgid "the program failed to record"
 msgstr ""
 
-#: src/docs_inc.c:689
+#: src/docs_inc.c:398
 msgid "the program is currently recording"
 msgstr ""
 
-#: src/docs_inc.c:3378
-msgid "the program is scheduled (upcoming)"
-msgstr ""
-
-#: src/docs_inc.c:685
+#: src/docs_inc.c:394
 msgid "the program is scheduled for recording"
 msgstr ""
 
-#: src/docs_inc.c:3394
-msgid "the program recorded successfully"
-msgstr ""
-
-#: src/docs_inc.c:1533
+#: src/docs_inc.c:1993
 msgid ""
 "the subscription is using - if the subscription is streaming a service/mux "
 "this cell will be blank."
 msgstr ""
 
-#: src/docs_inc.c:1539
+#: src/docs_inc.c:2001
 msgid "the subscription is using."
 msgstr ""
 
-#: src/docs_inc.c:2818
-msgid "this guide"
+#: src/docs_inc.c:1554
+msgid "the view level drop-down isn't always visible."
 msgstr ""
 
-#: src/docs_inc.c:3763
+#: src/docs_inc.c:5314
+msgid "thetvdb.com"
+msgstr ""
+
+#: src/docs_inc.c:3415
 msgid "thread"
 msgstr ""
 
-#: src/docs_inc.c:3771
+#: src/docs_inc.c:2190
+msgid "ticket"
+msgstr ""
+
+#: src/docs_inc.c:3423
 msgid "time"
 msgstr ""
 
-#: src/docs_inc.c:4087
+#: src/docs_inc.c:3763
 msgid "timeshift"
 msgstr ""
 
-#: src/docs_inc.c:325
+#: src/docs_inc.c:5302
+msgid "tmdb"
+msgstr ""
+
+#: src/docs_inc.c:5306
+msgid "tmdb.org"
+msgstr ""
+
+#: src/docs_inc.c:3199
+msgid ""
+"to 9000 (or your preferred TCP port). Note that the TCP port must match "
+"OSCam's configuration. The following lines are required in"
+msgstr ""
+
+#: src/docs_inc.c:848
 msgid "to force a scan and effectively ask your tuner what it can see."
 msgstr ""
 
-#: src/docs_inc.c:4027
+#: src/docs_inc.c:3403
+msgid "tprof"
+msgstr ""
+
+#: src/docs_inc.c:3699
 msgid "transcode"
 msgstr ""
 
-#: src/docs_inc.c:4095
+#: src/docs_inc.c:3775
+msgid "tsdebug"
+msgstr ""
+
+#: src/docs_inc.c:3771
 msgid "tsfile"
 msgstr ""
 
-#: src/docs_inc.c:3919
+#: src/docs_inc.c:3575
 msgid "tsfix"
 msgstr ""
 
-#: src/docs_inc.c:4063
+#: src/docs_inc.c:5310 src/docs_inc.c:5318
+msgid "tvdb"
+msgstr ""
+
+#: src/docs_inc.c:3739
 msgid "tvhdhomerun"
 msgstr ""
 
-#: src/docs_inc.c:3767
+#: src/docs_inc.c:3419
 msgid "tvhpoll"
 msgstr ""
 
-#: src/docs_inc.c:3656
-msgid "two"
+#: src/docs_inc.c:5550 src/docs_inc.c:5578
+msgid "tvmovies/Gladiator (2000)"
 msgstr ""
 
-#: src/docs_inc.c:309
+#: src/docs_inc.c:5606
+msgid "tvmovies/Gladiator (2000)/Gladiator (2000)"
+msgstr ""
+
+#: src/docs_inc.c:5544
+msgid "tvshows/Bones/Bones - S02E06"
+msgstr ""
+
+#: src/docs_inc.c:5582
+msgid "tvshows/Bones/Bones - S05E11"
+msgstr ""
+
+#: src/docs_inc.c:5584
+msgid "tvshows/Bones/Bones - S05E11 - The X in the Files"
+msgstr ""
+
+#: src/docs_inc.c:5608
+msgid "tvshows/Bones/Season 5/Bones - S05E11"
+msgstr ""
+
+#: src/docs_inc.c:5580
+msgid "tvshows/Countdown/Countdown"
+msgstr ""
+
+#: src/docs_inc.c:832
 msgid "ukfree.tv"
 msgstr ""
 
-#: src/docs_inc.c:3807
+#: src/docs_inc.c:3459
 msgid "upnp"
 msgstr ""
 
-#: src/docs_inc.c:3795
+#: src/docs_inc.c:3447
 msgid "url"
 msgstr ""
 
-#: src/docs_inc.c:4377 src/docs_inc.c:4381 src/docs_inc.c:4755
-#: src/docs_inc.c:4759 src/docs_inc.c:5177 src/docs_inc.c:5181
+#: src/docs_inc.c:5674 src/docs_inc.c:5678 src/docs_inc.c:5774
+#: src/docs_inc.c:5778 src/docs_inc.c:5866 src/docs_inc.c:5870
 msgid "user"
 msgstr ""
 
-#: src/docs_inc.c:3787
+#: src/docs_inc.c:3439
 msgid "uuid"
 msgstr ""
 
-#: src/docs_inc.c:169
+#: src/docs_inc.c:3783
+msgid "vaapi"
+msgstr ""
+
+#: src/docs_inc.c:1252
+msgid "view level"
+msgstr ""
+
+#: src/docs_inc.c:1710
 msgid "webchat"
 msgstr ""
 
-#: src/docs_inc.c:4083
+#: src/docs_inc.c:3759
 msgid "webui"
 msgstr ""
 
-#: src/docs_inc.c:1421
+#: src/docs_inc.c:2340
 msgid "weight"
 msgstr ""
 
-#: src/docs_inc.c:153
+#: src/docs_inc.c:1698
 msgid "wiki"
 msgstr ""
 
-#: src/docs_inc.c:4444 src/docs_inc.c:4448
+#: src/docs_inc.c:5042
 msgid "will be"
 msgstr ""
 
-#: src/docs_inc.c:2060
-msgid ""
-"will now be displayed with __all__ services checked - feel free to make "
-"changes. Once you're happy with the selection press the \"Map services\" "
-"button, you will then be taken to the"
-msgstr ""
-
-#: src/docs_inc.c:4079
+#: src/docs_inc.c:3755
 msgid "xmltv"
 msgstr ""
 
-#: src/docs_inc.c:1301
+#: src/docs_inc.c:2170
 msgid "xspf"
 msgstr ""
 
-#: src/docs_inc.c:781 src/docs_inc.c:783 src/docs_inc.c:791 src/docs_inc.c:807
-#: src/docs_inc.c:809 src/docs_inc.c:815 src/docs_inc.c:835 src/docs_inc.c:837
-#: src/docs_inc.c:845
+#: src/docs_inc.c:534 src/docs_inc.c:536 src/docs_inc.c:544 src/docs_inc.c:560
+#: src/docs_inc.c:562 src/docs_inc.c:568 src/docs_inc.c:588 src/docs_inc.c:590
+#: src/docs_inc.c:598
 msgid "yes"
 msgstr ""
 
-#: src/docs_inc.c:2241
+#: src/docs_inc.c:4638
 msgid ""
 "you want to export. If you don't export any, you will see the following "
 "error message (in the log)."
 msgstr ""
 
-#: src/docs_inc.c:89
+#: src/docs_inc.c:1805
 msgid ""
 "| --------------------------- | ------------- Headless table cell 1 | "
 "Content from cell 2 Content in the first column | Content in the second "
 "column"
+msgstr ""
+
+#: src/docs_inc.c:5536 src/docs_inc.c:5538 src/docs_inc.c:5546
+#: src/docs_inc.c:5548
+msgid "〃"
 msgstr ""

--- a/intl/js/tvheadend.js.pot
+++ b/intl/js/tvheadend.js.pot
@@ -8,14 +8,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-29 21:07+0200\n"
+"POT-Creation-Date: 2024-02-01 08:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#. /finished recordings to autorecs.
+#: src/webui/static/app/epg.js:1530
+msgid " - "
+msgstr ""
 
 #: src/webui/static/app/i18n-post.js:137
 msgid "&#160;OK&#160;"
@@ -25,8 +30,9 @@ msgstr ""
 msgid "(?:st|nd|rd|th)#parseCodes.S.s"
 msgstr ""
 
-#: src/webui/static/app/chconf.js:6 src/webui/static/app/chconf.js:27
-#: src/webui/static/app/epg.js:3 src/webui/static/app/epg.js:68
+#: src/webui/static/app/chconf.js:10 src/webui/static/app/chconf.js:31
+#: src/webui/static/app/epg.js:3 src/webui/static/app/epg.js:93
+#: src/webui/static/app/epg.js:147
 msgid "(Clear filter)"
 msgstr ""
 
@@ -34,8 +40,17 @@ msgstr ""
 msgid "(None)"
 msgstr ""
 
-#: src/webui/static/app/epg.js:247
+#: src/webui/static/app/epg.js:415
 msgid "(default DVR Profile)"
+msgstr ""
+
+#: src/webui/static/app/tvheadend.js:587
+msgid ""
+"**You'll also see this page if you try and view documentation (for a "
+"feature) not included with your version of Tvheadend.**\n"
+"\n"
+"\n"
+"\n"
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:59
@@ -46,23 +61,27 @@ msgstr ""
 msgid "0,000.00#NumberColumn"
 msgstr ""
 
-#: src/webui/static/app/epg.js:69
+#: src/webui/static/app/epg.js:148
 msgid "00:00:00 - 00:15:00"
 msgstr ""
 
-#: src/webui/static/app/epg.js:70
+#: src/webui/static/app/epg.js:149
 msgid "00:15:00 - 00:30:00"
 msgstr ""
 
-#: src/webui/static/app/epg.js:71
-msgid "00:30:00 - 01:30:00"
+#: src/webui/static/app/epg.js:150
+msgid "00:30:00 - 01:00:00"
 msgstr ""
 
-#: src/webui/static/app/epg.js:72
+#: src/webui/static/app/epg.js:151
+msgid "01:00:00 - 01:30:00"
+msgstr ""
+
+#: src/webui/static/app/epg.js:152
 msgid "01:30:00 - 03:00:00"
 msgstr ""
 
-#: src/webui/static/app/epg.js:73
+#: src/webui/static/app/epg.js:153
 msgid "03:00:00 - No maximum"
 msgstr ""
 
@@ -110,15 +129,15 @@ msgstr ""
 msgid "9 #monthNumber"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:245
+#: src/webui/static/app/dvr.js:557
 msgid "Abort"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:243
+#: src/webui/static/app/dvr.js:555
 msgid "Abort the selected recording"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:836
+#: src/webui/static/app/tvheadend.js:1205
 msgid "About"
 msgstr ""
 
@@ -130,27 +149,31 @@ msgstr ""
 msgid "Access Entry"
 msgstr ""
 
+#: src/webui/static/app/epg.js:605 src/webui/static/app/epg.js:606
+msgid "Actions"
+msgstr ""
+
 #: src/webui/static/app/servicemapper.js:22
 msgid "Active"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1793 src/webui/static/app/idnode.js:2289
+#: src/webui/static/app/idnode.js:1851 src/webui/static/app/idnode.js:2360
 msgid "Add"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1791 src/webui/static/app/idnode.js:2287
+#: src/webui/static/app/idnode.js:1849 src/webui/static/app/idnode.js:2358
 msgid "Add a new entry"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1363 src/webui/static/app/idnode.js:1558
+#: src/webui/static/app/idnode.js:1397 src/webui/static/app/idnode.js:1598
 msgid "Add {0}"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:594 src/webui/static/app/idnode.js:610
+#: src/webui/static/app/idnode.js:604 src/webui/static/app/idnode.js:620
 msgid "Advanced"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1043
+#: src/webui/static/app/idnode.js:1054
 msgid "Advanced Settings"
 msgstr ""
 
@@ -158,25 +181,34 @@ msgstr ""
 msgid "After"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:209
+#: src/webui/static/app/mpegts.js:212
 msgid "After filtering and reordering (without PCR and PMT)"
 msgstr ""
 
-#: src/webui/static/app/epg.js:607 src/webui/static/app/epg.js:608
+#: src/webui/static/app/epg.js:872 src/webui/static/app/epg.js:873
 msgid "Age"
 msgstr ""
 
-#: src/webui/static/app/epg.js:134
+#: src/webui/static/app/epg.js:275 src/webui/static/app/dvr.js:149
 msgid "Age Rating"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1940 src/webui/static/app/idnode.js:1979
+#: src/webui/static/app/idnode.js:1998 src/webui/static/app/idnode.js:2037
+#: src/webui/static/app/epg.js:927
 msgid "All"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1153 src/webui/static/app/idnode.js:1166
-#: src/webui/static/app/idnode.js:1175 src/webui/static/app/idnode.js:1483
-#: src/webui/static/app/idnode.js:1501 src/webui/static/app/idnode.js:1511
+#: src/webui/static/app/epgevent.js:146
+msgid "Alternative Showings"
+msgstr ""
+
+#: src/webui/static/app/epgevent.js:207
+msgid "Alternative showings"
+msgstr ""
+
+#: src/webui/static/app/idnode.js:1185 src/webui/static/app/idnode.js:1198
+#: src/webui/static/app/idnode.js:1207 src/webui/static/app/idnode.js:1523
+#: src/webui/static/app/idnode.js:1541 src/webui/static/app/idnode.js:1551
 msgid "Apply"
 msgstr ""
 
@@ -188,7 +220,7 @@ msgstr ""
 msgid "Apply configuration (run-time only)"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1482
+#: src/webui/static/app/idnode.js:1522
 msgid "Apply settings"
 msgstr ""
 
@@ -200,7 +232,7 @@ msgstr ""
 msgid "April"
 msgstr ""
 
-#: src/webui/static/app/epg.js:159
+#: src/webui/static/app/epg.js:305
 msgid "Aspect"
 msgstr ""
 
@@ -212,15 +244,15 @@ msgstr ""
 msgid "Assign lowest free channel number"
 msgstr ""
 
-#: src/webui/static/app/esfilter.js:65
+#: src/webui/static/app/esfilter.js:43
 msgid "Audio Stream Filter"
 msgstr ""
 
-#: src/webui/static/app/esfilter.js:66
+#: src/webui/static/app/esfilter.js:44
 msgid "Audio Stream Filters"
 msgstr ""
 
-#: src/webui/static/app/epg.js:167
+#: src/webui/static/app/epg.js:313
 msgid "Audio description#EPG"
 msgstr ""
 
@@ -232,36 +264,40 @@ msgstr ""
 msgid "August"
 msgstr ""
 
-#: src/webui/static/app/epg.js:1063
+#: src/webui/static/app/epg.js:1501
 msgid "Auto Recorder"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:368
+#: src/webui/static/app/tvheadend.js:707
 msgid "Auto-refresh"
 msgstr ""
 
-#: src/webui/static/app/epg.js:263 src/webui/static/app/dvr.js:69
-#: src/webui/static/app/dvr.js:735
+#: src/webui/static/app/epg.js:434 src/webui/static/app/dvr.js:159
+#: src/webui/static/app/dvr.js:1077
 msgid "Autorec"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:736
+#: src/webui/static/app/dvr.js:1078
 msgid "Autorecs"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:446 src/webui/static/app/idnode.js:691
+#: src/webui/static/app/idnode.js:461 src/webui/static/app/idnode.js:701
 msgid "Available"
 msgstr ""
 
-#: src/webui/static/app/status.js:404
+#: src/webui/static/app/status.js:451
 msgid "BER"
 msgstr ""
 
-#: src/webui/static/app/status.js:396
+#: src/webui/static/app/tvheadend.js:520 src/webui/static/app/tvheadend.js:521
+msgid "Back to top"
+msgstr ""
+
+#: src/webui/static/app/status.js:443
 msgid "Bandwidth (kb/s)"
 msgstr ""
 
-#: src/webui/static/app/status.js:732 src/webui/static/app/status.js:825
+#: src/webui/static/app/status.js:875 src/webui/static/app/status.js:968
 msgid "Bandwidth monitor"
 msgstr ""
 
@@ -269,11 +305,11 @@ msgstr ""
 msgid "Base"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:592 src/webui/static/app/idnode.js:604
+#: src/webui/static/app/idnode.js:602 src/webui/static/app/idnode.js:614
 msgid "Basic"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1041
+#: src/webui/static/app/idnode.js:1052
 msgid "Basic Settings"
 msgstr ""
 
@@ -289,78 +325,88 @@ msgstr ""
 msgid "Bouquets"
 msgstr ""
 
-#: src/webui/static/app/epg.js:276
+#: src/webui/static/app/epg.js:201
 msgid "Broadcast Details"
 msgstr ""
 
-#: src/webui/static/app/epg.js:381
+#: src/webui/static/app/epg.js:29
 msgid "Broadcast details"
 msgstr ""
 
-#: src/webui/static/app/epg.js:870
-msgid "Buffering. Please wait..."
-msgstr ""
-
-#: src/webui/static/app/caclient.js:32
-msgid "CA"
-msgstr ""
-
-#: src/webui/static/app/esfilter.js:116
-msgid "CA Stream Filter"
-msgstr ""
-
-#: src/webui/static/app/esfilter.js:117
-msgid "CA Stream Filters"
-msgstr ""
-
-#: src/webui/static/app/mpegts.js:188
-msgid "CAIDS: "
+#: src/webui/static/app/epg.js:1280 src/webui/static/app/epgevent.js:79
+msgid "Buffering. Please wait…"
 msgstr ""
 
 #: src/webui/static/app/caclient.js:33
+msgid "CA"
+msgstr ""
+
+#: src/webui/static/app/esfilter.js:94
+msgid "CA Stream Filter"
+msgstr ""
+
+#: src/webui/static/app/esfilter.js:95
+msgid "CA Stream Filters"
+msgstr ""
+
+#: src/webui/static/app/mpegts.js:192
+msgid "CAIDS: "
+msgstr ""
+
+#: src/webui/static/app/caclient.js:34
 msgid "CAs"
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:111 src/webui/static/app/i18n-post.js:138
-#: src/webui/static/app/idnode.js:1110 src/webui/static/app/idnode.js:1522
+#: src/webui/static/app/idnode.js:1140 src/webui/static/app/idnode.js:1562
 msgid "Cancel"
 msgstr ""
 
-#: src/webui/static/app/status.js:559
+#: src/webui/static/app/status.js:629
 msgid "Cancel Connection"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1521
+#: src/webui/static/app/idnode.js:1561
 msgid "Cancel operation"
 msgstr ""
 
-#: src/webui/static/app/status.js:560
+#: src/webui/static/app/status.js:630
 msgid "Cancel the selected connection?"
 msgstr ""
 
-#: src/webui/static/app/status.js:556
+#: src/webui/static/app/status.js:626
 msgid "Cancel this connection"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1175 src/webui/static/app/idnode.js:1511
+#: src/webui/static/app/idnode.js:1207 src/webui/static/app/idnode.js:1551
 msgid "Cannot apply"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:622
+#: src/webui/static/app/epg.js:267 src/webui/static/app/dvr.js:143
+msgid "Categories"
+msgstr ""
+
+#: src/webui/static/app/epg.js:1495 src/webui/static/app/epg.js:1497
+#: src/webui/static/app/epg.js:1499
+msgid "Category"
+msgstr ""
+
+#: src/webui/static/app/idnode.js:632
 msgid "Change the user interface level (basic, advanced, expert)"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1167 src/webui/static/app/idnode.js:1502
+#: src/webui/static/app/idnode.js:1199 src/webui/static/app/idnode.js:1542
 msgid "Changes were applied!"
 msgstr ""
 
-#: src/webui/static/app/chconf.js:232 src/webui/static/app/epg.js:585
-#: src/webui/static/app/epg.js:586 src/webui/static/app/epg.js:1067
-#: src/webui/static/app/status.js:113
+#: src/webui/static/app/chconf.js:232 src/webui/static/app/epg.js:842
+#: src/webui/static/app/epg.js:843 src/webui/static/app/epg.js:1505
+#: src/webui/static/app/epgevent.js:134 src/webui/static/app/epgevent.js:135
+#: src/webui/static/app/status.js:123
 msgid "Channel"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:759
+#: src/webui/static/app/tvheadend.js:1124
 msgid "Channel / EPG"
 msgstr ""
 
@@ -384,115 +430,159 @@ msgstr ""
 msgid "Choose a month (Control+Up/Down to move years)"
 msgstr ""
 
-#: src/webui/static/app/config.js:78
+#: src/webui/static/app/config.js:75
 msgid "Clean image (icon) cache"
 msgstr ""
 
-#: src/webui/static/app/config.js:76
+#: src/webui/static/app/config.js:73
 msgid "Clean image cache on storage"
 msgstr ""
 
-#: src/webui/static/app/status.js:289 src/webui/static/app/status.js:292
+#: src/webui/static/app/status.js:534
+msgid "Clear all statistics"
+msgstr ""
+
+#: src/webui/static/app/status.js:318 src/webui/static/app/status.js:321
 msgid "Clear statistics"
 msgstr ""
 
-#: src/webui/static/app/status.js:293
+#: src/webui/static/app/status.js:322
 msgid "Clear statistics for selected input?"
 msgstr ""
 
-#: src/webui/static/app/caclient.js:34
+#: src/webui/static/app/status.js:116
+msgid "Client / User agent"
+msgstr ""
+
+#: src/webui/static/app/status.js:692
+msgid "Client Address"
+msgstr ""
+
+#: src/webui/static/app/status.js:704
+msgid "Client Data Ports"
+msgstr ""
+
+#: src/webui/static/app/caclient.js:35
 msgid "Client Name"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1430 src/webui/static/app/idnode.js:2299
+#: src/webui/static/app/status.js:698
+msgid "Client Port"
+msgstr ""
+
+#: src/webui/static/app/idnode.js:1470 src/webui/static/app/idnode.js:2373
 msgid "Clone"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:2297
+#: src/webui/static/app/idnode.js:2371
 msgid "Clone a new entry"
 msgstr ""
 
-#: src/webui/static/app/epg.js:270
+#: src/webui/static/app/epg.js:466
 msgid "Close"
+msgstr ""
+
+#: src/webui/static/app/codec.js:785
+msgid "Codec"
+msgstr ""
+
+#: src/webui/static/app/codec.js:771 src/webui/static/app/codec.js:783
+msgid "Codec Profile"
+msgstr ""
+
+#: src/webui/static/app/codec.js:773
+msgid "Codec Profile Name"
+msgstr ""
+
+#: src/webui/static/app/codec.js:772
+msgid "Codec Profiles"
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:205
 msgid "Columns"
 msgstr ""
 
-#: src/webui/static/app/comet.js:55
+#: src/webui/static/app/comet.js:38
 msgid "Comet failure"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:67
+#: src/webui/static/app/dvr.js:157
 msgid "Comment"
 msgstr ""
 
-#: src/webui/static/app/status.js:781
+#: src/webui/static/app/status.js:924
 msgid "Compression ratio"
 msgstr ""
 
-#: src/webui/static/app/caclient.js:46
+#: src/webui/static/app/caclient.js:47
 msgid "Conditional Access Client"
 msgstr ""
 
-#: src/webui/static/app/tvhlog.js:17 src/webui/static/app/tvheadend.js:698
+#: src/webui/static/app/tvhlog.js:17 src/webui/static/app/tvheadend.js:1063
 msgid "Configuration"
 msgstr ""
 
-#: src/webui/static/app/status.js:673
+#: src/webui/static/app/status.js:816
 msgid "Connections"
 msgstr ""
 
-#: src/webui/static/app/epg.js:145 src/webui/static/app/epg.js:614
-#: src/webui/static/app/epg.js:615
+#: src/webui/static/app/tvheadend.js:309 src/webui/static/app/tvheadend.js:310
+msgid "Content Icons"
+msgstr ""
+
+#: src/webui/static/app/epg.js:289 src/webui/static/app/epg.js:879
+#: src/webui/static/app/epg.js:880
 msgid "Content Type"
 msgstr ""
 
-#: src/webui/static/app/status.js:430
+#: src/webui/static/app/status.js:477
 msgid "Continuity Errors"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1456
+#: src/webui/static/app/idnode.js:1496
 msgid "Create"
 msgstr ""
 
-#: src/webui/static/app/epg.js:883
+#: src/webui/static/app/epg.js:1293
 msgid "Create AutoRec"
 msgstr ""
 
-#: src/webui/static/app/epg.js:262 src/webui/static/app/epg.js:885
+#: src/webui/static/app/epg.js:433 src/webui/static/app/epg.js:1295
 msgid ""
 "Create an automatic recording rule to record all future programs that match "
 "the current query."
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1455
+#: src/webui/static/app/idnode.js:1495
 msgid "Create new entry"
 msgstr ""
 
-#: src/webui/static/app/epg.js:1085
+#: src/webui/static/app/epg.js:1524
 msgid "Created from EPG query"
 msgstr ""
 
-#: src/webui/static/app/epg.js:1072
+#: src/webui/static/app/tvheadend.js:370
+msgid "Crew"
+msgstr ""
+
+#: src/webui/static/app/epg.js:1511
 #, javascript-format
 msgid "Currently this will match (and record) %d events."
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:740
+#: src/webui/static/app/tvheadend.js:1105
 msgid "DVB Inputs"
 msgstr ""
 
-#: src/webui/static/app/epg.js:352
+#: src/webui/static/app/epg.js:587
 msgid "DVR"
 msgstr ""
 
-#: src/webui/static/app/epg.js:163
+#: src/webui/static/app/epg.js:309
 msgid "Deaf signed#EPG"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:810
+#: src/webui/static/app/tvheadend.js:1179
 msgid "Debugging"
 msgstr ""
 
@@ -504,23 +594,23 @@ msgstr ""
 msgid "December"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1807 src/webui/static/app/idnode.js:2312
+#: src/webui/static/app/idnode.js:1865 src/webui/static/app/idnode.js:2386
 msgid "Delete"
 msgstr ""
 
-#: src/webui/static/app/epg.js:236
+#: src/webui/static/app/epg.js:403
 msgid "Delete recording"
 msgstr ""
 
-#: src/webui/static/app/epg.js:235
+#: src/webui/static/app/epg.js:402
 msgid "Delete scheduled recording of this program"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1805 src/webui/static/app/idnode.js:2310
+#: src/webui/static/app/idnode.js:1863 src/webui/static/app/idnode.js:2384
 msgid "Delete selected entries"
 msgstr ""
 
-#: src/webui/static/app/status.js:152
+#: src/webui/static/app/status.js:179
 msgid "Descramble"
 msgstr ""
 
@@ -532,85 +622,123 @@ msgstr ""
 msgid "Detach selected channels from bouquet"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:321
+#: src/webui/static/app/mpegts.js:352
 msgid "Detailed stream info"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:169 src/webui/static/app/mpegts.js:317
-#: src/webui/static/app/epg.js:367 src/webui/static/app/epg.js:368
-#: src/webui/static/app/dvr.js:137 src/webui/static/app/dvr.js:138
+#: src/webui/static/app/mpegts.js:169 src/webui/static/app/mpegts.js:348
+#: src/webui/static/app/epg.js:15 src/webui/static/app/epg.js:16
+#: src/webui/static/app/dvr.js:378 src/webui/static/app/dvr.js:379
 msgid "Details"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:865
+#: src/webui/static/app/dvr.js:1215
 msgid "Digital Video Recorder"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:705
+#: src/webui/static/app/dvr.js:1047
 msgid "Digital Video Recorder Profile"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:706
+#: src/webui/static/app/dvr.js:1048
 msgid "Digital Video Recorder Profiles"
+msgstr ""
+
+#: src/webui/static/app/tvheadend.js:368
+msgid "Director"
+msgstr ""
+
+#: src/webui/static/app/dvr.js:747
+msgid "Disable grouping"
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:185 src/webui/static/app/i18n-post.js:186
 msgid "Disabled"
 msgstr ""
 
-#: src/webui/static/app/config.js:135
+#: src/webui/static/app/config.js:132
 msgid "Discover SAT>IP servers"
+msgstr ""
+
+#: src/webui/static/app/epgevent.js:190
+msgid "Display dialog of related broadcasts"
+msgstr ""
+
+#: src/webui/static/app/epgevent.js:205
+msgid "Display dialog showing alternative broadcasts"
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:151
 msgid "Displaying {0} - {1} of {2}"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:263
+#: src/webui/static/app/dvr.js:563
 msgid "Do you really want to abort/unschedule the selection?"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:594
+#: src/webui/static/app/dvr.js:933
 msgid "Do you really want to delete the selected recordings?"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:327
+#: src/webui/static/app/tvheadend.js:666
 msgid "Do you really want to delete the selection?"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:233
+#: src/webui/static/app/dvr.js:547
 msgid "Do you really want to gracefully stop/unschedule the selection?"
 msgstr ""
 
-#: src/webui/static/app/epg.js:324
+#: src/webui/static/app/epg.js:559
 msgid "Do you really want to gracefully stop/unschedule this recording?"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:434
+#: src/webui/static/app/dvr.js:742
 msgid "Do you really want to remove the selected recordings from storage?"
 msgstr ""
 
-#: src/webui/static/app/epg.js:337
+#: src/webui/static/app/epg.js:572
 msgid "Do you really want to remove this recording?"
 msgstr ""
 
-#: src/webui/static/app/epg.js:1046 src/webui/static/app/epg.js:1052
-#: src/webui/static/app/epg.js:1055 src/webui/static/app/epg.js:1058
-#: src/webui/static/app/epg.js:1061
+#: src/webui/static/app/dvr.js:579
+msgid ""
+"Do you really want to toggle the previously recorded state for the selected "
+"recordings?"
+msgstr ""
+
+#: src/webui/static/app/epg.js:1475 src/webui/static/app/epg.js:1484
+#: src/webui/static/app/epg.js:1487 src/webui/static/app/epg.js:1490
+#: src/webui/static/app/epg.js:1493
 msgid "Don't care"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:339 src/webui/static/app/dvr.js:505
+#: src/webui/static/app/dvr.js:687 src/webui/static/app/dvr.js:872
 msgid "Download"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:337 src/webui/static/app/dvr.js:503
+#: src/webui/static/app/dvr.js:685 src/webui/static/app/dvr.js:870
 msgid "Download the selected recording"
 msgstr ""
 
-#: src/webui/static/app/epg.js:116 src/webui/static/app/epg.js:569
-#: src/webui/static/app/epg.js:570 src/webui/static/app/epg.js:1070
-#: src/webui/static/app/dvr.js:52
+#: src/webui/static/app/status.js:761
+msgid "Drop (current) connections to Tvheadend."
+msgstr ""
+
+#: src/webui/static/app/status.js:764
+msgid "Drop Connections"
+msgstr ""
+
+#: src/webui/static/app/status.js:760
+msgid "Drop all connections"
+msgstr ""
+
+#: src/webui/static/app/status.js:765
+msgid "Drop all current connections?"
+msgstr ""
+
+#: src/webui/static/app/epg.js:246 src/webui/static/app/epg.js:825
+#: src/webui/static/app/epg.js:826 src/webui/static/app/epg.js:1508
+#: src/webui/static/app/dvr.js:118
 msgid "Duration"
 msgstr ""
 
@@ -638,36 +766,41 @@ msgstr ""
 msgid "EPG Grabber Name"
 msgstr ""
 
-#: src/webui/static/app/epg.js:993
+#: src/webui/static/app/epg.js:76
 msgid "EPG Update"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1284 src/webui/static/app/idnode.js:1894
+#: src/webui/static/app/idnode.js:1317 src/webui/static/app/idnode.js:1952
 msgid "Edit"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1892
+#: src/webui/static/app/idnode.js:1950
 msgid "Edit selected entry"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1321 src/webui/static/app/idnode.js:1908
+#: src/webui/static/app/idnode.js:1354 src/webui/static/app/idnode.js:1966
 msgid "Edit {0}"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1318
+#: src/webui/static/app/idnode.js:1351
 msgid "Edit {0} ({1} entries)"
 msgstr ""
 
-#: src/webui/static/app/epg.js:928
+#: src/webui/static/app/epg.js:1341
 msgid "Electronic Program Guide"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:1049
+#: src/webui/static/app/tvheadend.js:1464
 msgid "Enable debug output"
 msgstr ""
 
-#: src/webui/static/app/epg.js:114 src/webui/static/app/epg.js:561
-#: src/webui/static/app/epg.js:562
+#: src/webui/static/app/dvr.js:747 src/webui/static/app/dvr.js:756
+msgid "Enable grouping"
+msgstr ""
+
+#: src/webui/static/app/epg.js:242 src/webui/static/app/epg.js:817
+#: src/webui/static/app/epg.js:818 src/webui/static/app/epgevent.js:126
+#: src/webui/static/app/epgevent.js:127
 msgid "End Time"
 msgstr ""
 
@@ -675,43 +808,56 @@ msgstr ""
 msgid "Enter Filter Text..."
 msgstr ""
 
-#: src/webui/static/app/epg.js:544 src/webui/static/app/epg.js:545
+#: src/webui/static/app/epg.js:800 src/webui/static/app/epg.js:801
+#: src/webui/static/app/epgevent.js:111 src/webui/static/app/epgevent.js:112
 msgid "Episode"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:238
+#: src/webui/static/app/tvheadend.js:576
 msgid "Error"
 msgstr ""
 
-#: src/webui/static/app/status.js:159
+#: src/webui/static/app/status.js:186
 msgid "Errors"
 msgstr ""
 
-#: src/webui/static/app/epg.js:935
+#: src/webui/static/app/epg.js:1348 src/webui/static/app/epgevent.js:156
 msgid "Events"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:162
+#: src/webui/static/app/dvr.js:417
 msgid "Every day"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:595 src/webui/static/app/idnode.js:616
+#: src/webui/static/app/idnode.js:605 src/webui/static/app/idnode.js:626
 msgid "Expert"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1045
+#: src/webui/static/app/idnode.js:1056
 msgid "Expert Settings"
+msgstr ""
+
+#: src/webui/static/app/epg.js:792 src/webui/static/app/epgevent.js:103
+msgid "Extra text"
+msgstr ""
+
+#: src/webui/static/app/epg.js:793 src/webui/static/app/epgevent.js:104
+msgid "Extra text: subtitle or summary or description"
+msgstr ""
+
+#: src/webui/static/app/epg.js:295
+msgid "FHDTV"
 msgstr ""
 
 #: src/webui/static/app/servicemapper.js:13
 msgid "Failed"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:588
+#: src/webui/static/app/dvr.js:927
 msgid "Failed Recording"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:589
+#: src/webui/static/app/dvr.js:928
 msgid "Failed Recordings"
 msgstr ""
 
@@ -723,40 +869,56 @@ msgstr ""
 msgid "February"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:65
+#: src/webui/static/app/dvr.js:155
 msgid "File size"
 msgstr ""
 
-#: src/webui/static/app/epg.js:675
-msgid "Filter channel..."
+#: src/webui/static/app/epg.js:1041
+msgid "Filter category…"
 msgstr ""
 
-#: src/webui/static/app/epg.js:722
-msgid "Filter content type..."
+#: src/webui/static/app/epg.js:966
+msgid "Filter channel…"
 msgstr ""
 
-#: src/webui/static/app/epg.js:743
-msgid "Filter duration..."
+#: src/webui/static/app/epg.js:1092
+msgid "Filter content type…"
 msgstr ""
 
-#: src/webui/static/app/epg.js:698
-msgid "Filter tag..."
+#: src/webui/static/app/epg.js:1113
+msgid "Filter duration…"
+msgstr ""
+
+#: src/webui/static/app/epg.js:1001
+msgid "Filter tag…"
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:253
 msgid "Filters"
 msgstr ""
 
+#: src/webui/static/app/epg.js:441 src/webui/static/app/dvr.js:208
+msgid "Find alternative showings for the DVR entry."
+msgstr ""
+
+#: src/webui/static/app/epg.js:446 src/webui/static/app/dvr.js:213
+msgid "Find related showings for the DVR entry."
+msgstr ""
+
 #: src/webui/static/app/wizard.js:160
 msgid "Finish"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:453
+#: src/webui/static/app/dvr.js:804
 msgid "Finished Recording"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:454
+#: src/webui/static/app/dvr.js:805
 msgid "Finished Recordings"
+msgstr ""
+
+#: src/webui/static/app/epg.js:244 src/webui/static/app/dvr.js:116
+msgid "First Aired"
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:146
@@ -771,7 +933,7 @@ msgstr ""
 msgid "Force new scan (all muxes) for selected networks"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:988
+#: src/webui/static/app/tvheadend.js:1357
 msgid "Free"
 msgstr ""
 
@@ -783,27 +945,43 @@ msgstr ""
 msgid "Friday"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:603
+#: src/webui/static/app/tvheadend.js:951
 msgid "Fullscreen"
 msgstr ""
 
-#: src/webui/static/app/epg.js:890 src/webui/static/app/epg.js:1048
+#: src/webui/static/app/epg.js:1301 src/webui/static/app/epg.js:1477
 msgid "Fulltext"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:708
+#: src/webui/static/app/tvheadend.js:1073
 msgid "General"
 msgstr ""
 
-#: src/webui/static/app/epg.js:1069
+#: src/webui/static/app/epg.js:1507
 msgid "Genre"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:978
+#: src/webui/static/app/tvheadend.js:1347
 msgid "GiB"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1633
+#: src/webui/static/app/epg.js:986
+msgid "Go to next channel"
+msgstr ""
+
+#: src/webui/static/app/epg.js:459 src/webui/static/app/dvr.js:226
+msgid "Go to next event"
+msgstr ""
+
+#: src/webui/static/app/epg.js:980
+msgid "Go to previous channel"
+msgstr ""
+
+#: src/webui/static/app/epg.js:453 src/webui/static/app/dvr.js:220
+msgid "Go to previous event"
+msgstr ""
+
+#: src/webui/static/app/idnode.js:1674
 msgid "Grid Update"
 msgstr ""
 
@@ -811,47 +989,43 @@ msgstr ""
 msgid "Group By This Field"
 msgstr ""
 
-#: src/webui/static/app/epg.js:151
+#: src/webui/static/app/epg.js:297
 msgid "HDTV"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1209 src/webui/static/app/idnode.js:2052
-#: src/webui/static/app/idnode.js:2439 src/webui/static/app/idnode.js:2877
-#: src/webui/static/app/epg.js:914 src/webui/static/app/status.js:193
-#: src/webui/static/app/status.js:486 src/webui/static/app/status.js:636
+#: src/webui/static/app/mpegts.js:223
+msgid "HbbTv"
+msgstr ""
+
+#: src/webui/static/app/idnode.js:1241 src/webui/static/app/idnode.js:2110
+#: src/webui/static/app/idnode.js:2516 src/webui/static/app/idnode.js:2961
+#: src/webui/static/app/epg.js:1325 src/webui/static/app/status.js:220
+#: src/webui/static/app/status.js:555 src/webui/static/app/status.js:778
 #: src/webui/static/app/servicemapper.js:53
 msgid "Help"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:182
-msgid "Help for"
-msgstr ""
-
-#: src/webui/static/app/idnode.js:1956
+#: src/webui/static/app/idnode.js:2014
 msgid "Hide"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:2387
+#: src/webui/static/app/idnode.js:2461
 msgid "Hide passwords"
 msgstr ""
 
-#: src/webui/static/app/status.js:92
+#: src/webui/static/app/status.js:95
 msgid "Hostname"
 msgstr ""
 
-#: src/webui/static/app/status.js:81
+#: src/webui/static/app/status.js:84
 msgid "ID"
 msgstr ""
 
-#: src/webui/static/app/status.js:616
-msgid "IP Address"
-msgstr ""
-
-#: src/webui/static/app/acleditor.js:106
+#: src/webui/static/app/acleditor.js:108
 msgid "IP Blocking Record"
 msgstr ""
 
-#: src/webui/static/app/acleditor.js:107
+#: src/webui/static/app/acleditor.js:109
 msgid "IP Blocking Records"
 msgstr ""
 
@@ -859,11 +1033,11 @@ msgstr ""
 msgid "Ignored"
 msgstr ""
 
-#: src/webui/static/app/config.js:108
+#: src/webui/static/app/config.js:105
 msgid "Image Cache"
 msgstr ""
 
-#: src/webui/static/app/status.js:779
+#: src/webui/static/app/status.js:922
 msgid "In"
 msgstr ""
 
@@ -871,12 +1045,20 @@ msgstr ""
 msgid "Index"
 msgstr ""
 
-#: src/webui/static/app/status.js:372 src/webui/static/app/status.js:869
+#: src/webui/static/app/status.js:402 src/webui/static/app/status.js:1012
 msgid "Input"
 msgstr ""
 
-#: src/webui/static/app/status.js:166
+#: src/webui/static/app/status.js:193
 msgid "Input (kb/s)"
+msgstr ""
+
+#: src/webui/static/app/idnode.js:2132
+msgid "Item"
+msgstr ""
+
+#: src/webui/static/app/idnode.js:2132
+msgid "Items"
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:35
@@ -903,15 +1085,19 @@ msgstr ""
 msgid "June"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:982
+#: src/webui/static/app/epg.js:265 src/webui/static/app/dvr.js:141
+msgid "Keywords"
+msgstr ""
+
+#: src/webui/static/app/tvheadend.js:1351
 msgid "KiB"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:168
+#: src/webui/static/app/mpegts.js:168 src/webui/static/app/mpegts.js:227
 msgid "Language"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:127
+#: src/webui/static/app/tvheadend.js:456
 msgid "Last Help Pages"
 msgstr ""
 
@@ -919,75 +1105,83 @@ msgstr ""
 msgid "Last Page"
 msgstr ""
 
-#: src/webui/static/app/epg.js:161
+#: src/webui/static/app/epg.js:307
 msgid "Lines"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:559
+#: src/webui/static/app/mpegts.js:229
+msgid "Link"
+msgstr ""
+
+#: src/webui/static/app/tvheadend.js:907
 msgid "Live TV Player"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:350
+#: src/webui/static/app/tvheadend.js:689
 msgid "Loading, please wait..."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:5 src/webui/static/app/i18n-post.js:17
-#: src/webui/static/app/i18n-post.js:197 src/webui/static/app/epg.js:666
-#: src/webui/static/app/epg.js:689 src/webui/static/app/epg.js:713
-#: src/webui/static/app/epg.js:734 src/webui/static/app/tvheadend.js:497
-#: src/webui/static/app/tvheadend.js:535
+#: src/webui/static/app/i18n-post.js:197 src/webui/static/app/tvheadend.js:844
+#: src/webui/static/app/tvheadend.js:883
 msgid "Loading..."
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:959
+#: src/webui/static/app/epg.js:957 src/webui/static/app/epg.js:992
+#: src/webui/static/app/epg.js:1032 src/webui/static/app/epg.js:1083
+#: src/webui/static/app/epg.js:1104
+msgid "Loading…"
+msgstr ""
+
+#: src/webui/static/app/tvheadend.js:1328
 msgid "Logged in as"
 msgstr ""
 
-#: src/webui/static/app/config.js:133
+#: src/webui/static/app/config.js:130
 msgid "Look for new SAT>IP servers"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:305
+#: src/webui/static/app/mpegts.js:336
 msgid "Maintenance"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:303
+#: src/webui/static/app/mpegts.js:334
 msgid "Maintenance operations"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:271
+#: src/webui/static/app/mpegts.js:302
 msgid "Map All"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:269
+#: src/webui/static/app/mpegts.js:300
 msgid "Map Selected"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:250 src/webui/static/app/chconf.js:147
+#: src/webui/static/app/mpegts.js:281 src/webui/static/app/chconf.js:147
 msgid "Map all services"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:248 src/webui/static/app/chconf.js:145
+#: src/webui/static/app/mpegts.js:279 src/webui/static/app/chconf.js:145
 msgid "Map all services to channels"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:244 src/webui/static/app/chconf.js:141
+#: src/webui/static/app/mpegts.js:275 src/webui/static/app/chconf.js:141
 msgid "Map selected services"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:242 src/webui/static/app/chconf.js:139
+#: src/webui/static/app/mpegts.js:273 src/webui/static/app/chconf.js:139
 msgid "Map selected services to channels"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:255 src/webui/static/app/chconf.js:158
-#: src/webui/static/app/servicemapper.js:119
-#: src/webui/static/app/servicemapper.js:135
+#: src/webui/static/app/mpegts.js:286 src/webui/static/app/chconf.js:158
+#: src/webui/static/app/servicemapper.js:120
+#: src/webui/static/app/servicemapper.js:136
 msgid "Map services"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:253 src/webui/static/app/chconf.js:156
-#: src/webui/static/app/servicemapper.js:116
-#: src/webui/static/app/servicemapper.js:132
+#: src/webui/static/app/mpegts.js:284 src/webui/static/app/chconf.js:156
+#: src/webui/static/app/servicemapper.js:117
+#: src/webui/static/app/servicemapper.js:133
 msgid "Map services to channels"
 msgstr ""
 
@@ -1003,11 +1197,11 @@ msgstr ""
 msgid "March"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:385
+#: src/webui/static/app/dvr.js:719
 msgid "Mark the selected recording as failed"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:551
+#: src/webui/static/app/dvr.js:904
 msgid "Mark the selected recording as finished"
 msgstr ""
 
@@ -1027,11 +1221,11 @@ msgstr ""
 msgid "Memory Information Entry"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:326
+#: src/webui/static/app/tvheadend.js:665
 msgid "Message"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:980
+#: src/webui/static/app/tvheadend.js:1349
 msgid "MiB"
 msgstr ""
 
@@ -1043,11 +1237,11 @@ msgstr ""
 msgid "Monday"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1863 src/webui/static/app/idnode.js:2359
+#: src/webui/static/app/idnode.js:1921 src/webui/static/app/idnode.js:2433
 msgid "Move Down"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1838 src/webui/static/app/idnode.js:2338
+#: src/webui/static/app/idnode.js:1896 src/webui/static/app/idnode.js:2412
 msgid "Move Up"
 msgstr ""
 
@@ -1059,27 +1253,27 @@ msgstr ""
 msgid "Move channel one number up"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1861
+#: src/webui/static/app/idnode.js:1919
 msgid "Move selected entries down"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1836
+#: src/webui/static/app/idnode.js:1894
 msgid "Move selected entries up"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:2357
+#: src/webui/static/app/idnode.js:2431
 msgid "Move selected entry down"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:2336
+#: src/webui/static/app/idnode.js:2410
 msgid "Move selected entry up"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:387
+#: src/webui/static/app/dvr.js:721
 msgid "Move to failed"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:553
+#: src/webui/static/app/dvr.js:906
 msgid "Move to finished"
 msgstr ""
 
@@ -1087,16 +1281,20 @@ msgstr ""
 msgid "Mux"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:390 src/webui/static/app/mpegts.js:398
+#: src/webui/static/app/mpegts.js:421 src/webui/static/app/mpegts.js:429
 msgid "Mux Scheduler"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:391
+#: src/webui/static/app/mpegts.js:422
 msgid "Mux Schedulers"
 msgstr ""
 
 #: src/webui/static/app/mpegts.js:98
 msgid "Muxes"
+msgstr ""
+
+#: src/webui/static/app/mpegts.js:228
+msgid "Name"
 msgstr ""
 
 #: src/webui/static/app/mpegts.js:66 src/webui/static/app/mpegts.js:72
@@ -1108,7 +1306,11 @@ msgstr ""
 msgid "Networks"
 msgstr ""
 
-#: src/webui/static/app/epg.js:153
+#: src/webui/static/app/epg.js:1301 src/webui/static/app/epg.js:1480
+msgid "New only"
+msgstr ""
+
+#: src/webui/static/app/epg.js:299
 msgid "New#EPG"
 msgstr ""
 
@@ -1128,29 +1330,29 @@ msgstr ""
 msgid "No data to display"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:164
+#: src/webui/static/app/dvr.js:419
 msgid "No days"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:962
+#: src/webui/static/app/tvheadend.js:1331
 msgid "No verified access"
 msgstr ""
 
 #. / {0} title (lowercase), {1} title
-#: src/webui/static/app/tvheadend.js:363
+#: src/webui/static/app/tvheadend.js:702
 msgid "No {0} to display"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1941 src/webui/static/app/mpegts.js:206
-#: src/webui/static/app/mpegts.js:216
+#: src/webui/static/app/idnode.js:1999 src/webui/static/app/mpegts.js:209
+#: src/webui/static/app/mpegts.js:219
 msgid "None"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:247
+#: src/webui/static/app/tvheadend.js:585
 msgid "Not Available"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:355
+#: src/webui/static/app/idnode.js:372
 msgid "Not set"
 msgstr ""
 
@@ -1162,7 +1364,11 @@ msgstr ""
 msgid "November"
 msgstr ""
 
-#: src/webui/static/app/epg.js:576 src/webui/static/app/epg.js:577
+#: src/webui/static/app/epg.js:928
+msgid "Now"
+msgstr ""
+
+#: src/webui/static/app/epg.js:833 src/webui/static/app/epg.js:834
 msgid "Number"
 msgstr ""
 
@@ -1194,23 +1400,23 @@ msgstr ""
 msgid "On#DateFilter"
 msgstr ""
 
-#: src/webui/static/app/esfilter.js:132
+#: src/webui/static/app/esfilter.js:110
 msgid "Other Stream Filter"
 msgstr ""
 
-#: src/webui/static/app/esfilter.js:133
+#: src/webui/static/app/esfilter.js:111
 msgid "Other Stream Filters"
 msgstr ""
 
-#: src/webui/static/app/status.js:780
+#: src/webui/static/app/status.js:923
 msgid "Out"
 msgstr ""
 
-#: src/webui/static/app/status.js:175
+#: src/webui/static/app/status.js:202
 msgid "Output (kb/s)"
 msgstr ""
 
-#: src/webui/static/app/status.js:411
+#: src/webui/static/app/status.js:458
 msgid "PER"
 msgstr ""
 
@@ -1218,17 +1424,26 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
+#: src/webui/static/app/status.js:162 src/webui/static/app/status.js:427
+msgid "PID list"
+msgstr ""
+
 #: src/webui/static/app/i18n-post.js:144
 msgid "Page"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:2469 src/webui/static/app/idnode.js:2652
-#: src/webui/static/app/epg.js:169
+#: src/webui/static/app/idnode.js:2547 src/webui/static/app/idnode.js:2733
+#: src/webui/static/app/epg.js:315
 msgid "Parameters"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1939
+#: src/webui/static/app/idnode.js:1997
 msgid "Parent disabled"
+msgstr ""
+
+#: src/webui/static/app/epg.js:277 src/webui/static/app/epg.js:865
+#: src/webui/static/app/dvr.js:151
+msgid "Parental Rating"
 msgstr ""
 
 #: src/webui/static/app/acleditor.js:70
@@ -1239,20 +1454,21 @@ msgstr ""
 msgid "Passwords"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:588
+#: src/webui/static/app/tvheadend.js:936
 msgid "Pause"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:374
+#: src/webui/static/app/tvheadend.js:713
 msgid "Per page"
 msgstr ""
 
 #: src/webui/static/app/mpegts.js:121 src/webui/static/app/mpegts.js:122
-#: src/webui/static/app/mpegts.js:362 src/webui/static/app/mpegts.js:363
+#: src/webui/static/app/mpegts.js:393 src/webui/static/app/mpegts.js:394
 #: src/webui/static/app/chconf.js:245 src/webui/static/app/chconf.js:246
-#: src/webui/static/app/dvr.js:476 src/webui/static/app/dvr.js:477
-#: src/webui/static/app/dvr.js:613 src/webui/static/app/dvr.js:614
-#: src/webui/static/app/tvheadend.js:484 src/webui/static/app/tvheadend.js:571
+#: src/webui/static/app/epg.js:367 src/webui/static/app/dvr.js:839
+#: src/webui/static/app/dvr.js:840 src/webui/static/app/dvr.js:959
+#: src/webui/static/app/dvr.js:960 src/webui/static/app/tvheadend.js:825
+#: src/webui/static/app/tvheadend.js:919
 msgid "Play"
 msgstr ""
 
@@ -1260,15 +1476,11 @@ msgstr ""
 msgid "Play Selected Channel"
 msgstr ""
 
-#: src/webui/static/app/epg.js:200
-msgid "Play program"
-msgstr ""
-
-#: src/webui/static/app/epg.js:199
+#: src/webui/static/app/epg.js:366
 msgid "Play this program"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:484
+#: src/webui/static/app/tvheadend.js:825
 msgid "Play this stream"
 msgstr ""
 
@@ -1276,14 +1488,18 @@ msgstr ""
 msgid "Please Wait..."
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:240
+#: src/webui/static/app/tvheadend.js:578
 msgid "Please check Tvheadend is running and try again."
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:249
+#: src/webui/static/app/tvheadend.js:588
 msgid ""
-"Please take a look at the other Help pages (Table of Contents). If you still "
+"Please take a look at the other Help pages (Table of Contents), if you still "
 "can't find what you're "
+msgstr ""
+
+#: src/webui/static/app/tvheadend.js:792
+msgid "Premiere"
 msgstr ""
 
 #: src/webui/static/app/wizard.js:66
@@ -1298,24 +1514,48 @@ msgstr ""
 msgid "Previous Page"
 msgstr ""
 
-#: src/webui/static/app/status.js:127
+#: src/webui/static/app/tvheadend.js:810
+msgid "Previous day"
+msgstr ""
+
+#: src/webui/static/app/dvr.js:573
+msgid "Previously recorded"
+msgstr ""
+
+#: src/webui/static/app/status.js:137
 msgid "Profile"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:707
+#: src/webui/static/app/dvr.js:1049
 msgid "Profile Name"
 msgstr ""
 
-#: src/webui/static/app/epg.js:499 src/webui/static/app/epg.js:500
+#: src/webui/static/app/epg.js:753 src/webui/static/app/epg.js:754
 msgid "Progress"
 msgstr ""
 
-#: src/webui/static/app/config.js:93 src/webui/static/app/config.js:95
+#: src/webui/static/app/status.js:752
+msgid "Proxy Address"
+msgstr ""
+
+#: src/webui/static/app/epg.js:864
+msgid "Rating"
+msgstr ""
+
+#: src/webui/static/app/ratinglabels.js:6
+msgid "Rating Label"
+msgstr ""
+
+#: src/webui/static/app/ratinglabels.js:7
+msgid "Rating Labels"
+msgstr ""
+
+#: src/webui/static/app/config.js:90 src/webui/static/app/config.js:92
 msgid "Re-fetch images"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:358 src/webui/static/app/dvr.js:524
-#: src/webui/static/app/dvr.js:642
+#: src/webui/static/app/dvr.js:706 src/webui/static/app/dvr.js:891
+#: src/webui/static/app/dvr.js:989
 msgid "Re-record"
 msgstr ""
 
@@ -1327,75 +1567,87 @@ msgstr ""
 msgid "Re-run all internal EPG grabbers to import EPG data now"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1047
+#: src/webui/static/app/idnode.js:1058
 msgid "Read-only Info"
 msgstr ""
 
-#: src/webui/static/app/comet.js:28
+#: src/webui/static/app/comet.js:21
 msgid "Reconnected to Tvheadend"
 msgstr ""
 
-#: src/webui/static/app/epg.js:257
-msgid "Record program"
+#: src/webui/static/app/epg.js:427
+msgid "Record"
 msgstr ""
 
-#: src/webui/static/app/epg.js:263
+#: src/webui/static/app/epg.js:434
 msgid "Record series"
 msgstr ""
 
-#: src/webui/static/app/epg.js:256
+#: src/webui/static/app/epg.js:426
 msgid "Record this program now"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:790
+#: src/webui/static/app/dvr.js:852 src/webui/static/app/tvheadend.js:1159
 msgid "Recording"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:146
+#: src/webui/static/app/dvr.js:387
 msgid "Recording details"
+msgstr ""
+
+#: src/webui/static/app/dvr.js:852
+msgid "Recordings"
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:150 src/webui/static/app/i18n-post.js:157
 msgid "Refresh"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:416
+#: src/webui/static/app/epgevent.js:146
+msgid "Related Showings"
+msgstr ""
+
+#: src/webui/static/app/epgevent.js:192
+msgid "Related broadcasts"
+msgstr ""
+
+#: src/webui/static/app/dvr.js:736
 msgid "Remove"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:300
+#: src/webui/static/app/mpegts.js:331
 msgid "Remove all unseen services (7 days+)"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:292
+#: src/webui/static/app/mpegts.js:323
 msgid ""
 "Remove old services marked as missing in PAT/SDT which were not detected "
 "more than 7 days (last seen column)"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:298
+#: src/webui/static/app/mpegts.js:329
 msgid ""
 "Remove old services which were not detected more than 7 days (last seen "
 "column)"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:414
+#: src/webui/static/app/dvr.js:734
 msgid "Remove the selected recording from storage"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:294
+#: src/webui/static/app/mpegts.js:325
 msgid "Remove unseen services (PAT/SDT) (7 days+)"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:674
+#: src/webui/static/app/dvr.js:1007
 msgid "Removed Recording"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:675
+#: src/webui/static/app/dvr.js:1008
 msgid "Removed Recordings"
 msgstr ""
 
-#: src/webui/static/app/epg.js:155
+#: src/webui/static/app/epg.js:301
 msgid "Repeat#EPG"
 msgstr ""
 
@@ -1407,7 +1659,7 @@ msgstr ""
 msgid "Reset (clear) the selected icon URLs"
 msgstr ""
 
-#: src/webui/static/app/epg.js:896
+#: src/webui/static/app/epg.js:1307
 msgid "Reset All"
 msgstr ""
 
@@ -1415,21 +1667,25 @@ msgstr ""
 msgid "Reset Icon"
 msgstr ""
 
-#: src/webui/static/app/epg.js:898
+#: src/webui/static/app/epg.js:1309
 msgid "Reset all filters (show all)"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1777 src/webui/static/app/idnode.js:2274
-#: src/webui/static/app/idnode.js:2810
+#: src/webui/static/app/idnode.js:1835 src/webui/static/app/idnode.js:2345
+#: src/webui/static/app/idnode.js:2891
 msgid "Revert pending changes (marked with red border)"
 msgstr ""
 
-#: src/webui/static/app/config.js:148
+#: src/webui/static/app/config.js:145
 msgid "SAT>IP Server"
 msgstr ""
 
-#: src/webui/static/app/status.js:445
+#: src/webui/static/app/status.js:492
 msgid "SNR"
+msgstr ""
+
+#: src/webui/static/app/tvheadend.js:794
+msgid "Same day"
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:99
@@ -1440,8 +1696,8 @@ msgstr ""
 msgid "Saturday"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1120 src/webui/static/app/idnode.js:1752
-#: src/webui/static/app/idnode.js:2254 src/webui/static/app/idnode.js:2791
+#: src/webui/static/app/idnode.js:1150 src/webui/static/app/idnode.js:1810
+#: src/webui/static/app/idnode.js:2325 src/webui/static/app/idnode.js:2872
 msgid "Save"
 msgstr ""
 
@@ -1449,44 +1705,40 @@ msgstr ""
 msgid "Save & Next"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1750 src/webui/static/app/idnode.js:2252
-#: src/webui/static/app/idnode.js:2789
+#: src/webui/static/app/idnode.js:1808 src/webui/static/app/idnode.js:2323
+#: src/webui/static/app/idnode.js:2870
 msgid "Save pending changes (marked with red border)"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:48
+#: src/webui/static/app/dvr.js:111
 msgid "Scheduled Start Time"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:50
+#: src/webui/static/app/dvr.js:113
 msgid "Scheduled Stop Time"
 msgstr ""
 
-#: src/webui/static/app/epg.js:185 src/webui/static/app/dvr.js:80
-msgid "Search IMDB (for title)"
+#: src/webui/static/app/epg.js:942
+msgid "Search title…"
 msgstr ""
 
-#: src/webui/static/app/epg.js:192 src/webui/static/app/dvr.js:86
-msgid "Search TheTVDB (for title)"
+#: src/webui/static/app/mpegts.js:226
+msgid "Section"
 msgstr ""
 
-#: src/webui/static/app/epg.js:655
-msgid "Search title..."
-msgstr ""
-
-#: src/webui/static/app/tvheadend.js:504
+#: src/webui/static/app/tvheadend.js:851
 msgid "Select channel..."
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:541
+#: src/webui/static/app/tvheadend.js:889
 msgid "Select stream profile..."
 msgstr ""
 
-#: src/webui/static/app/idnode.js:461 src/webui/static/app/idnode.js:714
+#: src/webui/static/app/idnode.js:476 src/webui/static/app/idnode.js:724
 msgid "Select {0} ..."
 msgstr ""
 
-#: src/webui/static/app/idnode.js:445 src/webui/static/app/idnode.js:690
+#: src/webui/static/app/idnode.js:460 src/webui/static/app/idnode.js:700
 msgid "Selected"
 msgstr ""
 
@@ -1498,7 +1750,15 @@ msgstr ""
 msgid "September"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:352 src/webui/static/app/status.js:120
+#: src/webui/static/app/status.js:740
+msgid "Server Address"
+msgstr ""
+
+#: src/webui/static/app/status.js:746
+msgid "Server Port"
+msgstr ""
+
+#: src/webui/static/app/mpegts.js:383 src/webui/static/app/status.js:130
 msgid "Service"
 msgstr ""
 
@@ -1507,15 +1767,15 @@ msgstr ""
 msgid "Service Mapper"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:219
+#: src/webui/static/app/mpegts.js:250
 msgid "Service details for"
 msgstr ""
 
-#: src/webui/static/app/mpegts.js:353
+#: src/webui/static/app/mpegts.js:384
 msgid "Services"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:991
+#: src/webui/static/app/idnode.js:1002
 msgid "Settings"
 msgstr ""
 
@@ -1523,15 +1783,15 @@ msgstr ""
 msgid "Show in Groups"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:2381
+#: src/webui/static/app/idnode.js:2455
 msgid "Show or hide passwords"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:2383 src/webui/static/app/idnode.js:2387
+#: src/webui/static/app/idnode.js:2457 src/webui/static/app/idnode.js:2461
 msgid "Show passwords"
 msgstr ""
 
-#: src/webui/static/app/status.js:465
+#: src/webui/static/app/status.js:512
 msgid "Signal Strength"
 msgstr ""
 
@@ -1543,20 +1803,25 @@ msgstr ""
 msgid "Sort Descending"
 msgstr ""
 
-#: src/webui/static/app/epg.js:132
+#: src/webui/static/app/epg.js:269
 msgid "Star Rating"
 msgstr ""
 
-#: src/webui/static/app/epg.js:599 src/webui/static/app/epg.js:600
+#: src/webui/static/app/tvheadend.js:367
+msgid "Starring"
+msgstr ""
+
+#: src/webui/static/app/epg.js:856 src/webui/static/app/epg.js:857
 msgid "Stars"
 msgstr ""
 
-#: src/webui/static/app/status.js:134
+#: src/webui/static/app/status.js:144
 msgid "Start"
 msgstr ""
 
-#: src/webui/static/app/epg.js:112 src/webui/static/app/epg.js:552
-#: src/webui/static/app/epg.js:553
+#: src/webui/static/app/epg.js:240 src/webui/static/app/epg.js:808
+#: src/webui/static/app/epg.js:809 src/webui/static/app/epgevent.js:118
+#: src/webui/static/app/epgevent.js:119
 msgid "Start Time"
 msgstr ""
 
@@ -1568,76 +1833,80 @@ msgstr ""
 msgid "Start wizard"
 msgstr ""
 
-#: src/webui/static/app/status.js:628
+#: src/webui/static/app/status.js:727
 msgid "Started"
 msgstr ""
 
-#: src/webui/static/app/status.js:145
+#: src/webui/static/app/status.js:155
 msgid "State"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:63 src/webui/static/app/status.js:683
+#: src/webui/static/app/dvr.js:153 src/webui/static/app/status.js:826
 msgid "Status"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:215 src/webui/static/app/tvheadend.js:595
+#: src/webui/static/app/dvr.js:541 src/webui/static/app/tvheadend.js:943
 msgid "Stop"
 msgstr ""
 
-#: src/webui/static/app/epg.js:227
+#: src/webui/static/app/epg.js:394
 msgid "Stop recording"
 msgstr ""
 
-#: src/webui/static/app/epg.js:226
+#: src/webui/static/app/epg.js:393
 msgid "Stop recording of this program"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:213
+#: src/webui/static/app/dvr.js:539
 msgid "Stop the selected recording"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:985
+#: src/webui/static/app/tvheadend.js:1354
 msgid "Storage space"
 msgstr ""
 
-#: src/webui/static/app/status.js:378 src/webui/static/app/status.js:525
-#: src/webui/static/app/tvheadend.js:777
+#: src/webui/static/app/status.js:408 src/webui/static/app/status.js:595
+#: src/webui/static/app/tvheadend.js:1143
 msgid "Stream"
 msgstr ""
 
-#: src/webui/static/app/esfilter.js:23 src/webui/static/app/esfilter.js:30
+#: src/webui/static/app/esfilter.js:11
+msgid "Stream Filters"
+msgstr ""
+
+#: src/webui/static/app/profile.js:23 src/webui/static/app/profile.js:30
 msgid "Stream Profile"
 msgstr ""
 
-#: src/webui/static/app/esfilter.js:25
+#: src/webui/static/app/profile.js:25
 msgid "Stream Profile Name"
 msgstr ""
 
-#: src/webui/static/app/esfilter.js:24
+#: src/webui/static/app/profile.js:24
 msgid "Stream Profiles"
 msgstr ""
 
-#: src/webui/static/app/status.js:384
+#: src/webui/static/app/status.js:734
+msgid "Streaming"
+msgstr ""
+
+#: src/webui/static/app/status.js:414
 msgid "Subs No."
 msgstr ""
 
-#: src/webui/static/app/status.js:230
+#: src/webui/static/app/status.js:258
 msgid "Subscriptions"
 msgstr ""
 
-#: src/webui/static/app/epg.js:536 src/webui/static/app/epg.js:537
-msgid "Subtitle"
-msgstr ""
-
-#: src/webui/static/app/esfilter.js:99
+#: src/webui/static/app/esfilter.js:77
 msgid "Subtitle Stream Filter"
 msgstr ""
 
-#: src/webui/static/app/esfilter.js:100
+#: src/webui/static/app/esfilter.js:78
 msgid "Subtitle Stream Filters"
 msgstr ""
 
-#: src/webui/static/app/epg.js:165
+#: src/webui/static/app/epg.js:311
 msgid "Subtitled#EPG"
 msgstr ""
 
@@ -1657,23 +1926,27 @@ msgstr ""
 msgid "Swap the numbers for the two selected channels"
 msgstr ""
 
+#: src/webui/static/app/status.js:711
+msgid "TCP"
+msgstr ""
+
 #: src/webui/static/app/tvadapters.js:6
 msgid "TV adapters"
 msgstr ""
 
-#: src/webui/static/app/epg.js:1068
+#: src/webui/static/app/epg.js:1506
 msgid "Tag"
 msgstr ""
 
-#: src/webui/static/app/esfilter.js:82
+#: src/webui/static/app/esfilter.js:60
 msgid "Teletext Stream Filter"
 msgstr ""
 
-#: src/webui/static/app/esfilter.js:83
+#: src/webui/static/app/esfilter.js:61
 msgid "Teletext Stream Filters"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:595
+#: src/webui/static/app/dvr.js:934
 msgid "The associated file will be removed from storage."
 msgstr ""
 
@@ -1697,7 +1970,7 @@ msgstr ""
 msgid "The minimum length for this field is {0}"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1430
+#: src/webui/static/app/idnode.js:1470
 msgid "The selected entry is the original!"
 msgstr ""
 
@@ -1713,21 +1986,21 @@ msgstr ""
 msgid "The value in this field is invalid"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:248
-msgid ""
-"There is no documentation associated with the Help button pressed, or there "
-"was an problem loading the page.\n"
-"\n"
-msgstr ""
-
-#: src/webui/static/app/comet.js:36
+#: src/webui/static/app/comet.js:14
 msgid ""
 "There seems to be a problem with the live update feed from Tvheadend. Trying "
 "to reconnect..."
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:239
+#: src/webui/static/app/tvheadend.js:577
 msgid "There was a problem displaying the Help!"
+msgstr ""
+
+#: src/webui/static/app/tvheadend.js:586
+msgid ""
+"There's no documentation available, or there was a problem loading the "
+"page.\n"
+"\n"
 msgstr ""
 
 #: src/webui/static/app/tvhlog.js:26
@@ -1746,7 +2019,7 @@ msgstr ""
 msgid "This field is required"
 msgstr ""
 
-#: src/webui/static/app/epg.js:1063
+#: src/webui/static/app/epg.js:1501
 msgid ""
 "This will create an automatic rule that continuously scans the EPG for "
 "programs to record that match this query"
@@ -1760,15 +2033,15 @@ msgstr ""
 msgid "Thursday"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:71
+#: src/webui/static/app/dvr.js:161
 msgid "Time Scheduler"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:810
+#: src/webui/static/app/dvr.js:1160
 msgid "Timer"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:811
+#: src/webui/static/app/dvr.js:1161
 msgid "Timers"
 msgstr ""
 
@@ -1776,8 +2049,9 @@ msgstr ""
 msgid "Timeshift"
 msgstr ""
 
-#: src/webui/static/app/epg.js:522 src/webui/static/app/epg.js:523
-#: src/webui/static/app/epg.js:1066 src/webui/static/app/status.js:106
+#: src/webui/static/app/epg.js:777 src/webui/static/app/epg.js:778
+#: src/webui/static/app/epg.js:1504 src/webui/static/app/epgevent.js:96
+#: src/webui/static/app/epgevent.js:97 src/webui/static/app/status.js:109
 msgid "Title"
 msgstr ""
 
@@ -1785,20 +2059,24 @@ msgstr ""
 msgid "Today"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:613
+#: src/webui/static/app/tvheadend.js:961
 msgid "Toggle mute"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:356 src/webui/static/app/dvr.js:522
-#: src/webui/static/app/dvr.js:640
+#: src/webui/static/app/dvr.js:704 src/webui/static/app/dvr.js:889
+#: src/webui/static/app/dvr.js:987
 msgid "Toggle re-record functionality"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:988
+#: src/webui/static/app/dvr.js:571
+msgid "Toggle the previously recorded state."
+msgstr ""
+
+#: src/webui/static/app/tvheadend.js:1357
 msgid "Total"
 msgstr ""
 
-#: src/webui/static/app/status.js:424
+#: src/webui/static/app/status.js:471
 msgid "Transport Errors"
 msgstr ""
 
@@ -1818,21 +2096,25 @@ msgstr ""
 msgid "Tune to the over-the-air EPG muxes to grab new events now"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:1024
+#: src/webui/static/app/tvheadend.js:1441
 msgid "Tvheadend Web-Panel"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:1045
+#: src/webui/static/app/tvheadend.js:1460
 msgid "Tvheadend log"
 msgstr ""
 
-#: src/webui/static/app/caclient.js:48 src/webui/static/app/esfilter.js:32
+#: src/webui/static/app/caclient.js:49 src/webui/static/app/profile.js:32
 #: src/webui/static/app/mpegts.js:74 src/webui/static/app/mpegts.js:167
-#: src/webui/static/app/status.js:610
+#: src/webui/static/app/status.js:686
 msgid "Type"
 msgstr ""
 
-#: src/webui/static/app/epg.js:149
+#: src/webui/static/app/status.js:714
+msgid "UDP"
+msgstr ""
+
+#: src/webui/static/app/epg.js:293
 msgid "UHDTV"
 msgstr ""
 
@@ -1840,64 +2122,72 @@ msgstr ""
 msgid "Unable to obtain wizard page!"
 msgstr ""
 
-#: src/webui/static/app/status.js:418
+#: src/webui/static/app/status.js:465
 msgid "Uncorrected Blocks"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:1779 src/webui/static/app/idnode.js:2276
-#: src/webui/static/app/idnode.js:2812
+#: src/webui/static/app/idnode.js:1837 src/webui/static/app/idnode.js:2347
+#: src/webui/static/app/idnode.js:2893
 msgid "Undo"
 msgstr ""
 
-#: src/webui/static/app/status.js:458 src/webui/static/app/status.js:478
+#: src/webui/static/app/status.js:505 src/webui/static/app/status.js:525
 msgid "Unknown"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:288
+#: src/webui/static/app/dvr.js:606
 msgid "Upcoming / Current Recordings"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:287
+#: src/webui/static/app/dvr.js:605
 msgid "Upcoming Recording"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:988
+#: src/webui/static/app/tvheadend.js:1357
 msgid "Used by tvheadend"
 msgstr ""
 
-#: src/webui/static/app/status.js:99 src/webui/static/app/status.js:622
+#: src/webui/static/app/status.js:102 src/webui/static/app/status.js:721
 msgid "Username"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:724
+#: src/webui/static/app/tvheadend.js:1089
 msgid "Users"
 msgstr ""
 
-#: src/webui/static/app/esfilter.js:48
+#: src/webui/static/app/esfilter.js:26
 msgid "Video Stream Filter"
 msgstr ""
 
-#: src/webui/static/app/esfilter.js:49
+#: src/webui/static/app/esfilter.js:27
 msgid "Video Stream Filters"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:624
+#: src/webui/static/app/idnode.js:1242 src/webui/static/app/idnode.js:2111
+#: src/webui/static/app/idnode.js:2517 src/webui/static/app/idnode.js:2962
+#: src/webui/static/app/epg.js:1326 src/webui/static/app/epg.js:1328
+#: src/webui/static/app/status.js:221 src/webui/static/app/status.js:556
+#: src/webui/static/app/status.js:779 src/webui/static/app/servicemapper.js:54
+msgid "View help docs."
+msgstr ""
+
+#: src/webui/static/app/idnode.js:634
 msgid "View level"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:627
+#: src/webui/static/app/idnode.js:637
 msgid "View level: "
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:622
+#: src/webui/static/app/tvheadend.js:970
 msgid "Volume"
 msgstr ""
 
-#: src/webui/static/app/epg.js:903
+#: src/webui/static/app/epg.js:612 src/webui/static/app/epg.js:1314
 msgid "Watch TV"
 msgstr ""
 
-#: src/webui/static/app/epg.js:905
+#: src/webui/static/app/epg.js:1316
 msgid "Watch live TV in a new browser window."
 msgstr ""
 
@@ -1909,15 +2199,19 @@ msgstr ""
 msgid "Wednesday"
 msgstr ""
 
-#: src/webui/static/app/status.js:390
+#: src/webui/static/app/status.js:420
 msgid "Weight"
 msgstr ""
 
-#: src/webui/static/app/epg.js:157
+#: src/webui/static/app/dvr.js:754
+msgid "When enabled, group the recordings by the selected column."
+msgstr ""
+
+#: src/webui/static/app/epg.js:303
 msgid "Widescreen"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:39
+#: src/webui/static/app/dvr.js:96
 msgid "Will be skipped"
 msgstr ""
 
@@ -1925,11 +2219,15 @@ msgstr ""
 msgid "Wizard - page \"{0}\" not found"
 msgstr ""
 
+#: src/webui/static/app/tvheadend.js:369
+msgid "Writer"
+msgstr ""
+
 #: src/webui/static/app/i18n-post.js:112 src/webui/static/app/i18n-post.js:258
 msgid "Yes"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:473 src/webui/static/app/idnode.js:856
+#: src/webui/static/app/idnode.js:486 src/webui/static/app/idnode.js:864
 msgid "You must provide a value - use octal chmod notation, e.g. 0664"
 msgstr ""
 
@@ -1941,7 +2239,11 @@ msgstr ""
 msgid "You must select one item in this group"
 msgstr ""
 
-#: src/webui/static/app/dvr.js:39
+#: src/webui/static/app/status.js:172 src/webui/static/app/status.js:437
+msgid "all"
+msgstr ""
+
+#: src/webui/static/app/dvr.js:96
 msgid "because it is a rerun of:"
 msgstr ""
 
@@ -1959,20 +2261,20 @@ msgid ""
 "H#TimeField"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:363 src/webui/static/app/idnode.js:364
-#: src/webui/static/app/epg.js:466 src/webui/static/app/epg.js:468
+#: src/webui/static/app/idnode.js:380 src/webui/static/app/idnode.js:381
+#: src/webui/static/app/epg.js:707 src/webui/static/app/epg.js:709
 msgid "hrs"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:963
+#: src/webui/static/app/tvheadend.js:1332
 msgid "login"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:960
+#: src/webui/static/app/tvheadend.js:1329
 msgid "logout"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:250
+#: src/webui/static/app/tvheadend.js:589
 msgid ""
 "looking for please see the [Wiki](http://tvheadend.org/projects/tvheadend/"
 "wiki) "
@@ -2002,9 +2304,9 @@ msgstr ""
 msgid "m/d/y#DatePicker"
 msgstr ""
 
-#: src/webui/static/app/idnode.js:364 src/webui/static/app/idnode.js:366
-#: src/webui/static/app/epg.js:116 src/webui/static/app/epg.js:468
-#: src/webui/static/app/epg.js:471 src/webui/static/app/dvr.js:52
+#: src/webui/static/app/idnode.js:381 src/webui/static/app/idnode.js:383
+#: src/webui/static/app/epg.js:246 src/webui/static/app/epg.js:709
+#: src/webui/static/app/epg.js:712 src/webui/static/app/dvr.js:118
 msgid "min"
 msgstr ""
 
@@ -2012,10 +2314,10 @@ msgstr ""
 msgid "of {0}"
 msgstr ""
 
-#: src/webui/static/app/tvheadend.js:251
+#: src/webui/static/app/tvheadend.js:590
 msgid ""
-"or join the [IRC channel on freenode](https://kiwiirc.com/client/chat."
-"freenode.net/?nick=tvhhelp|?#hts)."
+"or join the [IRC channel on libera](https://web.libera.chat/?nick=tvhhelp|?"
+"#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217
@@ -2043,6 +2345,6 @@ msgid "{0} selected row{1}"
 msgstr ""
 
 #. / {0} start, {1} end, {2} total, {3} title
-#: src/webui/static/app/tvheadend.js:361
+#: src/webui/static/app/tvheadend.js:700
 msgid "{3} {0} - {1} of {2}"
 msgstr ""

--- a/intl/tvheadend.pot
+++ b/intl/tvheadend.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-29 21:07+0200\n"
+"POT-Creation-Date: 2024-02-01 08:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,39 +17,30 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/main.c:529
+#: src/main.c:596
 msgid ""
 "\n"
 "For more information please visit the Tvheadend website:\n"
 "https://tvheadend.org\n"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:645
-msgid "# Channels"
-msgstr ""
-
-#: src/input/mpegts/mpegts_network.c:288
+#: src/input/mpegts/mpegts_network.c:337
 msgid "# Mapped channels"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:272
+#: src/input/mpegts/mpegts_network.c:321
 msgid "# Muxes"
 msgstr ""
 
-#: src/bouquet.c:1100 src/input/mpegts/mpegts_network.c:280
-#: src/input/mpegts/mpegts_mux.c:637
+#: src/input/mpegts/mpegts_network.c:329
 msgid "# Services"
 msgstr ""
 
-#: src/bouquet.c:1092
-msgid "# Services seen"
-msgstr ""
-
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:119
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:170
 msgid "# tune repeats"
 msgstr ""
 
-#: src/dvr/dvr_config.c:685
+#: src/dvr/dvr_config.c:710
 msgid "(Default profile)"
 msgstr ""
 
@@ -61,32 +52,66 @@ msgstr ""
 msgid "0"
 msgstr ""
 
+#: src/transcoding/codec/codecs/libs/libopus.c:115
+msgid ""
+"0 gives the fastest encodes but lower quality, while 10 gives the highest "
+"quality but slowest encoding [0-10]."
+msgstr ""
+
+#: src/input/mpegts/satip/satip.c:240
+msgid "0.20"
+msgstr ""
+
+#: src/input/mpegts/satip/satip.c:239
+msgid "0.25"
+msgstr ""
+
+#: src/input/mpegts/satip/satip.c:238
+msgid "0.35"
+msgstr ""
+
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:71
 msgid "1"
 msgstr ""
 
-#: src/dvr/dvr_db.c:2582 src/dvr/dvr_db.c:2606 src/dvr/dvr_config.c:721
-#: src/dvr/dvr_config.c:744
+#: src/dvr/dvr_db.c:3513 src/dvr/dvr_db.c:3537 src/dvr/dvr_config.c:747
+#: src/dvr/dvr_config.c:792 src/dvr/dvr_config.c:811
 msgid "1 day"
 msgstr ""
 
-#: src/dvr/dvr_db.c:2588 src/dvr/dvr_db.c:2612 src/dvr/dvr_config.c:727
-#: src/dvr/dvr_config.c:750
+#: src/dvr/dvr_config.c:787
+msgid "1 hour"
+msgstr ""
+
+#: src/dvr/dvr_config.c:784
+msgid "1 minute"
+msgstr ""
+
+#: src/dvr/dvr_db.c:3519 src/dvr/dvr_db.c:3543 src/dvr/dvr_config.c:753
+#: src/dvr/dvr_config.c:799 src/dvr/dvr_config.c:817
 msgid "1 month"
 msgstr ""
 
-#: src/dvr/dvr_db.c:2585 src/dvr/dvr_db.c:2609 src/dvr/dvr_config.c:724
-#: src/dvr/dvr_config.c:747
+#: src/dvr/dvr_db.c:3516 src/dvr/dvr_db.c:3540 src/dvr/dvr_config.c:750
+#: src/dvr/dvr_config.c:796 src/dvr/dvr_config.c:814
 msgid "1 week"
 msgstr ""
 
-#: src/dvr/dvr_db.c:2592 src/dvr/dvr_db.c:2616 src/dvr/dvr_config.c:731
-#: src/dvr/dvr_config.c:754
+#: src/dvr/dvr_db.c:3523 src/dvr/dvr_db.c:3547 src/dvr/dvr_config.c:757
+#: src/dvr/dvr_config.c:821
 msgid "1 year"
+msgstr ""
+
+#: src/transcoding/codec/profile_audio_class.c:266
+msgid "1. Language"
 msgstr ""
 
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:80
 msgid "10"
+msgstr ""
+
+#: src/dvr/dvr_config.c:785
+msgid "10 minutes"
 msgstr ""
 
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:81
@@ -97,8 +122,16 @@ msgstr ""
 msgid "12"
 msgstr ""
 
+#: src/dvr/dvr_config.c:791
+msgid "12 hours"
+msgstr ""
+
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:83
 msgid "13"
+msgstr ""
+
+#: src/satip/server.c:629
+msgid "1316 bytes"
 msgstr ""
 
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:84
@@ -109,58 +142,126 @@ msgstr ""
 msgid "15"
 msgstr ""
 
+#: src/satip/server.c:633
+msgid "16356 bytes"
+msgstr ""
+
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:72
 msgid "2"
 msgstr ""
 
-#: src/dvr/dvr_db.c:2589 src/dvr/dvr_db.c:2613 src/dvr/dvr_config.c:728
-#: src/dvr/dvr_config.c:751
+#: src/dvr/dvr_config.c:793
+msgid "2 days"
+msgstr ""
+
+#: src/dvr/dvr_config.c:788
+msgid "2 hours"
+msgstr ""
+
+#: src/dvr/dvr_db.c:3520 src/dvr/dvr_db.c:3544 src/dvr/dvr_config.c:754
+#: src/dvr/dvr_config.c:800 src/dvr/dvr_config.c:818
 msgid "2 months"
 msgstr ""
 
-#: src/dvr/dvr_db.c:2586 src/dvr/dvr_db.c:2610 src/dvr/dvr_config.c:725
-#: src/dvr/dvr_config.c:748
+#: src/dvr/dvr_db.c:3517 src/dvr/dvr_db.c:3541 src/dvr/dvr_config.c:751
+#: src/dvr/dvr_config.c:797 src/dvr/dvr_config.c:815
 msgid "2 weeks"
 msgstr ""
 
-#: src/dvr/dvr_db.c:2593 src/dvr/dvr_db.c:2617 src/dvr/dvr_config.c:732
-#: src/dvr/dvr_config.c:755
+#: src/dvr/dvr_db.c:3524 src/dvr/dvr_db.c:3548 src/dvr/dvr_config.c:758
+#: src/dvr/dvr_config.c:822
 msgid "2 years"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:732
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:795
 msgid "2-Port switch (universal LNB)"
+msgstr ""
+
+#: src/transcoding/codec/profile_audio_class.c:276
+msgid "2. Language"
+msgstr ""
+
+#: src/descrambler/cccam.c:985
+msgid "2.0.11"
+msgstr ""
+
+#: src/descrambler/cccam.c:986
+msgid "2.1.1"
+msgstr ""
+
+#: src/descrambler/cccam.c:987
+msgid "2.1.2"
+msgstr ""
+
+#: src/descrambler/cccam.c:988
+msgid "2.1.3"
+msgstr ""
+
+#: src/descrambler/cccam.c:989
+msgid "2.1.4"
+msgstr ""
+
+#: src/descrambler/cccam.c:990
+msgid "2.2.0"
+msgstr ""
+
+#: src/descrambler/cccam.c:991
+msgid "2.2.1"
+msgstr ""
+
+#: src/descrambler/cccam.c:992
+msgid "2.3.0"
+msgstr ""
+
+#: src/satip/server.c:630
+msgid "2632 bytes"
 msgstr ""
 
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:73
 msgid "3"
 msgstr ""
 
-#: src/dvr/dvr_db.c:2583 src/dvr/dvr_db.c:2607 src/dvr/dvr_config.c:722
-#: src/dvr/dvr_config.c:745
+#: src/dvr/dvr_db.c:3514 src/dvr/dvr_db.c:3538 src/dvr/dvr_config.c:748
+#: src/dvr/dvr_config.c:794 src/dvr/dvr_config.c:812
 msgid "3 days"
 msgstr ""
 
-#: src/dvr/dvr_db.c:2590 src/dvr/dvr_db.c:2614 src/dvr/dvr_config.c:729
-#: src/dvr/dvr_config.c:752
+#: src/dvr/dvr_db.c:3521 src/dvr/dvr_db.c:3545 src/dvr/dvr_config.c:755
+#: src/dvr/dvr_config.c:801 src/dvr/dvr_config.c:819
 msgid "3 months"
 msgstr ""
 
-#: src/dvr/dvr_db.c:2587 src/dvr/dvr_db.c:2611 src/dvr/dvr_config.c:726
-#: src/dvr/dvr_config.c:749
+#: src/dvr/dvr_db.c:3518 src/dvr/dvr_db.c:3542 src/dvr/dvr_config.c:752
+#: src/dvr/dvr_config.c:798 src/dvr/dvr_config.c:816
 msgid "3 weeks"
 msgstr ""
 
-#: src/dvr/dvr_db.c:2594 src/dvr/dvr_db.c:2618 src/dvr/dvr_config.c:733
-#: src/dvr/dvr_config.c:756
+#: src/dvr/dvr_db.c:3525 src/dvr/dvr_db.c:3549 src/dvr/dvr_config.c:759
+#: src/dvr/dvr_config.c:823
 msgid "3 years"
+msgstr ""
+
+#: src/transcoding/codec/profile_audio_class.c:286
+msgid "3. Language"
+msgstr ""
+
+#: src/dvr/dvr_config.c:786
+msgid "30 minutes"
+msgstr ""
+
+#: src/satip/server.c:634
+msgid "32712 bytes"
 msgstr ""
 
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:74
 msgid "4"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:738
+#: src/dvr/dvr_config.c:789
+msgid "4 hour"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:802
 msgid "4-Port switch (universal LNB)"
 msgstr ""
 
@@ -168,164 +269,186 @@ msgstr ""
 msgid "5"
 msgstr ""
 
-#: src/dvr/dvr_db.c:2584 src/dvr/dvr_db.c:2608 src/dvr/dvr_config.c:723
-#: src/dvr/dvr_config.c:746
+#: src/dvr/dvr_db.c:3515 src/dvr/dvr_db.c:3539 src/dvr/dvr_config.c:749
+#: src/dvr/dvr_config.c:795 src/dvr/dvr_config.c:813
 msgid "5 days"
 msgstr ""
 
-#: src/profile.c:1697
-msgid "5.0"
-msgstr ""
-
-#: src/profile.c:1698
-msgid "5.1"
+#: src/satip/server.c:631
+msgid "5264 bytes"
 msgstr ""
 
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:76
 msgid "6"
 msgstr ""
 
-#: src/dvr/dvr_db.c:2591 src/dvr/dvr_db.c:2615 src/dvr/dvr_config.c:730
-#: src/dvr/dvr_config.c:753
+#: src/dvr/dvr_db.c:3522 src/dvr/dvr_db.c:3546 src/dvr/dvr_config.c:756
+#: src/dvr/dvr_config.c:820
 msgid "6 months"
 msgstr ""
 
-#: src/profile.c:1699
-msgid "6.1"
+#: src/satip/server.c:635
+msgid "65424 bytes"
 msgstr ""
 
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:77
 msgid "7"
 msgstr ""
 
-#: src/profile.c:1700
-msgid "7.1"
+#: src/satip/server.c:632
+msgid "7896 bytes"
 msgstr ""
 
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:78
 msgid "8"
 msgstr ""
 
+#: src/dvr/dvr_config.c:790
+msgid "8 hour"
+msgstr ""
+
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:79
 msgid "9"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:315
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:368
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:95
 msgid "A"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1068
+#: src/dvr/dvr_autorec.c:1185
 msgid "A channel tag (e.g. a group of channels) to which this rule applies."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:353
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:667
+msgid "A delay before CAPMT after CAPMT query command (ms)."
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:658
+msgid "A delay between CAPMT commands (in ms)."
+msgstr ""
+
+#: src/descrambler/dvbcam.c:880
+msgid ""
+"A list of allowed CAIDs (hexa format, comma separated). E.g. "
+"'0D00,0F00,0100'."
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:406
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:57
 msgid "AA"
 msgstr ""
 
-#: src/profile.c:1316
+#: src/profile.c:1929
 msgid "AAC audio"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:365
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:418
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:58
 msgid "AB"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:502
+#: src/input/mpegts/mpegts_mux.c:507
 msgid "AC-3 = descriptor 6"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:661
+#: src/input/mpegts/mpegts_mux.c:676
 msgid "AC-3 detection"
 msgstr ""
 
-#: src/profile.c:1315
+#: src/profile.c:1932
+msgid "AC-4 audio"
+msgstr ""
+
+#: src/profile.c:1928
 msgid "AC3 audio"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:394
+#: src/input/mpegts/mpegts_mux.c:398
 msgid "ACTIVE"
 msgstr ""
 
-#: src/descrambler/constcw.c:351
-msgid "AES Constant Code Word"
+#: src/descrambler/constcw.c:464
+msgid "AES ECB Constant Code Word"
 msgstr ""
 
-#: src/config.c:1925
+#: src/descrambler/constcw.c:537
+msgid "AES128 ECB Constant Code Word"
+msgstr ""
+
+#: src/config.c:2050
 msgid "AF11"
 msgstr ""
 
-#: src/config.c:1926
+#: src/config.c:2051
 msgid "AF12"
 msgstr ""
 
-#: src/config.c:1927
+#: src/config.c:2052
 msgid "AF13"
 msgstr ""
 
-#: src/config.c:1929
+#: src/config.c:2054
 msgid "AF21"
 msgstr ""
 
-#: src/config.c:1930
+#: src/config.c:2055
 msgid "AF22"
 msgstr ""
 
-#: src/config.c:1931
+#: src/config.c:2056
 msgid "AF23"
 msgstr ""
 
-#: src/config.c:1933
+#: src/config.c:2058
 msgid "AF31"
 msgstr ""
 
-#: src/config.c:1934
+#: src/config.c:2059
 msgid "AF32"
 msgstr ""
 
-#: src/config.c:1935
+#: src/config.c:2060
 msgid "AF33"
 msgstr ""
 
-#: src/config.c:1937
+#: src/config.c:2062
 msgid "AF41"
 msgstr ""
 
-#: src/config.c:1938
+#: src/config.c:2063
 msgid "AF42"
 msgstr ""
 
-#: src/config.c:1939
+#: src/config.c:2064
 msgid "AF43"
 msgstr ""
 
-#: src/esfilter.c:314 src/esfilter.c:371
+#: src/esfilter.c:308 src/esfilter.c:364
 msgid "ANY"
 msgstr ""
 
-#: src/tvhlog.c:101
+#: src/tvhlog.c:110
 msgid "API"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:162
+#: src/input/mpegts/iptv/iptv_mux.c:189
 msgid "ATSC"
 msgstr ""
 
-#: src/tvhlog.c:161
+#: src/tvhlog.c:173
 msgid "ATSC PSIP EPG"
 msgstr ""
 
-#: src/tvhlog.c:114
+#: src/tvhlog.c:123
 msgid "ATSC SI Tables"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:152
+#: src/input/mpegts/mpegts_service.c:154
 msgid "ATSC source ID"
 msgstr ""
 
-#: src/satip/server.c:749
+#: src/satip/server.c:890
 msgid "ATSC-C"
 msgstr ""
 
@@ -333,11 +456,11 @@ msgstr ""
 msgid "ATSC-C Network"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:585
+#: src/input/mpegts/mpegts_mux_dvb.c:625
 msgid "ATSC-C multiplex"
 msgstr ""
 
-#: src/satip/server.c:741
+#: src/satip/server.c:882
 msgid "ATSC-T"
 msgstr ""
 
@@ -345,234 +468,323 @@ msgstr ""
 msgid "ATSC-T Network"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:544
+#: src/input/mpegts/mpegts_mux_dvb.c:584
 msgid "ATSC-T multiplex"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:228 src/input/mpegts/mpegts_mux_dvb.c:235
-#: src/input/mpegts/mpegts_mux_dvb.c:240 src/input/mpegts/mpegts_mux_dvb.c:247
-#: src/input/mpegts/mpegts_mux_dvb.c:252 src/input/mpegts/mpegts_mux_dvb.c:257
-#: src/input/mpegts/mpegts_mux_dvb.c:262 src/input/mpegts/mpegts_mux_dvb.c:329
-#: src/input/mpegts/mpegts_mux_dvb.c:334 src/input/mpegts/mpegts_mux_dvb.c:559
-#: src/input/mpegts/mpegts_mux_dvb.c:607 src/input/mpegts/mpegts_mux_dvb.c:612
-#: src/input/mpegts/mpegts_mux_dvb.c:685 src/input/mpegts/mpegts_mux_dvb.c:692
-#: src/input/mpegts/mpegts_mux_dvb.c:698 src/input/mpegts/mpegts_mux_dvb.c:702
-#: src/input/mpegts/mpegts_mux_dvb.c:721 src/input/mpegts/mpegts_mux_dvb.c:725
-#: src/input/mpegts/mpegts_mux_dvb.c:744 src/input/mpegts/mpegts_mux_dvb.c:748
-#: src/input/mpegts/mpegts_mux_dvb.c:799 src/input/mpegts/mpegts_mux_dvb.c:804
+#: src/input/mpegts/mpegts_mux_dvb.c:225 src/input/mpegts/mpegts_mux_dvb.c:232
+#: src/input/mpegts/mpegts_mux_dvb.c:237 src/input/mpegts/mpegts_mux_dvb.c:244
+#: src/input/mpegts/mpegts_mux_dvb.c:249 src/input/mpegts/mpegts_mux_dvb.c:254
+#: src/input/mpegts/mpegts_mux_dvb.c:259 src/input/mpegts/mpegts_mux_dvb.c:327
+#: src/input/mpegts/mpegts_mux_dvb.c:332 src/input/mpegts/mpegts_mux_dvb.c:599
+#: src/input/mpegts/mpegts_mux_dvb.c:647 src/input/mpegts/mpegts_mux_dvb.c:652
+#: src/input/mpegts/mpegts_mux_dvb.c:761 src/input/mpegts/mpegts_mux_dvb.c:768
+#: src/input/mpegts/mpegts_mux_dvb.c:774 src/input/mpegts/mpegts_mux_dvb.c:778
+#: src/input/mpegts/mpegts_mux_dvb.c:797 src/input/mpegts/mpegts_mux_dvb.c:801
+#: src/input/mpegts/mpegts_mux_dvb.c:820 src/input/mpegts/mpegts_mux_dvb.c:824
+#: src/input/mpegts/mpegts_mux_dvb.c:875 src/input/mpegts/mpegts_mux_dvb.c:880
+#: src/input/mpegts/mpegts_mux_dvb.c:1032
+#: src/input/mpegts/mpegts_mux_dvb.c:1039
+#: src/input/mpegts/mpegts_mux_dvb.c:1044
+#: src/input/mpegts/mpegts_mux_dvb.c:1051
+#: src/input/mpegts/mpegts_mux_dvb.c:1056
+#: src/input/mpegts/mpegts_mux_dvb.c:1061
+#: src/input/mpegts/mpegts_mux_dvb.c:1066
 msgid "AUTO"
 msgstr ""
 
-#: src/streaming.c:476
+#: src/streaming.c:504
 msgid "Aborted by user"
 msgstr ""
 
-#: src/satip/server.c:631
+#: src/satip/server.c:724
 msgid "Accept remote subscription weight"
 msgstr ""
 
-#: src/satip/server.c:632
+#: src/satip/server.c:725
 msgid "Accept the remote subscription weight (from the SAT>IP client)."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:654 src/input/mpegts/iptv/iptv.c:934
+#: src/input/mpegts/iptv/iptv.c:996
+msgid "Accept transport ID if zero."
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux.c:669 src/input/mpegts/iptv/iptv.c:995
 msgid "Accept zero value for TSID"
 msgstr ""
 
-#: src/access.c:1408
+#: src/access.c:1505
 msgid "Access"
 msgstr ""
 
-#: src/tvhlog.c:96
+#: src/tvhlog.c:105
 msgid "Access (ACL)"
 msgstr ""
 
-#: src/esfilter.c:689 src/esfilter.c:784 src/esfilter.c:879 src/esfilter.c:974
-#: src/esfilter.c:1079 src/esfilter.c:1161
+#: src/wizard.c:467
+msgid "Access Control"
+msgstr ""
+
+#: src/esfilter.c:681 src/esfilter.c:777 src/esfilter.c:873 src/esfilter.c:968
+#: src/esfilter.c:1076 src/esfilter.c:1159
 msgid "Action"
 msgstr ""
 
-#: src/streaming.c:459
+#: src/input/mpegts/mpegts_input.c:232
+#: src/input/mpegts/linuxdvb/linuxdvb_adapter.c:152
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:257
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1539
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1736
+#: src/input/mpegts/satip/satip.c:260
+#: src/input/mpegts/satip/satip_satconf.c:347
+#: src/input/mpegts/tvhdhomerun/tvhdhomerun.c:199
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:608
+msgid "Active"
+msgstr ""
+
+#: src/streaming.c:481
 msgid "Adapter in use by another subscription"
 msgstr ""
 
-#: src/main.c:879
+#: src/config.c:2311
+msgid "Add channel numbers to the channel name list"
+msgstr ""
+
+#: src/main.c:946
 msgid "Add file and line numbers to debug"
 msgstr ""
 
-#: src/main.c:880
+#: src/config.c:2320
+msgid "Add sources (like DVB-T string) to the channel name list"
+msgstr ""
+
+#: src/main.c:947
 msgid "Add the thread ID to debug"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:241
+#: src/input/mpegts/mpegts_service.c:243
 msgid ""
 "Add this value to PTS for the teletext subtitles. The time value is in "
 "milliseconds and may be negative."
 msgstr ""
 
-#: src/epggrab/module.c:188
+#: src/epggrab/module.c:211
 msgid "Additional arguments to pass to the grabber."
 msgstr ""
 
-#: src/epggrab/channel.c:807
+#: src/dvr/dvr_config.c:1106
+msgid ""
+"Additional command line options when fetching artwork for new recordings."
+msgstr ""
+
+#: src/epggrab/channel.c:825
 msgid "Additional service names found in EPG data."
 msgstr ""
 
-#: src/dvr/dvr_config.c:946
+#: src/dvr/dvr_config.c:1487
 msgid ""
 "Additional time (in seconds) in which to get the tuner ready for recording. "
 "This is useful for those with tuners that take some time to tune and/or send "
 "garbage data at the beginning. "
 msgstr ""
 
-#: src/access.c:1779
+#: src/access.c:1888
 msgid "Admin"
 msgstr ""
 
-#: src/wizard.c:433
+#: src/wizard.c:435
 msgid "Admin password"
 msgstr ""
 
-#: src/wizard.c:422
+#: src/wizard.c:424
 msgid "Admin username"
 msgstr ""
 
-#: src/wizard.c:399
+#: src/wizard.c:401
 msgid "Administrator login"
 msgstr ""
 
-#: src/epg.c:2288
+#: src/epg.c:1788
 msgid "Adult movie"
 msgstr ""
 
-#: src/access.c:1385 src/access.c:1500 src/config.c:1953
+#: src/access.c:1482 src/access.c:1607 src/config.c:2078
 msgid "Advanced"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:756
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:823
 msgid "Advanced (non-universal LNBs, rotors, etc.)"
 msgstr ""
 
-#: src/epg.c:2282
+#: src/transcoding/codec/profile_class.c:211
+msgid "Advanced Settings"
+msgstr ""
+
+#: src/epg.c:1782
 msgid "Adventure"
 msgstr ""
 
-#: src/epg.c:2448
+#: src/satip/server.c:790
+msgid ""
+"Advertise only NAT address and port in RTSP commands,even for local "
+"connections."
+msgstr ""
+
+#: src/epg.c:1948
 msgid "Advertisement / Shopping"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:742
+#: src/input/mpegts/iptv/iptv.c:825
 msgid "After creating the network scan it for services."
 msgstr ""
 
-#: src/access.c:1344
+#: src/ratinglabels.c:616
+msgid "Age"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4769
+msgid "Age Rating"
+msgstr ""
+
+#: src/ratinglabels.c:625
+msgid "Age to use in the EPG parental rating field."
+msgstr ""
+
+#: src/access.c:1430 src/access.c:1442
+#: src/input/mpegts/satip/satip_frontend.c:357
+#: src/input/mpegts/satip/satip_frontend.c:465
+#: src/input/mpegts/satip/satip_frontend.c:562
+msgid "All"
+msgstr ""
+
+#: src/access.c:1418
 msgid "All (Streaming plus DVR)"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1258
+#: src/descrambler/dvbcam.c:777
+msgid "All CAIDs"
+msgstr ""
+
+#: src/dvr/dvr_config.c:1342
 msgid ""
 "All characters that could possibly cause problems for filenaming will be "
 "replaced with an underscore. See Help for details."
 msgstr ""
 
-#: src/config.c:1964
+#: src/config.c:2089
 msgid "All lower-case"
 msgstr ""
 
-#: src/webui/extjs.c:236
-msgid ""
-"All proceeds are used to support server infrastructure and buy test "
-"equipment."
+#: src/dvr/dvr_autorec.c:1005
+msgid "All: Record if EPG/XMLTV indicates it is a unique programme"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:943
+#: src/dvr/dvr_autorec.c:1011
 msgid "All: Record if different description"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:939
+#: src/dvr/dvr_autorec.c:1007
 msgid "All: Record if different episode number"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:941
+#: src/dvr/dvr_autorec.c:1009
 msgid "All: Record if different subtitle"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:949
+#: src/dvr/dvr_autorec.c:1017
 msgid "All: Record once per day"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:945
+#: src/dvr/dvr_autorec.c:1013
 msgid "All: Record once per month"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:947
+#: src/dvr/dvr_autorec.c:1015
 msgid "All: Record once per week"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:199
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:153
+msgid "Allow all PIDs"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:154
+msgid "Allow all PIDs (no filter) when the 'Maximum PIDs' limit is reached."
+msgstr ""
+
+#: src/transcoding/codec/profile_video_class.c:205
+msgid "Allow control for scaling Up&Down, Up or Down"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:624
 msgid "Allow high bitrate mode (CI+ CAMs only)."
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:293
+#: src/input/mpegts/mpegts_input.c:304
 msgid "Allow idle scan tuning on this device."
 msgstr ""
 
-#: src/timeshift.c:267
+#: src/timeshift.c:265
 msgid ""
 "Allow the combined size of all timeshift buffers to potentially grow "
 "unbounded until your storage media runs out of space."
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:282
+#: src/input/mpegts/mpegts_input.c:290
 msgid ""
-"Allow the initial scan tuning on this device (scan when Tvheadend starts). "
-"See 'Skip Initial Scan' in the network settings for further details."
+"Allow the initial scan tuning on this device (scan when Tvheadend starts or "
+"when a new multiplex is added automatically). At least one tuner or input "
+"should have this settings turned on. See also 'Skip Startup Scan' in the "
+"network settings for further details."
 msgstr ""
 
-#: src/timeshift.c:233
+#: src/timeshift.c:231
 msgid ""
 "Allow the timeshift buffer to grow unbounded until your storage media runs "
 "out of space. Warning, enabling this option may cause your system to slow "
 "down or crash completely!"
 msgstr ""
 
-#: src/access.c:1780
+#: src/access.c:1889
 msgid "Allow/Disallow access to the 'Configuration' tab."
 msgstr ""
 
-#: src/access.c:1772
+#: src/access.c:1881
 msgid "Allow/Disallow web interface access (this  includes access to the EPG)."
 msgstr ""
 
-#: src/access.c:1760
+#: src/access.c:1869
 msgid "Allowed DVR profiles. This limits the profiles the user has access to."
 msgstr ""
 
-#: src/wizard.c:412
+#: src/wizard.c:414
 msgid "Allowed network"
 msgstr ""
 
-#: src/access.c:1633
+#: src/access.c:1742
 msgid "Allowed networks"
 msgstr ""
 
-#: src/main.c:822
+#: src/epggrab/module/xmltv.c:1103
+msgid "Alter programme description to include detailed information"
+msgstr ""
+
+#: src/main.c:889
 msgid "Alternate PID path"
 msgstr ""
 
-#: src/main.c:817
+#: src/main.c:884
 msgid "Alternate configuration path"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:701
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:754
 msgid "Altitude (in meters)."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:700
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:753
 msgid "Altitude (meters)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:252
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:290
 msgid ""
 "Always send the whole DiseqC sequence including LNB setup (voltage, tone). "
 "If this is not checked, only changed settings are sent, which may cause "
@@ -580,325 +792,384 @@ msgid ""
 "option."
 msgstr ""
 
-#: src/channels.c:389
+#: src/channels.c:424
 msgid "Always use the name defined by the network."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:169
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:240
 msgid ""
 "Always use the old ioctls to read the linuxdvb status (signal strength, SNR, "
 "error counters). Some drivers are not mature enough to provide the correct "
 "values using the new v5 linuxdvb API."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1100 src/dvr/dvr_autorec.c:1113
+#: src/dvr/dvr_autorec.c:1229 src/dvr/dvr_autorec.c:1242
 msgid ""
 "An event which starts between this \"start after\" and \"start before\" will "
 "be matched (including boundary values)."
 msgstr ""
 
-#: src/epg.c:2425
+#: src/epg.c:1925
 msgid "Animals"
 msgstr ""
 
-#: src/access.c:1748
+#: src/satip/server.c:697
+msgid "Anonymize"
+msgstr ""
+
+#: src/access.c:1857
 msgid "Anonymize HTSP access"
 msgstr ""
 
-#: src/profile.c:1313 src/dvr/dvr_autorec.c:628 src/dvr/dvr_autorec.c:664
-#: src/dvr/dvr_autorec.c:678 src/dvr/dvr_autorec.c:685
-#: src/dvr/dvr_autorec.c:973 src/dvr/dvr_autorec.c:1103
-#: src/dvr/dvr_autorec.c:1116 src/dvr/dvr_timerec.c:408
+#: src/profile.c:1926 src/dvr/dvr_autorec.c:740 src/dvr/dvr_autorec.c:775
+#: src/dvr/dvr_autorec.c:789 src/dvr/dvr_autorec.c:796
+#: src/dvr/dvr_autorec.c:974 src/dvr/dvr_autorec.c:1041
+#: src/dvr/dvr_autorec.c:1232 src/dvr/dvr_autorec.c:1245
+#: src/dvr/dvr_timerec.c:407
 msgid "Any"
 msgstr ""
 
-#: src/epg.c:2388
+#: src/transcoding/codec/codecs/libs/libopus.c:102
+msgid "Application"
+msgstr ""
+
+#: src/input/mpegts/iptv/iptv.c:1013
+msgid ""
+"Argument names to remove from the query string in the URL when the identical "
+"source is compared."
+msgstr ""
+
+#: src/input/mpegts/iptv/iptv.c:1003
+msgid "Argument names to remove from the query string in the URL."
+msgstr ""
+
+#: src/epg.c:1888
 msgid "Arts"
 msgstr ""
 
-#: src/epg.c:2400 src/epg.c:2401 src/epg.c:2402 src/epg.c:2403
+#: src/epg.c:1900 src/epg.c:1901 src/epg.c:1902 src/epg.c:1903
 msgid "Arts / Culture (without music)"
 msgstr ""
 
-#: src/epg.c:2398
+#: src/epg.c:1898
 msgid "Arts magazines"
 msgstr ""
 
-#: src/wizard.c:941
-msgid "Assign predefined muxes to networks"
+#: src/dvr/dvr_config.c:916
+msgid "Artwork Settings"
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:327
+#: src/dvr/dvr_config.c:1091
+msgid ""
+"Artwork fetching requires broadcasts to have good quality information that "
+"uniquely identifies them, such as year, season and episode. Without this "
+"information, lookups will frequently fail or return incorrect artwork. The "
+"default is to only lookup fanart for broadcasts that have high quality "
+"identifiable information."
+msgstr ""
+
+#: src/input/mpegts/mpegts_input.c:338
 msgid "Associate this device with one or more networks."
 msgstr ""
 
-#: src/epg.c:2340
+#: src/epg.c:1840
 msgid "Athletics"
 msgstr ""
 
-#: src/esfilter.c:723
-msgid "Audio Stream Filter"
-msgstr ""
-
-#: src/profile.c:1945
-msgid "Audio birate to use for transcoding."
-msgstr ""
-
-#: src/profile.c:1944
-msgid "Audio bitrate (kb/s) (0=auto)"
-msgstr ""
-
-#: src/profile.c:1878
+#: src/transcoding/codec/profile_audio_class.c:321
 msgid "Audio channel layout."
 msgstr ""
 
-#: src/profile.c:1932
-msgid "Audio codec"
+#: src/profile.c:2501
+msgid "Audio codec profile"
 msgstr ""
 
-#: src/profile.c:1933
-msgid ""
-"Audio codec to use for the transcode. \"Do not use\" will disable audio "
-"output."
+#: src/transcoding/codec/profile_audio_class.c:297
+msgid "Audio sample format."
 msgstr ""
 
-#: src/profile.c:1327
+#: src/profile.c:1941
 msgid "Audio stream"
 msgstr ""
 
-#: src/profile.c:1332
+#: src/profile.c:1946
 msgid "Audio type"
 msgstr ""
 
-#: src/profile.c:2260
-msgid "Audio-only stream"
-msgstr ""
-
-#: src/tvhlog.c:125
+#: src/tvhlog.c:135
 msgid "Audioes muxer"
 msgstr ""
 
-#: src/satip/server.c:568
+#: src/webui/webui.c:190
+msgid "Authenticated user"
+msgstr ""
+
+#: src/config.c:2468
+msgid "Authentication type"
+msgstr ""
+
+#: src/ratinglabels.c:646
+msgid "Authority"
+msgstr ""
+
+#: src/satip/server.c:618 src/input/mpegts/satip/satip.c:237
+#: src/descrambler/capmt.c:2697
 msgid "Auto"
 msgstr ""
 
-#: src/service.c:145
+#: src/service.c:136
 msgid "Auto check disabled"
 msgstr ""
 
-#: src/service.c:144
+#: src/service.c:135
 msgid "Auto check enabled"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3354
+#: src/dvr/dvr_db.c:4589
 msgid "Auto record"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3363
+#: src/dvr/dvr_db.c:4598
 msgid "Auto record caption"
 msgstr ""
 
-#: src/dvr/dvr_db.c:1461
+#: src/dvr/dvr_db.c:2095
 #, c-format
 msgid "Auto recording%s%s"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3371
+#: src/dvr/dvr_db.c:4606
 msgid "Auto time record"
 msgstr ""
 
-#: src/bouquet.c:991
+#: src/input/mpegts/mpegts_mux.c:491
+msgid "Auto-Detected"
+msgstr ""
+
+#: src/bouquet.c:1018
 msgid "Auto-Map to channels"
 msgstr ""
 
-#: src/service.c:187
+#: src/service.c:180
 msgid "Automatic checking"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3364
+#: src/dvr/dvr_db.c:4599
 msgid "Automatic recording caption."
 msgstr ""
 
-#: src/htsp_server.c:2110 src/htsp_server.c:2146
+#: src/htsp_server.c:2320 src/htsp_server.c:2356
 msgid "Automatic schedule entry not found"
 msgstr ""
 
-#: src/htsp_server.c:2221 src/htsp_server.c:2256
+#: src/htsp_server.c:2431 src/htsp_server.c:2466
 msgid "Automatic time scheduler entry not found"
 msgstr ""
 
-#: src/channels.c:441
+#: src/dvr/dvr_config.c:995
+msgid "Automatically delete played recordings"
+msgstr ""
+
+#: src/channels.c:476
 msgid ""
 "Automatically link EPG data to the channel (using the channel name for "
 "matching). If you turn this option off, only the OTA EPG grabber will be "
 "used for this channel unless you've specifically set a different EPG Source."
 msgstr ""
 
-#: src/channels.c:440
+#: src/channels.c:475
 msgid "Automatically map EPG source"
 msgstr ""
 
-#: src/wizard.c:1087
+#: src/wizard.c:1113
 msgid "Automatically map all available services to channels."
 msgstr ""
 
-#: src/bouquet.c:992
+#: src/bouquet.c:1019
 msgid "Automatically map channels defined within the bouquet."
 msgstr ""
 
-#: src/channels.c:388
+#: src/channels.c:423
 msgid "Automatically name from network"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3355
+#: src/dvr/dvr_db.c:4590
 msgid "Automatically record."
 msgstr ""
 
-#: src/epggrab.c:304
+#: src/epggrab.c:398
 msgid ""
 "Automatically update channel icons using information provided by the enabled "
-"EPG providers. Note: this may cause unwanted changes to already defined "
+"EPG providers. Note, this may cause unwanted changes to already defined "
 "channel icons."
 msgstr ""
 
-#: src/epggrab.c:280
+#: src/epggrab.c:374
 msgid ""
 "Automatically update channel names using information provided by the enabled "
-"EPG providers. Note: this may cause unwanted changes to already defined "
+"EPG providers. Note, this may cause unwanted changes to already defined "
 "channel names."
 msgstr ""
 
-#: src/epggrab.c:292
+#: src/epggrab.c:386
 msgid ""
 "Automatically update channel numbers using information provided by the "
-"enabled EPG providers. Note: this may cause unwanted changes to already "
+"enabled EPG providers. Note, this may cause unwanted changes to already "
 "defined channel numbers."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1011
+#: src/dvr/dvr_config.c:1411
 msgid "Autorec maximum count (0=unlimited)"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1020
+#: src/dvr/dvr_config.c:1421
 msgid "Autorec maximum schedules limit (0=unlimited)"
 msgstr ""
 
-#: src/tvhlog.c:99
+#: src/tvhlog.c:108
 msgid "Avahi"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:327
+#: src/transcoding/codec/codecs/libs/libx26x.c:77
+#: src/transcoding/codec/codecs/libs/libvorbis.c:69
+msgid "Average bitrate (ABR) mode."
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:380
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:96
 msgid "B"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:377
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:430
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:59
 msgid "BA"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:389
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:442
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:60
 msgid "BB"
 msgstr ""
 
-#: src/subscriptions.c:971
+#: src/subscriptions.c:1029
 msgid "Bad"
 msgstr ""
 
-#: src/htsp_server.c:1361
+#: src/htsp_server.c:1534
 msgid "Bad request"
 msgstr ""
 
-#: src/epg.c:2370 src/epg.c:2376
+#: src/epg.c:1870 src/epg.c:1876
 msgid "Ballet"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:228 src/input/mpegts/mpegts_mux_dvb.c:685
+#: src/input/mpegts/mpegts_mux_dvb.c:225 src/input/mpegts/mpegts_mux_dvb.c:761
+#: src/input/mpegts/mpegts_mux_dvb.c:1032
 msgid "Bandwidth"
 msgstr ""
 
-#: src/tvhlog.c:110
+#: src/tvhlog.c:119
 msgid "Base DVB SI Tables (PAT,CAT,PMT,SDT etc.)"
 msgstr ""
 
-#: src/webui/extjs.c:210
+#: src/webui/extjs.c:204
 msgid "Based on software from"
 msgstr ""
 
-#: src/access.c:1384 src/access.c:1495 src/access.c:1538 src/config.c:1952
+#: src/access.c:1431 src/access.c:1443 src/access.c:1481 src/access.c:1602
+#: src/access.c:1645 src/config.c:2077
 msgid "Basic"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:326
+#: src/access.c:1432
+msgid "Basic Alternative (No Hash)"
+msgstr ""
+
+#: src/satip/server.c:800
+msgid ""
+"Bind RTP source address of the outgoing RTP packets to specific local IP "
+"address (empty = same IP as the listening RTSP; 0.0.0.0 = IP in network of "
+"default gateway; or write here a valid local IP address)."
+msgstr ""
+
+#: src/input/mpegts/satip/satip.c:383
 msgid "Bind to specific local IP address."
 msgstr ""
 
-#: src/profile.c:1922
-msgid "Bitrate to use for the transcode. See Help for detailed information."
+#: src/transcoding/codec/codecs/mp2.c:56
+msgid "Bitrate (kb/s)"
 msgstr ""
 
-#: src/access.c:1406
+#: src/transcoding/codec/codecs/aac.c:88
+#: src/transcoding/codec/codecs/mpeg2video.c:49
+#: src/transcoding/codec/codecs/libs/libx26x.c:76
+#: src/transcoding/codec/codecs/libs/libvpx.c:85
+#: src/transcoding/codec/codecs/libs/libtheora.c:49
+#: src/transcoding/codec/codecs/libs/libvorbis.c:68
+#: src/transcoding/codec/codecs/libs/libopus.c:81
+msgid "Bitrate (kb/s) (0=auto)"
+msgstr ""
+
+#: src/transcoding/codec/codecs/libs/libopus.c:91
+msgid "Bitrate mode"
+msgstr ""
+
+#: src/transcoding/codec/codecs/libs/libopus.c:92
+msgid "Bitrate mode."
+msgstr ""
+
+#: src/access.c:1503
 msgid "Blue"
 msgstr ""
 
-#: src/tvhlog.c:100
+#: src/tvhlog.c:109
 msgid "Bonjour"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:439
+#: src/input/mpegts/satip/satip.c:506
 msgid "Boot ID"
 msgstr ""
 
-#: src/tvhlog.c:131
+#: src/config.c:2111
+msgid "Both plain and digest"
+msgstr ""
+
+#: src/tvhlog.c:141
 msgid "Bouquet"
 msgstr ""
 
-#: src/channels.c:524
+#: src/channels.c:580
 msgid "Bouquet (auto)"
 msgstr ""
 
-#: src/bouquet.c:1074
+#: src/bouquet.c:1101
 msgid "Bouquet source."
 msgstr ""
 
-#: src/bouquet.c:971
-msgid "Bouquets"
-msgstr ""
-
-#: src/dvr/dvr_autorec.c:1252
-msgid "Brand"
-msgstr ""
-
-#: src/dvr/dvr_autorec.c:1253
-msgid "Branding information (if available)."
-msgstr ""
-
-#: src/dvr/dvr_db.c:3415
+#: src/dvr/dvr_db.c:4658
 msgid "Broadcast"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1079
+#: src/dvr/dvr_autorec.c:1196
 msgid "Broadcast type"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3416
+#: src/dvr/dvr_db.c:4659
 msgid "Broadcast."
 msgstr ""
 
-#: src/epg.c:2396
+#: src/epg.c:1896
 msgid "Broadcasting"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:252
+#: src/input/mpegts/iptv/iptv_mux.c:296
 msgid "Buffering limit (ms)"
 msgstr ""
 
-#: src/webui/extjs.c:214
+#: src/webui/extjs.c:208
 msgid "Build"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:154
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:205
 msgid ""
 "By default, linuxdvb's status read period is 1000ms (one second). The "
 "accepted range is 250ms to 8000ms. Note that for some hardware or drivers "
@@ -908,695 +1179,952 @@ msgid ""
 "faster."
 msgstr ""
 
-#: src/tvhlog.c:136
+#: src/descrambler/capmt.c:2698
+msgid "Byte index tag order"
+msgstr ""
+
+#: src/tvhlog.c:146
 msgid "CA (descrambling) Client"
 msgstr ""
 
-#: src/descrambler/constcw.c:290 src/descrambler/constcw.c:356
+#: src/descrambler/constcw.c:324 src/descrambler/constcw.c:397
+#: src/descrambler/constcw.c:470 src/descrambler/constcw.c:543
 msgid "CA ID"
 msgstr ""
 
-#: src/esfilter.c:1008
-msgid "CA Stream Filter"
-msgstr ""
-
-#: src/descrambler/caclient.c:180
+#: src/descrambler/caclient.c:201
 #, c-format
 msgid "CA client %i"
 msgstr ""
 
-#: src/esfilter.c:1025
+#: src/esfilter.c:1020
 msgid "CA identification"
 msgstr ""
 
-#: src/esfilter.c:1035
+#: src/esfilter.c:1031
 msgid "CA provider"
 msgstr ""
 
-#: src/service.c:229
+#: src/service.c:222
 msgid "CAID"
 msgstr ""
 
-#: src/descrambler/capmt.c:2376
+#: src/descrambler/dvbcam.c:879
+msgid "CAID filter list"
+msgstr ""
+
+#: src/descrambler/dvbcam.c:869
+msgid "CAID selection"
+msgstr ""
+
+#: src/descrambler/dvbcam.c:889
+msgid "CAM can decode multiple channels"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:692
+msgid "CAM slot number."
+msgstr ""
+
+#: src/descrambler/capmt.c:2710
 msgid "CAPMT (Linux Network DVBAPI)"
 msgstr ""
 
-#: src/tvhlog.c:138
+#: src/tvhlog.c:148
 msgid "CAPMT CA Client"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:233
-msgid "CAPMT interval (in ms)."
-msgstr ""
-
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:232
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:657
 msgid "CAPMT interval (ms)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:241
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:666
 msgid "CAPMT query interval (ms)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:242
-msgid "CAPMT query interval (ms)."
+#: src/descrambler/cccam.c:1001
+msgid "CCcam"
 msgstr ""
 
-#: src/tvhlog.c:156
+#: src/tvhlog.c:168
 msgid "CI Module"
 msgstr ""
 
-#: src/tvhlog.c:78
+#: src/config.c:2526
+msgid "CORS origin"
+msgstr ""
+
+#: src/tvhlog.c:87
 msgid "CPU"
 msgstr ""
 
-#: src/tvhlog.c:77
+#: src/tvhlog.c:86
 msgid "CRASH"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:597 src/input/mpegts/mpegts_service.c:176
+#: src/input/mpegts/mpegts_mux.c:612 src/input/mpegts/mpegts_service.c:178
 msgid "CRID authority"
 msgstr ""
 
-#: src/config.c:1923
+#: src/config.c:2048
 msgid "CS0"
 msgstr ""
 
-#: src/config.c:1924
+#: src/config.c:2049
 msgid "CS1"
 msgstr ""
 
-#: src/config.c:1928
+#: src/config.c:2053
 msgid "CS2"
 msgstr ""
 
-#: src/config.c:1932
+#: src/config.c:2057
 msgid "CS3"
 msgstr ""
 
-#: src/config.c:1936
+#: src/config.c:2061
 msgid "CS4"
 msgstr ""
 
-#: src/config.c:1940
+#: src/config.c:2065
 msgid "CS5"
 msgstr ""
 
-#: src/config.c:1942
+#: src/config.c:2067
 msgid "CS6"
 msgstr ""
 
-#: src/config.c:1943
+#: src/config.c:2068
 msgid "CS7"
 msgstr ""
 
-#: src/tvhlog.c:137
+#: src/tvhlog.c:147
 msgid "CSA (descrambling)"
 msgstr ""
 
-#: src/tvhlog.c:139
+#: src/descrambler/constcw.c:318
+msgid "CSA CBC Constant Code Word"
+msgstr ""
+
+#: src/descrambler/capmt.c:2742
+msgid "CW Mode"
+msgstr ""
+
+#: src/tvhlog.c:149
 msgid "CWC CA Client"
 msgstr ""
 
-#: src/dvr/dvr_config.c:888
+#: src/tvhlog.c:150
+msgid "CWC CCCam Client"
+msgstr ""
+
+#: src/input/mpegts/mpegts_network_dvb.c:367
+msgid "CableCARD Network"
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux_dvb.c:666
+msgid "CableCARD multiplex"
+msgstr ""
+
+#: src/dvr/dvr_config.c:1201
 msgid "Cache scheme"
 msgstr ""
 
-#: src/descrambler/capmt.c:2390
+#: src/input/mpegts/mpegts_mux_dvb.c:686
+msgid "Callsign"
+msgstr ""
+
+#: src/descrambler/capmt.c:2726
 msgid "Camd.socket filename / IP Address (TCP mode)"
 msgstr ""
 
-#: src/epg.c:2357
+#: src/descrambler/cclient.c:1354
+msgid "Card client"
+msgstr ""
+
+#: src/epg.c:1857
 msgid "Cartoons"
 msgstr ""
 
-#: src/access.c:1643
+#: src/epggrab/module/xmltv.c:775
+msgid "Categories: "
+msgstr ""
+
+#: src/dvr/dvr_db.c:4734
+msgid "Category"
+msgstr ""
+
+#: src/dvr/dvr_autorec.c:1083
+msgid "Category "
+msgstr ""
+
+#: src/access.c:1752
 msgid "Change parameters"
 msgstr ""
 
-#: src/tvhlog.c:128 src/service.c:200 src/dvr/dvr_db.c:3121
-#: src/dvr/dvr_autorec.c:1054 src/dvr/dvr_timerec.c:574
+#: src/tvhlog.c:138 src/service.c:193 src/dvr/dvr_db.c:4299
+#: src/dvr/dvr_autorec.c:1171 src/dvr/dvr_timerec.c:572
+#: src/input/mpegts/mpegts_mux_dvb.c:671
 msgid "Channel"
 msgstr ""
 
-#: src/channels.c:1429
-msgid "Channel Tags"
-msgstr ""
-
-#: src/htsp_server.c:1553 src/htsp_server.c:1595 src/htsp_server.c:1680
-#: src/htsp_server.c:1850 src/htsp_server.c:2391 src/htsp_server.c:2394
+#: src/htsp_server.c:1726 src/htsp_server.c:1768 src/htsp_server.c:1853
+#: src/htsp_server.c:2007 src/htsp_server.c:2601 src/htsp_server.c:2604
 msgid "Channel does not exist"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3132
+#: src/dvr/dvr_db.c:4310
 msgid "Channel icon"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3133
+#: src/dvr/dvr_db.c:4311
 msgid "Channel icon URL."
 msgstr ""
 
-#: src/epggrab/channel.c:825
+#: src/epggrab/channel.c:843
 msgid "Channel icon as defined in EPG data."
 msgstr ""
 
-#: src/config.c:2340
+#: src/config.c:2414
 msgid "Channel icon name scheme"
 msgstr ""
 
-#: src/config.c:2327
+#: src/config.c:2401
 msgid "Channel icon path"
 msgstr ""
 
-#: src/bouquet.c:1001
+#: src/config.c:2183
+msgid "Channel icon/Picon Settings"
+msgstr ""
+
+#: src/transcoding/codec/profile_audio_class.c:320
+msgid "Channel layout"
+msgstr ""
+
+#: src/bouquet.c:1028
 msgid "Channel mapping options"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3140
+#: src/dvr/dvr_db.c:4318
 msgid "Channel name"
 msgstr ""
 
-#: src/htsp_server.c:2336
+#: src/config.c:2310
+msgid "Channel name with numbers"
+msgstr ""
+
+#: src/config.c:2319
+msgid "Channel name with sources"
+msgstr ""
+
+#: src/htsp_server.c:2546
 msgid "Channel not found"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:175
+#: src/input/mpegts/iptv/iptv_mux.c:202
 msgid "Channel number"
 msgstr ""
 
-#: src/epggrab/channel.c:817
+#: src/epggrab/channel.c:835
 msgid "Channel number as defined in EPG data."
 msgstr ""
 
-#: src/bouquet.c:1115
+#: src/bouquet.c:1142
 msgid "Channel number offset"
 msgstr ""
 
-#: src/access.c:1421
+#: src/access.c:1518
 msgid "Channel number range"
 msgstr ""
 
-#: src/epggrab/module/xmltv.c:751
+#: src/epggrab/module/xmltv.c:1087
 msgid "Channel numbers (heuristic)"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:910
+#: src/input/mpegts/iptv/iptv.c:971
 msgid "Channel numbers from"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1067
+#: src/dvr/dvr_autorec.c:1184
 msgid "Channel tag"
 msgstr ""
 
-#: src/htsp_server.c:1686
+#: src/htsp_server.c:1859
 msgid "Channel tag does not exist"
 msgstr ""
 
-#: src/bouquet.c:1029
+#: src/bouquet.c:1056
 msgid "Channel tag reference"
 msgstr ""
 
-#: src/access.c:1426 src/access.c:1834 src/input/mpegts/iptv/iptv_mux.c:238
+#: src/access.c:1523 src/access.c:1943 src/input/mpegts/iptv/iptv_mux.c:265
 msgid "Channel tags"
 msgstr ""
 
-#: src/access.c:1835
+#: src/access.c:1944
 msgid "Channel tags the user is allowed access to/excluded from."
 msgstr ""
 
-#: src/dvr/dvr_timerec.c:575
+#: src/dvr/dvr_timerec.c:573
 msgid "Channel to use/used for the recording."
 msgstr ""
 
-#: src/epggrab/channel.c:855
+#: src/epggrab/channel.c:873
 msgid "Channel update options"
 msgstr ""
 
-#: src/channels.c:369 src/profile.c:1877 src/epggrab/channel.c:833
+#: src/epggrab/channel.c:851
 msgid "Channels"
 msgstr ""
 
-#: src/epggrab/channel.c:834
+#: src/bouquet.c:998
+msgid "Channels / EPG - Bouquets"
+msgstr ""
+
+#: src/channels.c:1766
+msgid "Channels / EPG - Channel Tags"
+msgstr ""
+
+#: src/channels.c:403
+msgid "Channels / EPG - Channels"
+msgstr ""
+
+#: src/epggrab/channel.c:743
+msgid "Channels / EPG - EPG Grabber Channels"
+msgstr ""
+
+#: src/epggrab.c:344
+msgid "Channels / EPG - EPG Grabber Configuration"
+msgstr ""
+
+#: src/epggrab/module.c:135
+msgid "Channels / EPG - EPG Grabber Modules"
+msgstr ""
+
+#: src/epggrab/channel.c:852
 msgid "Channels EPG data is used by."
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:253 src/input/mpegts/mpegts_mux.c:626
-#: src/input/mpegts/mpegts_service.c:203
+#: src/dvr/dvr_config.c:1176 src/input/mpegts/mpegts_network.c:302
+#: src/input/mpegts/mpegts_mux.c:641 src/input/mpegts/mpegts_service.c:205
 msgid "Character set"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1278
+#: src/dvr/dvr_config.c:1364
 msgid ""
 "Characters not supported in Windows filenames (e.g. for an SMB/CIFS share) "
 "will be stripped out or converted."
 msgstr ""
 
-#: src/tvhlog.c:145
+#: src/tvhlog.c:157
 msgid "Charset"
 msgstr ""
 
-#: src/service_mapper.c:507
+#: src/service_mapper.c:598
 msgid "Check availability"
 msgstr ""
 
-#: src/service.c:188
+#: src/service.c:181
 msgid ""
 "Check for the services' presence. If the service is no longer broadcast this "
 "field will change to Missing In PAT/SDT."
 msgstr ""
 
-#: src/service_mapper.c:508
-msgid "Check service availability (add live services only)."
+#: src/service_mapper.c:599
+msgid ""
+"Check services for availability. If enabled, services that are not currently "
+"broadcasting (or can't be decrypted) will be ignored. Leave disabled if you "
+"want Tvheadend to also map offline services."
 msgstr ""
 
-#: src/epg.c:2358 src/epg.c:2359 src/epg.c:2360 src/epg.c:2361 src/epg.c:2362
-#: src/epg.c:2363 src/epg.c:2364 src/epg.c:2365 src/epg.c:2366 src/epg.c:2367
+#: src/profile.c:412
+msgid "Check the descrambling status after this timeout."
+msgstr ""
+
+#: src/input/mpegts/satip/satip.c:405
+msgid "Check tuner-number in signal-status messages"
+msgstr ""
+
+#: src/epg.c:1858 src/epg.c:1859 src/epg.c:1860 src/epg.c:1861 src/epg.c:1862
+#: src/epg.c:1863 src/epg.c:1864 src/epg.c:1865 src/epg.c:1866 src/epg.c:1867
 msgid "Children's / Youth Programs"
 msgstr ""
 
-#: src/epg.c:2352
+#: src/epg.c:1852
 msgid "Children's / Youth programs"
 msgstr ""
 
-#: src/epg.c:2394
+#: src/epg.c:1894
 msgid "Cinema"
 msgstr ""
 
-#: src/esfilter.c:604 src/profile.c:297 src/descrambler/caclient.c:258
+#: src/esfilter.c:595 src/profile.c:305 src/descrambler/caclient.c:285
 msgid "Class"
 msgstr ""
 
-#: src/epg.c:2287
+#: src/epg.c:1787
 msgid "Classical"
 msgstr ""
 
-#: src/epg.c:2372
+#: src/epg.c:1872
 msgid "Classical music"
 msgstr ""
 
-#: src/streaming.c:580
+#: src/streaming.c:616
 msgid "Clean effects"
 msgstr ""
 
-#: src/descrambler/caclient.c:280
+#: src/descrambler/constcw.c:300
+msgid "Client"
+msgstr ""
+
+#: src/descrambler/caclient.c:310
 msgid "Client name"
 msgstr ""
 
-#: src/dvr/dvr_config.c:924
+#: src/descrambler/cccam.c:1007
+msgid "Client node ID. Leave field empty to generate a random ID."
+msgstr ""
+
+#: src/dvr/dvr_config.c:1041
 msgid "Clone scheduled entry on error"
 msgstr ""
 
-#: src/descrambler/cwc.c:1828
+#: src/descrambler/cwc.c:772
 msgid "Code Word Client (newcamd)"
 msgstr ""
 
-#: src/epg.c:2284
+#: src/tvhlog.c:182 src/transcoding/codec/profile_class.c:241
+msgid "Codec"
+msgstr ""
+
+#: src/transcoding/codec/profile_class.c:207
+msgid "Codec Settings"
+msgstr ""
+
+#: src/transcoding/codec/profile_class.c:250
+msgid "Codec name"
+msgstr ""
+
+#: src/transcoding/codec/profile_class.c:251
+msgid "Codec name."
+msgstr ""
+
+#: src/transcoding/codec/profile_class.c:269
+msgid "Codec status."
+msgstr ""
+
+#: src/transcoding/codec/profile_class.c:242
+msgid "Codec title."
+msgstr ""
+
+#: src/transcoding/codec/profile_class.c:260
+msgid "Codec type."
+msgstr ""
+
+#: src/transcoding/codec/codecs/aac.c:109
+msgid "Coding algorithm"
+msgstr ""
+
+#: src/transcoding/codec/codecs/aac.c:110
+msgid "Coding algorithm."
+msgstr ""
+
+#: src/epg.c:1784
 msgid "Comedy"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:159
-msgid "Command delay time (ms) (10-200)"
+#: src/profile.c:1607
+msgid "Command line"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:109
-msgid "Command time (ms) (10-100)"
+#: src/profile.c:1608
+msgid ""
+"Command line to run a task which accepts MPEG-TS stream on stdin and writes "
+"output to stdout in format specified by the selected mime type."
 msgstr ""
 
-#: src/access.c:1845 src/access.c:2064 src/access.c:2201 src/channels.c:1508
-#: src/esfilter.c:711 src/esfilter.c:806 src/esfilter.c:901 src/esfilter.c:996
-#: src/esfilter.c:1101 src/esfilter.c:1183 src/profile.c:336 src/bouquet.c:1108
-#: src/epggrab/channel.c:867 src/dvr/dvr_db.c:3473 src/dvr/dvr_autorec.c:1297
-#: src/dvr/dvr_timerec.c:678 src/dvr/dvr_config.c:867
-#: src/descrambler/caclient.c:288
+#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:132
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:110
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:158
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:216
+msgid "Command time (ms) (10-300)"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:763
+msgid "Command to move the dish with an external command."
+msgstr ""
+
+#: src/access.c:1974 src/access.c:2320 src/access.c:2459 src/channels.c:1845
+#: src/esfilter.c:703 src/esfilter.c:799 src/esfilter.c:895 src/esfilter.c:990
+#: src/esfilter.c:1098 src/esfilter.c:1181 src/profile.c:344 src/bouquet.c:1135
+#: src/epggrab/channel.c:885 src/dvr/dvr_db.c:4726 src/dvr/dvr_autorec.c:1442
+#: src/dvr/dvr_timerec.c:679 src/dvr/dvr_config.c:1118
+#: src/descrambler/caclient.c:319
 msgid "Comment"
 msgstr ""
 
-#: src/dvr/dvr_db.c:629
+#: src/dvr/dvr_db.c:656
 msgid "Commercial break"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1124
+#: src/dvr/dvr_config.c:1443
 msgid ""
 "Commercials will be dropped from the recordings. Commercial detection works "
 "using EITp/f (EPG running state) and for the Swedish channel TV4 (using "
 "teletext info)."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:125
+#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:140
 msgid "Committed"
 msgstr ""
 
-#: src/dvr/dvr_db.c:660
+#: src/descrambler/dvbcam.c:852
+msgid "Common Interface Settings"
+msgstr ""
+
+#: src/dvr/dvr_db.c:687
 msgid "Completed OK"
 msgstr ""
 
-#: src/config.c:2213
+#: src/config.c:2360
 msgid "Compress EPG database"
 msgstr ""
 
-#: src/config.c:2214
+#: src/config.c:2361
 msgid "Compress the EPG database to reduce disk I/O and space."
 msgstr ""
 
-#: src/input/mpegts/satip/satip_satconf.c:379
-msgid ""
-"Concurrent limit per network position (src=) for satellite SAT>IP tuners. "
-"The first limit number is for src=1 (AA), second for src=2 (AB) etc."
+#: src/transcoding/codec/codecs/flac.c:62
+msgid "Compression level"
 msgstr ""
 
-#: src/config.c:2165
-msgid "Conditional Access"
+#: src/transcoding/codec/codecs/flac.c:63
+msgid "Compression level (0-12), -1 means ffmpeg default"
 msgstr ""
 
-#: src/descrambler/caclient.c:245
+#: src/input/mpegts/satip/satip_satconf.c:396
+msgid "Concurrent input limit per network group for satellite SAT>IP tuners."
+msgstr ""
+
+#: src/config.c:2286
+msgid "Conditional Access (for advanced view level)"
+msgstr ""
+
+#: src/descrambler/caclient.c:265
 msgid "Conditional Access Client"
 msgstr ""
 
-#: src/descrambler/constcw.c:291 src/descrambler/constcw.c:357
+#: src/descrambler/constcw.c:325 src/descrambler/constcw.c:398
+#: src/descrambler/constcw.c:471 src/descrambler/constcw.c:544
 msgid "Conditional Access Identification."
 msgstr ""
 
-#: src/tvhlog.c:95 src/profile.c:288 src/profile.c:1084 src/profile.c:1216
-#: src/profile.c:1498 src/profile.c:1842 src/epggrab/channel.c:735
+#: src/tvhlog.c:104 src/profile.c:2100 src/epggrab/channel.c:752
 msgid "Configuration"
 msgstr ""
 
-#: src/config.c:2017
+#: src/config.c:2164
 msgid "Configuration - Base"
 msgstr ""
 
-#: src/imagecache.c:79
+#: src/imagecache.c:81
 msgid "Configuration - Image Cache"
 msgstr ""
 
-#: src/satip/server.c:582
+#: src/satip/server.c:646
 msgid "Configuration - SAT>IP Server"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:447
+#: src/input/mpegts/satip/satip.c:514
 msgid "Configuration ID"
 msgstr ""
 
-#: src/dvr/dvr_config.c:856
+#: src/epggrab/module.c:278
+msgid ""
+"Configuration containing regular expressions to use for scraping additional "
+"information from the broadcast guide.This option does not access or retrieve "
+"details from the Internet.This can be left blank to use the default or set "
+"to one of the Tvheadend configurations from the epggrab/eit/scrape directory "
+"such as \"uk\" (without the quotes)."
+msgstr ""
+
+#: src/dvr/dvr_config.c:937
 msgid "Configuration name"
 msgstr ""
 
-#: src/config.c:2053
+#: src/config.c:2213
 msgid "Configuration version"
 msgstr ""
 
-#: src/access.c:1786
+#: src/descrambler/cclient.c:1369
+msgid "Connection Settings"
+msgstr ""
+
+#: src/access.c:1895
 msgid "Connection limit type"
 msgstr ""
 
-#: src/access.c:1441
+#: src/access.c:1538
 msgid "Connection limits"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:235 src/input/mpegts/mpegts_mux_dvb.c:329
-#: src/input/mpegts/mpegts_mux_dvb.c:607 src/input/mpegts/mpegts_mux_dvb.c:799
+#: src/transcoding/codec/codecs/libs/libx26x.c:86
+#: src/transcoding/codec/codecs/libs/libvpx.c:95
+msgid "Constant Rate Factor (0=auto)"
+msgstr ""
+
+#: src/transcoding/codec/codecs/aac.c:89 src/transcoding/codec/codecs/mp2.c:57
+#: src/transcoding/codec/codecs/mpeg2video.c:50
+#: src/transcoding/codec/codecs/libs/libvpx.c:86
+#: src/transcoding/codec/codecs/libs/libtheora.c:50
+#: src/transcoding/codec/codecs/libs/libopus.c:82
+msgid "Constant bitrate (CBR) mode."
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux_dvb.c:232 src/input/mpegts/mpegts_mux_dvb.c:327
+#: src/input/mpegts/mpegts_mux_dvb.c:647 src/input/mpegts/mpegts_mux_dvb.c:875
+#: src/input/mpegts/mpegts_mux_dvb.c:1039
 msgid "Constellation"
 msgstr ""
 
-#: src/profile.c:1855
+#: src/profile.c:2468
 msgid "Container"
 msgstr ""
 
-#: src/profile.c:1856
+#: src/profile.c:2469
 msgid "Container to use for the transcoded stream."
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:899
+#: src/input/mpegts/iptv/iptv.c:960
 msgid "Content character set"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:177
+#: src/input/mpegts/mpegts_service.c:179
 msgid "Content reference identifier authority."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3406 src/dvr/dvr_autorec.c:1089
+#: src/dvr/dvr_db.c:4641 src/dvr/dvr_autorec.c:1206
 msgid "Content type"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3407
+#: src/dvr/dvr_db.c:4642
 msgid "Content type."
 msgstr ""
 
-#: src/epg.c:2317
+#: src/epg.c:1817
 msgid "Contest"
 msgstr ""
 
-#: src/profile.c:389
-msgid "Continue even if descrambling fails"
+#: src/profile.c:399
+msgid "Continue if descrambling fails"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1136
+#: src/dvr/dvr_autorec.c:1265
 msgid "Continue recording for x minutes after scheduled stop time"
 msgstr ""
 
-#: src/channels.c:482 src/dvr/dvr_db.c:3095 src/dvr/dvr_config.c:976
+#: src/channels.c:528 src/dvr/dvr_db.c:4273 src/dvr/dvr_config.c:1031
 msgid "Continue recording for x minutes after scheduled stop time."
 msgstr ""
 
-#: src/config.c:2125
+#: src/epggrab.c:433
+msgid ""
+"Convert broadcast ratings codes into human-readable labels like 'PG' or 'FSK "
+"16'."
+msgstr ""
+
+#: src/config.c:2491
 msgid "Cookie expiration (days)"
 msgstr ""
 
-#: src/epg.c:2447
+#: src/epg.c:1947
 msgid "Cooking"
 msgstr ""
 
-#: src/profile.c:1750
-msgid "Copy codec type"
+#: src/profile.c:2293
+msgid "Copy"
 msgstr ""
 
-#: src/profile.c:1692
-msgid "Copy layout"
+#: src/dvr/dvr_db.c:4650
+msgid "Copyright year"
 msgstr ""
 
-#: src/memoryinfo.c:69
+#: src/memoryinfo.c:70
 msgid "Count of objects"
 msgstr ""
 
-#: src/service_mapper.c:532
+#: src/ratinglabels.c:609
+msgid "Country"
+msgstr ""
+
+#: src/ratinglabels.c:610
+msgid "Country recieved via OTA EPG."
+msgstr ""
+
+#: src/service_mapper.c:649
 msgid "Create SDTV/HDTV/Radio tags."
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:892
-msgid "Create a bouquet from the playlist."
+#: src/input/mpegts/mpegts_network.c:236
+msgid "Create a bouquet with all services in the network."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1172
+#: src/dvr/dvr_config.c:1228
 msgid ""
 "Create a directory per channel when storing recordings. If both this and the "
 "'directory per day' checkbox is enabled, the date-directory will be the "
 "parent of the per-channel directory."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1184
+#: src/dvr/dvr_config.c:1240
 msgid ""
 "Create a directory per title when storing recordings. If the day/channel "
 "directory checkboxes are also enabled, those directories will be parents of "
 "this directory."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1160
+#: src/dvr/dvr_config.c:1216
 msgid ""
 "Create a new directory per day in the recording system path. Folders will "
 "only be created when something is recorded. The format of the directory will "
 "be ISO standard YYYY-MM-DD."
 msgstr ""
 
-#: src/service_mapper.c:540
+#: src/service_mapper.c:657
 msgid "Create a provider name tag."
 msgstr ""
 
-#: src/wizard.c:1105
+#: src/wizard.c:1131
 msgid "Create and associate a network tag to created channels."
 msgstr ""
 
-#: src/wizard.c:1096
+#: src/wizard.c:1122
 msgid "Create and associate a provider tag to created channels."
 msgstr ""
 
-#: src/bouquet.c:1016
+#: src/bouquet.c:1043
 msgid "Create and link these tags to channels when mapping."
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:891
+#: src/input/mpegts/mpegts_network.c:235
 msgid "Create bouquet"
 msgstr ""
 
-#: src/bouquet.c:794
+#: src/bouquet.c:822
 msgid "Create bouquet tag"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1150
+#: src/dvr/dvr_config.c:1157
 msgid "Create directories using these permissions."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1091
+#: src/dvr/dvr_config.c:1167
 msgid "Create files using these permissions."
 msgstr ""
 
-#: src/service_mapper.c:547 src/bouquet.c:809
+#: src/service_mapper.c:664 src/bouquet.c:837
 msgid "Create network name tags"
 msgstr ""
 
-#: src/service_mapper.c:548
+#: src/service_mapper.c:665
 msgid "Create network name tags (set by provider)."
 msgstr ""
 
-#: src/wizard.c:1104
+#: src/wizard.c:1130
 msgid "Create network tags"
 msgstr ""
 
-#: src/service_mapper.c:539 src/bouquet.c:804
+#: src/service_mapper.c:656 src/bouquet.c:832
 msgid "Create provider name tags"
 msgstr ""
 
-#: src/wizard.c:1095
+#: src/wizard.c:1121
 msgid "Create provider tags"
 msgstr ""
 
-#: src/bouquet.c:1015
+#: src/bouquet.c:1042
 msgid "Create tags"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1113
+#: src/dvr/dvr_config.c:1376
 msgid ""
 "Create tags in recordings using media containers that support metadata (if "
 "possible)."
 msgstr ""
 
-#: src/service_mapper.c:531 src/bouquet.c:799
+#: src/service_mapper.c:648 src/bouquet.c:827
 msgid "Create type-based tags"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:248
+#: src/input/mpegts/mpegts_mux.c:703 src/input/mpegts/mpegts_service.c:250
 msgid "Created"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3270 src/dvr/dvr_autorec.c:1287 src/dvr/dvr_timerec.c:668
+#: src/dvr/dvr_db.c:4497 src/dvr/dvr_autorec.c:1432 src/dvr/dvr_timerec.c:669
 msgid "Creator"
 msgstr ""
 
-#: src/tvhlog.c:97 src/input/mpegts/mpegts_mux_sched.c:153
+#: src/dvr/dvr_db.c:4743
+msgid "Credits"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4744
+msgid "Credits such as cast members"
+msgstr ""
+
+#: src/epggrab/module/xmltv.c:774
+msgid "Credits: "
+msgstr ""
+
+#: src/tvhlog.c:106 src/input/mpegts/mpegts_mux_sched.c:154
 msgid "Cron"
 msgstr ""
 
-#: src/epggrab.c:327
+#: src/epggrab.c:441
 msgid "Cron multi-line"
 msgstr ""
 
-#: src/epg.c:2388
+#: src/descrambler/capmt.c:2743
+msgid "CryptoWord mode."
+msgstr ""
+
+#: src/epg.c:1888
 msgid "Culture (without music)"
 msgstr ""
 
-#: src/epg.c:2398
+#: src/epg.c:1898
 msgid "Culture magazines"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:360
+#: src/input/mpegts/satip/satip.c:427
 msgid "Current RTSP port."
 msgstr ""
 
-#: src/epg.c:2298
+#: src/epg.c:1798
 msgid "Current affairs"
 msgstr ""
 
-#: src/memoryinfo.c:70
+#: src/memoryinfo.c:71
 msgid "Current number of objects."
 msgstr ""
 
-#: src/memoryinfo.c:54
+#: src/memoryinfo.c:55
 msgid "Current object size."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:392
+#: src/input/mpegts/satip/satip.c:459
 msgid "Current tuner configuration."
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:231
+#: src/input/mpegts/iptv/iptv_mux.c:258
 msgid "Custom HTTP headers"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network_dvb.c:436
+#: src/config.c:2327
+msgid "Custom date Format"
+msgstr ""
+
+#: src/config.c:2328
+msgid "Custom date mask like (%yyyy-%M-%dd %h:%m:%s)"
+msgstr ""
+
+#: src/input/mpegts/mpegts_network_dvb.c:469
 msgid "DAB Network"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:876
+#: src/input/mpegts/mpegts_mux_dvb.c:1102
 msgid "DAB multiplex"
 msgstr ""
 
-#: src/tvhlog.c:98
+#: src/tvhlog.c:107
 msgid "DBUS"
 msgstr ""
 
-#: src/main.c:832
+#: src/main.c:899
 msgid "DBus - use the session message bus instead of the system one"
 msgstr ""
 
-#: src/descrambler/constcw.c:285
-msgid "DES Constant Code Word"
+#: src/tvhlog.c:185
+msgid "DD-CI"
 msgstr ""
 
-#: src/descrambler/cwc.c:1866
+#: src/descrambler/cwc.c:778
 msgid "DES Key."
 msgstr ""
 
-#: src/descrambler/cwc.c:1865
+#: src/descrambler/constcw.c:391
+msgid "DES NCB Constant Code Word"
+msgstr ""
+
+#: src/descrambler/cwc.c:777
 msgid "DES key"
 msgstr ""
 
-#: src/config.c:2148
+#: src/config.c:2664
 msgid "DSCP/TOS for streaming"
 msgstr ""
 
-#: src/tvhlog.c:146
+#: src/input/mpegts/mpegts_network_dvb.c:446
+msgid "DTMB Network"
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux_dvb.c:1015
+msgid "DTMB multiplex"
+msgstr ""
+
+#: src/tvhlog.c:158
 msgid "DVB"
 msgstr ""
 
-#: src/tvhlog.c:140
+#: src/tvhlog.c:151
 msgid "DVB CAM Client"
 msgstr ""
 
-#: src/tvhlog.c:111
+#: src/tvhlog.c:120
 msgid "DVB CSA (descrambling) Tables"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3322
+#: src/dvr/dvr_db.c:4549
 msgid "DVB EPG ID"
 msgstr ""
 
-#: src/tvhlog.c:112
+#: src/tvhlog.c:121
 msgid "DVB EPG Tables"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:149
+#: src/input/mpegts/mpegts_mux.c:518
+msgid "DVB Inputs - Multiplex"
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux_sched.c:128
+msgid "DVB Inputs - Mux Schedulers"
+msgstr ""
+
+#: src/input/mpegts/mpegts_network.c:181
 msgid "DVB Inputs - Networks"
 msgstr ""
 
-#: src/tvhlog.c:109
+#: src/input/mpegts/mpegts_service.c:91
+msgid "DVB Inputs - Services"
+msgstr ""
+
+#: src/tvhlog.c:118
 msgid "DVB SI Tables"
 msgstr ""
 
-#: src/tvhlog.c:113
+#: src/tvhlog.c:122
 msgid "DVB Time Tables"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:139
+#: src/input/mpegts/mpegts_mux_dvb.c:136
 msgid "DVB multiplex"
 msgstr ""
 
-#: src/config.c:2036
-msgid "DVB scan files"
-msgstr ""
-
-#: src/config.c:2269
+#: src/config.c:2702
 msgid "DVB scan files path"
 msgstr ""
 
-#: src/satip/server.c:725
+#: src/satip/server.c:866 src/input/mpegts/satip/satip_frontend.c:563
 msgid "DVB-C"
 msgstr ""
 
@@ -1604,15 +2132,15 @@ msgstr ""
 msgid "DVB-C Network"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:307
+#: src/input/mpegts/mpegts_mux_dvb.c:305
 msgid "DVB-C multiplex"
 msgstr ""
 
-#: src/satip/server.c:733
+#: src/satip/server.c:874 src/input/mpegts/satip/satip_frontend.c:564
 msgid "DVB-C2"
 msgstr ""
 
-#: src/satip/server.c:693
+#: src/satip/server.c:834 src/input/mpegts/satip/satip_frontend.c:466
 msgid "DVB-S"
 msgstr ""
 
@@ -1620,19 +2148,19 @@ msgstr ""
 msgid "DVB-S Network"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:217
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:248
 msgid "DVB-S Satellite Configuration"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:438
+#: src/input/mpegts/mpegts_mux_dvb.c:462
 msgid "DVB-S multiplex"
 msgstr ""
 
-#: src/satip/server.c:701
+#: src/satip/server.c:842 src/input/mpegts/satip/satip_frontend.c:467
 msgid "DVB-S2"
 msgstr ""
 
-#: src/satip/server.c:709
+#: src/satip/server.c:850 src/input/mpegts/satip/satip_frontend.c:358
 msgid "DVB-T"
 msgstr ""
 
@@ -1640,234 +2168,284 @@ msgstr ""
 msgid "DVB-T Network"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:211
+#: src/input/mpegts/mpegts_mux_dvb.c:208
 msgid "DVB-T multiplex"
 msgstr ""
 
-#: src/satip/server.c:717
+#: src/satip/server.c:858 src/input/mpegts/satip/satip_frontend.c:359
 msgid "DVB-T2"
 msgstr ""
 
-#: src/access.c:1346
+#: src/access.c:1420
 msgid "DVR"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:998
+#: src/dvr/dvr_autorec.c:1100
 msgid "DVR - Auto-recording (Autorecs)"
 msgstr ""
 
-#: src/dvr/dvr_config.c:803
+#: src/dvr/dvr_config.c:875
 msgid "DVR - Profiles"
 msgstr ""
 
-#: src/dvr/dvr_timerec.c:526
+#: src/dvr/dvr_timerec.c:524
 msgid "DVR - Time-based Recording (Timers)"
 msgstr ""
 
-#: src/dvr/dvr_config.c:813
-msgid "DVR behavior"
+#: src/tvhlog.c:153
+msgid "DVR Inotify"
 msgstr ""
 
-#: src/dvr/dvr_db.c:2581 src/dvr/dvr_db.c:2605 src/dvr/dvr_db.c:3249
-#: src/dvr/dvr_autorec.c:1241 src/dvr/dvr_timerec.c:649
+#: src/dvr/dvr_db.c:3512 src/dvr/dvr_db.c:3536 src/dvr/dvr_db.c:4476
+#: src/dvr/dvr_autorec.c:1405 src/dvr/dvr_timerec.c:650
 msgid "DVR configuration"
 msgstr ""
 
-#: src/access.c:1759
+#: src/access.c:1868
 msgid "DVR configuration profiles"
 msgstr ""
 
-#: src/access.c:1431
+#: src/access.c:1528
 msgid "DVR configurations"
 msgstr ""
 
-#: src/htsp_server.c:1924
+#: src/htsp_server.c:2109
 msgid "DVR entry not found"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3221 src/dvr/dvr_autorec.c:1213 src/dvr/dvr_timerec.c:639
-#: src/dvr/dvr_config.c:913
+#: src/dvr/dvr_db.c:4448 src/dvr/dvr_autorec.c:1377 src/dvr/dvr_timerec.c:640
 msgid "DVR file retention period"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3211 src/dvr/dvr_autorec.c:1203 src/dvr/dvr_timerec.c:629
+#: src/dvr/dvr_db.c:4438 src/dvr/dvr_autorec.c:1367 src/dvr/dvr_timerec.c:630
 msgid "DVR log retention"
 msgstr ""
 
-#: src/dvr/dvr_config.c:902
-msgid "DVR log retention period"
-msgstr ""
-
-#: src/profile.c:254
+#: src/profile.c:261
 msgid "DVR override: high"
 msgstr ""
 
-#: src/profile.c:253
+#: src/profile.c:260
 msgid "DVR override: important"
 msgstr ""
 
-#: src/profile.c:256
+#: src/profile.c:263
 msgid "DVR override: low"
 msgstr ""
 
-#: src/profile.c:255
+#: src/profile.c:262
 msgid "DVR override: normal"
 msgstr ""
 
-#: src/profile.c:257
+#: src/profile.c:264
 msgid "DVR override: unimportant"
 msgstr ""
 
-#: src/dvr/dvr_timerec.c:650
+#: src/dvr/dvr_timerec.c:651
 msgid "DVR profile to use/used for the recording."
 msgstr ""
 
-#: src/htsp_server.c:2344 src/htsp_server.c:2705
+#: src/htsp_server.c:2554 src/htsp_server.c:2930
 msgid "DVR schedule does not exist"
 msgstr ""
 
-#: src/htsp_server.c:2713
+#: src/htsp_server.c:2938
 msgid "DVR schedule does not have a file yet"
 msgstr ""
 
-#: src/htsp_server.c:2292
+#: src/htsp_server.c:2502
 msgid "DVR schedule not found"
 msgstr ""
 
-#: src/epg.c:2370
+#: src/epg.c:1870
 msgid "Dance"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3313
+#: src/dvr/dvr_db.c:4540
 msgid "Data errors"
 msgstr ""
 
-#: src/epggrab/channel.c:772
+#: src/epggrab/channel.c:790
 msgid "Data path (if applicable)."
 msgstr ""
 
-#: src/epggrab/channel.c:781
+#: src/input/mpegts/mpegts_mux_dvb.c:347 src/input/mpegts/mpegts_mux_dvb.c:895
+msgid "Data slice"
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux_dvb.c:348 src/input/mpegts/mpegts_mux_dvb.c:896
+msgid "Data slice code."
+msgstr ""
+
+#: src/profile.c:353
+msgid "Data timeout (sec) (0=infinite)"
+msgstr ""
+
+#: src/epggrab/channel.c:799
 msgid "Date the EPG data was last updated (not set for OTA grabbers)."
 msgstr ""
 
-#: src/dvr/dvr_timerec.c:607
+#: src/dvr/dvr_timerec.c:605
 msgid "Days of Week"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1147
+#: src/dvr/dvr_autorec.c:1276
 msgid "Days of the week to which the rule should apply."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1146
+#: src/dvr/dvr_autorec.c:1275
 msgid "Days of week"
 msgstr ""
 
-#: src/epg.c:2302
+#: src/dvr/dvr_config.c:974
+msgid ""
+"Days to retain information about recordings. Once this period is exceeded, "
+"duplicate detection will not be possible."
+msgstr ""
+
+#: src/epg.c:1802
 msgid "Debate"
 msgstr ""
 
-#: src/tvhlog.c:795
+#: src/tvhlog.c:866
 msgid "Debug libav log"
 msgstr ""
 
-#: src/tvhlog.c:727
-msgid "Debug log path"
-msgstr ""
-
-#: src/main.c:868
+#: src/main.c:935
 msgid "Debug options"
 msgstr ""
 
-#: src/tvhlog.c:756
+#: src/tvhlog.c:839
 msgid "Debug subsystems"
 msgstr ""
 
-#: src/tvhlog.c:747
+#: src/tvhlog.c:818
 msgid "Debug to syslog"
 msgstr ""
 
-#: src/tvhlog.c:768
+#: src/tvhlog.c:827
 msgid "Debug trace (low-level)"
 msgstr ""
 
-#: src/tvhlog.c:712
+#: src/tvhlog.c:776
 msgid "Debugging"
 msgstr ""
 
-#: src/access.c:1383 src/access.c:1395 src/config.c:1922 src/profile.c:316
+#: src/access.c:1480 src/access.c:1492 src/config.c:2047 src/profile.c:334
+#: src/dvr/dvr_db.c:3498
 msgid "Default"
 msgstr ""
 
-#: src/config.c:2198
+#: src/config.c:2232
+msgid "Default language"
+msgstr ""
+
+#: src/config.c:2345
 msgid "Default language(s)"
 msgstr ""
 
-#: src/access.c:1678
+#: src/access.c:1787
 msgid "Default language."
 msgstr ""
 
-#: src/profile.c:345
+#: src/http.c:708
+msgid "Default login"
+msgstr ""
+
+#: src/profile.c:365
 msgid "Default priority"
 msgstr ""
 
-#: src/access.c:1656
+#: src/input/mpegts/satip/satip_frontend.c:221
+msgid "Default server config"
+msgstr ""
+
+#: src/access.c:1765
 msgid "Default user interface level."
 msgstr ""
 
-#: src/input/mpegts/satip/satip_satconf.c:390
-msgid "Define network group to limit network usage."
+#: src/config.c:2263
+msgid "Default view level"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:214 src/input/mpegts/mpegts_mux_dvb.c:310
-#: src/input/mpegts/mpegts_mux_dvb.c:441 src/input/mpegts/mpegts_mux_dvb.c:547
-#: src/input/mpegts/mpegts_mux_dvb.c:588 src/input/mpegts/mpegts_mux_dvb.c:673
-#: src/input/mpegts/mpegts_mux_dvb.c:780 src/input/mpegts/mpegts_mux_dvb.c:833
-#: src/input/mpegts/mpegts_mux_dvb.c:879
+#: src/input/mpegts/satip/satip_satconf.c:405
+msgid ""
+"Define network group to limit network usage (value 1-1000). All SAT>IP "
+"positions in the same group must have identical network limit, otherwise the "
+"limiting will not work correctly."
+msgstr ""
+
+#: src/transcoding/codec/profile_video_class.c:183
+msgid "Deinterlace"
+msgstr ""
+
+#: src/transcoding/codec/profile_video_class.c:184
+msgid "Deinterlace."
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux_dvb.c:211 src/input/mpegts/mpegts_mux_dvb.c:308
+#: src/input/mpegts/mpegts_mux_dvb.c:465 src/input/mpegts/mpegts_mux_dvb.c:587
+#: src/input/mpegts/mpegts_mux_dvb.c:628 src/input/mpegts/mpegts_mux_dvb.c:749
+#: src/input/mpegts/mpegts_mux_dvb.c:856 src/input/mpegts/mpegts_mux_dvb.c:927
+#: src/input/mpegts/mpegts_mux_dvb.c:1018
+#: src/input/mpegts/mpegts_mux_dvb.c:1105
+#: src/input/mpegts/satip/satip_frontend.c:382
+#: src/input/mpegts/satip/satip_frontend.c:512
+#: src/input/mpegts/satip/satip_frontend.c:587
 msgid "Delivery system"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:86
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:120
 msgid "Demux path"
 msgstr ""
 
-#: src/satip/server.c:641
+#: src/satip/server.c:734
 msgid "Descramble services (limit per mux)"
 msgstr ""
 
-#: src/tvhlog.c:134
+#: src/tvhlog.c:144
 msgid "Descrambler"
 msgstr ""
 
-#: src/tvhlog.c:135
+#: src/tvhlog.c:145
 msgid "Descrambler EMM"
 msgstr ""
 
-#: src/config.c:2176
+#: src/config.c:2681
 msgid "Descrambler buffer (TS packets)"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3184 src/dvr/dvr_db.c:3192
+#: src/profile.c:411
+msgid "Descrambling timeout (ms)"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4399 src/dvr/dvr_db.c:4407
+#: src/transcoding/codec/profile_class.c:233
 msgid "Description"
 msgstr ""
 
-#: src/epg.c:2281
+#: src/epg.c:1781
 msgid "Detective"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:455
+#: src/input/mpegts/satip/satip.c:522
 msgid "Device ID"
 msgstr ""
 
-#: src/input/mpegts/tvhdhomerun/tvhdhomerun.c:200
+#: src/input/mpegts/tvhdhomerun/tvhdhomerun.c:234
 msgid "Device model"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_adapter.c:119
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:258
+#: src/input/mpegts/linuxdvb/linuxdvb_adapter.c:159
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:683
 msgid "Device path"
 msgstr ""
 
-#: src/config.c:2149
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:136
+msgid "Device path in sysfs"
+msgstr ""
+
+#: src/config.c:2665
 msgid ""
 "Differentiated Services Code Point / Type of Service: Set the service class "
 "Tvheadend sends with each packet. Depending on the option selected this "
@@ -1876,1310 +2454,1736 @@ msgid ""
 "wiki/Differentiated_services for more information. "
 msgstr ""
 
-#: src/config.c:2114
+#: src/config.c:2110
+msgid "Digest"
+msgstr ""
+
+#: src/config.c:2469
 msgid ""
 "Digest access authentication is intended as a security trade-off. It is "
 "intended to replace unencrypted HTTP basic access authentication. This "
 "option should be enabled for standard usage."
 msgstr ""
 
-#: src/tvhlog.c:141 src/dvr/dvr_db.c:3038
+#: src/config.c:2480
+msgid "Digest hash type"
+msgstr ""
+
+#: src/tvhlog.c:152 src/dvr/dvr_db.c:4199
 msgid "Digital Video Recorder"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3289 src/dvr/dvr_autorec.c:1025 src/dvr/dvr_timerec.c:563
+#: src/dvr/dvr_db.c:4516 src/dvr/dvr_autorec.c:1127 src/dvr/dvr_timerec.c:561
 msgid "Directory"
 msgstr ""
 
-#: src/dvr/dvr_timerec.c:564
+#: src/dvr/dvr_timerec.c:562
 msgid ""
 "Directory override. Override the subdirectory rules specified by the DVR "
 "configuration and put all recordings done by this entry into the specified "
 "subdirectory"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1149
+#: src/dvr/dvr_config.c:1156
 msgid "Directory permissions (octal, e.g. 0775)"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3290
+#: src/dvr/dvr_db.c:4517
 msgid "Directory used by the entry."
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:136 src/input/mpegts/mpegts_mux.c:471
-#: src/input/mpegts/mpegts_mux.c:481
+#: src/input/mpegts/mpegts_network.c:154 src/input/mpegts/mpegts_mux.c:477
+#: src/input/mpegts/mpegts_mux.c:487
 msgid "Disable"
 msgstr ""
 
-#: src/main.c:889
+#: src/main.c:956
 msgid "Disable DVB bouquets"
 msgstr ""
 
-#: src/main.c:847
+#: src/satip/server.c:946
+msgid "Disable RTP/AVP/TCP support"
+msgstr ""
+
+#: src/main.c:914
 msgid "Disable SAT>IP client"
 msgstr ""
 
-#: src/satip/server.c:684
+#: src/satip/server.c:706
+msgid "Disable UPnP"
+msgstr ""
+
+#: src/satip/server.c:707
+msgid "Disable UPnP discovery."
+msgstr ""
+
+#: src/satip/server.c:937
 msgid "Disable X_SATIPM3U tag"
 msgstr ""
 
-#: src/main.c:887
+#: src/main.c:954
 msgid "Disable all access control checks"
 msgstr ""
 
-#: src/main.c:870
+#: src/main.c:937
 msgid "Disable debug on stderr"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:341
+#: src/input/mpegts/satip/satip.c:398
 msgid "Disable device/firmware-specific workarounds"
 msgstr ""
 
-#: src/main.c:872
+#: src/main.c:939
 msgid "Disable syslog (all messages)"
 msgstr ""
 
-#: src/channels.c:358 src/epggrab/module/xmltv.c:760
+#: src/channels.c:392 src/profile.c:2292 src/epggrab/module/xmltv.c:1129
 msgid "Disabled"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:184
+#: src/satip/server.c:967
+msgid ""
+"Discard the frontend parameter in RTSP requests, as some clients incorrectly "
+"use it."
+msgstr ""
+
+#: src/input/mpegts/mpegts_network.c:224
 msgid "Discover more muxes using the Network Information Table (if available)."
 msgstr ""
 
-#: src/epg.c:2302
+#: src/epg.c:1802
 msgid "Discussion"
 msgstr ""
 
-#: src/tvhlog.c:155 src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1601
+#: src/tvhlog.c:167 src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1728
 msgid "DiseqC"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:237
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:275
 msgid "DiseqC repeats"
 msgstr ""
 
-#: src/satip/server.c:685
+#: src/ratinglabels.c:624
+msgid "Display Age"
+msgstr ""
+
+#: src/ratinglabels.c:632
+msgid "Display Label"
+msgstr ""
+
+#: src/satip/server.c:938
 msgid "Do not send X_SATIPM3U information in the XML description to clients."
 msgstr ""
 
-#: src/access.c:1749
+#: src/access.c:1858
 msgid ""
 "Do not send any stream specific information to the HTSP client like signal "
 "strength, input source etc."
 msgstr ""
 
-#: src/profile.c:1748
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:232
+msgid "Do not set"
+msgstr ""
+
+#: src/input/mpegts/satip/satip_frontend.c:232
+#: src/input/mpegts/iptv/iptv_mux.c:98
 msgid "Do not use"
 msgstr ""
 
-#: src/epg.c:2301 src/epg.c:2407
+#: src/epg.c:1801 src/epg.c:1907
 msgid "Documentary"
 msgstr ""
 
-#: src/profile.c:390
+#: src/profile.c:400
 msgid ""
 "Don't abort streaming when an encrypted stream can't be decrypted by a CA "
 "client that normally should be able to decrypt the stream."
 msgstr ""
 
-#: src/main.c:818
+#: src/main.c:885
 msgid "Don't backup configuration tree at upgrade"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1249
+#: src/dvr/dvr_config.c:1333
 msgid "Don't include the title in the filename."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1248
+#: src/dvr/dvr_config.c:1332
 msgid "Don't include title in filename"
 msgstr ""
 
-#: src/dvr/dvr_config.c:710
+#: src/dvr/dvr_config.c:736
 msgid "Don't keep"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3338
+#: src/dvr/dvr_db.c:4565
 msgid "Don't re-record"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3339
+#: src/dvr/dvr_db.c:4566
 msgid "Don't re-record if recording fails."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3331
+#: src/dvr/dvr_db.c:4558
 msgid "Don't re-schedule if recording fails."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3330
+#: src/dvr/dvr_db.c:4557
 msgid "Don't reschedule"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:235
+#: src/input/mpegts/mpegts_network.c:284
 msgid "Don't use the provider's channel numbers."
 msgstr ""
 
-#: src/epg.c:2280 src/epg.c:2287 src/epg.c:2288
+#: src/transcoding/codec/profile_video_class.c:31
+msgid "Down (only)"
+msgstr ""
+
+#: src/epg.c:1780 src/epg.c:1787 src/epg.c:1788
 msgid "Drama"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1192
+#: src/satip/server.c:966
+msgid "Drop \"fe=\" parameter"
+msgstr ""
+
+#: src/dvr/dvr_autorec.c:1356 src/dvr/dvr_config.c:1430
 msgid "Duplicate handling"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1193
+#: src/dvr/dvr_autorec.c:1357 src/dvr/dvr_config.c:1431
 msgid "Duplicate recording handling."
 msgstr ""
 
-#: src/config.c:1941
+#: src/config.c:2066
 msgid "EF"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:671
+#: src/input/mpegts/mpegts_mux.c:686
 msgid "EIT - skip TSID check"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:263
+#: src/input/mpegts/mpegts_network.c:312
 msgid "EIT time offset"
 msgstr ""
 
-#: src/tvhlog.c:143
+#: src/descrambler/cclient.c:1365
+msgid "EMM Settings"
+msgstr ""
+
+#: src/epggrab/module/xmltv.c:1182
+msgid "EPG - External XMLTV EPG Grabber"
+msgstr ""
+
+#: src/epggrab/module/xmltv.c:1139
+msgid "EPG - Internal XMLTV EPG Grabber"
+msgstr ""
+
+#: src/epggrab/module.c:241
+msgid "EPG - Over-the-air EPG Grabber"
+msgstr ""
+
+#: src/tvhlog.c:155
 msgid "EPG Database"
 msgstr ""
 
-#: src/tvhlog.c:144 src/epggrab/module.c:112
+#: src/tvhlog.c:156
 msgid "EPG Grabber"
-msgstr ""
-
-#: src/epggrab/channel.c:726
-msgid "EPG Grabber Channel"
-msgstr ""
-
-#: src/epggrab.c:254
-msgid "EPG Grabber Configuration"
 msgstr ""
 
 #: src/wizard.c:188
 msgid "EPG Language (priority order)"
 msgstr ""
 
-#: src/epggrab/channel.c:791
+#: src/ratinglabels.c:589
+msgid "EPG Parental Rating Labels"
+msgstr ""
+
+#: src/config.c:2179
+msgid "EPG Settings"
+msgstr ""
+
+#: src/epggrab/module.c:253
+msgid "EPG behaviour"
+msgstr ""
+
+#: src/epggrab/channel.c:809
 msgid "EPG data ID."
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:187
+#: src/input/mpegts/mpegts_mux.c:553
+msgid "EPG module id"
+msgstr ""
+
+#: src/input/mpegts/iptv/iptv_mux.c:214
 msgid "EPG name"
 msgstr ""
 
-#: src/config.c:2225
+#: src/config.c:2372
 msgid "EPG overlap cut"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:537
+#: src/input/mpegts/mpegts_mux.c:542
 msgid "EPG scan"
 msgstr ""
 
-#: src/epggrab.c:364
-msgid "EPG scan timeout in seconds (30-7200)"
+#: src/epggrab.c:487
+msgid "EPG scan time-out in seconds (30-7200)"
 msgstr ""
 
-#: src/channels.c:454
+#: src/channels.c:500
 msgid "EPG source"
 msgstr ""
 
-#: src/dvr/dvr_config.c:986
+#: src/config.c:2381 src/dvr/dvr_config.c:1386
 msgid "EPG update window"
 msgstr ""
 
-#: src/epg.c:2406 src/epg.c:2408
+#: src/dvr/dvr_config.c:908
+msgid "EPG/Autorec Settings"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:586
+msgid "EXTERNAL"
+msgstr ""
+
+#: src/epg.c:1906 src/epg.c:1908
 msgid "Economics"
 msgstr ""
 
-#: src/epg.c:2424
+#: src/epg.c:1924
 msgid "Education"
 msgstr ""
 
-#: src/epg.c:2432 src/epg.c:2433 src/epg.c:2434 src/epg.c:2435 src/epg.c:2436
-#: src/epg.c:2437 src/epg.c:2438 src/epg.c:2439
+#: src/epg.c:1932 src/epg.c:1933 src/epg.c:1934 src/epg.c:1935 src/epg.c:1936
+#: src/epg.c:1937 src/epg.c:1938 src/epg.c:1939
 msgid "Education / Science / Factual topics"
 msgstr ""
 
-#: src/epg.c:2356
+#: src/epg.c:1856
 msgid "Educational"
 msgstr ""
 
-#: src/tvhlog.c:142
+#: src/tvhlog.c:154
 msgid "Electronic Program Guide"
 msgstr ""
 
-#: src/tvhlog.c:132
+#: src/tvhlog.c:142
 msgid "Elementary Stream Filter"
 msgstr ""
 
-#: src/esfilter.c:591
+#: src/esfilter.c:583
 msgid "Elementary stream filter"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:472
+#: src/access.c:2211 src/input/mpegts/mpegts_mux.c:478
 msgid "Enable"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:482
+#: src/input/mpegts/mpegts_mux.c:488
 msgid "Enable (auto)"
 msgstr ""
 
-#: src/main.c:830
+#: src/main.c:897
 msgid "Enable DBus"
 msgstr ""
 
-#: src/config.c:2293
+#: src/config.c:2630
+msgid "Enable HDHomeRun Server Emulation"
+msgstr ""
+
+#: src/config.c:2735
 msgid "Enable NTP driver"
 msgstr ""
 
-#: src/main.c:886
+#: src/main.c:953
 msgid "Enable coredumps for daemon"
 msgstr ""
 
-#: src/main.c:869
+#: src/main.c:936
 msgid "Enable debug on stderr"
 msgstr ""
 
-#: src/main.c:874
+#: src/main.c:941
 msgid "Enable debug subsystems"
 msgstr ""
 
-#: src/main.c:873
+#: src/main.c:940
 msgid "Enable debug to file"
 msgstr ""
 
-#: src/main.c:871
+#: src/main.c:938
 msgid "Enable debug to syslog"
 msgstr ""
 
-#: src/access.c:1824
+#: src/access.c:1933
 msgid ""
 "Enable exclusion of user-config defined channel tags. This will prevent the "
 "user from accessing channels associated with the tags selected (below)."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:307
+#: src/input/mpegts/satip/satip.c:353
 msgid ""
 "Enable if the SAT>IP box requests plts=on parameter in the SETUP RTSP "
 "command for DVB-S2 muxes."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:298
-msgid ""
-"Enable if the SAT>IP box requires pids=0 parameter in the SETUP RTSP command."
-msgstr ""
-
-#: src/input/mpegts/satip/satip.c:317
+#: src/input/mpegts/satip/satip.c:374
 msgid ""
 "Enable if the SAT>IP box requires pids=21 parameter in the SETUP RTSP command"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:289
+#: src/input/mpegts/satip/satip.c:363
+msgid ""
+"Enable if the SAT>IP box requires ro= parameter in the SETUP RTSP command "
+"for DVB-S2 muxes."
+msgstr ""
+
+#: src/input/mpegts/satip/satip.c:333
 msgid "Enable if the SAT>IP box supports the addpids/delpids commands."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:236
+#: src/input/mpegts/satip/satip.c:342
 msgid ""
-"Enable or disable RTP/AVP/TCP transfer mode (embedded data in the RTSP "
-"session) support."
+"Enable if the SAT>IP box supports the frontend identifier. This allows the "
+"auto-tuner allocation, but it might cause trouble for boxes with different "
+"tuner reception connections like satellite inputs."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:245
+#: src/input/mpegts/satip/satip.c:289
 msgid "Enable or disable fast input switching."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:253
+#: src/input/mpegts/satip/satip.c:297
 msgid "Enable or disable full mux mode."
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:195
+#: src/input/mpegts/mpegts_service.c:197
 msgid ""
-"Enable or disable ignoring of Event Information Table (EIT) data on this mux."
+"Enable or disable ignoring of Event Information Table (EIT) data for this "
+"service."
 msgstr ""
 
-#: src/input/mpegts/satip/satip_satconf.c:338
+#: src/input/mpegts/satip/satip_satconf.c:355
 msgid "Enable or disable this configuration."
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:273
+#: src/input/mpegts/mpegts_input.c:281
 msgid "Enable over-the-air program guide (EPG) scanning on this input device."
 msgstr ""
 
-#: src/tvhlog.c:738
+#: src/config.c:2337
+msgid "Enable parser for kodi label formatting"
+msgstr ""
+
+#: src/tvhlog.c:809
 msgid "Enable syslog"
 msgstr ""
 
-#: src/config.c:2283
+#: src/config.c:2725
 msgid ""
 "Enable system time updates. This will only work if the user running "
 "Tvheadend has rights to update the system clock (normally only root)."
 msgstr ""
 
-#: src/config.c:2166
+#: src/config.c:2631
 msgid ""
-"Enable the CAs (conditional accesses) tab in web user interface for the "
-"advanced level. By default, this tab is visible only in the expert level."
+"Enable the Tvheadend server to emulate an HDHomeRun server.  This allows "
+"LiveTV to be used on some media servers."
 msgstr ""
 
-#: src/esfilter.c:619
+#: src/esfilter.c:610
 msgid "Enable this filter."
 msgstr ""
 
-#: src/main.c:876
+#: src/main.c:943
 msgid "Enable trace subsystems"
 msgstr ""
 
-#: src/main.c:884
+#: src/main.c:951
 msgid "Enable web UI debug (non-minified JS)"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:525
+#: src/input/mpegts/mpegts_mux.c:530
 msgid ""
 "Enable, disable or ignore the mux. When the mux is marked as ignore, all "
 "discovered services are removed."
 msgstr ""
 
-#: src/descrambler/caclient.c:274
+#: src/descrambler/caclient.c:303
 msgid "Enable/Disable CA client."
 msgstr ""
 
-#: src/service.c:180
+#: src/input/mpegts/mpegts_network.c:192
+msgid "Enable/Disable network."
+msgstr ""
+
+#: src/service.c:173
 msgid "Enable/Disable service."
 msgstr ""
 
-#: src/access.c:1619
+#: src/config.c:2287
+msgid ""
+"Enable/Disable the CAs (conditional accesses) tab for the advanced view "
+"level. By default, it's visible only to the Expert level."
+msgstr ""
+
+#: src/access.c:1728
 msgid "Enable/Disable the entry."
 msgstr ""
 
-#: src/timeshift.c:194
+#: src/timeshift.c:195
 msgid "Enable/Disable timeshift."
 msgstr ""
 
-#: src/epggrab/channel.c:745
+#: src/config.c:2255
+msgid "Enable/Disable web interface mouse-over tooltips."
+msgstr ""
+
+#: src/epggrab/channel.c:762
 msgid "Enable/disable EPG data for the entry."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:191
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:262
 msgid "Enable/disable LNA."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1011
+#: src/dvr/dvr_autorec.c:1113
 msgid "Enable/disable auto-rec rule."
 msgstr ""
 
-#: src/tvhlog.c:748
+#: src/tvhlog.c:819
 msgid "Enable/disable debugging output to syslog."
 msgstr ""
 
-#: src/tvhlog.c:769
+#: src/tvhlog.c:828
 msgid "Enable/disable inclusion of low-level debug traces."
 msgstr ""
 
-#: src/config.c:2105
-msgid "Enable/disable interface quick tips."
-msgstr ""
-
-#: src/tvhlog.c:796
+#: src/tvhlog.c:867
 msgid "Enable/disable libav log output."
 msgstr ""
 
-#: src/tvhlog.c:739
+#: src/tvhlog.c:810
 msgid "Enable/disable logging to syslog."
 msgstr ""
 
-#: src/descrambler/cwc.c:1876
+#: src/descrambler/cclient.c:1415
 msgid "Enable/disable offering of Entitlement Management Message updates."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:480
+#: src/input/mpegts/mpegts_mux_dvb.c:504
 msgid "Enable/disable pilot tone."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:112
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:163
 msgid "Enable/disable power save mode (if supported by the device)."
 msgstr ""
 
-#: src/dvr/dvr_config.c:846
+#: src/profile.c:325 src/dvr/dvr_config.c:927
 msgid "Enable/disable profile."
 msgstr ""
 
-#: src/bouquet.c:983
+#: src/epggrab/module.c:295
+msgid "Enable/disable scraping episode details using the grabber."
+msgstr ""
+
+#: src/epggrab/module.c:316
+msgid ""
+"Enable/disable scraping subtitle from the programme description. Some "
+"broadcasters do not send separate title, subtitle, description, and summary "
+"fields. This allows scraping of common subtitle formats from within the "
+"broadcast summary field if supported by the configuration file."
+msgstr ""
+
+#: src/epggrab/module.c:329
+msgid ""
+"Enable/disable scraping summary from the programme description. Some "
+"broadcasters do not send separate title, subtitle, description, and summary "
+"fields. This allows scraping of a modified summary from within the broadcast "
+"summary field if supported by the configuration file."
+msgstr ""
+
+#: src/epggrab/module.c:303
+msgid ""
+"Enable/disable scraping title from the programme title and description. Some "
+"broadcasters can split the title over the separate title, and summary "
+"fields. This allows scraping of common split title formats from within the "
+"broadcast title and summary field if supported by the configuration file."
+msgstr ""
+
+#: src/bouquet.c:1010
 msgid "Enable/disable the bouquet."
 msgstr ""
 
-#: src/channels.c:381
+#: src/channels.c:415
 msgid "Enable/disable the channel."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:191
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:616
 msgid "Enable/disable the device."
 msgstr ""
 
-#: src/access.c:2032 src/access.c:2185 src/dvr/dvr_db.c:3051
-#: src/dvr/dvr_timerec.c:539 src/input/mpegts/mpegts_mux_sched.c:138
+#: src/access.c:2266 src/access.c:2443 src/dvr/dvr_db.c:4212
+#: src/dvr/dvr_timerec.c:537 src/input/mpegts/mpegts_mux_sched.c:139
 msgid "Enable/disable the entry."
 msgstr ""
 
-#: src/epggrab/module.c:149
+#: src/epggrab/module.c:172
 msgid "Enable/disable the grabber."
 msgstr ""
 
-#: src/profile.c:307
-msgid "Enable/disable the profile."
+#: src/ratinglabels.c:601
+msgid "Enable/disable the rating label."
 msgstr ""
 
-#: src/channels.c:1441
+#: src/channels.c:1778
 msgid "Enable/disable the tag."
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:232
+#: src/input/mpegts/mpegts_input.c:240
 msgid "Enable/disable tuner/adapter."
 msgstr ""
 
-#: src/access.c:1618 src/access.c:2031 src/access.c:2184 src/channels.c:359
-#: src/channels.c:380 src/channels.c:1440 src/service.c:179 src/imagecache.c:88
-#: src/esfilter.c:618 src/profile.c:306 src/bouquet.c:982
-#: src/epggrab/module.c:148 src/epggrab/channel.c:744 src/dvr/dvr_db.c:3050
-#: src/dvr/dvr_autorec.c:1010 src/dvr/dvr_timerec.c:538
-#: src/dvr/dvr_config.c:845 src/descrambler/caclient.c:273
-#: src/input/mpegts/mpegts_input.c:231 src/input/mpegts/mpegts_mux.c:524
-#: src/input/mpegts/mpegts_mux_sched.c:137
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1432
-#: src/input/mpegts/satip/satip_satconf.c:337 src/timeshift.c:193
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:190
+#: src/access.c:1727 src/access.c:2265 src/access.c:2442 src/channels.c:393
+#: src/channels.c:414 src/channels.c:1777 src/service.c:172 src/imagecache.c:90
+#: src/esfilter.c:609 src/profile.c:324 src/bouquet.c:1009
+#: src/ratinglabels.c:600 src/epggrab/module.c:171 src/epggrab/channel.c:761
+#: src/dvr/dvr_db.c:4211 src/dvr/dvr_autorec.c:1112 src/dvr/dvr_timerec.c:536
+#: src/dvr/dvr_config.c:926 src/descrambler/caclient.c:302
+#: src/input/mpegts/mpegts_input.c:239 src/input/mpegts/mpegts_network.c:191
+#: src/input/mpegts/mpegts_mux.c:529 src/input/mpegts/mpegts_mux_sched.c:138
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1546
+#: src/input/mpegts/satip/satip_satconf.c:354 src/timeshift.c:194
+#: src/transcoding/codec/profile_class.c:268
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:615
 msgid "Enabled"
 msgstr ""
 
-#: src/service.c:221
+#: src/transcoding/codec/codecs/libs/libopus.c:114
+msgid "Encoding algorithm complexity"
+msgstr ""
+
+#: src/service.c:214
 msgid "Encrypted"
 msgstr ""
 
-#: src/htsp_server.c:860
+#: src/htsp_server.c:902
 msgid "Encrypted service"
 msgstr ""
 
-#: src/tvhlog.c:730
-msgid "Enter a filename you want to save the debug log to."
-msgstr ""
-
-#: src/wizard.c:452
+#: src/wizard.c:454
 msgid "Enter a non-admin user password."
 msgstr ""
 
-#: src/wizard.c:443
+#: src/wizard.c:445
 msgid "Enter a non-admin user username."
 msgstr ""
 
-#: src/wizard.c:413
+#: src/wizard.c:415
 msgid ""
 "Enter allowed network prefix(es). You can enter a comma-seperated list of "
 "prefixes here."
 msgstr ""
 
-#: src/wizard.c:434
+#: src/wizard.c:436
 msgid "Enter an administrator password."
 msgstr ""
 
-#: src/wizard.c:423
+#: src/wizard.c:425
 msgid ""
 "Enter an administrator username. Note: do not use the same username as the "
 "superuser backdoor account."
 msgstr ""
 
-#: src/tvhlog.c:757
+#: src/tvhlog.c:840
 msgid ""
-"Enter comma-separated list of subsystems you want debugging output for (e.g "
-"+linuxdvb,+subscriptions,+mpegts)."
+"Enter comma-separated list of subsystems you want debugging output for (e.g. "
+"linuxdvb,subscription,mpegts)."
 msgstr ""
 
-#: src/tvhlog.c:781
+#: src/tvhlog.c:852
 msgid ""
 "Enter comma-separated list of subsystems you want to get traces for (e.g "
-"+linuxdvb,+subscriptions,+mpegts)."
+"linuxdvb,subscription,mpegts)."
 msgstr ""
 
-#: src/satip/server.c:675
+#: src/satip/server.c:770
 msgid ""
 "Enter external IP if behind Network address translation (NAT). Asterisk (*) "
 "means accept all IP addresses."
 msgstr ""
 
-#: src/epg.c:2355
+#: src/satip/server.c:780
+msgid ""
+"Enter external PORT if behind Forwarding redirection.(0 = use the same local "
+"port)."
+msgstr ""
+
+#: src/tvhlog.c:800
+msgid ""
+"Enter the filename (including path) where Tvheadend should write the log."
+msgstr ""
+
+#: src/epg.c:1855
 msgid "Entertainment programs for 10 to 16"
 msgstr ""
 
-#: src/epg.c:2354
+#: src/epg.c:1854
 msgid "Entertainment programs for 6 to 14"
 msgstr ""
 
-#: src/epg.c:2425
+#: src/epg.c:1925
 msgid "Environment"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:224
+#: src/input/mpegts/iptv/iptv_mux.c:251
 msgid "Environment (pipe)"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3424
+#: src/dvr/dvr_db.c:3881 src/dvr/dvr_db.c:4668
 msgid "Episode"
 msgstr ""
 
-#: src/dvr/dvr_db.c:807
+#: src/dvr/dvr_db.c:927
 #, c-format
 msgid "Episode %d"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3425
+#: src/dvr/dvr_db.c:4328
+msgid "Episode image"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4329
+msgid "Episode image."
+msgstr ""
+
+#: src/dvr/dvr_db.c:4669
 msgid "Episode number/ID."
 msgstr ""
 
-#: src/epg.c:2344
+#: src/epg.c:1844
 msgid "Equestrian"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3297
+#: src/dvr/dvr_db.c:4524
 msgid "Error code"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3298
+#: src/dvr/dvr_db.c:4525
 msgid "Error code of entry."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3305
+#: src/dvr/dvr_db.c:4532
 msgid "Errors"
 msgstr ""
 
-#: src/descrambler/constcw.c:326 src/descrambler/constcw.c:392
+#: src/descrambler/constcw.c:364 src/descrambler/constcw.c:437
+#: src/descrambler/constcw.c:510 src/descrambler/constcw.c:583
 msgid "Even key"
 msgstr ""
 
-#: src/descrambler/constcw.c:327 src/descrambler/constcw.c:393
+#: src/descrambler/constcw.c:365 src/descrambler/constcw.c:438
+#: src/descrambler/constcw.c:511 src/descrambler/constcw.c:584
 msgid "Even key."
 msgstr ""
 
-#: src/htsp_server.c:1573 src/htsp_server.c:1598
+#: src/htsp_server.c:1746 src/htsp_server.c:1771
 msgid "Event does not exist"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:794
+#: src/dvr/dvr_autorec.c:905
 msgid "Every day"
 msgstr ""
 
-#: src/access.c:1823
+#: src/access.c:1932
 msgid "Exclude channel tags"
 msgstr ""
 
-#: src/epg.c:2428
+#: src/epg.c:1928
 msgid "Expeditions"
 msgstr ""
 
-#: src/epg.c:2395
+#: src/epg.c:1895
 msgid "Experimental film"
 msgstr ""
 
-#: src/access.c:1386 src/config.c:1954
+#: src/access.c:1483 src/config.c:2079
 msgid "Expert"
 msgstr ""
 
-#: src/satip/server.c:593
-msgid "Exported tuners"
+#: src/transcoding/codec/profile_class.c:215
+msgid "Expert Settings"
 msgstr ""
 
-#: src/epggrab/module.c:59
+#: src/imagecache.c:108
+msgid "Expire time"
+msgstr ""
+
+#: src/satip/server.c:665
+msgid "Exported Tuner(s) Settings"
+msgstr ""
+
+#: src/descrambler/capmt.c:2686
+msgid "Extended (OE 2.2)"
+msgstr ""
+
+#: src/descrambler/capmt.c:2687
+msgid "Extended (OE 2.2), mode follows key"
+msgstr ""
+
+#: src/descrambler/capmt.c:2688
+msgid "Extended DES (OE 2.0)"
+msgstr ""
+
+#: src/descrambler/cccam.c:1015
+msgid "Extended mode"
+msgstr ""
+
+#: src/descrambler/cccam.c:1016
+msgid "Extended mode settings."
+msgstr ""
+
+#: src/epggrab/module.c:56
 msgid "External"
 msgstr ""
 
-#: src/epggrab/module.c:200
+#: src/epggrab/module.c:223
 msgid "External EPG grabber"
 msgstr ""
 
-#: src/satip/server.c:674
+#: src/satip/server.c:769
 msgid "External IP (NAT)"
 msgstr ""
 
-#: src/epggrab/module/pyepg.c:471
-msgid "External PyEPG Grabber"
+#: src/satip/server.c:779
+msgid "External RTSP port (NAT)"
 msgstr ""
 
-#: src/bouquet.c:1045
+#: src/bouquet.c:1072
 msgid "External URL"
 msgstr ""
 
-#: src/bouquet.c:1046
+#: src/bouquet.c:1073
 msgid "External URL of the bouquet."
 msgstr ""
 
-#: src/epggrab/module/xmltv.c:789
-msgid "External XMLTV EPG Grabber"
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:152
+msgid "External position"
 msgstr ""
 
-#: src/epggrab/module.c:187
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:762
+msgid "External rotor command"
+msgstr ""
+
+#: src/epggrab/module.c:210
 msgid "Extra arguments"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1125
+#: src/dvr/dvr_db.c:4735
+msgid "Extra categories, typically from xmltv"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4753
+msgid "Extra keywords, typically from xmltv"
+msgstr ""
+
+#: src/dvr/dvr_autorec.c:1254
 msgid "Extra start time"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1135
+#: src/dvr/dvr_autorec.c:1264
 msgid "Extra stop time"
 msgstr ""
 
-#: src/dvr/dvr_config.c:945
+#: src/dvr/dvr_db.c:4415
+msgid "Extra text"
+msgstr ""
+
+#: src/dvr/dvr_config.c:1486
 msgid "Extra warming up time (seconds)"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:401
+#: src/input/mpegts/mpegts_mux.c:405
 msgid "FAIL"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:334 src/input/mpegts/mpegts_mux_dvb.c:469
-#: src/input/mpegts/mpegts_mux_dvb.c:612 src/input/mpegts/mpegts_mux_dvb.c:804
+#: src/input/mpegts/satip/satip.c:341
+msgid "FE supported"
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux_dvb.c:332 src/input/mpegts/mpegts_mux_dvb.c:493
+#: src/input/mpegts/mpegts_mux_dvb.c:652 src/input/mpegts/mpegts_mux_dvb.c:880
 msgid "FEC"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:257
+#: src/input/mpegts/mpegts_mux_dvb.c:254 src/input/mpegts/mpegts_mux_dvb.c:1061
 msgid "FEC high"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:262
+#: src/input/mpegts/mpegts_mux_dvb.c:259 src/input/mpegts/mpegts_mux_dvb.c:1066
 msgid "FEC low"
 msgstr ""
 
-#: src/epg.c:2424
+#: src/service.c:151
+msgid "FHD TV"
+msgstr ""
+
+#: src/profile.c:276
+msgid "FHD: full high definition"
+msgstr ""
+
+#: src/epg.c:1924
 msgid "Factual topics"
 msgstr ""
 
-#: src/subscriptions.c:997
+#: src/subscriptions.c:1056
 #, c-format
 msgid "Failed"
 msgstr ""
 
-#: src/htsp_server.c:2720
+#: src/htsp_server.c:2950
 msgid "Failed to open image"
 msgstr ""
 
-#: src/access.c:1558
+#: src/access.c:1665
 msgid "Failed view"
 msgstr ""
 
-#: src/epg.c:2283
+#: src/dvr/dvr_db.c:4338
+msgid "Fanart image"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4339
+msgid "Fanart image."
+msgstr ""
+
+#: src/epg.c:1783
 msgid "Fantasy"
 msgstr ""
 
-#: src/epg.c:2399
+#: src/epg.c:1899
 msgid "Fashion"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:244
+#: src/input/mpegts/satip/satip.c:288
 msgid "Fast input switch"
 msgstr ""
 
-#: src/tvhlog.c:117
+#: src/tvhlog.c:126
 msgid "Fastscan DVB"
 msgstr ""
 
-#: src/dvr/dvr_db.c:654
-msgid "File missing"
+#: src/dvr/dvr_config.c:1080
+msgid ""
+"Fetch additional artwork from installed providers. Tvheadend has a 'tmdb' "
+"and `tvdb' provider which require you to specify your authorized key in the "
+"options below."
 msgstr ""
 
-#: src/dvr/dvr_db.c:643
-msgid "File not created"
+#: src/dvr/dvr_config.c:1079
+msgid "Fetch artwork for new recordings."
 msgstr ""
 
 #: src/dvr/dvr_config.c:1090
+msgid "Fetch artwork for unidentifiable broadcasts."
+msgstr ""
+
+#: src/dvr/dvr_db.c:680
+msgid "File missing"
+msgstr ""
+
+#: src/ratinglabels.c:654
+msgid "File name for this rating's icon."
+msgstr ""
+
+#: src/dvr/dvr_db.c:670
+msgid "File not created"
+msgstr ""
+
+#: src/dvr/dvr_config.c:1166
 msgid "File permissions (octal, e.g. 0664)"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3346
+#: src/dvr/dvr_db.c:4573
 msgid "File removed"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3440
+#: src/dvr/dvr_db.c:4685
 msgid "File size"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3281
+#: src/dvr/dvr_db.c:4508
 msgid "Filename"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1100
-msgid "Filename character set"
+#: src/tvhlog.c:799
+msgid "Filename (including path)"
 msgstr ""
 
-#: src/dvr/dvr_config.c:829
-msgid "Filename options"
-msgstr ""
-
-#: src/dvr/dvr_db.c:3282
+#: src/dvr/dvr_db.c:4509
 msgid "Filename used by the entry."
 msgstr ""
 
-#: src/tvhlog.c:86
+#: src/dvr/dvr_config.c:897
+msgid "Filename/Tagging Settings"
+msgstr ""
+
+#: src/dvr/dvr_config.c:889
+msgid "Filesystem Settings"
+msgstr ""
+
+#: src/tvhlog.c:95
 msgid "Filesystem monitor"
 msgstr ""
 
-#: src/epg.c:2394
+#: src/epg.c:1894
 msgid "Film"
 msgstr ""
 
-#: src/epg.c:2390
+#: src/descrambler/constcw.c:304
+msgid "Filter"
+msgstr ""
+
+#: src/epg.c:1890
 msgid "Fine arts"
 msgstr ""
 
-#: src/wizard.c:1169 src/dvr/dvr_db.c:635
+#: src/wizard.c:1195 src/dvr/dvr_db.c:662
 msgid "Finished"
 msgstr ""
 
-#: src/epggrab/module/xmltv.c:761
+#: src/dvr/dvr_db.c:4718
+msgid "First aired"
+msgstr ""
+
+#: src/descrambler/dvbcam.c:778
+msgid "First hit"
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux.c:711
+msgid "First scan"
+msgstr ""
+
+#: src/epggrab/module/xmltv.c:1130
 msgid "First word"
 msgstr ""
 
-#: src/timeshift.c:286
+#: src/timeshift.c:284
 msgid "Fit to RAM (cut rewind)"
 msgstr ""
 
-#: src/epg.c:2446
+#: src/epg.c:1946
 msgid "Fitness and health"
 msgstr ""
 
-#: src/epg.c:2373
+#: src/epg.c:1873
 msgid "Folk"
 msgstr ""
 
-#: src/epg.c:2285
+#: src/epg.c:1785
 msgid "Folkloric"
 msgstr ""
 
-#: src/epg.c:2337
+#: src/epg.c:1837
 msgid "Football"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:483
+#: src/dvr/dvr_config.c:1062
+msgid "For autorecs, attempt to find better time slots"
+msgstr ""
+
+#: src/input/mpegts/iptv/iptv_mux.c:290
+msgid "For example: 12610500. This frequency is 12610.5Mhz or 12.6105Ghz."
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux_dvb.c:546 src/input/mpegts/mpegts_mux_dvb.c:554
+#: src/input/mpegts/iptv/iptv_mux.c:282
+msgid "For example: 312000000. This frequency is 312Mhz."
+msgstr ""
+
+#: src/input/mpegts/iptv/iptv_mux.c:274
+msgid "For example: 658000000. This frequency is 658Mhz."
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux.c:489
 msgid "Force (auto)"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:232
+#: src/input/mpegts/mpegts_service.c:234
 msgid "Force CA ID (e.g. 0x2600)"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:349
-#: src/input/mpegts/satip/satip_frontend.c:212
+#: src/satip/server.c:789
+msgid "Force RTSP announcement of the external (NAT) ip:port"
+msgstr ""
+
+#: src/input/mpegts/satip/satip.c:416
+#: src/input/mpegts/satip/satip_frontend.c:341
 msgid ""
 "Force all network connections to this tuner to be made over the specified IP "
 "address, similar to the setting for the SAT>IP device itself. Setting this "
 "overrides the device-specific setting."
 msgstr ""
 
-#: src/epggrab.c:342
+#: src/epggrab.c:456
+msgid "Force an initial EPG grab at start-up (internal grabbers)."
+msgstr ""
+
+#: src/epggrab.c:465
 msgid "Force an initial EPG grab at start-up."
 msgstr ""
 
-#: src/epggrab.c:341
+#: src/epggrab.c:464
 msgid "Force initial EPG grab at start-up"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:168
+#: src/epggrab.c:455
+msgid "Force initial EPG grab at start-up (internal grabbers)"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:239
 msgid "Force old status"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:306
+#: src/input/mpegts/satip/satip.c:352
 msgid "Force pilot for DVB-S2"
 msgstr ""
 
-#: src/profile.c:359
+#: src/profile.c:379
 msgid "Force priority"
 msgstr ""
 
-#: src/config.c:1975
+#: src/profile.c:380
+msgid "Force profile to use this priority."
+msgstr ""
+
+#: src/config.c:2100
 msgid "Force service type to 1"
 msgstr ""
 
-#: src/input/mpegts/satip/satip_frontend.c:191
+#: src/satip/server.c:825
+msgid "Force signal level"
+msgstr ""
+
+#: src/satip/server.c:826
+msgid "Force signal level for all streaming (1-240, 0=do not use)."
+msgstr ""
+
+#: src/input/mpegts/satip/satip_frontend.c:311
 msgid "Force teardown delay"
 msgstr ""
 
-#: src/input/mpegts/satip/satip_frontend.c:192
+#: src/input/mpegts/satip/satip_frontend.c:312
 msgid ""
 "Force the delay between RTSP TEARDOWN and RTSP SETUP command (value from "
 "'Next tune delay in ms' is used). Some devices are not able to handle quick "
 "continuous tuning."
 msgstr ""
 
-#: src/input/mpegts/satip/satip_frontend.c:161
+#: src/input/mpegts/satip/satip_frontend.c:301
+msgid ""
+"Force the grace period for which SAT>IP client waits for the data from "
+"server. After this grace period, the tuner is handled as dead. The default "
+"value is 5 seconds (for DVB-S/S2: 10 seconds)."
+msgstr ""
+
+#: src/input/mpegts/satip/satip_frontend.c:270
 msgid ""
 "Force the local UDP Port number here. The number should be even (RTP port). "
 "The next odd number (+1) will be used as the RTCP port."
 msgstr ""
 
-#: src/profile.c:360
-msgid "Force the stream profile to use this priority."
-msgstr ""
-
-#: src/input/mpegts/mpegts_service.c:233
+#: src/input/mpegts/mpegts_service.c:235
 msgid "Force usage of entered CA ID on this service."
 msgstr ""
 
-#: src/epg.c:2428
+#: src/streaming.c:453
+msgid "Forced OK"
+msgstr ""
+
+#: src/epg.c:1928
 msgid "Foreign countries"
 msgstr ""
 
-#: src/dvr/dvr_db.c:2596 src/dvr/dvr_db.c:2620 src/dvr/dvr_config.c:735
-#: src/dvr/dvr_config.c:758
+#: src/dvr/dvr_db.c:3527 src/dvr/dvr_db.c:3551 src/dvr/dvr_config.c:761
+#: src/dvr/dvr_config.c:825
 msgid "Forever"
 msgstr ""
 
-#: src/main.c:819
+#: src/main.c:886
 msgid "Fork and run as daemon"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1136
-msgid "Format string"
+#: src/access.c:1964
+msgid "Format for htsp output"
 msgstr ""
 
-#: src/wizard.c:1002
+#: src/access.c:1954
+msgid "Format for xmltv output"
+msgstr ""
+
+#: src/dvr/dvr_config.c:1188
+msgid "Format string/Pathname specification"
+msgstr ""
+
+#: src/wizard.c:1028
 msgid "Found muxes"
 msgstr ""
 
-#: src/wizard.c:1011
+#: src/wizard.c:1037
 msgid "Found services"
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:301
+#: src/input/mpegts/mpegts_input.c:312
 msgid "Free subscription weight"
 msgstr ""
 
-#: src/dvr/dvr_config.c:868
+#: src/dvr/dvr_config.c:1119
 msgid "Free-form field, enter whatever you like here."
 msgstr ""
 
-#: src/access.c:1846 src/access.c:2065 src/access.c:2200 src/channels.c:1509
-#: src/dvr/dvr_db.c:3474 src/dvr/dvr_autorec.c:1298 src/dvr/dvr_timerec.c:679
+#: src/access.c:1975 src/access.c:2321 src/access.c:2458 src/channels.c:1846
+#: src/dvr/dvr_db.c:4727 src/dvr/dvr_autorec.c:1443 src/dvr/dvr_timerec.c:680
 msgid "Free-form text field, enter whatever you like here."
 msgstr ""
 
-#: src/bouquet.c:1109 src/epggrab/channel.c:868 src/descrambler/caclient.c:289
+#: src/bouquet.c:1136 src/epggrab/channel.c:886 src/descrambler/caclient.c:320
 msgid "Free-form text field, enter whatever you like."
 msgstr ""
 
-#: src/profile.c:337
+#: src/profile.c:345
 msgid "Free-form text field. You can enter whatever you like here."
 msgstr ""
 
-#: src/esfilter.c:712 src/esfilter.c:807 src/esfilter.c:902 src/esfilter.c:997
-#: src/esfilter.c:1102 src/esfilter.c:1184
+#: src/esfilter.c:704 src/esfilter.c:800 src/esfilter.c:896 src/esfilter.c:991
+#: src/esfilter.c:1099 src/esfilter.c:1182
 msgid "Free-format text field. Enter whatever you like here."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:155
-#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:193
-msgid "Frequency"
-msgstr ""
-
-#: src/input/mpegts/mpegts_mux_dvb.c:222 src/input/mpegts/mpegts_mux_dvb.c:316
-#: src/input/mpegts/mpegts_mux_dvb.c:553 src/input/mpegts/mpegts_mux_dvb.c:594
-#: src/input/mpegts/mpegts_mux_dvb.c:679 src/input/mpegts/mpegts_mux_dvb.c:786
-#: src/input/mpegts/mpegts_mux_dvb.c:885
+#: src/input/mpegts/mpegts_mux_dvb.c:219 src/input/mpegts/mpegts_mux_dvb.c:314
+#: src/input/mpegts/mpegts_mux_dvb.c:593 src/input/mpegts/mpegts_mux_dvb.c:634
+#: src/input/mpegts/mpegts_mux_dvb.c:678 src/input/mpegts/mpegts_mux_dvb.c:755
+#: src/input/mpegts/mpegts_mux_dvb.c:862 src/input/mpegts/mpegts_mux_dvb.c:1026
+#: src/input/mpegts/mpegts_mux_dvb.c:1111
 msgid "Frequency (Hz)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:492
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:556
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:535
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:599
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:174
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:232
 msgid "Frequency (MHz)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:493
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:557
-msgid "Frequency (in MHz)."
-msgstr ""
-
-#: src/input/mpegts/mpegts_mux_dvb.c:447 src/input/mpegts/mpegts_mux_dvb.c:839
+#: src/input/mpegts/mpegts_mux_dvb.c:471 src/input/mpegts/mpegts_mux_dvb.c:933
 msgid "Frequency (kHz)"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:776
+#: src/dvr/dvr_autorec.c:887
 msgid "Fri"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:375
-#: src/input/mpegts/tvhdhomerun/tvhdhomerun.c:193
+#: src/input/mpegts/satip/satip.c:442
+#: src/input/mpegts/tvhdhomerun/tvhdhomerun.c:227
 msgid "Friendly name"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:94
-#: src/input/mpegts/satip/satip_frontend.c:152
-#: src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c:571
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:128
+#: src/input/mpegts/satip/satip_frontend.c:252
+#: src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c:646
 msgid "Frontend number"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:70
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:104
 msgid "Frontend path"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:251
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:289
 msgid "Full DiseqC"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:252
+#: src/input/mpegts/satip/satip.c:296
 msgid "Full mux RX mode supported"
 msgstr ""
 
-#: src/channels.c:1482
+#: src/channels.c:1819
 msgid ""
 "Full path to an icon used to depict the tag. This can be a TV network "
 "logotype, etc."
 msgstr ""
 
-#: src/dvr/dvr_config.c:821
-msgid "Full pathname specification"
-msgstr ""
-
-#: src/dvr/dvr_autorec.c:1046
+#: src/dvr/dvr_autorec.c:1163
 msgid "Full-text"
 msgstr ""
 
-#: src/epg.c:2430
+#: src/epg.c:1930
 msgid "Further education"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:472
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:582
 msgid "GOTOX"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:127
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:128
 msgid "GOTOX position"
 msgstr ""
 
-#: src/epg.c:2316 src/epg.c:2317
+#: src/epg.c:1816 src/epg.c:1817
 msgid "Game show"
 msgstr ""
 
-#: src/epg.c:2449
+#: src/epg.c:1949
 msgid "Gardening"
 msgstr ""
 
-#: src/satip/server.c:589
-msgid "General"
+#: src/main.c:968
+msgid "Gather timing statistics for the code"
 msgstr ""
 
-#: src/epggrab.c:262
-msgid "General configuration"
+#: src/tvhlog.c:782 src/epggrab.c:352 src/profile.c:296 src/profile.c:1344
+#: src/profile.c:1590 src/profile.c:1825 src/profile.c:2455
+#: src/satip/server.c:653 src/dvr/dvr_config.c:885
+#: src/descrambler/caclient.c:276 src/transcoding/codec/profile_class.c:199
+#: src/descrambler/cclient.c:1357 src/descrambler/dvbcam.c:848
+msgid "General Settings"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:263
+#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:264
 msgid "Generic"
 msgstr ""
 
-#: src/main.c:812
+#: src/main.c:879
 msgid "Generic options"
 msgstr ""
 
-#: src/tvhlog.c:120
+#: src/dvr/dvr_db.c:4761
+msgid "Genre"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4762
+msgid "Genre of program"
+msgstr ""
+
+#: src/tvhlog.c:130
 msgid "Global Headers"
 msgstr ""
 
-#: src/tvhlog.c:80
-msgid "Global timer"
+#: src/epggrab/module.c:143
+msgid "Grabber Settings"
 msgstr ""
 
-#: src/epggrab/module.c:157
+#: src/epggrab/module.c:180
 msgid ""
-"Grabber priority. This option let's you pick which EPG grabber's data get "
+"Grabber priority. This option lets you pick which EPG grabber's data get "
 "used first. Priority is given to the grabber with the highest value set "
 "here. See Help for more info."
 msgstr ""
 
-#: src/access.c:1407
+#: src/input/mpegts/satip/satip_frontend.c:300
+msgid "Grace period"
+msgstr ""
+
+#: src/access.c:1504
 msgid "Gray"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:247 src/input/mpegts/mpegts_mux_dvb.c:692
+#: src/input/mpegts/mpegts_mux_dvb.c:244 src/input/mpegts/mpegts_mux_dvb.c:768
+#: src/input/mpegts/mpegts_mux_dvb.c:1051
 msgid "Guard interval"
 msgstr ""
 
-#: src/service.c:159
+#: src/service.c:150
 msgid "HD TV"
 msgstr ""
 
-#: src/profile.c:268
+#: src/profile.c:275
 msgid "HD: high definition"
 msgstr ""
 
-#: src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c:613
+#: src/config.c:2191
+msgid "HDHomeRun"
+msgstr ""
+
+#: src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c:688
 msgid "HDHomeRun ATSC-C frontend"
 msgstr ""
 
-#: src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c:603
+#: src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c:678
 msgid "HDHomeRun ATSC-T frontend"
 msgstr ""
 
-#: src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c:565
+#: src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c:698
+msgid "HDHomeRun CableCARD frontend"
+msgstr ""
+
+#: src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c:640
 msgid "HDHomeRun DVB frontend"
 msgstr ""
 
-#: src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c:593
+#: src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c:668
 msgid "HDHomeRun DVB-C frontend"
 msgstr ""
 
-#: src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c:583
+#: src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c:658
 msgid "HDHomeRun DVB-T frontend"
 msgstr ""
 
-#: src/tvhlog.c:122
+#: src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c:708
+msgid "HDHomeRun ISDB-T frontend"
+msgstr ""
+
+#: src/config.c:2539
+msgid "HDHomerun IP Address"
+msgstr ""
+
+#: src/tvhlog.c:132
 msgid "HEVC - H.265"
 msgstr ""
 
-#: src/access.c:1505 src/access.c:1543
+#: src/access.c:1612 src/access.c:1650
 msgid "HTSP"
 msgstr ""
 
-#: src/tvhlog.c:107
+#: src/tvhlog.c:116
 msgid "HTSP Answer"
 msgstr ""
 
-#: src/profile.c:2244
-msgid "HTSP Default Stream Settings"
-msgstr ""
-
-#: src/tvhlog.c:106
+#: src/tvhlog.c:115
 msgid "HTSP Request"
 msgstr ""
 
-#: src/tvhlog.c:104
+#: src/tvhlog.c:113
 msgid "HTSP Server"
 msgstr ""
 
-#: src/profile.c:1008
+#: src/profile.c:1201
 msgid "HTSP Stream Profile"
 msgstr ""
 
-#: src/tvhlog.c:105
+#: src/tvhlog.c:114
 msgid "HTSP Subscription"
 msgstr ""
 
-#: src/config.c:2136
+#: src/access.c:1568
+msgid "HTSP output format"
+msgstr ""
+
+#: src/config.c:2527
 msgid ""
 "HTTP CORS (cross-origin resource sharing) origin. This option is usually set "
 "when Tvheadend is behind a proxy. Enter a domain (or IP) to allow cross-"
 "domain requests."
 msgstr ""
 
-#: src/config.c:2135
-msgid "HTTP CORS origin"
-msgstr ""
-
-#: src/tvhlog.c:103
+#: src/tvhlog.c:112
 msgid "HTTP Client"
 msgstr ""
 
-#: src/tvhlog.c:102
+#: src/tvhlog.c:111
 msgid "HTTP Server"
 msgstr ""
 
-#: src/epg.c:2444
+#: src/config.c:2187
+msgid "HTTP Server Settings"
+msgstr ""
+
+#: src/config.c:2646
+msgid "HTTP User Agent"
+msgstr ""
+
+#: src/epg.c:1944
 msgid "Handicraft"
 msgstr ""
 
-#: src/streaming.c:581
+#: src/epggrab/module/eit.c:1586
+msgid ""
+"Handle the running state (EITp/f) immediately. Usually, keep this off. It "
+"might increase the recordings accuracy on very slow systems."
+msgstr ""
+
+#: src/transcoding/codec/profile_video_class.c:214
+msgid "Hardware acceleration"
+msgstr ""
+
+#: src/streaming.c:617
 msgid "Hearing impaired"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:252
+#: src/transcoding/codec/profile_video_class.c:193
+msgid "Height (pixels) (0=no scaling)"
+msgstr ""
+
+#: src/transcoding/codec/profile_video_class.c:194
+msgid ""
+"Height of the output video stream. Horizontal resolution is adjusted "
+"automatically to preserve aspect ratio. When set to 0, the input resolution "
+"is used."
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux_dvb.c:249 src/input/mpegts/mpegts_mux_dvb.c:1056
 msgid "Hierarchy"
 msgstr ""
 
-#: src/profile.c:249 src/dvr/dvr_db.c:2569
+#: src/profile.c:256 src/dvr/dvr_db.c:3500
 msgid "High"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:198
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:623
 msgid "High bitrate mode (CI+ CAMs only)"
 msgstr ""
 
-#: src/access.c:1816
+#: src/input/mpegts/linuxdvb/linuxdvb_lnb.c:73
+msgid "High frequency offset"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:234
+msgid "Higher"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:313
+msgid "Higher LNB voltage"
+msgstr ""
+
+#: src/access.c:1925
 msgid "Highest channel number the user can access."
 msgstr ""
 
-#: src/memoryinfo.c:78
+#: src/memoryinfo.c:79
 msgid "Highest count of objects."
 msgstr ""
 
-#: src/epg.c:2287
+#: src/epg.c:1787
 msgid "Historical movie"
 msgstr ""
 
-#: src/epg.c:2283
+#: src/epg.c:1783
 msgid "Horror"
 msgstr ""
 
-#: src/descrambler/cwc.c:1850
+#: src/descrambler/cclient.c:1397
 msgid "Hostname (or IP) of the server."
 msgstr ""
 
-#: src/descrambler/cwc.c:1849
+#: src/descrambler/cclient.c:1396
 msgid "Hostname/IP"
 msgstr ""
 
-#: src/imagecache.c:115
+#: src/imagecache.c:127
 msgid ""
 "How frequently it will re-try fetching an image that has failed to be "
 "fetched."
 msgstr ""
 
-#: src/imagecache.c:107
+#: src/imagecache.c:119
 msgid "How frequently the upstream provider is checked for changes."
 msgstr ""
 
-#: src/epggrab/channel.c:790
+#: src/epggrab/channel.c:808
 msgid "ID"
 msgstr ""
 
-#: src/wizard.c:810
+#: src/wizard.c:819
 msgid "ID of the network."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:392
+#: src/input/mpegts/mpegts_mux.c:395
 msgid "IDLE"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:403
+#: src/input/mpegts/mpegts_mux.c:397
+msgid "IDLE PEND"
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux.c:407
 msgid "IGNORE"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:348
-#: src/input/mpegts/tvhdhomerun/tvhdhomerun.c:179
+#: src/input/mpegts/satip/satip.c:415
+#: src/input/mpegts/tvhdhomerun/tvhdhomerun.c:213
 msgid "IP address"
 msgstr ""
 
-#: src/access.c:2141
+#: src/config.c:2540
+msgid ""
+"IP address of the HDHomerun device. This is needed if you plan to run "
+"TVheadend in a container and you want to stream from an HDHomerun without "
+"enabling host networking for the container."
+msgstr ""
+
+#: src/access.c:2400
 msgid "IP blocking"
 msgstr ""
 
-#: src/tvhlog.c:151 src/input/mpegts/iptv/iptv.c:138
+#: src/config.c:2552
+msgid ""
+"IP of the Docker host. Each HDHomeRun tuner sends data to TVheadend through "
+"a socket. This lets you define the IP address that HDHomeRun needs to send "
+"to. Leave this blank if you want TVheadend to automatically pick an address."
+msgstr ""
+
+#: src/tvhlog.c:163
 msgid "IPTV"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:876
+#: src/input/mpegts/iptv/iptv.c:945
 msgid "IPTV Automatic Network"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:118
+#: src/input/mpegts/iptv/iptv_mux.c:108
 msgid "IPTV Multiplex"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:735
+#: src/input/mpegts/iptv/iptv.c:806
 msgid "IPTV Network"
 msgstr ""
 
-#: src/tvhlog.c:152
+#: src/tvhlog.c:164
 msgid "IPTV PCR"
 msgstr ""
 
-#: src/tvhlog.c:153
+#: src/tvhlog.c:165
 msgid "IPTV Subcription"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:145
+#: src/input/mpegts/iptv/iptv.c:123
 msgid "IPTV input"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network_dvb.c:390
+#: src/satip/server.c:815
+msgid "IPTV signal level"
+msgstr ""
+
+#: src/input/mpegts/iptv/iptv.c:116
+msgid "IPTV thread #"
+msgstr ""
+
+#: src/config.c:2655
+msgid "IPTV threads"
+msgstr ""
+
+#: src/input/mpegts/mpegts_network_dvb.c:400
 msgid "ISDB-C Network"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:777
+#: src/input/mpegts/mpegts_mux_dvb.c:853
 msgid "ISDB-C multiplex"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network_dvb.c:413
+#: src/input/mpegts/mpegts_network_dvb.c:423
 msgid "ISDB-S Network"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:830
+#: src/input/mpegts/mpegts_mux_dvb.c:924
 msgid "ISDB-S multiplex"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network_dvb.c:367
+#: src/satip/server.c:898
+msgid "ISDB-T"
+msgstr ""
+
+#: src/input/mpegts/mpegts_network_dvb.c:377
 msgid "ISDB-T Network"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:670
+#: src/input/mpegts/mpegts_mux_dvb.c:746
 msgid "ISDB-T multiplex"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:486
+#: src/input/mpegts/mpegts_mux_dvb.c:510
 msgid "ISI (Stream ID)"
 msgstr ""
 
-#: src/epggrab/channel.c:647 src/epggrab/channel.c:824
+#: src/ratinglabels.c:653 src/epggrab/channel.c:664 src/epggrab/channel.c:842
 msgid "Icon"
 msgstr ""
 
-#: src/channels.c:1481
+#: src/channels.c:1818
 msgid "Icon (full URL)"
 msgstr ""
 
-#: src/channels.c:431 src/channels.c:1491 src/input/mpegts/iptv/iptv_mux.c:194
+#: src/channels.c:466 src/channels.c:1828 src/ratinglabels.c:660
+#: src/input/mpegts/iptv/iptv_mux.c:221
 msgid "Icon URL"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:810
+#: src/input/mpegts/iptv/iptv.c:893
 msgid "Icon base URL"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:811
+#: src/input/mpegts/iptv/iptv.c:894
 msgid "Icon base URL."
 msgstr ""
 
-#: src/channels.c:1499
+#: src/channels.c:1836
 msgid "Icon has title"
 msgstr ""
 
-#: src/webui/extjs.c:211
+#: src/webui/extjs.c:205
 msgid "Icons from"
 msgstr ""
 
-#: src/subscriptions.c:959
+#: src/subscriptions.c:1017
 msgid "Idle"
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:292
+#: src/input/mpegts/mpegts_input.c:303
 msgid "Idle scan"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:207
+#: src/input/mpegts/mpegts_network.c:256
 msgid "Idle scan muxes"
 msgstr ""
 
-#: src/dvr/dvr_config.c:925
+#: src/dvr/dvr_config.c:1042
 msgid ""
 "If an error occurs clone the scheduled entry and try to record again (if "
 "possible)."
 msgstr ""
 
-#: src/config.c:2318
+#: src/config.c:2392
 msgid ""
 "If both a picon and a channel-specific (e.g. channelname.jpg) icon are "
 "defined, prefer the picon."
 msgstr ""
 
-#: src/dvr/dvr_config.c:936
+#: src/epggrab/module/xmltv.c:1105
+msgid ""
+"If enabled then this will alter the programme descriptions to include "
+"information about actors, keywords and categories (if available from the "
+"xmltv file). This is useful for legacy clients that can not parse newer "
+"Tvheadend messages containing this information or do not display the "
+"information. For example the modified description might include 'Starring: "
+"Lorem Ipsum'. The description is altered for all clients, both legacy, "
+"modern, and GUI. Enabling scraping of detailed information can use "
+"significant resources (memory and CPU). You should not enable this if you "
+"use 'duplicate detect if different description' since the descriptions will "
+"change due to added information."
+msgstr ""
+
+#: src/service_mapper.c:625
+msgid ""
+"If merge same name is enabled then merge services with the same name into "
+"one channel but using fuzzy logic such as ignoring whitespace, case and some "
+"channel suffixes such as HD. So 'Channel 5+1', 'Channel 5 +1', 'Channel "
+"5+1HD' and 'Channel 5 +1HD' would all merge in to the same channel. The "
+"exact name chosen depends on the order the channels are mapped."
+msgstr ""
+
+#: src/dvr/dvr_config.c:1053
 msgid ""
 "If more than x errors occur during a recording schedule a re-record (if "
 "possible)."
 msgstr ""
 
-#: src/profile.c:346
+#: src/profile.c:366
 msgid ""
 "If no specific priority was requested. This gives certain users a higher "
 "priority by assigning a streaming profile with a higher priority."
 msgstr ""
 
-#: src/main.c:823
+#: src/main.c:890
 msgid ""
 "If no user account exists then create one with\n"
 "no username and no password. Use with care as\n"
@@ -3188,26 +4192,33 @@ msgid ""
 "the access control from within the Tvheadend web interface."
 msgstr ""
 
-#: src/channels.c:1500
+#: src/channels.c:1837
 msgid ""
 "If set, presentation of the tag icon will not superimpose the tag name on "
 "top of the icon."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:133
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:184
 msgid ""
 "If set, the first bytes from the MPEG-TS stream are discarded. It may be "
 "required for some drivers or hardware which do not flush the MPEG-TS buffers "
 "completely after a frequency/parameter change."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:637
+#: src/profile.c:422
+msgid ""
+"If something fails, try to switch to a different service on another network. "
+"Do not try to iterate through all inputs/tuners which are capable to receive "
+"the service."
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:690
 msgid ""
 "If the DiseqC switch is located before the rotor (i.e. tuner - switch - "
 "rotor), enable this."
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:302
+#: src/input/mpegts/mpegts_input.c:313
 msgid ""
 "If the subscription weight for the input is below the specified threshold, "
 "the tuner is handled as free (according the priority settings). Otherwise, "
@@ -3215,120 +4226,135 @@ msgid ""
 "you are willing to override scan and epggrab subscriptions."
 msgstr ""
 
-#: src/webui/extjs.c:235
-msgid "If you'd like to support the project, please consider a donation."
-msgstr ""
-
-#: src/input/mpegts/mpegts_mux.c:470
+#: src/input/mpegts/mpegts_mux.c:476
 msgid "Ignore"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:194
+#: src/input/mpegts/mpegts_service.c:196
 msgid "Ignore EPG (EIT)"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:503
+#: src/input/mpegts/iptv/iptv.c:1012
+msgid "Ignore HTTP arguments"
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux.c:508
 msgid "Ignore descriptor 5"
 msgstr ""
 
-#: src/service_mapper.c:517
+#: src/service_mapper.c:610
 msgid "Ignore encryption flag, include encrypted services anyway."
 msgstr ""
 
-#: src/imagecache.c:98
+#: src/imagecache.c:100
 msgid "Ignore invalid SSL certificate"
 msgstr ""
 
-#: src/imagecache.c:99
+#: src/imagecache.c:101
 msgid ""
 "Ignore invalid/unverifiable (expired, self-certified, etc.) certificates"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:234
+#: src/input/mpegts/iptv/iptv.c:1024
+msgid ""
+"Ignore last components in path. The defined count of last path components "
+"separated by / are removed when the identical source is compared - see Help "
+"for a detailed explanation."
+msgstr ""
+
+#: src/input/mpegts/iptv/iptv.c:1023
+msgid "Ignore path components"
+msgstr ""
+
+#: src/input/mpegts/mpegts_network.c:283
 msgid "Ignore provider's channel numbers"
 msgstr ""
 
-#: src/tvhlog.c:108
+#: src/tvhlog.c:117
 msgid "Image Cache"
 msgstr ""
 
-#: src/main.c:885
+#: src/dvr/dvr_config.c:783
+msgid "Immediately"
+msgstr ""
+
+#: src/main.c:952
 msgid "Immediately abort"
 msgstr ""
 
-#: src/profile.c:248 src/dvr/dvr_db.c:2568
+#: src/profile.c:255 src/dvr/dvr_db.c:3499
 msgid "Important"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1195
+#: src/dvr/dvr_config.c:1279
 msgid "Include channel name in filename"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1206
+#: src/dvr/dvr_config.c:1290
 msgid "Include date in filename"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1228
+#: src/dvr/dvr_config.c:1312
 msgid "Include episode in filename"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1238
+#: src/dvr/dvr_config.c:1322
 msgid "Include subtitle in filename"
 msgstr ""
 
-#: src/timeshift.c:297
+#: src/timeshift.c:295
 msgid "Include teletext"
 msgstr ""
 
-#: src/timeshift.c:298
+#: src/timeshift.c:296
 msgid ""
 "Include teletext in the timeshift buffer. Enabling this may cause issues "
 "with some services where the teletext DTS is invalid."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1207
+#: src/dvr/dvr_config.c:1291
 msgid ""
 "Include the date for the recording in the event title. This applies to both "
 "the title stored in the file and to the filename itself."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1239
+#: src/dvr/dvr_config.c:1323
 msgid "Include the episode subtitle in the title (if available)."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1196
+#: src/dvr/dvr_config.c:1280
 msgid ""
 "Include the name of the channel in the event title. This applies to both the "
 "title stored in the file and to the filename itself."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1229
+#: src/dvr/dvr_config.c:1313
 msgid "Include the season and episode in the title (if available)."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1218
+#: src/dvr/dvr_config.c:1302
 msgid ""
 "Include the time for the recording in the event title. This applies to both "
 "the title stored in the file and to the filename itself."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1217
+#: src/dvr/dvr_config.c:1301
 msgid "Include time in filename"
 msgstr ""
 
-#: src/access.c:1611 src/esfilter.c:611 src/descrambler/caclient.c:266
+#: src/access.c:1720 src/esfilter.c:602 src/descrambler/caclient.c:294
 msgid "Index"
 msgstr ""
 
-#: src/config.c:2235
+#: src/config.c:2298
 msgid "Information area"
 msgstr ""
 
-#: src/epg.c:2356
+#: src/epg.c:1856
 msgid "Informational"
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:281
+#: src/input/mpegts/mpegts_input.c:289
 msgid "Initial scan"
 msgstr ""
 
@@ -3336,7 +4362,7 @@ msgstr ""
 msgid "Input base"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:143
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:194
 msgid "Input buffer (bytes)"
 msgstr ""
 
@@ -3344,82 +4370,78 @@ msgstr ""
 msgid "Input instance"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:78
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:112
 msgid "Input path"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:154
+#: src/transcoding/codec/codecs/libs/libopus.c:103
+msgid "Intended application type."
+msgstr ""
+
+#: src/input/mpegts/iptv/iptv_mux.c:181
 msgid "Interface"
 msgstr ""
 
-#: src/channels.c:1463 src/epggrab/module.c:58
+#: src/channels.c:1800 src/epggrab/module.c:55
 msgid "Internal"
 msgstr ""
 
-#: src/epggrab/module.c:173
+#: src/epggrab/module.c:196
 msgid "Internal EPG grabber"
 msgstr ""
 
-#: src/epggrab/module/pyepg.c:464
-msgid "Internal PyEPG Grabber"
+#: src/epggrab.c:356
+msgid "Internal Grabber Settings"
 msgstr ""
 
-#: src/epggrab/module/xmltv.c:770
-msgid "Internal XMLTV EPG Grabber"
-msgstr ""
-
-#: src/htsp_server.c:1760
+#: src/htsp_server.c:1933
 msgid "Internal error"
 msgstr ""
 
-#: src/epggrab.c:266
-msgid "Internal grabber"
-msgstr ""
-
-#: src/epg.c:2302
+#: src/epg.c:1802
 msgid "Interview"
 msgstr ""
 
-#: src/dvr/dvr_db.c:637 src/dvr/dvr_db.c:668 src/dvr/dvr_timerec.c:430
+#: src/dvr/dvr_db.c:664 src/dvr/dvr_db.c:695 src/dvr/dvr_timerec.c:428
 msgid "Invalid"
 msgstr ""
 
-#: src/htsp_server.c:1756
+#: src/htsp_server.c:1929
 msgid "Invalid EPG object request"
 msgstr ""
 
-#: src/main.c:971
+#: src/main.c:1040
 #, c-format
 msgid "Invalid adapter number '%s'\n"
 msgstr ""
 
-#: src/htsp_server.c:1265 src/htsp_server.c:1268 src/htsp_server.c:1551
-#: src/htsp_server.c:1569 src/htsp_server.c:1669 src/htsp_server.c:1746
-#: src/htsp_server.c:1859 src/htsp_server.c:1919 src/htsp_server.c:2060
-#: src/htsp_server.c:2107 src/htsp_server.c:2143 src/htsp_server.c:2172
-#: src/htsp_server.c:2218 src/htsp_server.c:2253 src/htsp_server.c:2289
-#: src/htsp_server.c:2351 src/htsp_server.c:2387 src/htsp_server.c:2396
-#: src/htsp_server.c:2499 src/htsp_server.c:2528 src/htsp_server.c:2557
-#: src/htsp_server.c:2579 src/htsp_server.c:2599 src/htsp_server.c:2601
-#: src/htsp_server.c:2628 src/htsp_server.c:2656 src/htsp_server.c:2695
-#: src/htsp_server.c:3170
+#: src/htsp_server.c:1438 src/htsp_server.c:1441 src/htsp_server.c:1724
+#: src/htsp_server.c:1742 src/htsp_server.c:1842 src/htsp_server.c:1919
+#: src/htsp_server.c:2045 src/htsp_server.c:2104 src/htsp_server.c:2270
+#: src/htsp_server.c:2317 src/htsp_server.c:2353 src/htsp_server.c:2382
+#: src/htsp_server.c:2428 src/htsp_server.c:2463 src/htsp_server.c:2499
+#: src/htsp_server.c:2561 src/htsp_server.c:2597 src/htsp_server.c:2606
+#: src/htsp_server.c:2724 src/htsp_server.c:2753 src/htsp_server.c:2782
+#: src/htsp_server.c:2804 src/htsp_server.c:2824 src/htsp_server.c:2826
+#: src/htsp_server.c:2853 src/htsp_server.c:2881 src/htsp_server.c:2920
+#: src/htsp_server.c:3434
 msgid "Invalid arguments"
 msgstr ""
 
-#: src/htsp_server.c:2742 src/htsp_server.c:2790 src/htsp_server.c:2808
-#: src/htsp_server.c:2836
+#: src/htsp_server.c:2972 src/htsp_server.c:3023 src/htsp_server.c:3059
+#: src/htsp_server.c:3087
 msgid "Invalid file"
 msgstr ""
 
-#: src/htsp_server.c:2745 src/htsp_server.c:2839 src/htsp_server.c:2849
+#: src/htsp_server.c:2975 src/htsp_server.c:3090 src/htsp_server.c:3100
 msgid "Invalid parameters"
 msgstr ""
 
-#: src/streaming.c:473
+#: src/streaming.c:495
 msgid "Invalid service"
 msgstr ""
 
-#: src/streaming.c:444
+#: src/streaming.c:464
 msgid "Invalid target"
 msgstr ""
 
@@ -3427,59 +4449,87 @@ msgstr ""
 msgid "Items"
 msgstr ""
 
-#: src/epg.c:2374
+#: src/epg.c:1874
 msgid "Jazz"
 msgstr ""
 
-#: src/satip/server.c:569
+#: src/satip/server.c:619
 msgid "Keep"
 msgstr ""
 
-#: src/timeshift.c:277
+#: src/timeshift.c:275
 msgid ""
 "Keep timeshift buffers in RAM only. With this option enabled, the amount of "
-"rewind time is limited by how much RAM Tvheadend is allowed."
+"rewind time is limited by how much RAM TVHeadend is allowed."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1071
+#: src/dvr/dvr_config.c:1137
 msgid "Keep x amount of storage space free."
 msgstr ""
 
-#: src/descrambler/cwc.c:1891
+#: src/descrambler/cclient.c:1432
 msgid "Keepalive interval"
 msgstr ""
 
-#: src/descrambler/cwc.c:1892
+#: src/descrambler/cccam.c:1037
+msgid "Keepalive interval (0=disable)"
+msgstr ""
+
+#: src/descrambler/cclient.c:1433 src/descrambler/cccam.c:1038
 msgid "Keepalive interval in seconds"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:941
-msgid "Key and value pairs to remove from the query string in the URL."
+#: src/descrambler/constcw.c:308
+msgid "Keys"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:208
+#: src/dvr/dvr_db.c:4752
+msgid "Keyword"
+msgstr ""
+
+#: src/epggrab/module/xmltv.c:776
+msgid "Keywords: "
+msgstr ""
+
+#: src/profile.c:1626 src/input/mpegts/iptv/iptv_mux.c:235
 msgid "Kill signal (pipe)"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:216
+#: src/profile.c:1627
+msgid "Kill signal to send to the spawn."
+msgstr ""
+
+#: src/profile.c:1637 src/input/mpegts/iptv/iptv_mux.c:243
 msgid "Kill timeout (pipe/secs)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:190
+#: src/config.c:2336
+msgid "Kodi label formatting support"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:261
 msgid "LNA (low noise amplifier)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_lnb.c:61
+#: src/input/mpegts/linuxdvb/linuxdvb_lnb.c:60
 msgid "LNB"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1463
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1577
 msgid "LNB type"
 msgstr ""
 
-#: src/access.c:1446 src/access.c:1677 src/esfilter.c:646 src/esfilter.c:740
-#: src/esfilter.c:835 src/esfilter.c:930 src/esfilter.c:1130 src/profile.c:1888
-#: src/wizard.c:197
+#: src/input/mpegts/linuxdvb/linuxdvb_lnb.c:51
+#, c-format
+msgid "LNB: %s"
+msgstr ""
+
+#: src/ratinglabels.c:639
+msgid "Label"
+msgstr ""
+
+#: src/access.c:1543 src/access.c:1786 src/esfilter.c:638 src/esfilter.c:733
+#: src/esfilter.c:829 src/esfilter.c:924 src/esfilter.c:1128 src/wizard.c:197
 msgid "Language"
 msgstr ""
 
@@ -3495,112 +4545,144 @@ msgstr ""
 msgid "Language 3"
 msgstr ""
 
-#: src/config.c:2028
-msgid "Language settings"
-msgstr ""
-
-#: src/epg.c:2431
+#: src/epg.c:1931
 msgid "Languages"
 msgstr ""
 
-#: src/memoryinfo.c:62
+#: src/memoryinfo.c:63
 msgid "Largest size the object has reached."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3231
+#: src/descrambler/dvbcam.c:779
+msgid "Last hit"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4458
 msgid "Last played position"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3232
+#: src/dvr/dvr_db.c:4459
 msgid "Last played position when the recording isn't fully watched yet."
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:256
+#: src/input/mpegts/mpegts_mux.c:719
+msgid "Last scan"
+msgstr ""
+
+#: src/input/mpegts/mpegts_service.c:258
 msgid "Last seen"
 msgstr ""
 
-#: src/config.c:2062
+#: src/config.c:2222
 msgid "Last updated from"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:702
+#: src/input/mpegts/mpegts_mux_dvb.c:778
 msgid "Layer A: Constellation"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:698
+#: src/input/mpegts/mpegts_mux_dvb.c:774
 msgid "Layer A: FEC"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:708
+#: src/input/mpegts/mpegts_mux_dvb.c:784
 msgid "Layer A: Segment count"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:715
+#: src/input/mpegts/mpegts_mux_dvb.c:791
 msgid "Layer A: Time interleaving"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:725
+#: src/input/mpegts/mpegts_mux_dvb.c:801
 msgid "Layer B: Constellation"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:721
+#: src/input/mpegts/mpegts_mux_dvb.c:797
 msgid "Layer B: FEC"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:731
+#: src/input/mpegts/mpegts_mux_dvb.c:807
 msgid "Layer B: Segment count"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:738
+#: src/input/mpegts/mpegts_mux_dvb.c:814
 msgid "Layer B: Time interleaving"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:748
+#: src/input/mpegts/mpegts_mux_dvb.c:824
 msgid "Layer C: Constellation"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:744
+#: src/input/mpegts/mpegts_mux_dvb.c:820
 msgid "Layer C: FEC"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:754
+#: src/input/mpegts/mpegts_mux_dvb.c:830
 msgid "Layer C: Segment count"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:761
+#: src/input/mpegts/mpegts_mux_dvb.c:837
 msgid "Layer C: Time interleaving"
 msgstr ""
 
-#: src/epg.c:2442 src/epg.c:2450 src/epg.c:2451 src/epg.c:2452 src/epg.c:2453
-#: src/epg.c:2454 src/epg.c:2455 src/epg.c:2456 src/epg.c:2457
+#: src/epg.c:1942 src/epg.c:1950 src/epg.c:1951 src/epg.c:1952 src/epg.c:1953
+#: src/epg.c:1954 src/epg.c:1955 src/epg.c:1956 src/epg.c:1957
 msgid "Leisure hobbies"
 msgstr ""
 
-#: src/access.c:1796
+#: src/channels.c:488
+msgid "Limit EPG (days)"
+msgstr ""
+
+#: src/channels.c:489
+msgid ""
+"Limit EPG data to specified days to reduce the memory consumption. The zero "
+"value means unlimited EPG."
+msgstr ""
+
+#: src/transcoding/codec/profile_audio_class.c:257
+msgid "Limit audio tracks"
+msgstr ""
+
+#: src/access.c:1905
 msgid "Limit connections"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:176
+#: src/input/mpegts/satip/satip_frontend.c:383
+#: src/input/mpegts/satip/satip_frontend.c:513
+#: src/input/mpegts/satip/satip_frontend.c:588
+msgid "Limit delivery system."
+msgstr ""
+
+#: src/descrambler/dvbcam.c:862
+msgid "Limit of concurrent descrambled services (per one CAM)."
+msgstr ""
+
+#: src/input/mpegts/mpegts_network.c:216
 msgid "Limited/limit scanning to this network ID only."
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:337
+#: src/input/mpegts/mpegts_input.c:348
 msgid "Linked input"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:183
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:601
 msgid "Linux DVB CA"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:63
+#: src/descrambler/dvbcam.c:845
+msgid "Linux DVB CAM Client"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:97
 msgid "Linux DVB frontend"
 msgstr ""
 
-#: src/tvhlog.c:154
+#: src/tvhlog.c:166
 msgid "LinuxDVB Input"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_adapter.c:110
+#: src/input/mpegts/linuxdvb/linuxdvb_adapter.c:143
 msgid "LinuxDVB adapter"
 msgstr ""
 
@@ -3608,905 +4690,1023 @@ msgstr ""
 msgid "LinuxDVB network"
 msgstr ""
 
-#: src/access.c:1634
+#: src/access.c:1743
 msgid "List of allowed IPv4 or IPv6 hosts or networks (comma-separated)."
 msgstr ""
 
-#: src/main.c:878
+#: src/main.c:945
 msgid "List subsystems"
 msgstr ""
 
-#: src/descrambler/capmt.c:2398
+#: src/descrambler/capmt.c:2734
 msgid "Listen / Connect port"
 msgstr ""
 
-#: src/main.c:853
+#: src/main.c:920
 msgid "Listen on IPv6"
 msgstr ""
 
-#: src/epg.c:2393
+#: src/epg.c:1893
 msgid "Literature"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:482
+#: src/input/mpegts/dvb_support.c:560
 msgid "Local (server) time"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:325
+#: src/config.c:2551
+msgid "Local IP Address"
+msgstr ""
+
+#: src/config.c:2564
+msgid "Local Socket Port Number"
+msgstr ""
+
+#: src/input/mpegts/satip/satip.c:382
 msgid "Local bind IP address"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:136
+#: src/input/mpegts/mpegts_service.c:138
 msgid "Local channel minor"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:128
+#: src/input/mpegts/mpegts_service.c:130
 msgid "Local channel number"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:487
+#: src/input/mpegts/satip/satip.c:554
 msgid "Local discovery IP address"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:957
+#: src/dvr/dvr_autorec.c:1025
 msgid "Local: Record if different description"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:951
+#: src/dvr/dvr_autorec.c:1019
 msgid "Local: Record if different episode number"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:955
+#: src/dvr/dvr_autorec.c:1023
 msgid "Local: Record if different subtitle"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:953
+#: src/dvr/dvr_autorec.c:1021
 msgid "Local: Record if different title"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:963
+#: src/dvr/dvr_autorec.c:1031
 msgid "Local: Record once per day"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:959
+#: src/dvr/dvr_autorec.c:1027
 msgid "Local: Record once per month"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:961
+#: src/dvr/dvr_autorec.c:1029
 msgid "Local: Record once per week"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:471
+#: src/input/mpegts/satip/satip.c:538
 msgid "Location"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:472
+#: src/input/mpegts/satip/satip.c:539
 msgid "Location details of the SAT>IP Server."
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:221
+#: src/input/mpegts/mpegts_service.c:223
 msgid "Lock preferred CA PID"
 msgstr ""
 
-#: src/tvhlog.c:87
+#: src/tvhlog.c:96
 msgid "Locking"
 msgstr ""
 
-#: src/esfilter.c:702 src/esfilter.c:797 src/esfilter.c:892 src/esfilter.c:987
-#: src/esfilter.c:1092 src/esfilter.c:1174
+#: src/esfilter.c:694 src/esfilter.c:790 src/esfilter.c:886 src/esfilter.c:981
+#: src/esfilter.c:1089 src/esfilter.c:1172
 msgid "Log"
 msgstr ""
 
-#: src/descrambler/cwc.c:1842
+#: src/descrambler/cclient.c:1361
+msgid "Login Settings"
+msgstr ""
+
+#: src/descrambler/cclient.c:1388
 msgid "Login password."
 msgstr ""
 
-#: src/descrambler/cwc.c:1834
+#: src/descrambler/cclient.c:1379
 msgid "Login username."
 msgstr ""
 
-#: src/config.c:1912
+#: src/config.c:2037
 msgid "Login/Logout"
 msgstr ""
 
-#: src/profile.c:251 src/dvr/dvr_db.c:2571
+#: src/webui/comet.c:382
+msgid "Loglevel debug: disabled"
+msgstr ""
+
+#: src/webui/comet.c:380
+msgid "Loglevel debug: enabled"
+msgstr ""
+
+#: src/webui/webui.c:180
+msgid "Logout"
+msgstr ""
+
+#: src/profile.c:258 src/dvr/dvr_db.c:3502
 msgid "Low"
 msgstr ""
 
-#: src/access.c:1807
+#: src/input/mpegts/linuxdvb/linuxdvb_lnb.c:66
+msgid "Low frequency offset"
+msgstr ""
+
+#: src/access.c:1916
 msgid "Lowest channel number the user can access."
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:911
-msgid "Lowest starting channel number."
+#: src/input/mpegts/iptv/iptv.c:972
+msgid "Lowest starting channel number (when mapping). "
 msgstr ""
 
-#: src/profile.c:1317
+#: src/config.c:2120
+msgid "MD5"
+msgstr ""
+
+#: src/profile.c:1930
 msgid "MP4 audio"
 msgstr ""
 
-#: src/profile.c:1594
+#: src/profile.c:2187 src/profile.c:2267
 msgid "MP4/av-lib"
 msgstr ""
 
-#: src/profile.c:1314
+#: src/profile.c:1927
 msgid "MPEG-2 audio"
 msgstr ""
 
-#: src/profile.c:1680
+#: src/profile.c:2263
 msgid "MPEG-PS (DVD)/av-lib"
 msgstr ""
 
-#: src/tvhlog.c:147
+#: src/tvhlog.c:159
 msgid "MPEG-TS"
 msgstr ""
 
-#: src/tvhlog.c:168
+#: src/tvhlog.c:180
 msgid "MPEG-TS File"
 msgstr ""
 
-#: src/tvhlog.c:169
+#: src/tvhlog.c:181
 msgid "MPEG-TS Input Debug"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:513
-msgid "MPEG-TS Multiplex"
-msgstr ""
-
-#: src/tvhlog.c:118
+#: src/tvhlog.c:128
 msgid "MPEG-TS Parser"
 msgstr ""
 
-#: src/profile.c:2208
-msgid "MPEG-TS Pass-thru"
-msgstr ""
-
-#: src/profile.c:1081
+#: src/profile.c:1341
 msgid "MPEG-TS Pass-thru/built-in"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:89
-msgid "MPEG-TS Service"
+#: src/profile.c:1587
+msgid "MPEG-TS Spawn/built-in"
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:223
+#: src/input/mpegts/mpegts_input.c:224
 msgid "MPEG-TS input"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:44
+#: src/input/mpegts/mpegts_mux.c:45
 msgid "MPEG-TS multiplex PHY"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:903
+#: src/input/mpegts/mpegts_service.c:1010
 msgid "MPEG-TS raw service"
 msgstr ""
 
-#: src/profile.c:1424 src/profile.c:1679
+#: src/profile.c:2031 src/profile.c:2262
 msgid "MPEG-TS/av-lib"
 msgstr ""
 
-#: src/epg.c:2407
+#: src/epg.c:1907
 msgid "Magazines"
 msgstr ""
 
-#: src/tvhlog.c:79
+#: src/tvhlog.c:88
 msgid "Main"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1070
+#: src/dvr/dvr_config.c:1136
 msgid "Maintain free storage space in MiB"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1080
+#: src/dvr/dvr_config.c:1146
 msgid "Maintain used storage space in MiB (0=disabled)"
 msgstr ""
 
-#: src/dvr/dvr_db.c:2619 src/dvr/dvr_config.c:734
+#: src/dvr/dvr_db.c:3550 src/dvr/dvr_config.c:760
 msgid "Maintained space"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1171
+#: src/dvr/dvr_config.c:1227
 msgid "Make subdirectories per channel"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1159
+#: src/dvr/dvr_config.c:1215
 msgid "Make subdirectories per day"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1183
+#: src/dvr/dvr_config.c:1239
 msgid "Make subdirectories per title"
 msgstr ""
 
-#: src/access.c:1553
+#: src/access.c:1660
 msgid "Manage all"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:399
+#: src/access.c:2300
+msgid "Manage persistent authentication for HTTP streaming."
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux.c:490
+msgid "Manual selection"
+msgstr ""
+
+#: src/input/mpegts/iptv/iptv_mux.c:145
+msgid ""
+"Manually setup a retransmission URL for Multicast streams. For RTSP streams "
+"this URL is automatically setup if this value is not set."
+msgstr ""
+
+#: src/input/mpegts/satip/satip.c:466
 msgid "Manufacturer"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:407
+#: src/input/mpegts/satip/satip.c:474
 msgid "Manufacturer URL"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:432
+#: src/input/mpegts/satip/satip.c:499
 msgid "Manufacturer's model number."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:416
+#: src/input/mpegts/satip/satip.c:483
 msgid "Manufacturer's product description."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:408
+#: src/input/mpegts/satip/satip.c:475
 msgid "Manufacturer's product information page for the device."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:424
+#: src/input/mpegts/satip/satip.c:491
 msgid "Manufacturer's product name."
 msgstr ""
 
-#: src/wizard.c:1086
+#: src/wizard.c:1112
 msgid "Map all services"
 msgstr ""
 
-#: src/service_mapper.c:516 src/bouquet.c:731
+#: src/service_mapper.c:609 src/bouquet.c:749
 msgid "Map encrypted services"
 msgstr ""
 
-#: src/bouquet.c:726
+#: src/bouquet.c:744
 msgid "Map radio channels"
 msgstr ""
 
-#: src/bouquet.c:721
+#: src/bouquet.c:739
 msgid "Map unnamed channels"
 msgstr ""
 
-#: src/bouquet.c:716
+#: src/bouquet.c:734
 msgid "Map zero-numbered channels"
 msgstr ""
 
-#: src/epg.c:2345
+#: src/input/mpegts/mpegts_mux.c:660
+msgid "Mapped"
+msgstr ""
+
+#: src/epg.c:1845
 msgid "Martial sports"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:283
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:314
-#: src/input/mpegts/satip/satip_frontend.c:334
-#: src/input/mpegts/satip/satip_frontend.c:366
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:353
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:384
+#: src/input/mpegts/satip/satip_frontend.c:494
+#: src/input/mpegts/satip/satip_frontend.c:535
 msgid "Master tuner"
 msgstr ""
 
-#: src/profile.c:2228
-msgid "Matroska"
-msgstr ""
-
-#: src/profile.c:1682
+#: src/profile.c:2265
 msgid "Matroska (mkv)/av-lib"
 msgstr ""
 
-#: src/profile.c:1213 src/profile.c:1677
+#: src/profile.c:1822 src/profile.c:2260
 msgid "Matroska (mkv)/built-in"
 msgstr ""
 
-#: src/tvhlog.c:126
+#: src/profile.c:1829
+msgid "Matroska Specific Settings"
+msgstr ""
+
+#: src/tvhlog.c:136
 msgid "Matroska muxer"
 msgstr ""
 
-#: src/profile.c:1220 src/profile.c:1502
+#: src/profile.c:2104
 msgid "Matroska specific"
 msgstr ""
 
-#: src/profile.c:1495
+#: src/profile.c:2097
 msgid "Matroska/av-lib"
 msgstr ""
 
-#: src/access.c:1815
+#: src/satip/server.c:906
+msgid "Max Sessions"
+msgstr ""
+
+#: src/satip/server.c:916
+msgid "Max User connections"
+msgstr ""
+
+#: src/access.c:1924
 msgid "Maximal channel number"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:783
+#: src/input/mpegts/iptv/iptv.c:866
 msgid "Maximum # input streams"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:102
-#: src/input/mpegts/satip/satip.c:270
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:144
+#: src/input/mpegts/satip/satip.c:314
 msgid "Maximum PIDs"
 msgstr ""
 
-#: src/timeshift.c:254
+#: src/timeshift.c:252
 msgid "Maximum RAM size (MB)"
 msgstr ""
 
-#: src/dvr/dvr_config.c:987
+#: src/config.c:2382
 msgid ""
 "Maximum allowed difference between event start time when the EPG event is "
-"changed."
+"changed (in seconds)."
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:792
+#: src/dvr/dvr_config.c:1387
+msgid ""
+"Maximum allowed difference between event start time when the EPG event is "
+"changed in seconds."
+msgstr ""
+
+#: src/input/mpegts/iptv/iptv.c:875
 msgid "Maximum bandwidth (Kbps)"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1223
+#: src/dvr/dvr_autorec.c:1387
 msgid "Maximum count (0=default)"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1169
+#: src/dvr/dvr_autorec.c:1298
 msgid "Maximum duration"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:793
+#: src/input/mpegts/iptv/iptv.c:876
 msgid "Maximum input bandwidth."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:280
+#: src/input/mpegts/satip/satip.c:324
 msgid ""
 "Maximum length in characters for the command setting PIDs to the SAT>IP box."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:279
+#: src/input/mpegts/satip/satip.c:323
 msgid "Maximum length of PIDs"
 msgstr ""
 
-#: src/timeshift.c:224
+#: src/timeshift.c:222
 msgid "Maximum period (mins)"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1232
+#: src/dvr/dvr_autorec.c:1396
 msgid "Maximum schedules limit (0=default)"
 msgstr ""
 
-#: src/timeshift.c:243
+#: src/dvr/dvr_autorec.c:1335
+msgid "Maximum season"
+msgstr ""
+
+#: src/timeshift.c:241
 msgid "Maximum size (MB)"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:801
+#: src/input/mpegts/iptv/iptv.c:884
 msgid "Maximum time to wait (in seconds) for a stream before a timeout."
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:800
+#: src/input/mpegts/iptv/iptv.c:883
 msgid "Maximum timeout (seconds)"
 msgstr ""
 
-#: src/epg.c:2427
+#: src/dvr/dvr_autorec.c:1318
+msgid "Maximum year"
+msgstr ""
+
+#: src/epg.c:1927
 msgid "Medicine"
 msgstr ""
 
-#: src/epg.c:2285
+#: src/epg.c:1785
 msgid "Melodrama"
 msgstr ""
 
-#: src/memoryinfo.c:36
+#: src/memoryinfo.c:37
 msgid "Memory Information"
 msgstr ""
 
-#: src/service_mapper.c:524 src/bouquet.c:736
+#: src/service_mapper.c:617 src/bouquet.c:754
 msgid "Merge same name"
 msgstr ""
 
-#: src/service_mapper.c:525
-msgid "Merge services with the same name to one channel."
+#: src/service_mapper.c:618
+msgid "Merge services with the same name into one channel."
 msgstr ""
 
-#: src/htsp_server.c:3166
+#: src/htsp_server.c:3430
 msgid "Method not found"
 msgstr ""
 
-#: src/access.c:1806
+#: src/profile.c:1618
+msgid "Mime type"
+msgstr ""
+
+#: src/profile.c:1619
+msgid "Mime type string (for example 'video/mp2t')."
+msgstr ""
+
+#: src/access.c:1915
 msgid "Minimal channel number"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1158
+#: src/dvr/dvr_autorec.c:1287
 msgid "Minimum duration"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:657
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:710
 msgid "Minimum rotor time (seconds)"
 msgstr ""
 
-#: src/service.c:146
+#: src/dvr/dvr_autorec.c:1327
+msgid "Minimum season"
+msgstr ""
+
+#: src/dvr/dvr_autorec.c:1309
+msgid "Minimum year"
+msgstr ""
+
+#: src/tvhlog.c:790 src/config.c:2195 src/satip/server.c:669
+#: src/dvr/dvr_config.c:912
+msgid "Miscellaneous Settings"
+msgstr ""
+
+#: src/service.c:137
 msgid "Missing In PAT/SDT"
 msgstr ""
 
-#: src/descrambler/capmt.c:2381
+#: src/descrambler/capmt.c:2716
 msgid "Mode"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:415
+#: src/input/mpegts/satip/satip.c:482
 msgid "Model description"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:423
+#: src/input/mpegts/satip/satip.c:490
 msgid "Model name"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:431
+#: src/input/mpegts/satip/satip.c:498
 msgid "Model number"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:465 src/input/mpegts/mpegts_mux_dvb.c:559
+#: src/input/mpegts/mpegts_mux_dvb.c:489 src/input/mpegts/mpegts_mux_dvb.c:599
 msgid "Modulation"
 msgstr ""
 
-#: src/epggrab/channel.c:762
+#: src/epggrab/channel.c:780
 msgid "Module"
 msgstr ""
 
-#: src/epggrab/channel.c:752
+#: src/epggrab/channel.c:770
 msgid "Module ID"
 msgstr ""
 
-#: src/epggrab/channel.c:753
+#: src/epggrab/channel.c:771
 msgid "Module ID used to grab EPG data."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:772
+#: src/dvr/dvr_autorec.c:883
 msgid "Mon"
 msgstr ""
 
-#: src/tvhlog.c:81
-msgid "Monitonic timer"
-msgstr ""
-
-#: src/profile.c:1693
-msgid "Mono"
-msgstr ""
-
-#: src/main.c:882
+#: src/main.c:949
 msgid "More verbose libav log"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:710
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:772
 msgid "Motor rate (in milliseconds/deg)."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:709
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:771
 msgid "Motor rate (milliseconds/deg)"
 msgstr ""
 
-#: src/epg.c:2341
+#: src/epg.c:1841
 msgid "Motor sport"
 msgstr ""
 
-#: src/epg.c:2445
+#: src/epg.c:1945
 msgid "Motoring"
 msgstr ""
 
-#: src/epg.c:2280
+#: src/epg.c:1780
 msgid "Movie"
 msgstr ""
 
-#: src/epg.c:2289 src/epg.c:2290 src/epg.c:2291 src/epg.c:2292 src/epg.c:2293
-#: src/epg.c:2294 src/epg.c:2295
+#: src/epg.c:1789 src/epg.c:1790 src/epg.c:1791 src/epg.c:1792 src/epg.c:1793
+#: src/epg.c:1794 src/epg.c:1795
 msgid "Movie / drama"
 msgstr ""
 
-#: src/epggrab.c:351
-msgid ""
-"Multiple lines of the cron time specification. The default cron triggers the "
-"Over-the-air grabber daily at 02:04 and 14:04. See Help on how to define "
-"your own."
-msgstr ""
-
-#: src/epggrab.c:328
+#: src/epggrab.c:442
 msgid ""
 "Multiple lines of the cron time specification. The default cron triggers the "
 "internal grabbers daily at 12:04 and 00:04. See Help on how to define your "
 "own."
 msgstr ""
 
-#: src/epg.c:2370
+#: src/epggrab.c:474
+msgid ""
+"Multiple lines of the cron time specification. The default cron triggers the "
+"over-the-air grabber daily at 02:04 and 14:04. See Help on how to define "
+"your own."
+msgstr ""
+
+#: src/epg.c:1870
 msgid "Music"
 msgstr ""
 
-#: src/epg.c:2377 src/epg.c:2378 src/epg.c:2379 src/epg.c:2380 src/epg.c:2381
-#: src/epg.c:2382 src/epg.c:2383 src/epg.c:2384 src/epg.c:2385
+#: src/epg.c:1877 src/epg.c:1878 src/epg.c:1879 src/epg.c:1880 src/epg.c:1881
+#: src/epg.c:1882 src/epg.c:1883 src/epg.c:1884 src/epg.c:1885
 msgid "Music / Ballet / Dance"
 msgstr ""
 
-#: src/epg.c:2375
+#: src/epg.c:1875
 msgid "Musical"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:104
-#: src/input/mpegts/mpegts_mux_sched.c:145
+#: src/input/mpegts/mpegts_service.c:106
+#: src/input/mpegts/mpegts_mux_sched.c:146
 msgid "Mux"
 msgstr ""
 
-#: src/tvhlog.c:148 src/input/mpegts/mpegts_mux_sched.c:127
+#: src/tvhlog.c:160
 msgid "Mux Scheduler"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:112
+#: src/input/mpegts/mpegts_service.c:114
 msgid "Mux UUID"
 msgstr ""
 
-#: src/satip/server.c:662
+#: src/satip/server.c:744
 msgid "Mux handling"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:168
+#: src/input/mpegts/iptv/iptv_mux.c:195
 msgid "Mux name"
 msgstr ""
 
-#: src/streaming.c:457
+#: src/streaming.c:479
 msgid "Mux not enabled"
 msgstr ""
 
-#: src/tvhlog.c:123
+#: src/tvhlog.c:133
 msgid "Muxer"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:399
+#: src/satip/server.c:657
+msgid "NAT Settings"
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux.c:403
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:56
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:69
 #: src/input/mpegts/linuxdvb/linuxdvb_switch.c:94
 msgid "NONE"
 msgstr ""
 
-#: src/channels.c:397 src/channels.c:1456 src/bouquet.c:1038
-#: src/memoryinfo.c:45 src/epggrab/module.c:129 src/epggrab/channel.c:657
-#: src/epggrab/channel.c:798 src/dvr/dvr_autorec.c:1018
-#: src/dvr/dvr_timerec.c:546 src/input/mpegts/mpegts_input.c:264
-#: src/input/mpegts/mpegts_mux.c:564
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1438
-#: src/input/mpegts/satip/satip_satconf.c:344
+#: src/channels.c:432 src/channels.c:1793 src/bouquet.c:1065
+#: src/memoryinfo.c:46 src/epggrab/module.c:152 src/epggrab/channel.c:674
+#: src/epggrab/channel.c:816 src/dvr/dvr_autorec.c:1120
+#: src/dvr/dvr_timerec.c:544 src/input/mpegts/mpegts_input.c:272
+#: src/input/mpegts/mpegts_mux.c:579
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1552
+#: src/input/mpegts/satip/satip_satconf.c:361
+#: src/transcoding/codec/profile_class.c:224
 msgid "Name"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3466
+#: src/dvr/dvr_db.c:4711
 msgid "Name (or date) of program the entry is a rerun of."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3141
+#: src/dvr/dvr_db.c:4319
 msgid "Name of channel the entry recorded from."
 msgstr ""
 
-#: src/memoryinfo.c:46
+#: src/memoryinfo.c:47
 msgid "Name of object."
 msgstr ""
 
-#: src/bouquet.c:1039
+#: src/bouquet.c:1066
 msgid "Name of the bouquet."
 msgstr ""
 
-#: src/descrambler/caclient.c:281
+#: src/descrambler/caclient.c:311
 msgid "Name of the client."
 msgstr ""
 
-#: src/dvr/dvr_timerec.c:547
+#: src/dvr/dvr_timerec.c:545
 msgid "Name of the entry."
 msgstr ""
 
-#: src/epggrab/channel.c:763
+#: src/epggrab/channel.c:781
 msgid "Name of the module used to grab EPG data."
 msgstr ""
 
-#: src/channels.c:455
+#: src/channels.c:501
 msgid ""
 "Name of the module, grabber or channel that should be used to update this "
 "channels EPG info."
 msgstr ""
 
-#: src/wizard.c:802 src/input/mpegts/mpegts_network.c:160
+#: src/wizard.c:811 src/input/mpegts/mpegts_network.c:200
 msgid "Name of the network."
 msgstr ""
 
-#: src/dvr/dvr_config.c:857
+#: src/dvr/dvr_config.c:938
 msgid "Name of the profile."
 msgstr ""
 
-#: src/channels.c:1457
+#: src/channels.c:1794
 msgid "Name of the tag."
 msgstr ""
 
-#: src/wizard.c:567 src/wizard.c:575
+#: src/wizard.c:569 src/wizard.c:577
 msgid "Name of the tuner."
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:265
+#: src/input/mpegts/mpegts_input.c:273
 msgid "Name of the tuner/adapter."
 msgstr ""
 
-#: src/epggrab/channel.c:806
+#: src/transcoding/codec/profile_class.c:225
+msgid "Name."
+msgstr ""
+
+#: src/epggrab/channel.c:824
 msgid "Names"
 msgstr ""
 
-#: src/epg.c:2426
+#: src/epg.c:1926
 msgid "Natural sciences"
 msgstr ""
 
-#: src/epg.c:2425
+#: src/epg.c:1925
 msgid "Nature"
 msgstr ""
 
-#: src/wizard.c:777 src/wizard.c:801 src/input/mpegts/mpegts_mux.c:548
-#: src/input/mpegts/mpegts_service.c:96
-#: src/input/mpegts/tvhdhomerun/tvhdhomerun.c:172
+#: src/wizard.c:786 src/wizard.c:810 src/input/mpegts/mpegts_mux.c:563
+#: src/input/mpegts/mpegts_service.c:98
+#: src/input/mpegts/tvhdhomerun/tvhdhomerun.c:206
 msgid "Network"
 msgstr ""
 
-#: src/wizard.c:559
+#: src/wizard.c:561
 msgid "Network "
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:501
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:565
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:554
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:618
 msgid "Network A"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:513
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:577
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:566
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:630
 msgid "Network B"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:589
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:642
 msgid "Network C"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:601
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:654
 msgid "Network D"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:175
+#: src/input/mpegts/mpegts_network.c:215
 msgid "Network ID (limit scanning)"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:556
+#: src/input/mpegts/mpegts_mux.c:571
 msgid "Network UUID"
 msgstr ""
 
-#: src/wizard.c:395
+#: src/wizard.c:397
 msgid "Network access"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:183
+#: src/input/mpegts/mpegts_network.c:223
 msgid "Network discovery"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:316
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:502
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:566
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:369
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:555
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:619
 msgid "Network for port A."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:354
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:407
 msgid "Network for port AA."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:366
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:419
 msgid "Network for port AB."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:328
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:514
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:578
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:381
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:567
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:631
 msgid "Network for port B."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:378
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:431
 msgid "Network for port BA."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:390
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:443
 msgid "Network for port BB."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:590
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:643
 msgid "Network for port C."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:602
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:655
 msgid "Network for port D."
 msgstr ""
 
-#: src/input/mpegts/satip/satip_satconf.c:389
+#: src/input/mpegts/satip/satip_satconf.c:404
 msgid "Network group"
 msgstr ""
 
-#: src/input/mpegts/satip/satip_satconf.c:378
-msgid "Network limit per position"
+#: src/input/mpegts/satip/satip_satconf.c:395
+msgid "Network limit per group"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:159
+#: src/input/mpegts/mpegts_network.c:199
 msgid "Network name"
 msgstr ""
 
-#: src/access.c:2191
+#: src/access.c:2449
 msgid "Network prefix"
 msgstr ""
 
-#: src/wizard.c:668
+#: src/input/mpegts/iptv/iptv_mux.c:96
 msgid "Network settings"
 msgstr ""
 
-#: src/wizard.c:582 src/input/mpegts/satip/satip_frontend.c:233
-#: src/input/mpegts/satip/satip_frontend.c:398
-#: src/input/mpegts/tvhdhomerun/tvhdhomerun.c:207
+#: src/wizard.c:584 src/input/mpegts/satip/satip_frontend.c:373
+#: src/input/mpegts/satip/satip_frontend.c:578
+#: src/input/mpegts/tvhdhomerun/tvhdhomerun.c:241
 msgid "Network type"
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:326
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:289
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1453
-#: src/input/mpegts/satip/satip_satconf.c:397
+#: src/input/mpegts/mpegts_input.c:337
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:342
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1567
+#: src/input/mpegts/satip/satip_satconf.c:415
 msgid "Networks"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:975
+#: src/dvr/dvr_config.c:782
+msgid "Never"
+msgstr ""
+
+#: src/dvr/dvr_autorec.c:1045
+msgid "New / premiere"
+msgstr ""
+
+#: src/dvr/dvr_autorec.c:1043
 msgid "New / premiere / unknown"
 msgstr ""
 
-#: src/epg.c:2397
+#: src/http.c:711
+msgid "New login"
+msgstr ""
+
+#: src/epg.c:1897
 msgid "New media"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:138
+#: src/input/mpegts/mpegts_network.c:156
 msgid "New muxes + changed muxes"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:137
+#: src/input/mpegts/mpegts_network.c:155
 msgid "New muxes only"
 msgstr ""
 
-#: src/epg.c:2298 src/epg.c:2299
+#: src/epg.c:1798 src/epg.c:1799
 msgid "News"
 msgstr ""
 
-#: src/epg.c:2303 src/epg.c:2304 src/epg.c:2305 src/epg.c:2306 src/epg.c:2307
-#: src/epg.c:2308 src/epg.c:2309 src/epg.c:2310 src/epg.c:2311 src/epg.c:2312
-#: src/epg.c:2313
+#: src/epg.c:1803 src/epg.c:1804 src/epg.c:1805 src/epg.c:1806 src/epg.c:1807
+#: src/epg.c:1808 src/epg.c:1809 src/epg.c:1810 src/epg.c:1811 src/epg.c:1812
+#: src/epg.c:1813
 msgid "News / Current Affairs"
 msgstr ""
 
-#: src/epg.c:2300
+#: src/epg.c:1800
 msgid "News magazine"
 msgstr ""
 
-#: src/input/mpegts/satip/satip_frontend.c:170
+#: src/input/mpegts/satip/satip_frontend.c:279
 msgid "Next tune delay in ms (0-2000)"
 msgstr ""
 
-#: src/access.c:1396
+#: src/access.c:1493
 msgid "No"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:124
+#: src/streaming.c:499
+msgid "No A/V data received"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:126
 msgid "No PIN"
 msgstr ""
 
-#: src/streaming.c:481
+#: src/streaming.c:509
 msgid "No access"
 msgstr ""
 
-#: src/main.c:984
+#: src/main.c:1053
 msgid "No adapters specified!\n"
 msgstr ""
 
-#: src/streaming.c:471
+#: src/streaming.c:493
 msgid "No assigned adapters"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:796
+#: src/streaming.c:497
+msgid "No channel enabled"
+msgstr ""
+
+#: src/dvr/dvr_autorec.c:907
 msgid "No days"
 msgstr ""
 
-#: src/streaming.c:479
+#: src/streaming.c:507
 msgid "No descrambler"
 msgstr ""
 
-#: src/streaming.c:455
+#: src/streaming.c:477
 msgid "No free adapter"
 msgstr ""
 
-#: src/streaming.c:483
+#: src/streaming.c:511
 msgid "No input detected"
 msgstr ""
 
-#: src/config.c:1963
+#: src/dvr/dvr_autorec.c:950
+msgid "No rating needed"
+msgstr ""
+
+#: src/config.c:2088
 msgid "No scheme"
 msgstr ""
 
-#: src/streaming.c:469
+#: src/streaming.c:491
 msgid "No service assigned to channel"
 msgstr ""
 
-#: src/streaming.c:463
+#: src/streaming.c:485
 msgid "No service enabled"
 msgstr ""
 
-#: src/streaming.c:467
+#: src/streaming.c:489
 msgid "No source available"
 msgstr ""
 
-#: src/tvhlog.c:89
+#: src/descrambler/cccam.c:1006
+msgid "Node ID"
+msgstr ""
+
+#: src/tvhlog.c:98
 msgid "Node subsystem"
 msgstr ""
 
-#: src/tvhlog.c:74 src/service.c:156 src/profile.c:266
-#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:262
-#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:486
-#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:403
+#: src/tvhlog.c:83 src/service.c:147 src/profile.c:273
+#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:263
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:600
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:450 src/descrambler/cccam.c:975
 msgid "None"
 msgstr ""
 
-#: src/profile.c:250 src/dvr/dvr_db.c:2570
+#: src/profile.c:257 src/dvr/dvr_db.c:3501
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:233
 msgid "Normal"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:261
+#: src/input/mpegts/satip/satip.c:305
 msgid ""
 "Not all SAT>IP servers use the same signal scaling. Change this setting if "
 "the signal level displayed within Tvheadend looks too low."
 msgstr ""
 
-#: src/streaming.c:485
+#: src/streaming.c:513
 msgid "Not enough disk space"
 msgstr ""
 
-#: src/htsp_server.c:2761
+#: src/htsp_server.c:2991
 msgid "Not enough memory"
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:202
+#: src/input/mpegts/mpegts_input.c:203
 msgid "Not linked"
 msgstr ""
 
-#: src/channels.c:357 src/profile.c:1676 src/dvr/dvr_db.c:2567
+#: src/channels.c:391 src/profile.c:2259
 msgid "Not set"
 msgstr ""
 
-#: src/dvr/dvr_config.c:767
+#: src/dvr/dvr_config.c:834
 msgid "Not set (none or channel configuration)"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3018 src/dvr/dvr_autorec.c:671
+#: src/dvr/dvr_db.c:4179 src/dvr/dvr_autorec.c:782
 msgid "Not set (use channel or DVR configuration)"
 msgstr ""
 
-#: src/channels.c:409 src/epggrab/channel.c:652 src/epggrab/channel.c:816
+#: src/channels.c:444 src/epggrab/channel.c:669 src/epggrab/channel.c:834
 msgid "Number"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3222
+#: src/dvr/dvr_config.c:985
+msgid "Number of days to keep recorded files."
+msgstr ""
+
+#: src/dvr/dvr_db.c:4449
 msgid "Number of days to keep the file."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1214 src/dvr/dvr_timerec.c:640
+#: src/dvr/dvr_autorec.c:1378 src/dvr/dvr_timerec.c:641
 msgid "Number of days to keep the recorded file."
 msgstr ""
 
-#: src/dvr/dvr_config.c:914
-msgid "Number of days to keep the recorded files."
-msgstr ""
-
-#: src/dvr/dvr_db.c:3212 src/dvr/dvr_timerec.c:630
+#: src/dvr/dvr_db.c:4439 src/dvr/dvr_timerec.c:631
 msgid "Number of days to retain entry information."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1204
+#: src/dvr/dvr_autorec.c:1368
 msgid "Number of days to retain information about recording."
 msgstr ""
 
-#: src/dvr/dvr_config.c:903
-msgid ""
-"Number of days to retain information about recordings. Once this period is "
-"exceeded, duplicate detection will not be possible anymore."
-msgstr ""
-
-#: src/dvr/dvr_db.c:3314
+#: src/dvr/dvr_db.c:4541
 msgid "Number of errors that occurred during recording (Transport errors)."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3306
+#: src/dvr/dvr_db.c:4533
 msgid "Number of errors that occurred during recording."
 msgstr ""
 
-#: src/wizard.c:1003
+#: src/dvr/dvr_config.c:996
+msgid ""
+"Number of minutes after playback has finished before file should be "
+"automatically removed (unless its retention is 'forever'). Note that some "
+"clients may pre-cache playback which means the recording will be marked as "
+"played when the client has cached the data, which may be before the end of "
+"the programme is actually watched."
+msgstr ""
+
+#: src/wizard.c:1029
 msgid "Number of muxes found."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:238
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:276
 msgid ""
 "Number of repeats for the DiseqC commands (default is zero - no DiseqC "
 "repeats). Note: this represents the number of repeats, not the number of "
@@ -4514,7 +5714,7 @@ msgid ""
 "once, then send one repeat', etc."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:120
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:171
 msgid ""
 "Number of repeats for the tune requests (default is zero - no repeats). "
 "Note: this represents the number of repeats, not the number of requests - so "
@@ -4522,1182 +5722,1534 @@ msgid ""
 "one repeat', etc."
 msgstr ""
 
-#: src/input/mpegts/satip/satip_satconf.c:361
+#: src/input/mpegts/satip/satip_satconf.c:378
 msgid "Number of seconds to wait before timing out."
 msgstr ""
 
-#: src/bouquet.c:1083
+#: src/profile.c:1638
+msgid "Number of seconds to wait for spawn to die."
+msgstr ""
+
+#: src/bouquet.c:1110
 msgid "Number of services."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3241
+#: src/dvr/dvr_db.c:4468
 msgid "Number of times this recording was played."
 msgstr ""
 
-#: src/main.c:897
+#: src/main.c:964
 msgid "Number of tsfile tuners"
 msgstr ""
 
-#: src/streaming.c:433 src/input/mpegts/mpegts_mux.c:400
+#: src/config.c:2583
+msgid "Number of tuners to export for HDHomeRun Server Emulation"
+msgstr ""
+
+#: src/streaming.c:451 src/input/mpegts/mpegts_mux.c:404
 msgid "OK"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:402
+#: src/input/mpegts/mpegts_mux.c:406
 msgid "OK (partial)"
 msgstr ""
 
-#: src/descrambler/capmt.c:2365
+#: src/descrambler/capmt.c:2618
 msgid "OSCam (rev >= 9095)"
 msgstr ""
 
-#: src/descrambler/capmt.c:2364
+#: src/descrambler/capmt.c:2612
 msgid "OSCam TCP (rev >= 9574)"
 msgstr ""
 
-#: src/descrambler/capmt.c:2362
+#: src/descrambler/capmt.c:2606
 msgid "OSCam net protocol (rev >= 10389)"
 msgstr ""
 
-#: src/descrambler/capmt.c:2361
-msgid "OSCam new pc-nodmx (rev >= 10389)"
-msgstr ""
-
-#: src/descrambler/capmt.c:2363
+#: src/descrambler/capmt.c:2615
 msgid "OSCam pc-nodmx (rev >= 9756)"
 msgstr ""
 
-#: src/descrambler/constcw.c:336 src/descrambler/constcw.c:402
+#: src/epggrab.c:364
+msgid "OTA (Over-the-air) Genre Translation"
+msgstr ""
+
+#: src/epggrab.c:360
+msgid "OTA (Over-the-air) Grabber Settings"
+msgstr ""
+
+#: src/epggrab/module/xmltv.c:1094
+msgid ""
+"Obtain list of credits (actors, etc.), keywords and extra information from "
+"the xml tags (if available). Some xmltv providers supply a list of actors "
+"and additional keywords to describe programmes. This option will retrieve "
+"this additional information. This can be very detailed (20+ actors per "
+"movie) and will take a lot of memory and resources on this box, and will "
+"pass this information to your client machines and GUI too, using memory and "
+"resources on those boxes too. Do not enable on low-spec machines."
+msgstr ""
+
+#: src/descrambler/constcw.c:375 src/descrambler/constcw.c:448
+#: src/descrambler/constcw.c:521 src/descrambler/constcw.c:594
 msgid "Odd key"
 msgstr ""
 
-#: src/descrambler/constcw.c:337 src/descrambler/constcw.c:403
+#: src/descrambler/constcw.c:376 src/descrambler/constcw.c:449
+#: src/descrambler/constcw.c:522 src/descrambler/constcw.c:595
 msgid "Odd key."
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:76
+#: src/input/mpegts/mpegts_service.c:78
+#: src/input/mpegts/satip/satip_frontend.c:233
 msgid "Off"
 msgstr ""
 
-#: src/bouquet.c:1116
+#: src/bouquet.c:1143
 msgid "Offset the mapped channel numbers by x (value here + channel number)."
 msgstr ""
 
-#: src/descrambler/capmt.c:2366
+#: src/descrambler/capmt.c:2621
 msgid "Older OSCam"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:77
+#: src/input/mpegts/mpegts_service.c:79
+#: src/input/mpegts/satip/satip_frontend.c:234
 msgid "On"
 msgstr ""
 
-#: src/dvr/dvr_db.c:2595 src/dvr/dvr_config.c:757
+#: src/dvr/dvr_db.c:3526 src/dvr/dvr_config.c:824
 msgid "On file removal"
 msgstr ""
 
-#: src/timeshift.c:200
+#: src/timeshift.c:201
 msgid "On-demand (no first rewind)"
 msgstr ""
 
-#: src/epggrab/channel.c:844
+#: src/epggrab/channel.c:862
 msgid "Once per auto channel"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:227
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:265
 msgid ""
 "One tune request (setup) is sent before the DiseqC sequence (voltage, tone "
 "settings). Some linux drivers require this procedure."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:489
-msgid "Only Bulsatcom 39E"
-msgstr ""
-
-#: src/input/mpegts/mpegts_mux.c:484
-msgid "Only EIT"
-msgstr ""
-
-#: src/input/mpegts/mpegts_mux.c:492
-msgid "Only OpenTV Sky Ausat"
-msgstr ""
-
-#: src/input/mpegts/mpegts_mux.c:491
-msgid "Only OpenTV Sky Italia"
-msgstr ""
-
-#: src/input/mpegts/mpegts_mux.c:490
-msgid "Only OpenTV Sky UK"
-msgstr ""
-
-#: src/input/mpegts/mpegts_mux.c:485
-msgid "Only PSIP (ATSC)"
-msgstr ""
-
-#: src/input/mpegts/mpegts_mux.c:486
-msgid "Only UK Freesat"
-msgstr ""
-
-#: src/input/mpegts/mpegts_mux.c:487
-msgid "Only UK Freeview"
-msgstr ""
-
-#: src/input/mpegts/mpegts_mux.c:488
-msgid "Only Viasat Baltic"
-msgstr ""
-
-#: src/timeshift.c:204
+#: src/timeshift.c:202
 msgid ""
 "Only activate timeshift when the client makes the first rewind, fast-forward "
 "or pause request. Note, because there is no buffer on the first request "
 "rewinding is not possible at that point."
 msgstr ""
 
-#: src/channels.c:1472
+#: src/webui/comet.c:378
+msgid "Only admin can watch the realtime log."
+msgstr ""
+
+#: src/channels.c:1809
 msgid ""
 "Only allow users with this tag (or those with no tags at all) set in access "
 "configuration to use the tag."
 msgstr ""
 
-#: src/epggrab/module/xmltv.c:762
+#: src/epggrab/module/xmltv.c:1131
 msgid "Only digits"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:78
+#: src/input/mpegts/mpegts_service.c:80
 msgid "Only preferred CA PID"
 msgstr ""
 
-#: src/config.c:2306
+#: src/config.c:2748
 msgid ""
 "Only update the system clock (doesn't affect NTP driver) if the delta "
 "between the system clock and DVB time is greater than this. This can help "
 "stop excessive oscillations on the system clock."
 msgstr ""
 
-#: src/main.c:836
+#: src/main.c:903
 msgid "Only use specified DVB adapters (comma-separated, -1 = none)"
 msgstr ""
 
-#: src/epggrab/channel.c:845
+#: src/epggrab/channel.c:863
 msgid ""
 "Only use this EPG data once when automatically determining what EPG data to "
 "set for a channel."
 msgstr ""
 
-#: src/tvhlog.c:162
+#: src/tvhlog.c:174
 msgid "OpenTV EPG"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:144
+#: src/input/mpegts/mpegts_service.c:146
 msgid "OpenTV channel number"
 msgstr ""
 
-#: src/epg.c:2375
+#: src/epg.c:1875
 msgid "Opera"
 msgstr ""
 
-#: src/bouquet.c:1002
+#: src/bouquet.c:1029
 msgid "Options to use/used when mapping - see Help for details."
 msgstr ""
 
-#: src/epggrab/channel.c:856
+#: src/epggrab/channel.c:874
 msgid "Options used when updating channels."
 msgstr ""
 
 #: src/input/mpegts/mpegts_network_dvb.c:306
-#: src/input/mpegts/mpegts_mux_dvb.c:511
+#: src/input/mpegts/mpegts_mux_dvb.c:535
 msgid "Orbital position"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:628
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:681
 msgid "Orbital positions"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:629
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:682
 msgid "Orbital positions."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:580
+#: src/input/mpegts/mpegts_mux.c:595
 msgid "Original network ID"
 msgstr ""
 
-#: src/descrambler/capmt.c:2382
+#: src/descrambler/capmt.c:2717
 msgid "Oscam mode."
 msgstr ""
 
-#: src/esfilter.c:1113
-msgid "Other Stream Filter"
+#: src/descrambler/cccam.c:976
+msgid "Oscam-EXT"
 msgstr ""
 
-#: src/main.c:901
-msgid "Output directory for tsdebug"
+#: src/streaming.c:501
+msgid "Other service without A/V streams"
 msgstr ""
 
-#: src/epggrab/module.c:57
+#: src/epggrab/module.c:54
 msgid "Over-the-air"
 msgstr ""
 
-#: src/epggrab.c:350
+#: src/epggrab.c:473
 msgid "Over-the-air Cron multi-line"
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:272
+#: src/epggrab/module/eit.c:1570
+msgid "Over-the-air EIT EPG grabber"
+msgstr ""
+
+#: src/input/mpegts/mpegts_input.c:280
 msgid "Over-the-air EPG"
 msgstr ""
 
-#: src/epggrab/module.c:218
-msgid "Over-the-air EPG grabber"
+#: src/epggrab/module.c:250
+msgid "Over-the-air EPG grabber with scraping"
 msgstr ""
 
-#: src/epggrab.c:270
-msgid "Over-the-air grabbers"
+#: src/epggrab.c:497
+msgid "Over-the-air Genre Translation"
 msgstr ""
 
-#: src/service.c:155
+#: src/service.c:146
 msgid "Override disabled"
 msgstr ""
 
-#: src/input/mpegts/satip/satip_frontend.c:234
-#: src/input/mpegts/satip/satip_frontend.c:399
+#: src/transcoding/codec/codecs/libs/libx26x.c:196
+#: src/transcoding/codec/codecs/libs/libx26x.c:295
+msgid ""
+"Override the configuration using a ':' separated list of key=value "
+"parameters."
+msgstr ""
+
+#: src/input/mpegts/satip/satip_frontend.c:374
+#: src/input/mpegts/satip/satip_frontend.c:579
 msgid "Override the frontend type."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3260 src/dvr/dvr_autorec.c:1279 src/dvr/dvr_timerec.c:660
+#: src/dvr/dvr_db.c:4487 src/dvr/dvr_autorec.c:1424 src/dvr/dvr_timerec.c:661
 msgid "Owner"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3261 src/dvr/dvr_timerec.c:661
+#: src/dvr/dvr_db.c:4488 src/dvr/dvr_timerec.c:662
 msgid "Owner of the entry."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1280
+#: src/dvr/dvr_autorec.c:1425
 msgid "Owner of the rule."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:393
+#: src/tvhlog.c:127
+msgid "PCR Clocks"
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux.c:396
 msgid "PEND"
 msgstr ""
 
-#: src/esfilter.c:679 src/esfilter.c:774 src/esfilter.c:869 src/esfilter.c:964
-#: src/esfilter.c:1069 src/esfilter.c:1151
+#: src/esfilter.c:671 src/esfilter.c:767 src/esfilter.c:863 src/esfilter.c:958
+#: src/esfilter.c:1066 src/esfilter.c:1149
 msgid "PID"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:316
+#: src/input/mpegts/satip/satip.c:373
 msgid "PIDs 21 in setup"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:297
-msgid "PIDs in setup"
-msgstr ""
-
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:482
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:546
-#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:168
-#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:206
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:214
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:544
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:608
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:181
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:239
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:639
 msgid "PIN"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:223
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:648
 msgid "PIN inquiry match string"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:224
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:649
 msgid "PIN inquiry match string."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:483
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:547
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:545
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:609
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:182
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:240
 msgid "PIN."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:269
+#: src/input/mpegts/mpegts_mux_dvb.c:266 src/input/mpegts/mpegts_mux_dvb.c:338
+#: src/input/mpegts/mpegts_mux_dvb.c:886 src/input/mpegts/mpegts_mux_dvb.c:1073
 msgid "PLP ID"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:501
+#: src/input/mpegts/mpegts_mux_dvb.c:525
 msgid "PLS code"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:493
+#: src/input/mpegts/mpegts_mux_dvb.c:517
 msgid "PLS mode"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3388
+#: src/descrambler/capmt.c:2752
+msgid "PMT Mode"
+msgstr ""
+
+#: src/descrambler/capmt.c:2753
+msgid "PMT mode."
+msgstr ""
+
+#: src/config.c:2512
+msgid "PROXY protocol & X-Forwarded-For"
+msgstr ""
+
+#: src/config.c:2513
+msgid ""
+"PROXY protocol is an extension for support incoming TCP connections from a "
+"remote server (like a firewall) sending the original IP address of the "
+"client. The HTTP header 'X-Forwarded-For' do the same with HTTP connections. "
+"Both enable tunneled connections.This option should be disabled for standard "
+"usage."
+msgstr ""
+
+#: src/config.c:2691
+msgid "Packet backlog"
+msgstr ""
+
+#: src/transcoding/codec/codecs/libs/libx26x.c:195
+#: src/transcoding/codec/codecs/libs/libx26x.c:294
+msgid "Parameters"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4623
 msgid "Parent entry"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3389
+#: src/dvr/dvr_db.c:4624
 msgid "Parent entry."
 msgstr ""
 
-#: src/input/mpegts/satip/satip_frontend.c:202
+#: src/dvr/dvr_db.c:4796
+msgid "Parental rating label UUID."
+msgstr ""
+
+#: src/config.c:2715
+msgid "Parse HbbTV info"
+msgstr ""
+
+#: src/config.c:2716
+msgid "Parse HbbTV information from services."
+msgstr ""
+
+#: src/input/mpegts/satip/satip_frontend.c:332
+msgid "Pass Spectrum inversion to the SAT>IP server."
+msgstr ""
+
+#: src/input/mpegts/satip/satip_frontend.c:331
+msgid "Pass specinv"
+msgstr ""
+
+#: src/input/mpegts/satip/satip_frontend.c:322
 msgid "Pass subscription weight"
 msgstr ""
 
-#: src/input/mpegts/satip/satip_frontend.c:203
+#: src/input/mpegts/satip/satip_frontend.c:323
 msgid ""
 "Pass subscription weight to the SAT>IP server (Tvheadend specific extension)."
 msgstr ""
 
-#: src/tvhlog.c:124
+#: src/channels.c:550
+msgid "Pass timeshift commands to a remote RTSP server"
+msgstr ""
+
+#: src/tvhlog.c:134
 msgid "Pass-thru muxer"
 msgstr ""
 
-#: src/tvhlog.c:115
+#: src/tvhlog.c:124
 msgid "Passthrough Muxer SI Tables"
 msgstr ""
 
-#: src/access.c:2047 src/wizard.c:451 src/descrambler/cwc.c:1841
+#: src/access.c:2281 src/wizard.c:453 src/descrambler/cclient.c:1387
 msgid "Password"
 msgstr ""
 
-#: src/access.c:2048
+#: src/access.c:2282
 msgid "Password for the entry."
 msgstr ""
 
-#: src/access.c:2056
+#: src/access.c:2290
 msgid "Password2"
 msgstr ""
 
-#: src/epggrab/module.c:178 src/epggrab/module.c:205 src/epggrab/channel.c:771
+#: src/epggrab/module.c:201 src/epggrab/module.c:228 src/epggrab/channel.c:789
 msgid "Path"
 msgstr ""
 
-#: src/config.c:2353
+#: src/config.c:2427
 msgid ""
 "Path to a directory (folder) containing your picon collection. See Help for "
 "more detailed information."
 msgstr ""
 
-#: src/config.c:2328
+#: src/config.c:2402
 msgid ""
 "Path to an icon for this channel. This can be named however you wish, as "
 "either a local (file://) or remote (http://) image. See Help for more "
 "infomation."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:71
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:105
 msgid "Path to the frontend used by the device."
 msgstr ""
 
-#: src/epggrab/module.c:179
+#: src/epggrab/module.c:202
 msgid "Path to the grabber executable."
 msgstr ""
 
-#: src/epggrab/module.c:206
+#: src/epggrab/module.c:229
 msgid "Path to the socket Tvheadend will read data from."
 msgstr ""
 
-#: src/timeshift.c:215
+#: src/timeshift.c:213
 msgid ""
 "Path to where the timeshift data will be stored. If nothing is specified "
 "this will default to CONF_DIR/timeshift/buffer."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_adapter.c:120
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:259
+#: src/input/mpegts/linuxdvb/linuxdvb_adapter.c:160
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:684
 msgid "Path used by the device."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1061
+#: src/dvr/dvr_config.c:1127
 msgid ""
 "Path where the recordings are stored. If components of the path do not "
 "exist, Tvheadend will try to create them."
 msgstr ""
 
-#: src/memoryinfo.c:77
+#: src/memoryinfo.c:78
 msgid "Peak count of objects"
 msgstr ""
 
-#: src/memoryinfo.c:61
+#: src/memoryinfo.c:62
 msgid "Peak size"
 msgstr ""
 
-#: src/epg.c:2389
+#: src/epg.c:1889
 msgid "Performing arts"
 msgstr ""
 
-#: src/epggrab.c:315
+#: src/epggrab.c:409
 msgid "Periodically save EPG to disk (hours)"
 msgstr ""
 
-#: src/access.c:1665 src/config.c:2093
+#: src/access.c:2299
+msgid "Persistent authentication"
+msgstr ""
+
+#: src/access.c:2311
+msgid "Persistent authentication code"
+msgstr ""
+
+#: src/access.c:1774
 msgid "Persistent user interface level"
 msgstr ""
 
-#: src/epg.c:2427
+#: src/config.c:2275
+msgid "Persistent view level"
+msgstr ""
+
+#: src/epg.c:1927
 msgid "Physiology"
 msgstr ""
 
-#: src/profile.c:1333
+#: src/profile.c:1947
 msgid "Pick the stream with given audio type only."
 msgstr ""
 
-#: src/config.c:2044
-msgid "Picon"
-msgstr ""
-
-#: src/config.c:2364
+#: src/config.c:2438
 msgid "Picon name scheme"
 msgstr ""
 
-#: src/config.c:2352
+#: src/config.c:2426
 msgid "Picon path"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:479
+#: src/input/mpegts/mpegts_mux_dvb.c:503
 msgid "Pilot"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:461
+#: src/transcoding/codec/profile_video_class.c:223
+msgid "Pixel format"
+msgstr ""
+
+#: src/config.c:2109
+msgid "Plain (insecure)"
+msgstr ""
+
+#: src/webui/webui.c:193
+#, c-format
+msgid ""
+"Please, follow %s link and cancel the next authorization to correctly clear "
+"the cached browser credentals (login and password cache). Then click to the "
+"'Default login' (anonymous access) or 'New login' link in the error page to "
+"reauthenticate."
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux_dvb.c:485
 msgid "Polarization"
 msgstr ""
 
-#: src/epg.c:2406
+#: src/epg.c:1906
 msgid "Political issues"
 msgstr ""
 
-#: src/tvhlog.c:83
+#: src/tvhlog.c:92
 msgid "Poll multiplexer"
 msgstr ""
 
-#: src/epg.c:2371
+#: src/epg.c:1871
 msgid "Pop"
 msgstr ""
 
-#: src/epg.c:2392
+#: src/epg.c:1892
 msgid "Popular culture"
 msgstr ""
 
-#: src/descrambler/cwc.c:1858
+#: src/descrambler/cclient.c:1406
 msgid "Port"
 msgstr ""
 
-#: src/descrambler/cwc.c:1859
+#: src/descrambler/cclient.c:1407
 msgid "Port to connect to."
 msgstr ""
 
-#: src/descrambler/capmt.c:2399
-msgid "Port to listen on."
+#: src/descrambler/capmt.c:2735
+msgid "Port to listen on or to connect to."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:148
-#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:186
-#: src/input/mpegts/satip/satip_satconf.c:369
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:189
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:247
+#: src/input/mpegts/satip/satip_satconf.c:386
 msgid "Position"
 msgstr ""
 
-#: src/input/mpegts/satip/satip_satconf.c:370
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:190
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:248
+msgid "Position ID."
+msgstr ""
+
+#: src/input/mpegts/satip/satip_satconf.c:387
 msgid "Position of the input."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1040
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:153
+msgid "Position to send to the external command"
+msgstr ""
+
+#: src/dvr/dvr_config.c:1466
 msgid "Post-processor command"
 msgstr ""
 
-#: src/channels.c:481 src/dvr/dvr_db.c:3094 src/dvr/dvr_config.c:975
+#: src/channels.c:527 src/dvr/dvr_db.c:4272 src/dvr/dvr_config.c:1030
 msgid "Post-recording padding"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1050
+#: src/dvr/dvr_config.c:1476
 msgid "Post-remove command"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:111
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:162
 msgid "Power save"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:152
-#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:101
-msgid "Power-up time (ms) (15-200)"
+#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:124
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:102
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:150
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:208
+msgid "Power up time (ms) (10-500)"
 msgstr ""
 
-#: src/wizard.c:791 src/input/mpegts/mpegts_network_dvb.c:247
+#: src/wizard.c:800 src/input/mpegts/mpegts_network_dvb.c:247
 #: src/input/mpegts/mpegts_network_dvb.c:270
 #: src/input/mpegts/mpegts_network_dvb.c:293
 #: src/input/mpegts/mpegts_network_dvb.c:326
 #: src/input/mpegts/mpegts_network_dvb.c:349
-#: src/input/mpegts/mpegts_network_dvb.c:372
-#: src/input/mpegts/mpegts_network_dvb.c:395
-#: src/input/mpegts/mpegts_network_dvb.c:418
-#: src/input/mpegts/mpegts_network_dvb.c:441
+#: src/input/mpegts/mpegts_network_dvb.c:382
+#: src/input/mpegts/mpegts_network_dvb.c:405
+#: src/input/mpegts/mpegts_network_dvb.c:428
+#: src/input/mpegts/mpegts_network_dvb.c:451
+#: src/input/mpegts/mpegts_network_dvb.c:474
 msgid "Pre-defined muxes"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1029
+#: src/dvr/dvr_config.c:1455
 msgid "Pre-processor command"
 msgstr ""
 
-#: src/channels.c:466 src/dvr/dvr_db.c:3066 src/dvr/dvr_config.c:958
+#: src/channels.c:512 src/dvr/dvr_db.c:4244 src/dvr/dvr_config.c:1014
 msgid "Pre-recording padding"
 msgstr ""
 
-#: src/epg.c:2353
+#: src/epg.c:1853
 msgid "Pre-school children's programs"
 msgstr ""
 
-#: src/config.c:2317
-msgid "Prefer picons over channel name"
+#: src/wizard.c:965
+msgid "Predefined Muxes"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:212
+#: src/config.c:2391
+msgid "Prefer picons over channel icons"
+msgstr ""
+
+#: src/input/mpegts/mpegts_service.c:214
 msgid "Preferred CA PID"
 msgstr ""
 
-#: src/profile.c:1889
+#: src/transcoding/codec/profile_audio_class.c:267
+#: src/transcoding/codec/profile_audio_class.c:277
+#: src/transcoding/codec/profile_audio_class.c:287
 msgid "Preferred audio language."
 msgstr ""
 
-#: src/profile.c:401
+#: src/profile.c:434
 msgid "Preferred service video type"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:463
+#: src/input/mpegts/satip/satip.c:530
 msgid "Presentation"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:464
+#: src/input/mpegts/satip/satip.c:531
 msgid "Presentation details."
 msgstr ""
 
-#: src/epg.c:2396
+#: src/transcoding/codec/codecs/libs/libx26x.c:171
+#: src/transcoding/codec/codecs/libs/libx26x.c:270
+msgid "Preset"
+msgstr ""
+
+#: src/epg.c:1896
 msgid "Press"
 msgstr ""
 
-#: src/access.c:1666
+#: src/access.c:1775
 msgid ""
 "Prevent the user from overriding the default user interface level setting "
 "and removes the view level drop-dowm from the interface."
 msgstr ""
 
-#: src/config.c:2094
+#: src/config.c:2276
 msgid ""
-"Prevents users from overriding the above user interface level setting and "
-"removes the view level drop-dowm from the interface."
+"Prevent users from overriding the view level setting. This option shows or "
+"hides the View level drop-down (next to the Help button)."
 msgstr ""
 
-#: src/epggrab/module.c:156 src/dvr/dvr_db.c:3200 src/dvr/dvr_autorec.c:1180
-#: src/dvr/dvr_timerec.c:619 src/input/mpegts/mpegts_input.c:240
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1445
-#: src/input/mpegts/satip/satip_satconf.c:352 src/input/mpegts/iptv/iptv.c:759
-#: src/input/mpegts/iptv/iptv_mux.c:123
+#: src/streaming.c:474
+msgid "Previously recorded"
+msgstr ""
+
+#: src/epggrab/module.c:179 src/dvr/dvr_db.c:4424 src/dvr/dvr_autorec.c:1343
+#: src/dvr/dvr_timerec.c:617 src/dvr/dvr_config.c:961
+#: src/input/mpegts/mpegts_input.c:248
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1559
+#: src/input/mpegts/satip/satip_satconf.c:369 src/input/mpegts/iptv/iptv.c:842
+#: src/input/mpegts/iptv/iptv_mux.c:113
 msgid "Priority"
 msgstr ""
 
-#: src/service.c:211
+#: src/service.c:204
 msgid "Priority (-10..10)"
 msgstr ""
 
-#: src/dvr/dvr_timerec.c:620
+#: src/dvr/dvr_config.c:962
 msgid ""
 "Priority of the entry, higher-priority entries will take precedence and "
 "cancel lower-priority events."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3201
+#: src/dvr/dvr_db.c:4425 src/dvr/dvr_autorec.c:1344 src/dvr/dvr_timerec.c:618
 msgid ""
 "Priority of the recording. Higher priority entries will take precedence and "
-"cancel lower-priority events."
+"cancel lower-priority events. The 'Not Set' value inherits the settings from "
+"the assigned DVR configuration."
 msgstr ""
 
-#: src/channels.c:1471
+#: src/channels.c:1808
 msgid "Private"
 msgstr ""
 
-#: src/profile.c:326
+#: src/descrambler/capmt.c:2609
+msgid "Problematic: OSCam new pc-nodmx (rev >= 10389)"
+msgstr ""
+
+#: src/epggrab.c:432
+msgid "Process Parental Rating Labels"
+msgstr ""
+
+#: src/transcoding/codec/profile_class.c:277
+msgid "Profile"
+msgstr ""
+
+#: src/transcoding/codec/profile_class.c:203
+msgid "Profile Settings"
+msgstr ""
+
+#: src/transcoding/codec/profile_class.c:234
+msgid "Profile description."
+msgstr ""
+
+#: src/profile.c:314
 msgid "Profile name"
 msgstr ""
 
-#: src/esfilter.c:680 src/esfilter.c:775 src/esfilter.c:870 src/esfilter.c:965
-#: src/esfilter.c:1070 src/esfilter.c:1152
+#: src/transcoding/codec/profile_class.c:278
+msgid "Profile."
+msgstr ""
+
+#: src/esfilter.c:672 src/esfilter.c:768 src/esfilter.c:864 src/esfilter.c:959
+#: src/esfilter.c:1067 src/esfilter.c:1150
 msgid ""
 "Program identification (PID) number to compare. Zero means any. This "
 "comparison is processed only when service comparison is active and for the "
 "Conditional Access filter."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3193
+#: src/dvr/dvr_db.c:4408
 msgid "Program synopsis (display only)."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3185
+#: src/dvr/dvr_db.c:4400
 msgid "Program synopsis."
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:168
+#: src/dvr/dvr_db.c:4581
+msgid "Program unique ID (from grabber)"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4582
+msgid "Program unique ID (from grabber), such as MV101010101.0000"
+msgstr ""
+
+#: src/wizard.c:779
+msgid "Progress"
+msgstr ""
+
+#: src/descrambler/cccam.c:1027
+msgid "Protocol version."
+msgstr ""
+
+#: src/input/mpegts/mpegts_service.c:170
 msgid "Provider"
 msgstr ""
 
-#: src/descrambler/constcw.c:299 src/descrambler/constcw.c:365
+#: src/descrambler/constcw.c:334 src/descrambler/constcw.c:407
+#: src/descrambler/constcw.c:480 src/descrambler/constcw.c:553
 msgid "Provider ID"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:167 src/input/mpegts/mpegts_mux.c:572
+#: src/input/mpegts/mpegts_network.c:207 src/input/mpegts/mpegts_mux.c:587
 msgid "Provider network name"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:168
+#: src/input/mpegts/mpegts_network.c:208
 msgid "Provider's network name."
 msgstr ""
 
-#: src/epg.c:2427
+#: src/epg.c:1927
 msgid "Psychology"
 msgstr ""
 
-#: src/epg.c:2357
+#: src/epg.c:1857
 msgid "Puppets"
 msgstr ""
 
-#: src/tvhlog.c:163
+#: src/tvhlog.c:175
 msgid "PyEPG Import"
 msgstr ""
 
-#: src/profile.c:1696
-msgid "Quad (4.0)"
+#: src/transcoding/codec/codecs/libs/libvpx.c:106
+msgid "Quality"
 msgstr ""
 
-#: src/epg.c:2317
+#: src/transcoding/codec/codecs/aac.c:98
+#: src/transcoding/codec/codecs/mpeg2video.c:59
+#: src/transcoding/codec/codecs/vorbis.c:50
+#: src/transcoding/codec/codecs/libs/libtheora.c:59
+#: src/transcoding/codec/codecs/libs/libvorbis.c:78
+msgid "Quality (0=auto)"
+msgstr ""
+
+#: src/transcoding/codec/codecs/libs/libvpx.c:119
+msgid "Quality/Speed ratio modifier."
+msgstr ""
+
+#: src/tvhlog.c:90
+msgid "Queue profiling"
+msgstr ""
+
+#: src/epg.c:1817
 msgid "Quiz"
 msgstr ""
 
-#: src/timeshift.c:276
+#: src/timeshift.c:274
 msgid "RAM only"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:235
-msgid "RTP/AVP/TCP (embedded data)"
+#: src/satip/server.c:799
+msgid "RTP Local bind IP address"
 msgstr ""
 
-#: src/tvhlog.c:92
+#: src/satip/server.c:756
+msgid "RTP over TCP payload"
+msgstr ""
+
+#: src/input/mpegts/satip/satip_frontend.c:222
+msgid "RTP over UDP"
+msgstr ""
+
+#: src/input/mpegts/satip/satip.c:278
+msgid "RTP/AVP/TCP transport supported"
+msgstr ""
+
+#: src/tvhlog.c:101
 msgid "RTSP Protocol"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:359
+#: src/input/mpegts/satip/satip.c:426
 msgid "RTSP port"
 msgstr ""
 
-#: src/satip/server.c:611
+#: src/satip/server.c:687
 msgid "RTSP port (554 or 9983, 0 = disable)"
 msgstr ""
 
-#: src/service.c:157
+#: src/service.c:148
 msgid "Radio"
 msgstr ""
 
-#: src/profile.c:1681
+#: src/dvr/dvr_db.c:4806
+msgid "Rating Icon"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4807
+msgid "Rating Icon URL."
+msgstr ""
+
+#: src/dvr/dvr_db.c:4814
+msgid "Rating Label"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4795
+msgid "Rating Label UUID"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4815
+msgid "Rating Label."
+msgstr ""
+
+#: src/tvhlog.c:188
+msgid "Rating Labels"
+msgstr ""
+
+#: src/ratinglabels.c:633
+msgid "Rating label to be displayed."
+msgstr ""
+
+#: src/profile.c:2264
 msgid "Raw Audio Stream"
 msgstr ""
 
-#: src/imagecache.c:106
+#: src/imagecache.c:118
 msgid "Re-fetch period (hours)"
 msgstr ""
 
-#: src/bouquet.c:1063 src/input/mpegts/iptv/iptv.c:917
+#: src/bouquet.c:1090 src/input/mpegts/iptv/iptv.c:978
 msgid "Re-fetch period (mins)"
 msgstr ""
 
-#: src/bouquet.c:1064
+#: src/bouquet.c:1091
 msgid "Re-fetch the bouquet every x minutes."
 msgstr ""
 
-#: src/dvr/dvr_db.c:1201
+#: src/dvr/dvr_db.c:1471
 #, c-format
 msgid "Re-record%s%s"
 msgstr ""
 
-#: src/imagecache.c:114
+#: src/imagecache.c:126
 msgid "Re-try period (hours)"
 msgstr ""
 
-#: src/htsp_server.c:2768
+#: src/htsp_server.c:2998
 msgid "Read error"
 msgstr ""
 
-#: src/satip/server.c:612
+#: src/satip/server.c:688
 msgid ""
 "Real Time Streaming Protocol (RTSP) port the server should listen on (554 or "
 "9983, 0 = disable)."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:937
+#: src/config.c:2459
+msgid "Realm name"
+msgstr ""
+
+#: src/dvr/dvr_autorec.c:1003
 msgid "Record all"
 msgstr ""
 
-#: src/dvr/dvr_timerec.c:608
+#: src/dvr/dvr_timerec.c:606
 msgid "Record on these days only."
 msgstr ""
 
-#: src/dvr/dvr_config.c:817
-msgid "Recording file options"
+#: src/dvr/dvr_config.c:984
+msgid "Recorded file(s) retention period"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3441
+#: src/dvr/dvr_db.c:4686
 msgid "Recording file size."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3240
+#: src/dvr/dvr_config.c:973
+msgid "Recording info retention period"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4467
 msgid "Recording play count"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1060
-msgid "Recording system path"
-msgstr ""
-
-#: src/satip/server.c:570
+#: src/satip/server.c:620
 msgid "Reject"
 msgstr ""
 
-#: src/satip/server.c:571
+#: src/satip/server.c:621
 msgid "Reject exact match"
 msgstr ""
 
-#: src/channels.c:1492
+#: src/channels.c:1829
 msgid "Relative path to the imagecache copy of the icon."
 msgstr ""
 
-#: src/epg.c:2391
+#: src/epg.c:1891
 msgid "Religion"
 msgstr ""
 
-#: src/epg.c:2287
+#: src/epg.c:1787
 msgid "Religious"
 msgstr ""
 
-#: src/epg.c:2409
+#: src/epg.c:1909
 msgid "Remarkable people"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:940
+#: src/channels.c:549
+msgid "Remote timeshift"
+msgstr ""
+
+#: src/input/mpegts/iptv/iptv.c:1002
 msgid "Remove HTTP arguments"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1257
+#: src/dvr/dvr_config.c:1341
 msgid "Remove all unsafe characters from filename"
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:315 src/input/mpegts/iptv/iptv.c:819
+#: src/input/mpegts/mpegts_input.c:326 src/input/mpegts/iptv/iptv.c:902
 msgid "Remove scrambled bits"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:977
+#: src/satip/server.c:947
+msgid ""
+"Remove server support for RTP/AVP/TCP transfer mode (embedded data in the "
+"RTSP session)."
+msgstr ""
+
+#: src/profile.c:1849
+msgid "Reorder DVB subtitle packets."
+msgstr ""
+
+#: src/profile.c:1848
+msgid "Reorder DVBSUB"
+msgstr ""
+
+#: src/dvr/dvr_autorec.c:1047
 msgid "Repeated"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1268
+#: src/satip/server.c:957
+msgid ""
+"Replace the full Transport Stream with a range 0x00-0x02,0x10-0x1F,0x1FFB "
+"pids only."
+msgstr ""
+
+#: src/dvr/dvr_config.c:1353
 msgid "Replace whitespace in title with '-'"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1269
+#: src/dvr/dvr_config.c:1354
 msgid "Replaces all whitespace in the title with '-'."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:206
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:631
 msgid "Reply to CAM PIN inquiries"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:207
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:632
 msgid "Reply to PIN inquiries."
 msgstr ""
 
-#: src/epg.c:2407
+#: src/epg.c:1907
 msgid "Reports"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3465
+#: src/dvr/dvr_db.c:4710
 msgid "Rerun of"
 msgstr ""
 
-#: src/streaming.c:585
+#: src/streaming.c:621
 msgid "Reserved"
 msgstr ""
 
-#: src/profile.c:1865
-msgid "Resolution (height)"
+#: src/access.c:2217
+msgid "Reset"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:201
+#: src/input/mpegts/iptv/iptv_mux.c:228
 msgid "Respawn (pipe)"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_sched.c:170
+#: src/input/mpegts/mpegts_mux_sched.c:171
 msgid "Restart"
 msgstr ""
 
-#: src/profile.c:378
+#: src/profile.c:388
 msgid "Restart on error"
 msgstr ""
 
-#: src/profile.c:379
+#: src/profile.c:389
 msgid ""
 "Restart streaming on error. This is useful for DVR so a recording isn't "
 "aborted if an error occurs."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_sched.c:171
+#: src/input/mpegts/mpegts_mux_sched.c:172
 msgid ""
 "Restart when the subscription is overriden (in then timeout time window)."
 msgstr ""
 
-#: src/access.c:1787
+#: src/satip/server.c:956
+msgid "Restrict \"pids=all\""
+msgstr ""
+
+#: src/access.c:1896
 msgid "Restrict connections to this type."
 msgstr ""
 
-#: src/channels.c:535
+#: src/webui/comet.c:298
+msgid "Restricted log mode (no administrator)"
+msgstr ""
+
+#: src/input/mpegts/iptv/iptv_mux.c:144
+msgid "Retransmission URL"
+msgstr ""
+
+#: src/channels.c:591
 msgid "Reuse EPG from"
 msgstr ""
 
-#: src/channels.c:536
+#: src/channels.c:592
 msgid "Reuse the EPG from another channel."
 msgstr ""
 
-#: src/profile.c:1133
+#: src/profile.c:1429 src/profile.c:1719
 msgid "Rewrite EIT"
 msgstr ""
 
-#: src/profile.c:1134
+#: src/profile.c:1430 src/profile.c:1720
 msgid ""
 "Rewrite EIT (Event Information Table) packets to only include information "
-"about the currently-streamed service."
+"about the currently-streamed service. Rewrite can be unset only if 'Rewrite "
+"Service ID' is set to zero."
 msgstr ""
 
-#: src/profile.c:1088
-msgid "Rewrite MPEG-TS SI tables"
+#: src/profile.c:1348 src/profile.c:1598
+msgid "Rewrite MPEG-TS SI Table(s) Settings"
 msgstr ""
 
-#: src/profile.c:1109
+#: src/profile.c:1414 src/profile.c:1704
+msgid "Rewrite NIT"
+msgstr ""
+
+#: src/profile.c:1415 src/profile.c:1705
+msgid ""
+"Rewrite NIT (Network Information Table) packets to only include information "
+"about the currently-streamed service. Rewrite can be unset only if 'Rewrite "
+"Service ID' is set to zero."
+msgstr ""
+
+#: src/profile.c:1384 src/profile.c:1674
 msgid "Rewrite PAT"
 msgstr ""
 
-#: src/profile.c:1110
+#: src/profile.c:1385 src/profile.c:1675
 msgid ""
 "Rewrite PAT (Program Association Table) packets to only include information "
-"about the currently-streamed service."
+"about the currently-streamed service. Rewrite can be unset only if 'Rewrite "
+"Service ID' is set to zero."
 msgstr ""
 
-#: src/profile.c:1097 src/satip/server.c:651
+#: src/profile.c:1369 src/profile.c:1659 src/satip/server.c:926
 msgid "Rewrite PMT"
 msgstr ""
 
-#: src/profile.c:1098
+#: src/profile.c:1370 src/profile.c:1660
 msgid ""
 "Rewrite PMT (Program Map Table) packets to only include information about "
-"the currently-streamed service."
+"the currently-streamed service. Rewrite can be unset only if 'Rewrite "
+"Service ID' is set to zero."
 msgstr ""
 
-#: src/satip/server.c:652
+#: src/satip/server.c:927
 msgid ""
-"Rewrite Program Association Table (PMT) packets to only include information "
-"about the currently streamed service."
+"Rewrite Program Map Table (PMT) packets to only include information about "
+"the currently streamed service."
 msgstr ""
 
-#: src/profile.c:1121
+#: src/profile.c:1399 src/profile.c:1689
 msgid "Rewrite SDT"
 msgstr ""
 
-#: src/profile.c:1122
+#: src/profile.c:1400 src/profile.c:1690
 msgid ""
 "Rewrite SDT (Service Description Table) packets to only include information "
-"about the currently-streamed service."
+"about the currently-streamed service. Rewrite can be unset only if 'Rewrite "
+"Service ID' is set to zero."
 msgstr ""
 
-#: src/access.c:1416
+#: src/profile.c:1357 src/profile.c:1647
+msgid "Rewrite Service ID"
+msgstr ""
+
+#: src/profile.c:1358 src/profile.c:1648
+msgid ""
+"Rewrite service identifier (SID) using the specified value (usually 1). Zero "
+"means no rewrite."
+msgstr ""
+
+#: src/access.c:1513
 msgid "Rights"
 msgstr ""
 
-#: src/epg.c:2371
+#: src/epg.c:1871
 msgid "Rock"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:474
+#: src/input/mpegts/mpegts_mux_dvb.c:498
 msgid "Rolloff"
 msgstr ""
 
-#: src/epg.c:2286
+#: src/epg.c:1786
 msgid "Romance"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:645
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:698
 msgid "Rotor initialization time (seconds)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1481
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1595
 msgid "Rotor type"
 msgstr ""
 
-#: src/main.c:821
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:85
+#, c-format
+msgid "Rotor: %s"
+msgstr ""
+
+#: src/main.c:888
 msgid "Run as group"
 msgstr ""
 
-#: src/main.c:820
+#: src/main.c:887
 msgid "Run as user"
 msgstr ""
 
-#: src/subscriptions.c:967 src/dvr/dvr_db.c:627
+#: src/subscriptions.c:1025 src/dvr/dvr_db.c:654
 msgid "Running"
 msgstr ""
 
-#: src/input/mpegts/satip/satip_frontend.c:153
+#: src/epggrab/module/eit.c:1585
+msgid "Running state immediately"
+msgstr ""
+
+#: src/input/mpegts/satip/satip_frontend.c:253
 msgid "SAT->IP frontend number."
 msgstr ""
 
-#: src/input/mpegts/satip/satip_frontend.c:422
-msgid "SAT>IP ATSC-C Frontend"
-msgstr ""
-
-#: src/input/mpegts/satip/satip_frontend.c:412
+#: src/input/mpegts/satip/satip_frontend.c:601
 msgid "SAT>IP ATSC-T Frontend"
 msgstr ""
 
-#: src/tvhlog.c:158 src/input/mpegts/satip/satip.c:215
+#: src/tvhlog.c:170 src/input/mpegts/satip/satip.c:251
 msgid "SAT>IP Client"
 msgstr ""
 
-#: src/input/mpegts/satip/satip_frontend.c:146
-msgid "SAT>IP DVB Frontend"
+#: src/input/mpegts/mpegts_mux_dvb.c:544 src/input/mpegts/iptv/iptv_mux.c:280
+msgid "SAT>IP DVB-C frequency (Hz)"
 msgstr ""
 
-#: src/input/mpegts/satip/satip_frontend.c:393
-msgid "SAT>IP DVB-C Frontend"
+#: src/input/mpegts/iptv/iptv_mux.c:288
+msgid "SAT>IP DVB-S frequency (kHz)"
 msgstr ""
 
-#: src/input/mpegts/satip/satip_frontend.c:316
-msgid "SAT>IP DVB-S Frontend"
-msgstr ""
-
-#: src/input/mpegts/satip/satip_frontend.c:361
-msgid "SAT>IP DVB-S Slave Frontend"
-msgstr ""
-
-#: src/input/mpegts/satip/satip_frontend.c:228
-msgid "SAT>IP DVB-T Frontend"
-msgstr ""
-
-#: src/input/mpegts/iptv/iptv_mux.c:245
+#: src/input/mpegts/mpegts_mux_dvb.c:552 src/input/mpegts/iptv/iptv_mux.c:272
 msgid "SAT>IP DVB-T frequency (Hz)"
 msgstr ""
 
-#: src/main.c:842
+#: src/input/mpegts/satip/satip_frontend.c:621
+msgid "SAT>IP ISDB-T Frontend"
+msgstr ""
+
+#: src/main.c:909
 msgid ""
 "SAT>IP RTSP port number for server\n"
 "(default: -1 = disable, 0 = webconfig, standard port is 554)"
 msgstr ""
 
-#: src/input/mpegts/satip/satip_satconf.c:328
+#: src/input/mpegts/satip/satip_satconf.c:338
 msgid "SAT>IP Satellite Configuration"
 msgstr ""
 
-#: src/tvhlog.c:159
+#: src/tvhlog.c:171
 msgid "SAT>IP Server"
 msgstr ""
 
-#: src/tvhlog.c:116
+#: src/tvhlog.c:125
 msgid "SAT>IP Server SI Tables"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:244
+#: src/input/mpegts/mpegts_network.c:293
 msgid "SAT>IP source number"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:472
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:536
-#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:161
-#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:199
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:525
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:589
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:166
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:224
 msgid "SCR (ID)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:473
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:537
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:526
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:590
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:167
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:225
 msgid "SCR (Satellite Channel Router) ID."
 msgstr ""
 
-#: src/service.c:158
+#: src/service.c:149
 msgid "SD TV"
 msgstr ""
 
-#: src/profile.c:267
+#: src/profile.c:274
 msgid "SD: standard definition"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:107
+#: src/config.c:2121
+msgid "SHA-256"
+msgstr ""
+
+#: src/config.c:2122
+msgid "SHA-512/256"
+msgstr ""
+
+#: src/proplib.c:35
 msgid "SIGHUP"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:106
+#: src/proplib.c:34
 msgid "SIGINT"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:104
+#: src/proplib.c:32
 msgid "SIGKILL"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:105
+#: src/proplib.c:33
 msgid "SIGTERM"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:108
+#: src/proplib.c:36
 msgid "SIGUSR1"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:109
+#: src/proplib.c:37
 msgid "SIGUSR2"
 msgstr ""
 
-#: src/bouquet.c:1054 src/input/mpegts/iptv/iptv.c:926
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:229
+msgid "SNR multiplier"
+msgstr ""
+
+#: src/bouquet.c:1081 src/input/mpegts/iptv/iptv.c:987
 msgid "SSL verify peer"
 msgstr ""
 
-#: src/tvhlog.c:75
+#: src/tvhlog.c:84
 msgid "START"
 msgstr ""
 
-#: src/tvhlog.c:76
+#: src/tvhlog.c:85
 msgid "STOP"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:777
+#: src/transcoding/codec/profile_audio_class.c:296
+msgid "Sample format"
+msgstr ""
+
+#: src/transcoding/codec/profile_audio_class.c:308
+msgid "Sample rate"
+msgstr ""
+
+#: src/transcoding/codec/profile_audio_class.c:309
+msgid "Samples per second."
+msgstr ""
+
+#: src/dvr/dvr_autorec.c:888
 msgid "Sat"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1422
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1529
 msgid "Satconf"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:272
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:342
 msgid "Satellite config"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:134
-#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:151
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:135
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:159
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:176
 msgid "Satellite longitude"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:135
-#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:152
-msgid "Satellite longitude."
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:136
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:160
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:177
+msgid "Satellite longitude (like 9.0 (east) or -33.0 (west))."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:128
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:129
 msgid "Satellite position."
 msgstr ""
 
-#: src/input/mpegts/satip/satip_frontend.c:322
+#: src/input/mpegts/satip/satip_frontend.c:482
 msgid "Satellite positions"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:741
+#: src/epggrab.c:421
+msgid "Save EPG to disk after xmltv import"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4785
+msgid "Saved Rating Icon Path"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4777
+msgid "Saved Rating Label"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4778
+msgid "Saved parental rating for once recording is complete."
+msgstr ""
+
+#: src/dvr/dvr_db.c:4786
+msgid "Saved parental rating icon for once recording is complete."
+msgstr ""
+
+#: src/transcoding/codec/profile_video_class.c:204
+msgid "Scaling mode"
+msgstr ""
+
+#: src/input/mpegts/iptv/iptv.c:824
 msgid "Scan after creation"
 msgstr ""
 
-#: src/wizard.c:770
-msgid "Scan progress"
-msgstr ""
-
-#: src/input/mpegts/mpegts_network.c:296
+#: src/input/mpegts/mpegts_network.c:345
 msgid "Scan queue length"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:617
+#: src/input/mpegts/mpegts_mux.c:632
 msgid "Scan result"
 msgstr ""
 
-#: src/wizard.c:1024 src/input/mpegts/mpegts_mux.c:605
+#: src/input/mpegts/mpegts_mux.c:620
 msgid "Scan status"
 msgstr ""
 
-#: src/tvhlog.c:167
+#: src/tvhlog.c:179
 msgid "Scanfile"
 msgstr ""
 
-#: src/dvr/dvr_config.c:935
-msgid "Schedule a re-recording if more errors than (0=off)"
+#: src/wizard.c:1050
+msgid "Scanning"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_sched.c:154
+#: src/input/mpegts/mpegts_mux_sched.c:155
 msgid "Schedule frequency (in cron format)."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3457
+#: src/dvr/dvr_db.c:4702
 msgid "Schedule status"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3458
+#: src/dvr/dvr_db.c:4703
 msgid "Schedule status."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3113
+#: src/dvr/dvr_db.c:4291
 msgid "Scheduled Duration"
 msgstr ""
 
-#: src/dvr/dvr_db.c:617
+#: src/dvr/dvr_db.c:644
 msgid "Scheduled for recording"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3078
+#: src/dvr/dvr_db.c:4256
 msgid "Scheduled start time"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3105
+#: src/dvr/dvr_db.c:4283
 msgid "Scheduled stop time"
 msgstr ""
 
-#: src/config.c:2341
+#: src/config.c:2415
 msgid ""
 "Scheme to generate the channel icon names (all lower-case, service name "
 "picons etc.)."
 msgstr ""
 
-#: src/epg.c:2356
+#: src/epg.c:1856
 msgid "School programs"
 msgstr ""
 
-#: src/epg.c:2424
+#: src/epg.c:1924
 msgid "Science"
 msgstr ""
 
-#: src/epg.c:2283
+#: src/epg.c:1783
 msgid "Science fiction"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1041
-msgid "Script/program to be run when a recording completes."
+#: src/epggrab/module.c:294
+msgid "Scrape Episode"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1051
-msgid "Script/program to be run when a recording gets removed."
+#: src/epggrab/module.c:315
+msgid "Scrape Subtitle"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1030
+#: src/epggrab/module.c:328
+msgid "Scrape Summary"
+msgstr ""
+
+#: src/epggrab/module.c:302
+msgid "Scrape Title"
+msgstr ""
+
+#: src/epggrab/module.c:257
+msgid "Scrape behaviour"
+msgstr ""
+
+#: src/epggrab/module/xmltv.c:1092
+msgid "Scrape credits and extra information"
+msgstr ""
+
+#: src/epggrab/module.c:277
+msgid "Scraper configuration to use"
+msgstr ""
+
+#: src/dvr/dvr_config.c:1467
+msgid "Script/program to run when a recording completes."
+msgstr ""
+
+#: src/dvr/dvr_config.c:1477
+msgid "Script/program to run when a recording gets removed."
+msgstr ""
+
+#: src/dvr/dvr_config.c:1456
 msgid ""
-"Script/program to be run when a recording starts (service is subscribed but "
-"no filename available)."
+"Script/program to run when a recording starts (service is subscribed but no "
+"filename available)."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1261
+#: src/dvr/dvr_db.c:3880
 msgid "Season"
 msgstr ""
 
-#: src/dvr/dvr_db.c:807
+#: src/dvr/dvr_db.c:927
 #, c-format
 msgid "Season %d"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1262
-msgid "Season information (if available)."
-msgstr ""
-
-#: src/htsp_server.c:2859
+#: src/htsp_server.c:3110
 msgid "Seek error"
 msgstr ""
 
-#: src/wizard.c:583
+#: src/wizard.c:585
 msgid "Select an available network type for this tuner."
+msgstr ""
+
+#: src/profile.c:2502
+msgid "Select audio codec profile to use for transcoding."
 msgstr ""
 
 #: src/wizard.c:210
 msgid "Select high priority (default) EPG language."
 msgstr ""
 
-#: src/satip/server.c:663
+#: src/satip/server.c:745
 msgid "Select how Tvheadend should handle muxes. See Help for details."
 msgstr ""
 
@@ -5709,13 +7261,13 @@ msgstr ""
 msgid "Select medium priority EPG language."
 msgstr ""
 
-#: src/config.c:2365
+#: src/config.c:2439
 msgid ""
 "Select scheme to generate the picon names (standard, force service type to 1)"
 msgstr ""
 
-#: src/profile.c:1955
-msgid "Select subtitle codec to use for transcoding."
+#: src/profile.c:2524
+msgid "Select subtitle codec profile to use for transcoding."
 msgstr ""
 
 #: src/wizard.c:198
@@ -5724,455 +7276,610 @@ msgid ""
 "\"Access Entries\" on a per-user basis."
 msgstr ""
 
-#: src/config.c:2199
+#: src/config.c:2346
 msgid ""
 "Select the list of languages (in order of priority) to be used for supplying "
 "EPG information to clients that don't provide their own configuration."
 msgstr ""
 
-#: src/input/mpegts/satip/satip_frontend.c:335
-#: src/input/mpegts/satip/satip_frontend.c:367
+#: src/input/mpegts/satip/satip_frontend.c:495
+#: src/input/mpegts/satip/satip_frontend.c:536
 msgid ""
 "Select the master tuner.The signal from the standard universal LNB can be "
 "split using a simple coaxial splitter (no multiswitch) to several outputs. "
 "In this case, the position, the polarization and low-high band settings must "
 "be equal.if you set other tuner as master, then this tuner will act like a "
-"slave one and tvheadend will assure that this tuner will not use "
+"slave one and Tvheadend will assure that this tuner will not use "
 "incompatible parameters (position, polarization, lo-hi)."
 msgstr ""
 
-#: src/input/mpegts/satip/satip_frontend.c:323
+#: src/input/mpegts/satip/satip_frontend.c:483
 msgid ""
 "Select the number of satellite positions supported by the SAT>IP hardware "
 "and your coaxial cable wiring."
 msgstr ""
 
-#: src/config.c:2270
+#: src/config.c:2703
 msgid ""
 "Select the path to use for DVB scan configuration files. Typically dvb-apps "
-"stores these in /usr/share/dvb/. Leave blank to use Tvheadend's internal "
-"file set."
+"stores these in /usr/share/dvb/. Leave blank to use the internal file set."
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:264
+#: src/satip/server.c:757
+msgid ""
+"Select the payload size for RTP contents used in the TCP embedded data mode. "
+"Some implementations like ffmpeg and VideoLAN have maximum limit 7896 bytes. "
+"The recommended value for tvheadend is 16356 or 32712 bytes."
+msgstr ""
+
+#: src/transcoding/codec/codecs/libs/libx26x.c:87
+msgid "Select the quality for constant quality mode [0-51]."
+msgstr ""
+
+#: src/transcoding/codec/codecs/libs/libvpx.c:96
+msgid "Select the quality for constant quality mode [0-63]."
+msgstr ""
+
+#: src/input/mpegts/mpegts_network.c:313
 msgid "Select the time offset for EIT events."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1080
+#: src/input/mpegts/satip/satip_frontend.c:261
+msgid "Select the transport used for this tuner."
+msgstr ""
+
+#: src/dvr/dvr_autorec.c:1197
 msgid "Select type of broadcast."
 msgstr ""
 
-#: src/imagecache.c:89
+#: src/profile.c:2480
+msgid "Select video codec profile to use for transcoding."
+msgstr ""
+
+#: src/imagecache.c:91
 msgid ""
-"Select whether or not to enable caching. Note: even with this disabled you "
+"Select whether or not to enable caching. Note, even with this disabled you "
 "can still specify local (file://) icons and these will be served by the "
 "built-in webserver."
 msgstr ""
 
-#: src/service_mapper.c:498
+#: src/service_mapper.c:589
 msgid "Select/Selected services to map."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:251
+#: src/descrambler/dvbcam.c:870
+msgid "Selection method for CAID."
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:676
 msgid "Send CAPMT OK query before descrambling."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:250
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:675
 msgid "Send CAPMT query"
 msgstr ""
 
-#: src/input/mpegts/satip/satip_frontend.c:181
+#: src/input/mpegts/iptv/iptv_mux.c:137
+msgid "Send RTCP status reports"
+msgstr ""
+
+#: src/input/mpegts/satip/satip_frontend.c:290
 msgid "Send full PLAY cmd"
 msgstr ""
 
-#: src/config.c:2187
+#: src/config.c:2692
 msgid ""
 "Send previous stream frames to upper layers (before frame start is signalled "
 "in the stream). It may cause issues with some clients / players."
 msgstr ""
 
-#: src/input/mpegts/satip/satip_frontend.c:182
+#: src/input/mpegts/satip/satip.c:362
+msgid "Send rolloff settings for DVB-S2"
+msgstr ""
+
+#: src/input/mpegts/satip/satip_frontend.c:291
 msgid ""
 "Send the full RTSP PLAY command after full RTSP SETUP command. Some devices "
 "firmware require this to get an MPEG-TS stream."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:383
+#: src/input/mpegts/satip/satip.c:450
 msgid "Serial number"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1270
+#: src/dvr/dvr_autorec.c:1416
 msgid "Series link"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1271
+#: src/dvr/dvr_autorec.c:1417
 msgid "Series link ID."
 msgstr ""
 
-#: src/epg.c:2287
+#: src/epg.c:1787
 msgid "Serious"
 msgstr ""
 
-#: src/epg.c:2372
+#: src/epg.c:1872
 msgid "Serious music"
 msgstr ""
 
-#: src/config.c:2024 src/input/mpegts/satip/satip.c:479
+#: src/input/mpegts/satip/satip.c:546
 msgid "Server"
 msgstr ""
 
-#: src/satip/server.c:602
+#: src/config.c:2171
+msgid "Server Settings"
+msgstr ""
+
+#: src/satip/server.c:678
 msgid "Server UUID"
 msgstr ""
 
-#: src/main.c:852
+#: src/main.c:919
 msgid "Server connectivity"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:480
+#: src/input/mpegts/satip/satip.c:547
 msgid "Server details."
 msgstr ""
 
-#: src/tvhlog.c:127 src/service.c:169 src/esfilter.c:656 src/esfilter.c:750
-#: src/esfilter.c:845 src/esfilter.c:940 src/esfilter.c:1045
-#: src/esfilter.c:1140
+#: src/config.c:2450
+msgid "Server name"
+msgstr ""
+
+#: src/tvhlog.c:137 src/service.c:161 src/esfilter.c:648 src/esfilter.c:743
+#: src/esfilter.c:839 src/esfilter.c:934 src/esfilter.c:1042
+#: src/esfilter.c:1138
 msgid "Service"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:120 src/input/mpegts/iptv/iptv.c:750
-#: src/descrambler/constcw.c:317 src/descrambler/constcw.c:383
+#: src/input/mpegts/mpegts_mux.c:695 src/input/mpegts/mpegts_service.c:122
+#: src/input/mpegts/iptv/iptv.c:833 src/descrambler/constcw.c:354
+#: src/descrambler/constcw.c:427 src/descrambler/constcw.c:500
+#: src/descrambler/constcw.c:573
 msgid "Service ID"
 msgstr ""
 
-#: src/tvhlog.c:130
+#: src/tvhlog.c:140
 msgid "Service Mapper"
 msgstr ""
 
-#: src/service_mapper.c:487
+#: src/wizard.c:1142
+msgid "Service Mapping"
+msgstr ""
+
+#: src/service_mapper.c:578
 msgid "Service Mapping (Map services to channels)"
 msgstr ""
 
-#: src/main.c:816
+#: src/main.c:883
 msgid "Service configuration"
 msgstr ""
 
-#: src/bouquet.c:930
+#: src/bouquet.c:957
 #, c-format
 msgid "Service count %zi"
 msgstr ""
 
-#: src/wizard.c:1116
-msgid "Service mapping"
+#: src/descrambler/dvbcam.c:861
+msgid "Service limit"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:160 src/input/mpegts/iptv/iptv_mux.c:181
+#: src/input/mpegts/mpegts_service.c:162 src/input/mpegts/iptv/iptv_mux.c:208
 msgid "Service name"
 msgstr ""
 
-#: src/epggrab/channel.c:799
+#: src/epggrab/channel.c:817
 msgid "Service name found in EPG data."
 msgstr ""
 
-#: src/config.c:1965
+#: src/config.c:2090
 msgid "Service name picons"
 msgstr ""
 
-#: src/service.c:212
+#: src/service.c:205
 msgid ""
 "Service priority. Enter a value between -10 and 10. A higher value indicates "
 "a higher preference. See Help for more info."
 msgstr ""
 
-#: src/service.c:250
+#: src/service.c:243
 msgid "Service raw"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:184
+#: src/input/mpegts/mpegts_service.c:186
 msgid "Service type"
 msgstr ""
 
-#: src/service.c:238
+#: src/service.c:231
 msgid ""
 "Service type override. This value will override the service type provided by "
 "the stream."
 msgstr ""
 
-#: src/channels.c:503 src/service_mapper.c:497 src/bouquet.c:1082
+#: src/channels.c:559 src/service_mapper.c:588 src/bouquet.c:1109
+#: src/bouquet.c:1127 src/input/mpegts/mpegts_mux.c:652
 msgid "Services"
 msgstr ""
 
-#: src/channels.c:504
+#: src/channels.c:560
 msgid "Services associated with the channel."
 msgstr ""
 
-#: src/profile.c:317
-msgid "Set profile as default."
+#: src/bouquet.c:1119
+msgid "Services seen"
 msgstr ""
 
-#: src/input/mpegts/satip/satip_satconf.c:345
+#: src/profile.c:335
+msgid "Set as default profile."
+msgstr ""
+
+#: src/input/mpegts/satip/satip_satconf.c:362
 msgid "Set the display name."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:271
+#: src/transcoding/codec/codecs/libs/libx26x.c:172
+msgid "Set the encoding preset (cf. x264 --fullhelp)."
+msgstr ""
+
+#: src/input/mpegts/satip/satip.c:315
 msgid "Set the maxiumum packet identifiers your SAT>IP server supports."
 msgstr ""
 
-#: src/config.c:2073
+#: src/config.c:2205
 msgid ""
-"Set the name of the server so you can distinguish multiple instances apart "
-"on your LAN."
+"Set the name of the server so you can distinguish multiple instances apart."
 msgstr ""
 
-#: src/input/mpegts/satip/satip_satconf.c:353
+#: src/config.c:2656
+msgid "Set the number of threads for IPTV to split load across more CPUs."
+msgstr ""
+
+#: src/input/mpegts/satip/satip_satconf.c:370
 msgid "Set the priority of this configuration."
 msgstr ""
 
-#: src/config.c:2082
-msgid "Sets the default interface view level (next to the Help button)."
+#: src/epggrab/module/eit.c:1576
+msgid ""
+"Set the short EIT destription to given target (subtitle, summary or both)."
 msgstr ""
 
-#: src/tvhlog.c:94 src/tvhlog.c:718 src/epggrab/module.c:120
+#: src/tvhlog.c:103
 msgid "Settings"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:240
+#: src/input/mpegts/mpegts_service.c:242
 msgid "Shift PTS (ms)"
 msgstr ""
 
-#: src/epg.c:2316
+#: src/epggrab/module/eit.c:1575
+msgid "Short EIT description"
+msgstr ""
+
+#: src/epg.c:1816
 msgid "Show"
 msgstr ""
 
-#: src/epg.c:2320 src/epg.c:2321 src/epg.c:2322 src/epg.c:2323 src/epg.c:2324
-#: src/epg.c:2325 src/epg.c:2326 src/epg.c:2327 src/epg.c:2328 src/epg.c:2329
-#: src/epg.c:2330 src/epg.c:2331
+#: src/epg.c:1820 src/epg.c:1821 src/epg.c:1822 src/epg.c:1823 src/epg.c:1824
+#: src/epg.c:1825 src/epg.c:1826 src/epg.c:1827 src/epg.c:1828 src/epg.c:1829
+#: src/epg.c:1830 src/epg.c:1831
 msgid "Show / Game show"
 msgstr ""
 
-#: src/main.c:813
+#: src/satip/server.c:698
+msgid ""
+"Show only information for sessions which are initiated from an IP address of "
+"the requester."
+msgstr ""
+
+#: src/main.c:880
 msgid "Show this page"
 msgstr ""
 
-#: src/main.c:814
+#: src/main.c:881
 msgid "Show version information"
 msgstr ""
 
-#: src/config.c:2236
+#: src/config.c:2299
 msgid ""
 "Show, hide and sort the various details that appear on the interface next to "
 "the About tab."
 msgstr ""
 
-#: src/streaming.c:465
+#: src/satip/server.c:661
+msgid "Signal Settings"
+msgstr ""
+
+#: src/satip/server.c:816
+msgid "Signal level for IPTV sources (0-240)."
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:219
+msgid "Signal multiplier"
+msgstr ""
+
+#: src/streaming.c:487
 msgid "Signal quality too poor"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:260
+#: src/input/mpegts/satip/satip.c:304
 msgid "Signal scale (240 or 100)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:666
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:719
 msgid "Site latitude"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:667
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:720
 msgid "Site latitude."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:674
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:727
 msgid "Site longitude"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:675
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:728
 msgid "Site longitude."
 msgstr ""
 
-#: src/memoryinfo.c:53
+#: src/memoryinfo.c:54
 msgid "Size"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:333
+#: src/input/mpegts/satip/satip.c:390
 msgid "Skip TS packets (0-200)"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:672
+#: src/input/mpegts/mpegts_mux.c:687
 msgid ""
 "Skip TSID checking. For when providers use invalid Transport Stream IDs."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1123
+#: src/dvr/dvr_config.c:1442
 msgid "Skip commercials"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:132
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:183
 msgid "Skip initial bytes"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:195
-msgid "Skip initial scan"
-msgstr ""
-
-#: src/input/mpegts/mpegts_network.c:196
+#: src/input/mpegts/mpegts_network.c:245
 msgid ""
-"Skip scanning known muxes when Tvheadend starts. If \"initial scan\" is "
+"Skip scanning known muxes when Tvheadend starts. If \"startup scan\" is "
 "allowed and new muxes are found then they will still be scanned. See Help "
 "for more details."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:334
+#: src/input/mpegts/mpegts_network.c:244
+msgid "Skip startup scan"
+msgstr ""
+
+#: src/input/mpegts/satip/satip.c:391
 msgid "Skip x number of transport packets."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3397
+#: src/dvr/dvr_db.c:4632
 msgid "Slave entry"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3398
+#: src/dvr/dvr_db.c:4633
 msgid "Slave entry."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:266
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:691
+msgid "Slot number"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:699
 msgid "Slot state"
 msgstr ""
 
-#: src/epg.c:2285
+#: src/epg.c:1785
 msgid "Soap"
 msgstr ""
 
-#: src/epg.c:2337
+#: src/epg.c:1837
 msgid "Soccer"
 msgstr ""
 
-#: src/epg.c:2406 src/epg.c:2429
+#: src/epg.c:1906 src/epg.c:1929
 msgid "Social"
 msgstr ""
 
-#: src/epg.c:2410 src/epg.c:2411 src/epg.c:2412 src/epg.c:2413 src/epg.c:2414
-#: src/epg.c:2415 src/epg.c:2416 src/epg.c:2417 src/epg.c:2418 src/epg.c:2419
-#: src/epg.c:2420 src/epg.c:2421
+#: src/epg.c:1910 src/epg.c:1911 src/epg.c:1912 src/epg.c:1913 src/epg.c:1914
+#: src/epg.c:1915 src/epg.c:1916 src/epg.c:1917 src/epg.c:1918 src/epg.c:1919
+#: src/epg.c:1920 src/epg.c:1921
 msgid "Social / Political issues / Economics"
 msgstr ""
 
-#: src/epg.c:2408
+#: src/epg.c:1908
 msgid "Social advisory"
 msgstr ""
 
-#: src/descrambler/capmt.c:2391
+#: src/descrambler/capmt.c:2727
 msgid "Socket or IP Address (when in TCP mode)."
 msgstr ""
 
-#: src/channels.c:1448
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:314
+msgid ""
+"Some DVB devices have an optional ioctl that allows changing between normal "
+"voltage for LNB (13V/18V) to a higher voltage mode (usually, 14V/19V), meant "
+"to compensate for voltage loss on long cabling. Without that, it is not "
+"possible to properly switch the polarization."
+msgstr ""
+
+#: src/dvr/dvr_config.c:1107
+msgid ""
+"Some artwork providers require additional arguments such as '--tmdb-key "
+"my_key_from_website'. These can be specified here. See Help for full details."
+msgstr ""
+
+#: src/service_mapper.c:638
+msgid ""
+"Some broadcasters distinguish channels by appending descriptors such as "
+"'HD'. This option strips those so 'Channel 4 HD' would be named 'Channel 4'. "
+"Note that xmltv settings may try and match by channel name so changing a "
+"channel name may require manual xmltv mapping."
+msgstr ""
+
+#: src/epggrab/module/xmltv.c:1117
+msgid ""
+"Some xmltv providers supply multiple category tags, however mapping to "
+"genres is imprecise and many categories have no genre mapping at all. Some "
+"frontends will only pass through categories unchanged if there is no genre "
+"so for these we can avoid the genre mappings and only use categories. If "
+"this option is not ticked then we continue to map xmltv categories to genres "
+"and supply both to clients."
+msgstr ""
+
+#: src/channels.c:1785
 msgid "Sort index"
 msgstr ""
 
-#: src/channels.c:1449
+#: src/channels.c:1786
 msgid "Sort index."
 msgstr ""
 
-#: src/bouquet.c:1073
+#: src/bouquet.c:1100
 msgid "Source"
 msgstr ""
 
-#: src/streaming.c:440
+#: src/profile.c:2512
+msgid "Source audio codec"
+msgstr ""
+
+#: src/streaming.c:460
 msgid "Source deleted"
 msgstr ""
 
-#: src/streaming.c:438
+#: src/streaming.c:458
 msgid "Source quality is bad"
 msgstr ""
 
-#: src/streaming.c:436
+#: src/streaming.c:456
 msgid "Source reconfigured"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:682
+#: src/profile.c:2534
+msgid "Source subtitle codec"
+msgstr ""
+
+#: src/profile.c:2490
+msgid "Source video codec"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:735
 msgid "Southern hemisphere (latitude direction)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:683
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:736
 msgid "Southern hemisphere (latitude direction)."
 msgstr ""
 
-#: src/tvhlog.c:85
+#: src/tvhlog.c:94
 msgid "Spawn"
 msgstr ""
 
-#: src/epg.c:2335
+#: src/profile.c:1594
+msgid "Spawn Settings"
+msgstr ""
+
+#: src/epg.c:1835
 msgid "Special events (Olympic Games, World Cup, etc.)"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:253
+#: src/input/mpegts/iptv/iptv_mux.c:297
 msgid ""
 "Specifies the incoming buffering limit in milliseconds (PCR based). If the "
 "PCR time difference from the system clock is higher than this, the incoming "
 "stream is paused."
 msgstr ""
 
-#: src/main.c:863
+#: src/main.c:930
 msgid "Specify User-Agent header for the http client"
 msgstr ""
 
-#: src/main.c:859
+#: src/main.c:926
 msgid "Specify alternative htsp port"
 msgstr ""
 
-#: src/main.c:855
+#: src/main.c:922
 msgid "Specify alternative http port"
 msgstr ""
 
-#: src/main.c:857
+#: src/main.c:924
 msgid "Specify alternative http webroot"
 msgstr ""
 
-#: src/main.c:854
+#: src/main.c:921
 msgid "Specify bind address"
 msgstr ""
 
-#: src/main.c:840
+#: src/main.c:907
 msgid "Specify bind address for SAT>IP server"
 msgstr ""
 
-#: src/main.c:861
+#: src/main.c:928
 msgid "Specify extra htsp port"
 msgstr ""
 
-#: src/access.c:1644
+#: src/access.c:1965
+msgid "Specify format for htsp output."
+msgstr ""
+
+#: src/access.c:1955
+msgid "Specify format for xmltv output."
+msgstr ""
+
+#: src/access.c:1753
 msgid "Specify the parameters to be changed. See Help for details."
 msgstr ""
 
-#: src/epg.c:2429
+#: src/transcoding/codec/codecs/libs/libvpx.c:118
+msgid "Speed"
+msgstr ""
+
+#: src/epg.c:1929
 msgid "Spiritual sciences"
 msgstr ""
 
-#: src/epg.c:2334 src/epg.c:2346 src/epg.c:2347 src/epg.c:2348 src/epg.c:2349
+#: src/epg.c:1834 src/epg.c:1846 src/epg.c:1847 src/epg.c:1848 src/epg.c:1849
 msgid "Sports"
 msgstr ""
 
-#: src/epg.c:2336
+#: src/epg.c:1836
 msgid "Sports magazines"
 msgstr ""
 
-#: src/epg.c:2338
+#: src/epg.c:1838
 msgid "Squash"
 msgstr ""
 
-#: src/config.c:1974 src/input/mpegts/mpegts_mux.c:501
+#: src/config.c:2099 src/input/mpegts/mpegts_mux.c:506
 msgid "Standard"
 msgstr ""
 
-#: src/dvr/dvr_timerec.c:584
+#: src/descrambler/capmt.c:2685
+msgid "Standard / auto"
+msgstr ""
+
+#: src/dvr/dvr_autorec.c:1216
+msgid "Star rating"
+msgstr ""
+
+#: src/dvr/dvr_timerec.c:582
 msgid "Start"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1099
+#: src/dvr/dvr_autorec.c:1228
 msgid "Start after"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1112
+#: src/dvr/dvr_autorec.c:1241
 msgid "Start before"
 msgstr ""
 
-#: src/channels.c:467
+#: src/channels.c:513
 msgid ""
 "Start recording earlier than the EPG/timer defined start time by x minutes, "
 "for example if a program is to start at 13:00 and you set a padding of 5 "
@@ -6181,178 +7888,260 @@ msgid ""
 "entry or DVR profile will be used."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3067
+#: src/dvr/dvr_db.c:4245
 msgid ""
 "Start recording earlier than the EPG/timer-defined start time by x minutes."
 msgstr ""
 
-#: src/dvr/dvr_config.c:959
-msgid ""
-"Start recording earlier than the defined Start recording earlier than the "
-"defined start time by x minutes: for example, if a program is to start at "
-"13:00 and you set a padding of 5 minutes it will start recording at 12:54:30 "
-"(including a warm-up time of 30 seconds). If this isn't specified, any pre-"
-"recording padding as set in the channel or DVR entry will be used."
-msgstr ""
-
-#: src/dvr/dvr_autorec.c:1126
+#: src/dvr/dvr_autorec.c:1255
 msgid "Start recording earlier than the defined start time by x minutes."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3057
+#: src/dvr/dvr_config.c:1015
+msgid ""
+"Start recording earlier than the defined start time by x minutes: for "
+"example, if a program is to start at 13:00 and you set a padding of 5 "
+"minutes it will start recording at 12:54:30 (including a warm-up time of 30 "
+"seconds). If this isn't specified, any pre-recording padding as set in the "
+"channel or DVR entry will be used."
+msgstr ""
+
+#: src/dvr/dvr_db.c:4235
 msgid "Start time"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3448 src/descrambler/caclient.c:295
+#: src/config.c:2565
+msgid ""
+"Starting port number of the UDP listeners. The listeners listen for traffic "
+"from the HDHomerun tuners. This is needed if you plan to run TVheadend in a "
+"container and you want to stream from an HDHomerun without enabling host "
+"networking for the container. Set this to 0 if you want the port numbers to "
+"be assigned dynamically. If you have multiple tuners, this will be the start "
+"of the port range. For example, if you have 4 tuners and you set this to "
+"9983, then tuner 0 will talk to port 9983, tuner 1 will talk to port 9984, "
+"tuner 2 will talk to port 9985, and tuner 3 will talk to port 9986."
+msgstr ""
+
+#: src/dvr/dvr_db.c:4693 src/descrambler/caclient.c:327
 msgid "Status"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:153
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:204
 msgid "Status period (ms)"
 msgstr ""
 
-#: src/profile.c:1694
-msgid "Stereo"
-msgstr ""
-
-#: src/dvr/dvr_timerec.c:595
+#: src/dvr/dvr_timerec.c:593
 msgid "Stop"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3086
+#: src/dvr/dvr_db.c:4264
 msgid "Stop time"
 msgstr ""
 
-#: src/timeshift.c:214
+#: src/dvr/dvr_config.c:1126 src/timeshift.c:212
 msgid "Storage path"
 msgstr ""
 
-#: src/config.c:1913
+#: src/config.c:2038
 msgid "Storage space"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:847
+#: src/transcoding/codec/profile_class.c:191
+msgid "Stream - Codec Profiles"
+msgstr ""
+
+#: src/profile.c:287
+msgid "Stream - Stream Profiles"
+msgstr ""
+
+#: src/esfilter.c:715
+msgid "Stream Filters - Audio"
+msgstr ""
+
+#: src/esfilter.c:1002
+msgid "Stream Filters - CA"
+msgstr ""
+
+#: src/esfilter.c:1110
+msgid "Stream Filters - Other"
+msgstr ""
+
+#: src/esfilter.c:907
+msgid "Stream Filters - Subtitles"
+msgstr ""
+
+#: src/esfilter.c:811
+msgid "Stream Filters - Teletext"
+msgstr ""
+
+#: src/esfilter.c:620
+msgid "Stream Filters - Video"
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux_dvb.c:941
 msgid "Stream ID"
 msgstr ""
 
-#: src/profile.c:279
-msgid "Stream Profile"
-msgstr ""
-
-#: src/esfilter.c:666 src/esfilter.c:761 src/esfilter.c:856 src/esfilter.c:951
-#: src/esfilter.c:1056 src/profile.c:1341
+#: src/esfilter.c:658 src/esfilter.c:754 src/esfilter.c:850 src/esfilter.c:945
+#: src/esfilter.c:1053 src/profile.c:1956
 msgid "Stream index"
 msgstr ""
 
-#: src/profile.c:1342
+#: src/profile.c:1957
 msgid "Stream index (starts with zero)."
 msgstr ""
 
-#: src/dvr/dvr_config.c:875
+#: src/dvr/dvr_config.c:948
 msgid "Stream profile"
 msgstr ""
 
-#: src/htsp_server.c:2443
+#: src/htsp_server.c:2663
 msgid "Stream setup error"
 msgstr ""
 
-#: src/esfilter.c:635 src/esfilter.c:729 src/esfilter.c:824 src/esfilter.c:919
-#: src/esfilter.c:1014 src/esfilter.c:1119
+#: src/esfilter.c:626 src/esfilter.c:721 src/esfilter.c:817 src/esfilter.c:913
+#: src/esfilter.c:1008 src/esfilter.c:1116
 msgid "Stream type"
 msgstr ""
 
-#: src/access.c:1345 src/access.c:1706
+#: src/access.c:1419 src/access.c:1815
 msgid "Streaming"
 msgstr ""
 
-#: src/tvhlog.c:133
+#: src/tvhlog.c:143
 msgid "Streaming Profile"
 msgstr ""
 
-#: src/access.c:1707
+#: src/access.c:1816
 msgid ""
 "Streaming flags, allow/disallow HTTP streaming, advanced HTTP streaming (e."
 "g, direct service or mux links), HTSP protocol streaming (e.g, Kodi (via pvr."
 "hts) or Movian."
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:251 src/input/mpegts/iptv/iptv.c:771
-#: src/input/mpegts/iptv/iptv_mux.c:131
+#: src/input/mpegts/mpegts_input.c:259 src/input/mpegts/iptv/iptv.c:854
+#: src/input/mpegts/iptv/iptv_mux.c:121
 msgid "Streaming priority"
 msgstr ""
 
-#: src/access.c:1436 src/access.c:1720
+#: src/access.c:1533 src/access.c:1829
 msgid "Streaming profiles"
 msgstr ""
 
-#: src/dvr/dvr_config.c:825
-msgid "Subdirectory options"
+#: src/dvr/dvr_config.c:893
+msgid "Subdirectory Settings"
 msgstr ""
 
-#: src/main.c:891
+#: src/dvr/dvr_config.c:1251
+msgid "Subdirectory for tvmovies for $q format specifier"
+msgstr ""
+
+#: src/dvr/dvr_config.c:1265
+msgid "Subdirectory for tvshows for $q format specifier"
+msgstr ""
+
+#: src/dvr/dvr_config.c:1252
+msgid ""
+"Subdirectory to use for tvmovies when using the $q specifier. This can "
+"contain any alphanumeric characters (A-Za-z0-9). Other characters may be "
+"supported depending on your OS and filesystem."
+msgstr ""
+
+#: src/dvr/dvr_config.c:1266
+msgid ""
+"Subdirectory to use for tvshows when using the $q specifier. This can "
+"contain any alphanumeric characters (A-Za-z0-9). Other characters may be "
+"supported depending on your OS and filesystem."
+msgstr ""
+
+#: src/main.c:958
 msgid "Subscribe to a service permanently"
 msgstr ""
 
-#: src/tvhlog.c:129
+#: src/tvhlog.c:139
 msgid "Subscription"
 msgstr ""
 
-#: src/htsp_server.c:2537 src/htsp_server.c:2564 src/htsp_server.c:2608
-#: src/htsp_server.c:2635 src/htsp_server.c:2663
+#: src/htsp_server.c:2762 src/htsp_server.c:2789 src/htsp_server.c:2833
+#: src/htsp_server.c:2860 src/htsp_server.c:2888
 msgid "Subscription does not exist"
 msgstr ""
 
-#: src/streaming.c:442
+#: src/streaming.c:462
 msgid "Subscription overridden"
 msgstr ""
 
-#: src/satip/server.c:621
+#: src/satip/server.c:714
 msgid "Subscription weight"
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv_mux.c:147
+#: src/input/mpegts/iptv/iptv_mux.c:162
 msgid "Substitute formatters"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3167 src/dvr/dvr_db.c:3175
+#: src/tvhlog.c:786
+msgid "Subsystem Output Settings"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4365 src/dvr/dvr_db.c:4373 src/epggrab/module/eit.c:1560
 msgid "Subtitle"
 msgstr ""
 
-#: src/esfilter.c:913
-msgid "Subtitle Stream Filter"
+#: src/epggrab/module/eit.c:1562
+msgid "Subtitle and summary"
 msgstr ""
 
-#: src/profile.c:1954
-msgid "Subtitle codec"
+#: src/profile.c:2523
+msgid "Subtitle codec profile"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3176
+#: src/dvr/dvr_db.c:4374
 msgid "Subtitle of the program (if any) (display only)."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3168
+#: src/dvr/dvr_db.c:4366
 msgid "Subtitle of the program (if any)."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:778
+#: src/dvr/dvr_db.c:4416
+msgid "Subtitle, summary or description of the program (if any)."
+msgstr ""
+
+#: src/dvr/dvr_db.c:4382 src/dvr/dvr_db.c:4390 src/epggrab/module/eit.c:1561
+msgid "Summary"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4391
+msgid "Summary of the program (if any) (display only)."
+msgstr ""
+
+#: src/dvr/dvr_db.c:4383
+msgid "Summary of the program (if any)."
+msgstr ""
+
+#: src/dvr/dvr_autorec.c:889
 msgid "Sun"
 msgstr ""
 
-#: src/profile.c:1695
-msgid "Surround (2 front, rear mono)"
-msgstr ""
-
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:636
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:689
 msgid "Switch before rotor"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:265
+#: src/input/mpegts/linuxdvb/linuxdvb_lnb.c:80
+msgid "Switch frequency offset"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:303
 msgid ""
 "Switch off the power to the LNB when idle. Note: this may cause interference "
 "with other devices when the LNB is powered back up."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1472
+#: src/profile.c:421
+msgid "Switch to another service"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1586
 msgid "Switch type"
 msgstr ""
 
@@ -6361,510 +8150,636 @@ msgstr ""
 msgid "Switch: %s"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:324 src/input/mpegts/mpegts_mux_dvb.c:455
-#: src/input/mpegts/mpegts_mux_dvb.c:602 src/input/mpegts/mpegts_mux_dvb.c:794
+#: src/input/mpegts/mpegts_mux_dvb.c:322 src/input/mpegts/mpegts_mux_dvb.c:479
+#: src/input/mpegts/mpegts_mux_dvb.c:642 src/input/mpegts/mpegts_mux_dvb.c:870
 msgid "Symbol rate (Sym/s)"
 msgstr ""
 
-#: src/dvr/dvr_config.c:711
+#: src/dvr/dvr_config.c:737
 msgid "Sync"
 msgstr ""
 
-#: src/dvr/dvr_config.c:712
+#: src/dvr/dvr_config.c:738
 msgid "Sync + Don't keep"
 msgstr ""
 
-#: src/dvr/dvr_config.c:709
+#: src/dvr/dvr_config.c:735
 msgid "System"
 msgstr ""
 
-#: src/tvhlog.c:91
+#: src/input/mpegts/satip/satip_frontend.c:223
+msgid "TCP Interleaved"
+msgstr ""
+
+#: src/tvhlog.c:100
 msgid "TCP Protocol"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:362
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:475
+msgid "TV Adapters - DTMB Frontend"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:432
 msgid "TV Adapters - Linux ATSC-C Frontend"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:351
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:421
 msgid "TV Adapters - Linux ATSC-T Frontend"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:405
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:485
 msgid "TV Adapters - Linux DAB Frontend"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:340
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:410
 msgid "TV Adapters - Linux DVB-C Frontend"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:266
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:336
 msgid "TV Adapters - Linux DVB-S Frontend (Master)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:309
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:379
 msgid "TV Adapters - Linux DVB-S Slave Frontend"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:185
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:256
 msgid "TV Adapters - Linux DVB-T Frontend"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:384
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:454
 msgid "TV Adapters - Linux ISDB-C Frontend"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:395
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:465
 msgid "TV Adapters - Linux ISDB-S Frontend (Master)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:373
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:443
 msgid "TV Adapters - Linux ISDB-T Frontend"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:348
+#: src/input/mpegts/satip/satip_frontend.c:611
+msgid "TV Adapters - SAT>IP ATSC-C Frontend"
+msgstr ""
+
+#: src/input/mpegts/satip/satip_frontend.c:246
+msgid "TV Adapters - SAT>IP DVB Frontend"
+msgstr ""
+
+#: src/input/mpegts/satip/satip_frontend.c:573
+msgid "TV Adapters - SAT>IP DVB-C Frontend"
+msgstr ""
+
+#: src/input/mpegts/satip/satip_frontend.c:476
+msgid "TV Adapters - SAT>IP DVB-S Frontend"
+msgstr ""
+
+#: src/input/mpegts/satip/satip_frontend.c:530
+msgid "TV Adapters - SAT>IP DVB-S Slave Frontend"
+msgstr ""
+
+#: src/input/mpegts/satip/satip_frontend.c:368
+msgid "TV Adapters - SAT>IP DVB-T Frontend"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:401
 msgid "TV Adapters - SatConfig - 4-Port"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:622
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:675
 msgid "TV Adapters - SatConfig - Advanced"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:95
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:96
 msgid "TV Adapters - SatConfig - DiseqC Rotor"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:118
+#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:117
 msgid "TV Adapters - SatConfig - DiseqC Switch"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:467
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:520
 msgid "TV Adapters - SatConfig - EN50494/UniCable I"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:531
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:584
 msgid "TV Adapters - SatConfig - EN50607/UniCable II"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:122
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:147
+msgid "TV Adapters - SatConfig - External Rotor"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:123
 msgid "TV Adapters - SatConfig - GOTOX Rotor"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:310
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:363
 msgid "TV Adapters - SatConfig - Tone Burst/2 Port"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:146
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:171
 msgid "TV Adapters - SatConfig - USALS Rotor"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:284
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:337
 msgid "TV Adapters - SatConfig - Universal LNB (Simple)"
 msgstr ""
 
-#: src/tvhlog.c:160
+#: src/tvhlog.c:172
 msgid "TVHDHomeRun Client"
 msgstr ""
 
-#: src/dvr/dvr_config.c:1112
+#: src/dvr/dvr_config.c:1375
 msgid "Tag files with metadata"
 msgstr ""
 
-#: src/channels.c:514
+#: src/channels.c:570
 msgid "Tags"
 msgstr ""
 
-#: src/channels.c:515
+#: src/channels.c:571
 msgid "Tags linked/to link to the channel."
 msgstr ""
 
-#: src/epg.c:2319
+#: src/epg.c:1819
 msgid "Talk show"
 msgstr ""
 
-#: src/epg.c:2339
+#: src/epg.c:1839
 msgid "Team sports (excluding football)"
 msgstr ""
 
-#: src/epg.c:2426
+#: src/epg.c:1926
 msgid "Technology"
 msgstr ""
 
 #: src/esfilter.c:818
-msgid "Teletext Stream Filter"
-msgstr ""
-
-#: src/esfilter.c:825
 msgid "Teletext stream type is only available for this filter."
 msgstr ""
 
-#: src/epg.c:2338
+#: src/epg.c:1838
 msgid "Tennis"
 msgstr ""
 
-#: src/subscriptions.c:963
+#: src/subscriptions.c:1021
 msgid "Testing"
 msgstr ""
 
-#: src/main.c:896
+#: src/main.c:963
 msgid "Testing options"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:153
+#: src/input/mpegts/mpegts_service.c:155
 msgid "The ATSC source ID as set by the provider."
 msgstr ""
 
-#: src/esfilter.c:1036
+#: src/esfilter.c:1032
 msgid "The CA provider to compare. Leave blank to apply to all providers."
 msgstr ""
 
-#: src/esfilter.c:1015
+#: src/esfilter.c:1009
 msgid "The CA stream type is only available for this filter."
 msgstr ""
 
-#: src/esfilter.c:1026
+#: src/esfilter.c:1021
 msgid "The CAID to compare. Leave blank to apply to all IDs."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:267
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:700
 msgid "The CAM slot status."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:236
+#: src/input/mpegts/mpegts_mux_dvb.c:233 src/input/mpegts/mpegts_mux_dvb.c:1040
 msgid ""
 "The COFDM modulation used by the mux. If you're not sure of the value leave "
 "as AUTO."
 msgstr ""
 
-#: src/service.c:230
+#: src/service.c:223
 msgid "The Conditional Access ID used for the service."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:598
+#: src/input/mpegts/mpegts_mux.c:613
 msgid "The Content reference identifier (CRID) authority."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3250
+#: src/dvr/dvr_db.c:4477
 msgid "The DVR profile to be used/used by the recording."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1242
+#: src/dvr/dvr_autorec.c:1406
 msgid "The DVR profile to be used/used by this rule."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3323
+#: src/dvr/dvr_db.c:4550
 msgid "The EPG ID used by the entry."
 msgstr ""
 
-#: src/epggrab/module.c:130
+#: src/epggrab/module.c:153
 msgid "The EPG grabber name."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:538
+#: src/input/mpegts/mpegts_mux.c:543
 msgid ""
 "The EPG grabber to use on the mux. Enable (auto) is the recommended value."
 msgstr ""
 
-#: src/epggrab/module.c:139
+#: src/input/mpegts/mpegts_mux.c:554
+msgid ""
+"The EPG grabber to use on the mux. The 'EPG scan' field must be set to "
+"'manual'."
+msgstr ""
+
+#: src/epggrab/module.c:162
 msgid "The EPG grabber type."
 msgstr ""
 
-#: src/esfilter.c:1120
+#: src/esfilter.c:1117
 msgid "The MPEGTS stream type is only available for this filter."
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:145
+#: src/input/mpegts/mpegts_service.c:147
 msgid "The OpenTV channel number as set by the provider."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:215
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:640
 msgid "The PIN to use."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:502
+#: src/input/mpegts/mpegts_mux_dvb.c:526
 msgid "The Physical Layer Scrambling (PLS) code used on the mux."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:494
+#: src/input/mpegts/mpegts_mux_dvb.c:518
 msgid "The Physical Layer Scrambling (PLS) mode used on the mux."
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:213
+#: src/input/mpegts/mpegts_service.c:215
 msgid ""
 "The Preferred Conditional Access Packet Identifier. Used for decrypting "
 "scrambled streams."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:376
+#: src/input/mpegts/satip/satip.c:443
 msgid "The SAT>IP server's name."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:368
+#: src/input/mpegts/satip/satip.c:435
 msgid "The SAT>IP server's universally unique identifier."
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:245
+#: src/input/mpegts/mpegts_network.c:294
 msgid "The SAT>IP source number."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:488
+#: src/input/mpegts/satip/satip.c:555
 msgid "The SAT>IP's discovered IP address."
 msgstr ""
 
-#: src/channels.c:422
-msgid "The URL (or path) to the icon to use/used for the channel."
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:230
+msgid ""
+"The SNR level reported by the driver is multiplied with this value and "
+"divided by 100."
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:882
+#: src/channels.c:457
+msgid ""
+"The URL to the icon to use/used for the channel. The local files are "
+"referred using file:/// URLs."
+msgstr ""
+
+#: src/input/mpegts/iptv/iptv.c:951
 msgid "The URL to the playlist."
 msgstr ""
 
-#: src/esfilter.c:730
+#: src/dvr/dvr_db.c:4770
+msgid "The age rating of the program."
+msgstr ""
+
+#: src/esfilter.c:722
 msgid "The audio stream types the filter should apply to."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:229 src/input/mpegts/mpegts_mux_dvb.c:686
+#: src/input/mpegts/mpegts_mux_dvb.c:226 src/input/mpegts/mpegts_mux_dvb.c:762
+#: src/input/mpegts/mpegts_mux_dvb.c:1033
 msgid ""
 "The bandwidth the mux uses. If you're not sure of the value leave as AUTO "
 "but be aware that tuning may fail as some drivers do not like the AUTO "
 "setting."
 msgstr ""
 
-#: src/channels.c:525
+#: src/channels.c:581
 msgid "The bouquet the channel is associated with."
 msgstr ""
 
-#: src/dvr/dvr_config.c:889
+#: src/dvr/dvr_config.c:1202
 msgid ""
 "The cache scheme to use/used to store recordings. Leave as \"system\" unless "
 "you have a special use case for one of the others. See Help for details."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3122
+#: src/dvr/dvr_autorec.c:1084
+msgid ""
+"The category of the program to look for. The xmltv providers often supply "
+"detailed categories such as Sitcom, Movie, Track/field, etc. This let you "
+"select from categories for current programmes. It is then combined (AND) "
+"with other fields to limit to programmes that match all categories. If this "
+"selection list is empty then it means your provider does not supply "
+"programme categories."
+msgstr ""
+
+#: src/dvr/dvr_db.c:4300
 msgid "The channel name the entry will record from."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1055
+#: src/input/mpegts/mpegts_mux_dvb.c:672
+msgid "The channel on the cable provider's network."
+msgstr ""
+
+#: src/dvr/dvr_autorec.c:1172
 msgid ""
 "The channel on which this rule applies, i.e. the channel you're aiming to "
 "record. You can leave this field blank to apply the rule to all channels."
 msgstr ""
 
-#: src/service.c:201
+#: src/service.c:194
 msgid "The channel this service is mapped to."
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:254
+#: src/input/mpegts/mpegts_mux_dvb.c:687
+msgid "The channel's name or callsign as set by the cable provider."
+msgstr ""
+
+#: src/input/mpegts/mpegts_network.c:303
 msgid "The character encoding for this network (e.g. UTF-8)."
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:204
+#: src/input/mpegts/mpegts_service.c:206
 msgid "The character encoding for this service (e.g. UTF-8)."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:627
+#: src/input/mpegts/mpegts_mux.c:642
 msgid ""
-"The character set used on this mux. You should not have to change this "
-"unless channel names, etc  appear garbled."
+"The character set to use/used. You should not have to change this unless "
+"channel names and EPG data appear garbled."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1090
+#: src/access.c:2312
+msgid "The code which may be used for HTTP streaming."
+msgstr ""
+
+#: src/dvr/dvr_autorec.c:1207
 msgid ""
 "The content type (Movie/Drama, Sports, etc.) to be used to filter matching "
 "events/programs."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:440
+#: src/dvr/dvr_db.c:4651
+msgid "The copyright year of the program."
+msgstr ""
+
+#: src/dvr/dvr_db.c:4219
+msgid "The create time of the entry describing the recording."
+msgstr ""
+
+#: src/input/mpegts/satip/satip.c:507
 msgid "The current boot ID."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:448
+#: src/input/mpegts/satip/satip.c:515
 msgid "The current configuration ID."
 msgstr ""
 
-#: src/config.c:2054
+#: src/config.c:2214
 msgid "The current configuration version."
 msgstr ""
 
-#: src/config.c:2248
-msgid ""
-"The default language to use if the user  language isn't set in the Access "
-"Entries tab."
+#: src/config.c:2264
+msgid "The default interface view level (next to the Help button)."
 msgstr ""
 
-#: src/satip/server.c:622
+#: src/config.c:2233
+msgid ""
+"The default language to use if the user  language isn't set (in the Access "
+"Entries tab)."
+msgstr ""
+
+#: src/satip/server.c:715
 msgid "The default subscription weight for each subscription."
 msgstr ""
 
-#: src/config.c:2258
+#: src/config.c:2243
 msgid ""
-"The default web interface to use if the user's  theme isn't set in the "
-"Access Entries tab."
+"The default web interface theme, if a user-specific one isn't set (in the "
+"Access Entries tab)."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:215
+#: src/input/mpegts/mpegts_mux_dvb.c:212 src/input/mpegts/mpegts_mux_dvb.c:1019
 msgid ""
 "The delivery system the mux uses. Make sure that your tuner supports the "
 "delivery system selected here."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:880
+#: src/input/mpegts/mpegts_mux_dvb.c:1106
 msgid "The delivery system used by the mux."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:311 src/input/mpegts/mpegts_mux_dvb.c:781
+#: src/input/mpegts/mpegts_mux_dvb.c:309 src/input/mpegts/mpegts_mux_dvb.c:857
 msgid "The delivery system used by your cable provider."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:442 src/input/mpegts/mpegts_mux_dvb.c:548
-#: src/input/mpegts/mpegts_mux_dvb.c:589 src/input/mpegts/mpegts_mux_dvb.c:674
-#: src/input/mpegts/mpegts_mux_dvb.c:834
+#: src/input/mpegts/mpegts_mux_dvb.c:466 src/input/mpegts/mpegts_mux_dvb.c:588
+#: src/input/mpegts/mpegts_mux_dvb.c:629 src/input/mpegts/mpegts_mux_dvb.c:750
+#: src/input/mpegts/mpegts_mux_dvb.c:928
 msgid "The delivery system used by your provider."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:87
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:121
 msgid "The demux path used by the device."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:456
+#: src/input/mpegts/satip/satip.c:523
 msgid "The device ID."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:384
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:137
+msgid "The device path in sysfs filesystem (/sys)."
+msgstr ""
+
+#: src/input/mpegts/satip/satip.c:451
 msgid "The device's serial number."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:258
+#: src/dvr/dvr_autorec.c:1328
+msgid ""
+"The earliest season for the programme. Programmes must be equal to or later "
+"than this season."
+msgstr ""
+
+#: src/dvr/dvr_autorec.c:1310
+msgid ""
+"The earliest year for the programme. Programmes must be equal to or later "
+"than this year."
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux_dvb.c:255 src/input/mpegts/mpegts_mux_dvb.c:1062
 msgid ""
 "The forward error correction high value. Most people will not need to change "
 "this setting."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:263
+#: src/input/mpegts/mpegts_mux_dvb.c:260 src/input/mpegts/mpegts_mux_dvb.c:1067
 msgid ""
 "The forward error correction low value. Most people will not need to change "
 "this setting."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:335 src/input/mpegts/mpegts_mux_dvb.c:613
-#: src/input/mpegts/mpegts_mux_dvb.c:805
+#: src/input/mpegts/mpegts_mux_dvb.c:333 src/input/mpegts/mpegts_mux_dvb.c:653
+#: src/input/mpegts/mpegts_mux_dvb.c:881
 msgid "The forward error correction used on the mux."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:470
+#: src/input/mpegts/mpegts_mux_dvb.c:494
 msgid ""
 "The forward error correction. Most people will not need to change this "
 "setting."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:223 src/input/mpegts/mpegts_mux_dvb.c:317
-#: src/input/mpegts/mpegts_mux_dvb.c:554 src/input/mpegts/mpegts_mux_dvb.c:595
-#: src/input/mpegts/mpegts_mux_dvb.c:680 src/input/mpegts/mpegts_mux_dvb.c:787
-#: src/input/mpegts/mpegts_mux_dvb.c:840 src/input/mpegts/mpegts_mux_dvb.c:886
+#: src/input/mpegts/mpegts_mux_dvb.c:220 src/input/mpegts/mpegts_mux_dvb.c:315
+#: src/input/mpegts/mpegts_mux_dvb.c:594 src/input/mpegts/mpegts_mux_dvb.c:635
+#: src/input/mpegts/mpegts_mux_dvb.c:679 src/input/mpegts/mpegts_mux_dvb.c:756
+#: src/input/mpegts/mpegts_mux_dvb.c:863 src/input/mpegts/mpegts_mux_dvb.c:934
+#: src/input/mpegts/mpegts_mux_dvb.c:1027
+#: src/input/mpegts/mpegts_mux_dvb.c:1112
 msgid "The frequency of the mux (in Hertz)."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:448
+#: src/input/mpegts/mpegts_mux_dvb.c:472
 msgid "The frequency of the mux/transponder in Hertz."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:95
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:129
 msgid "The frontend number given to the device."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:248 src/input/mpegts/mpegts_mux_dvb.c:693
+#: src/input/mpegts/mpegts_mux_dvb.c:245 src/input/mpegts/mpegts_mux_dvb.c:769
+#: src/input/mpegts/mpegts_mux_dvb.c:1052
 msgid ""
 "The guard interval used by the mux. If you're not sure of the value leave as "
 "AUTO."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:253
+#: src/config.c:2481
+msgid "The hash algorithm type for the digest authentication."
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux_dvb.c:250 src/input/mpegts/mpegts_mux_dvb.c:1057
 msgid ""
 "The hierarchical modulation used by the mux. Most people will not need to "
 "change this setting."
 msgstr ""
 
-#: src/channels.c:432
+#: src/channels.c:467
 msgid "The imagecache path to the icon to use/used for the channel."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:79
+#: src/ratinglabels.c:661
+msgid "The imagecache path to the icon to use/used for the rating label."
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:113
 msgid "The input path used by the device."
 msgstr ""
 
-#: src/webui/doc_md.c:121
-msgid "The items have the following functions:"
+#: src/input/mpegts/iptv/iptv.c:814 src/input/mpegts/iptv/iptv_mux.c:171
+msgid ""
+"The input stream is remuxed with A/V library (libav or or ffmpeg) to the "
+"MPEG-TS format which is accepted by Tvheadend."
 msgstr ""
 
-#: src/esfilter.c:647 src/esfilter.c:741 src/esfilter.c:836 src/esfilter.c:931
-#: src/esfilter.c:1131
+#: src/esfilter.c:639 src/esfilter.c:734 src/esfilter.c:830 src/esfilter.c:925
+#: src/esfilter.c:1129
 msgid "The language to which the filter should apply."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:703
+#: src/dvr/dvr_autorec.c:1336
+msgid ""
+"The latest season for the programme. Programmes must be equal to or earlier "
+"than this season."
+msgstr ""
+
+#: src/dvr/dvr_autorec.c:1319
+msgid ""
+"The latest year for the programme. Programmes must be equal to or earlier "
+"than this year."
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux_dvb.c:779
 msgid "The layer A constellation."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:699
+#: src/input/mpegts/mpegts_mux_dvb.c:775
 msgid "The layer A forward error correction."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:709
+#: src/input/mpegts/mpegts_mux_dvb.c:785
 msgid "The layer A segment count."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:716
+#: src/input/mpegts/mpegts_mux_dvb.c:792
 msgid "The layer A time interleaving."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:726
+#: src/input/mpegts/mpegts_mux_dvb.c:802
 msgid "The layer B constellation."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:722
+#: src/input/mpegts/mpegts_mux_dvb.c:798
 msgid "The layer B forward error correction."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:732
+#: src/input/mpegts/mpegts_mux_dvb.c:808
 msgid "The layer B segment count."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:739
+#: src/input/mpegts/mpegts_mux_dvb.c:815
 msgid "The layer B time interleaving."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:749
+#: src/input/mpegts/mpegts_mux_dvb.c:825
 msgid "The layer C constellation."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:745
+#: src/input/mpegts/mpegts_mux_dvb.c:821
 msgid "The layer C forward error correction."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:755
+#: src/input/mpegts/mpegts_mux_dvb.c:831
 msgid "The layer C segment count."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:762
+#: src/input/mpegts/mpegts_mux_dvb.c:838
 msgid "The layer C time interleaving."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_sched.c:163
+#: src/input/mpegts/mpegts_mux_sched.c:164
 msgid "The length of time (in seconds) to play the mux (1 hour = 3600)."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:103
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:145
 msgid "The limit for the PID filter (driver or hardware)."
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:222
+#: src/input/mpegts/mpegts_service.c:224
 msgid ""
 "The locking mechanism selection for The Preferred Conditional Access Packet "
 "Identifier. See Help for more information."
 msgstr ""
 
-#: src/esfilter.c:667 src/esfilter.c:762 src/esfilter.c:857 src/esfilter.c:952
-#: src/esfilter.c:1057
+#: src/esfilter.c:659 src/esfilter.c:755 src/esfilter.c:851 src/esfilter.c:946
+#: src/esfilter.c:1054
 msgid ""
 "The logical stream index to compare. Note that this index is computed using "
 "all filters.Example: If filter is set to AC3 audio type and the language to "
@@ -6872,215 +8787,243 @@ msgid ""
 "could be identified using number 1 and the second using number 2."
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:400
+#: src/input/mpegts/satip/satip.c:467
 msgid "The manufacturer of the SAT>IP server."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1170
+#: src/dvr/dvr_autorec.c:1299
 msgid ""
 "The maximal duration of a matching event - in other words, only match "
 "programmes that are no longer than this duration."
 msgstr ""
 
-#: src/timeshift.c:255
+#: src/timeshift.c:253
 msgid ""
 "The maximum RAM (system memory) size for timeshift buffers. When free RAM "
-"buffers are available, they are used for timeshift data in preference to "
+"buffers are available they are used for timeshift data in preference to "
 "using storage."
 msgstr ""
 
-#: src/timeshift.c:244
+#: src/epggrab.c:488
+msgid ""
+"The maximum amount of time a grabber is allowed scan a mux for data (in "
+"seconds)."
+msgstr ""
+
+#: src/timeshift.c:242
 msgid ""
 "The maximum combined size of all timeshift buffers. If you specify an "
 "unlimited period it's highly recommended you specify a value here."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1012
+#: src/satip/server.c:917
+msgid ""
+"The maximum concurrent RTSP connections from the same IP address (if 0 no "
+"limit)."
+msgstr ""
+
+#: src/satip/server.c:907
+msgid "The maximum number of active RTSP sessions (if 0 no limit)."
+msgstr ""
+
+#: src/dvr/dvr_config.c:1412
 msgid "The maximum number of entries that can be matched."
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:784
+#: src/input/mpegts/iptv/iptv.c:867
 msgid "The maximum number of input streams allowed on this network."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1233
+#: src/dvr/dvr_autorec.c:1397
 msgid "The maximum number of recording entries this rule can create."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1021
+#: src/dvr/dvr_config.c:1422
 msgid "The maximum number of recordings that can be scheduled."
 msgstr ""
 
-#: src/satip/server.c:642
+#: src/satip/server.c:735
 msgid "The maximum number of services to decrypt per mux."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1224
+#: src/dvr/dvr_autorec.c:1388
 msgid "The maximum number of times this rule can be triggered."
 msgstr ""
 
-#: src/timeshift.c:225
+#: src/timeshift.c:223
 msgid ""
 "The maximum time period that will be buffered for any given (client) "
 "subscription."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1159
+#: src/dvr/dvr_autorec.c:1288
 msgid ""
 "The minimal duration of a matching event - in other words, only match "
 "programs that are no shorter than this duration."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:658
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:711
 msgid "The minimum delay after the rotor movement command is sent."
 msgstr ""
 
-#: src/input/mpegts/satip/satip_frontend.c:171
+#: src/input/mpegts/satip/satip_frontend.c:280
 msgid ""
 "The minimum delay before tuning in milliseconds after tuner stop. If the "
 "time between the previous and next start is greater than this value then the "
 "delay is not applied."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:466 src/input/mpegts/mpegts_mux_dvb.c:560
+#: src/dvr/dvr_autorec.c:1217
+msgid ""
+"The minimum number of stars the broadcast should have - in other words, only "
+"match programs that have at least this rating."
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux_dvb.c:490 src/input/mpegts/mpegts_mux_dvb.c:600
 msgid "The modulation used on the mux."
 msgstr ""
 
-#: src/epggrab.c:365
-msgid ""
-"The multiplex (mux) is tuned for this amount of time at most. If the EPG "
-"data is complete before this limit, the mux is released sooner."
-msgstr ""
-
-#: src/input/mpegts/mpegts_service.c:105
+#: src/input/mpegts/mpegts_service.c:107
 msgid "The mux the service is on."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_sched.c:146
+#: src/input/mpegts/mpegts_mux_sched.c:147
 msgid "The mux to play when the entry is triggered."
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:113
+#: src/input/mpegts/mpegts_service.c:115
 msgid "The mux's universally unique identifier."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:565
+#: src/input/mpegts/mpegts_mux.c:580
 msgid "The name (or frequency) the mux is on."
 msgstr ""
 
-#: src/channels.c:398
+#: src/channels.c:433
 msgid ""
 "The name given to/of the channel (This is how it'll appear in your EPG.)"
 msgstr ""
 
-#: src/profile.c:327
+#: src/profile.c:315
 msgid "The name of the profile."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1019
+#: src/dvr/dvr_autorec.c:1121
 msgid "The name of the the rule."
 msgstr ""
 
-#: src/access.c:2192
+#: src/access.c:2450
 msgid ""
 "The network prefix(es) to block, e.g.192.168.2.0/24 (comma-separated list)."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:549
+#: src/input/mpegts/mpegts_mux.c:564
 msgid "The network the mux is on."
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:97
+#: src/input/mpegts/mpegts_service.c:99
 msgid "The network the service is on."
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:760
+#: src/input/mpegts/iptv/iptv.c:843
 msgid ""
 "The network's priority. The network with the highest priority value will be "
 "used out of preference if available. See Help for details."
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:751
+#: src/input/mpegts/iptv/iptv.c:834
 msgid "The network's service ID"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:290
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:343
 msgid "The networks assigned to the device."
 msgstr ""
 
-#: src/input/mpegts/satip/satip_satconf.c:398
+#: src/input/mpegts/satip/satip_satconf.c:416
 msgid "The networks using this configuration."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:557
+#: src/input/mpegts/mpegts_mux.c:572
 msgid "The networks' universally unique identifier (UUID)."
 msgstr ""
 
-#: src/satip/server.c:750
+#: src/satip/server.c:891
 msgid "The number of ATSC-C (Cable/AnnexB) tuners to export."
 msgstr ""
 
-#: src/satip/server.c:742
+#: src/satip/server.c:883
 msgid "The number of ATSC-T (Terresterial) tuners to export."
 msgstr ""
 
-#: src/satip/server.c:726
+#: src/satip/server.c:867
 msgid "The number of DVB-C (Cable) tuners to export."
 msgstr ""
 
-#: src/satip/server.c:734
+#: src/satip/server.c:875
 msgid "The number of DVB-C2 (Cable) tuners to export."
 msgstr ""
 
-#: src/satip/server.c:694
+#: src/satip/server.c:835
 msgid "The number of DVB-S (Satellite) tuners to export."
 msgstr ""
 
-#: src/satip/server.c:702
+#: src/satip/server.c:843
 msgid "The number of DVB-S2 (Satellite) tuners to export."
 msgstr ""
 
-#: src/satip/server.c:710
+#: src/satip/server.c:851
 msgid "The number of DVB-T (Terresterial) tuners to export."
 msgstr ""
 
-#: src/satip/server.c:718
+#: src/satip/server.c:859
 msgid "The number of DVB-T2 (Terresterial) tuners to export."
 msgstr ""
 
-#: src/config.c:2177
+#: src/satip/server.c:899
+msgid "The number of ISDB-T (Terresterial) tuners to export."
+msgstr ""
+
+#: src/config.c:2682
 msgid ""
 "The number of MPEG-TS packets Tvheadend buffers in case there is a delay "
 "receiving CA keys. "
 msgstr ""
 
-#: src/access.c:1797
+#: src/access.c:1906
 msgid "The number of allowed connections this user can make to the server."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:144
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:195
 msgid ""
 "The number of bytes to buffer. By default, linuxdvb's input buffer is 18800 "
 "bytes long. The accepted range is 18800-1880000 bytes."
 msgstr ""
 
-#: src/config.c:2126
+#: src/config.c:2492
 msgid "The number of days cookies set by Tvheadend should expire."
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:297
+#: src/input/mpegts/mpegts_network.c:346
 msgid "The number of muxes left to scan on this network."
 msgstr ""
 
-#: src/profile.c:369
-msgid "The number of seconds to wait for a stream to start."
+#: src/config.c:2503
+msgid ""
+"The number of seconds in which authentication tickets generated by Tvheadend "
+"should expire."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:646
-msgid "The number of services on the mux that are mapped to channels."
+#: src/profile.c:354
+msgid ""
+"The number of seconds to wait for data. It handles the situations where no "
+"data are received at start or the input stream is stalled."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:512
+#: src/input/mpegts/mpegts_mux.c:661
+msgid "The number of services currently mapped to channels."
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux_dvb.c:536
 msgid "The orbital position of the satellite the mux is on."
 msgstr ""
 
@@ -7088,157 +9031,170 @@ msgstr ""
 msgid "The orbital position of the satellite your dish is pointing at."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:618
-msgid "The outcome of the last scan performed on this mux."
+#: src/input/mpegts/mpegts_mux.c:633
+msgid "The outcome of the last scan performed."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:270
+#: src/input/mpegts/mpegts_mux_dvb.c:267 src/input/mpegts/mpegts_mux_dvb.c:339
+#: src/input/mpegts/mpegts_mux_dvb.c:887 src/input/mpegts/mpegts_mux_dvb.c:1074
 msgid ""
 "The physical layer pipe ID. Most people will not need to change this setting."
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:900
+#: src/input/mpegts/iptv/iptv.c:961
 msgid "The playlist's character set."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:462
+#: src/input/mpegts/mpegts_mux_dvb.c:486
 msgid "The polarization used on the mux."
 msgstr ""
 
-#: src/channels.c:410
+#: src/channels.c:445
 msgid ""
 "The position the channel will appear on your EPG. This is not used by "
 "Tvheadend internally, but rather intended to be used by HTSP clients for "
 "mapping to remote control buttons, presentation order, etc."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1181
-msgid ""
-"The priority of any recordings set because of this rule will take precedence "
-"and cancel lower-priority events."
-msgstr ""
-
-#: src/descrambler/constcw.c:300 src/descrambler/constcw.c:366
+#: src/descrambler/constcw.c:335 src/descrambler/constcw.c:408
+#: src/descrambler/constcw.c:481 src/descrambler/constcw.c:554
 msgid "The provider's ID."
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:169
+#: src/input/mpegts/mpegts_service.c:171
 msgid "The provider's name."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:581
+#: src/input/mpegts/mpegts_mux.c:596
 msgid "The provider's network ID."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:573
+#: src/input/mpegts/mpegts_mux.c:588
 msgid "The provider's network name."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:330 src/input/mpegts/mpegts_mux_dvb.c:608
-#: src/input/mpegts/mpegts_mux_dvb.c:800
+#: src/input/mpegts/mpegts_mux_dvb.c:328 src/input/mpegts/mpegts_mux_dvb.c:648
+#: src/input/mpegts/mpegts_mux_dvb.c:876
 msgid ""
 "The quadrature amplitude modulation (QAM) used by the mux. If you're not "
 "sure of the value leave as AUTO."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3347
+#: src/config.c:2460
+msgid "The realm name for HTTP authorization."
+msgstr ""
+
+#: src/dvr/dvr_db.c:4574
 msgid "The recorded file was removed intentionally"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3450
+#: src/dvr/dvr_db.c:4695
 msgid "The recording/entry status."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:475
+#: src/input/mpegts/mpegts_mux_dvb.c:499
 msgid "The rolloff used on the mux."
 msgstr ""
 
-#: src/esfilter.c:690 src/esfilter.c:785 src/esfilter.c:880 src/esfilter.c:975
-#: src/esfilter.c:1080 src/esfilter.c:1162
+#: src/esfilter.c:682 src/esfilter.c:778 src/esfilter.c:874 src/esfilter.c:969
+#: src/esfilter.c:1077 src/esfilter.c:1160
 msgid ""
 "The rule action defines the operation when all comparisons succeed. See Help "
 "for more information on what the various rules do."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:273
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:343
 msgid "The satellite configuration to use."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:606
+#: src/input/mpegts/mpegts_mux.c:621
 msgid ""
 "The scan state. New muxes will automatically be changed to the PEND state. "
 "You can change this to ACTIVE to queue a scan of this mux."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3079
+#: src/dvr/dvr_db.c:4257
 msgid "The scheduled start time, including any padding."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3106
+#: src/dvr/dvr_db.c:4284
 msgid "The scheduled stop time, including any padding."
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:316 src/input/mpegts/iptv/iptv.c:820
+#: src/input/mpegts/mpegts_input.c:327 src/input/mpegts/iptv/iptv.c:903
 msgid ""
 "The scrambled bits in MPEG-TS packets are always cleared. It is a workaround "
 "for the special streams which are descrambled, but these bits are not "
 "touched."
 msgstr ""
 
-#: src/profile.c:402
+#: src/profile.c:435
 msgid ""
 "The selected video type should be preferred when multiple services are "
 "available for a channel."
 msgstr ""
 
-#: src/descrambler/constcw.c:384
+#: src/config.c:2451
+msgid "The server name for 'Server:' HTTP headers."
+msgstr ""
+
+#: src/input/mpegts/satip/satip.c:279
+msgid ""
+"The server suports the Interlaved TCP transfer mode (embedded data in the "
+"RTSP session). Selecting this option enables this mode in all tuners by "
+"default."
+msgstr ""
+
+#: src/descrambler/constcw.c:574
 msgid "The service ID"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:121
+#: src/input/mpegts/mpegts_service.c:123
 msgid "The service ID as set by the provider."
 msgstr ""
 
-#: src/descrambler/constcw.c:318
+#: src/descrambler/constcw.c:355 src/descrambler/constcw.c:428
+#: src/descrambler/constcw.c:501
 msgid "The service ID."
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:161
+#: src/input/mpegts/mpegts_service.c:163
 msgid "The service name as set by the provider."
 msgstr ""
 
-#: src/esfilter.c:751 src/esfilter.c:846 src/esfilter.c:941 src/esfilter.c:1046
-#: src/esfilter.c:1141
+#: src/esfilter.c:744 src/esfilter.c:840 src/esfilter.c:935 src/esfilter.c:1043
+#: src/esfilter.c:1139
 msgid ""
 "The service the filter should apply to. Leave blank to apply the filter to "
 "all services."
 msgstr ""
 
-#: src/esfilter.c:657
+#: src/esfilter.c:649
 msgid ""
 "The service to which the filter should apply. Leave blank to apply the "
 "filter to all services."
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:185
+#: src/input/mpegts/mpegts_service.c:187
 msgid ""
 "The service type flag as defined by the DVB specifications (e.g. 0x02 = "
 "radio, 0x11 = MPEG2 HD TV, 0x19 = H.264 HD TV)"
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:137
+#: src/input/mpegts/mpegts_service.c:139
 msgid "The service's channel minor as set by the provider."
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:129
+#: src/input/mpegts/mpegts_service.c:131
 msgid "The service's channel number as set by the provider."
 msgstr ""
 
-#: src/service.c:222
+#: src/service.c:215
 msgid "The service's encryption status."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:284
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:354
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:385
 msgid ""
 "The signal from the standard universal LNB can be split using a simple "
 "coaxial splitter (no multiswitch) to several outputs. In this case, the "
@@ -7248,729 +9204,879 @@ msgid ""
 "(position, polarization, lo-hi)."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:315
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:220
 msgid ""
-"The signal from the standard universal LNB can be split using a simple "
-"coaxial splitter (no multiswitch) to several outputs. In this case, the "
-"position, the polarization and low-high band settings must be equal. If you "
-"set another tuner as master, then this tuner will act as a slave and "
-"tvheadend will assure that this tuner will not use incompatible parameters "
-"(position, polarization, lo-hi)."
+"The signal level reported by the driver is multiplied with this value and "
+"divided by 100."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3058
+#: src/dvr/dvr_db.c:4236
 msgid "The start time of the recording."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:487 src/input/mpegts/mpegts_mux_dvb.c:848
+#: src/input/mpegts/mpegts_mux_dvb.c:511 src/input/mpegts/mpegts_mux_dvb.c:942
 msgid "The stream ID used for the mux."
 msgstr ""
 
-#: src/dvr/dvr_config.c:876
+#: src/dvr/dvr_config.c:949
 msgid "The stream profile the DVR profile will use for recordings."
 msgstr ""
 
-#: src/access.c:1721
+#: src/access.c:1830
 msgid ""
 "The streaming profile to use/used. If not set, the default will be used."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1137
+#: src/dvr/dvr_config.c:1189
 msgid ""
 "The string allows you to manually specify the full path generation using "
 "predefined modifiers. See Help for full details."
 msgstr ""
 
-#: src/esfilter.c:920
+#: src/esfilter.c:914
 msgid "The subtitle stream types the filter should apply to."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:325
+#: src/input/mpegts/mpegts_mux_dvb.c:323
 msgid "The symbol rate used on the mux."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:456
+#: src/input/mpegts/mpegts_mux_dvb.c:480
 msgid "The symbol rate used on the mux/transponder."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:603 src/input/mpegts/mpegts_mux_dvb.c:795
+#: src/input/mpegts/mpegts_mux_dvb.c:643 src/input/mpegts/mpegts_mux_dvb.c:871
 msgid "The symbol rate."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3087
+#: src/imagecache.c:109
+msgid ""
+"The time in days after the cached URL will be removed. The time starts when "
+"the URL was lastly requested. Zero means unlimited cache (not recommended)."
+msgstr ""
+
+#: src/dvr/dvr_db.c:4265
 msgid "The time the entry stops/stopped being recorded."
 msgstr ""
 
-#: src/config.c:2226
+#: src/config.c:2373
 msgid ""
 "The time window to cut the stop time from the overlapped event in seconds."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1038
+#: src/dvr/dvr_autorec.c:1140
 msgid ""
 "The title of the program to look for. Note that this accepts case-"
 "insensitive regular expressions."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:638
-msgid "The total number of services found on this mux."
+#: src/input/mpegts/mpegts_mux.c:653
+msgid "The total number of services found."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3114
+#: src/dvr/dvr_db.c:4292
 msgid "The total scheduled duration."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:241
+#: src/input/mpegts/mpegts_mux_dvb.c:238 src/input/mpegts/mpegts_mux_dvb.c:1045
 msgid ""
 "The transmission/OFDM mode used by the mux. If you're not sure of the value "
 "leave as AUTO but be aware that tuning may fail as some drivers do not like "
 "the AUTO setting."
 msgstr ""
 
-#: src/descrambler/constcw.c:309 src/descrambler/constcw.c:375
+#: src/descrambler/constcw.c:345 src/descrambler/constcw.c:418
+#: src/descrambler/constcw.c:491 src/descrambler/constcw.c:564
 msgid "The transponder ID."
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:589
+#: src/input/mpegts/mpegts_mux.c:604
 msgid "The transport stream ID of the mux within the network."
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:241
+#: src/input/mpegts/mpegts_input.c:249
 msgid ""
 "The tuner priority value (a higher value means to use this tuner out of "
 "preference). See Help for details."
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:252
+#: src/input/mpegts/mpegts_input.c:260
 msgid ""
 "The tuner priority value for streamed channels through HTTP or HTSP (a "
 "higher value means to use this tuner out of preference). If not set (zero), "
 "the standard priority value is used. See Help for details."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3271 src/dvr/dvr_autorec.c:1288 src/dvr/dvr_timerec.c:669
+#: src/config.c:2647
+msgid "The user agent string for the build-in HTTP client."
+msgstr ""
+
+#: src/dvr/dvr_db.c:4498 src/dvr/dvr_autorec.c:1433 src/dvr/dvr_timerec.c:670
 msgid ""
 "The user who created the recording, or the auto-recording source and IP "
 "address if scheduled by a matching rule."
 msgstr ""
 
-#: src/config.c:2063
+#: src/config.c:2223
 msgid "The version of Tvheadend that last updated the config."
 msgstr ""
 
-#: src/esfilter.c:636
+#: src/esfilter.c:627
 msgid "The video stream types the filter should apply to."
 msgstr ""
 
-#: src/access.c:1456 src/config.c:2257
+#: src/access.c:1553 src/config.c:2242
 msgid "Theme"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:246
-#: src/input/mpegts/satip/satip_frontend.c:302
+#: src/input/mpegts/satip/satip.c:406
+msgid ""
+"This is a workaround for some tuners that mess up the numbers of tuners. "
+"Turn this off when you are not seeing signal strength on all tuners but only "
+"on some."
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_frontend.c:316
+#: src/input/mpegts/satip/satip_frontend.c:451
 msgid "This tuner"
 msgstr ""
 
-#: src/config.c:2294
+#: src/config.c:2736
 msgid ""
 "This will create an NTP driver (using shmem interface) that you can feed "
 "into ntpd. This can be run without root privileges, but generally the "
 "performance is not that great."
 msgstr ""
 
-#: src/tvhlog.c:82
+#: src/tvhlog.c:91
 msgid "Thread"
 msgstr ""
 
-#: src/epg.c:2281
+#: src/main.c:970
+msgid "Thread debugging"
+msgstr ""
+
+#: src/epg.c:1781
 msgid "Thriller"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:775
+#: src/dvr/dvr_autorec.c:886
 msgid "Thu"
 msgstr ""
 
-#: src/tvhlog.c:84 src/config.c:1914
+#: src/config.c:2502
+msgid "Ticket expiration (seconds)"
+msgstr ""
+
+#: src/bouquet.c:764
+msgid "Tidy channel name (e.g., stripping HD/UHD suffix)"
+msgstr ""
+
+#: src/service_mapper.c:637
+msgid "Tidy the channel name such as removing trailing HD text"
+msgstr ""
+
+#: src/tvhlog.c:93 src/config.c:2039
 msgid "Time"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:110
+#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:133
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:111
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:159
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:217
 msgid "Time (in milliseconds) for a command to complete."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:102
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:151
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:209
+msgid "Time (in milliseconds) for the Unicable device to power up."
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:103
 msgid "Time (in milliseconds) for the rotor to power up."
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:918
+#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:125
+msgid "Time (in milliseconds) for the switch to power up."
+msgstr ""
+
+#: src/input/mpegts/iptv/iptv.c:979
 msgid "Time (in minutes) to re-fetch the playlist."
 msgstr ""
 
-#: src/tvhlog.c:121
+#: src/tvhlog.c:131
 msgid "Time Stamp Fix"
 msgstr ""
 
-#: src/dvr/dvr_db.c:665
+#: src/dvr/dvr_db.c:692
 msgid "Time missed"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3380
+#: src/tvhlog.c:89
+msgid "Time profiling"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4615
 msgid "Time record caption"
 msgstr ""
 
-#: src/dvr/dvr_timerec.c:153
+#: src/dvr/dvr_timerec.c:142
 #, c-format
 msgid "Time recording%s%s"
 msgstr ""
 
-#: src/dvr/dvr_timerec.c:585
+#: src/dvr/dvr_db.c:4218
+msgid "Time the entry was created"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4227
+msgid "Time the entry was last watched"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4228
+msgid "Time the entry was last watched."
+msgstr ""
+
+#: src/transcoding/codec/codecs/libs/libvpx.c:107
+msgid "Time to spend encoding, in microseconds."
+msgstr ""
+
+#: src/dvr/dvr_timerec.c:583
 msgid "Time to start the recording/time the recording started."
 msgstr ""
 
-#: src/dvr/dvr_timerec.c:596
+#: src/dvr/dvr_timerec.c:594
 msgid "Time to stop recording/time the recording stopped."
 msgstr ""
 
-#: src/config.c:2040
-msgid "Time update"
+#: src/dvr/dvr_db.c:4719
+msgid "Time when the program was first aired"
 msgstr ""
 
-#: src/profile.c:368
-msgid "Timeout (sec) (0=infinite)"
-msgstr ""
-
-#: src/input/mpegts/satip/satip_satconf.c:360
+#: src/input/mpegts/satip/satip_satconf.c:377
 msgid "Timeout (seconds)"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_sched.c:162
+#: src/input/mpegts/mpegts_mux_sched.c:163
 msgid "Timeout (secs)"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3381
+#: src/dvr/dvr_db.c:4616
 msgid "Timer-based automatic record caption."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3372
+#: src/dvr/dvr_db.c:4607
 msgid "Timer-based automatic recording."
 msgstr ""
 
-#: src/tvhlog.c:166 src/timeshift.c:183
+#: src/tvhlog.c:178 src/timeshift.c:184
 msgid "Timeshift"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3150 src/dvr/dvr_db.c:3158 src/dvr/dvr_timerec.c:553
+#: src/dvr/dvr_db.c:4348 src/dvr/dvr_db.c:4356 src/dvr/dvr_timerec.c:551
 msgid "Title"
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1037
+#: src/dvr/dvr_autorec.c:1139
 msgid "Title (regexp)"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3159
+#: src/dvr/dvr_db.c:4357
 msgid "Title of the program (display only)."
 msgstr ""
 
-#: src/dvr/dvr_db.c:3151
+#: src/dvr/dvr_db.c:4349
 msgid "Title of the program."
 msgstr ""
 
-#: src/dvr/dvr_timerec.c:554
+#: src/dvr/dvr_timerec.c:552
 msgid "Title of the recording - this is used to generate the filename."
 msgstr ""
 
-#: src/webui/extjs.c:223
+#: src/descrambler/dvbcam.c:890
+msgid "To enable MCD and MTD for this CAM."
+msgstr ""
+
+#: src/webui/extjs.c:229
+msgid "To support Tvheadend development please consider making a donation"
+msgstr ""
+
+#: src/webui/extjs.c:217
 msgid "Toggle details"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:139
+#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:154
 msgid "Tone burst"
 msgstr ""
 
-#: src/dvr/dvr_db.c:656
+#: src/dvr/dvr_db.c:683
 msgid "Too many data errors"
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:289
+#: src/config.c:2254
+msgid "Tooltips"
+msgstr ""
+
+#: src/input/mpegts/mpegts_network.c:338
 msgid "Total number of mapped channels on this network."
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:273
+#: src/input/mpegts/mpegts_network.c:322
 msgid "Total number of muxes found on this network."
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:281
+#: src/input/mpegts/mpegts_network.c:330
 msgid "Total number of services found on this network."
 msgstr ""
 
-#: src/wizard.c:1012
+#: src/wizard.c:1038
 msgid "Total number of services found."
 msgstr ""
 
-#: src/bouquet.c:1093
+#: src/bouquet.c:1120
 msgid "Total number of services seen."
 msgstr ""
 
-#: src/bouquet.c:1101
+#: src/bouquet.c:1128
 msgid "Total number of services."
 msgstr ""
 
-#: src/epg.c:2443
+#: src/epg.c:1943
 msgid "Tourism / Travel"
 msgstr ""
 
-#: src/tvhlog.c:780
+#: src/tvhlog.c:851
 msgid "Trace subsystems"
 msgstr ""
 
-#: src/epg.c:2392
+#: src/epg.c:1892
 msgid "Traditional arts"
 msgstr ""
 
-#: src/epg.c:2373
+#: src/epg.c:1873
 msgid "Traditional music"
 msgstr ""
 
-#: src/tvhlog.c:150
+#: src/tvhlog.c:162
 msgid "Transcode"
 msgstr ""
 
-#: src/profile.c:1839
+#: src/profile.c:2513
+msgid "Transcode audio only for selected codecs."
+msgstr ""
+
+#: src/profile.c:2535
+msgid "Transcode subtitle only for selected codecs."
+msgstr ""
+
+#: src/profile.c:2491
+msgid "Transcode video only for selected codecs."
+msgstr ""
+
+#: src/profile.c:2452
 msgid "Transcode/av-lib"
 msgstr ""
 
-#: src/profile.c:1846
-msgid "Transcoding"
+#: src/profile.c:2459
+msgid "Transcoding Settings"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux_dvb.c:240
+#: src/epggrab.c:498
+msgid ""
+"Translate the genre codes received from the broadcaster to another genre "
+"code.<br>Use the form xxx=yyy, where xxx and yyy are 'ETSI EN 300 468' "
+"content descriptor values expressed in decimal (0-255). <br>Genre code xxx "
+"will be converted to genre code yyy.<br>Use a separate line for each genre "
+"code to be converted."
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux_dvb.c:237 src/input/mpegts/mpegts_mux_dvb.c:1044
 msgid "Transmission mode"
 msgstr ""
 
-#: src/descrambler/constcw.c:308 src/descrambler/constcw.c:374
+#: src/descrambler/constcw.c:344 src/descrambler/constcw.c:417
+#: src/descrambler/constcw.c:490 src/descrambler/constcw.c:563
 msgid "Transponder ID"
 msgstr ""
 
-#: src/tvhlog.c:119
+#: src/tvhlog.c:129
 msgid "Transport Stream"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:588
+#: src/input/mpegts/satip/satip_frontend.c:260
+msgid "Transport mode"
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux.c:603
 msgid "Transport stream ID"
 msgstr ""
 
-#: src/epggrab/module/xmltv.c:753
+#: src/dvr/dvr_config.c:1052
+msgid "Try re-scheduling recording if more errors than (0=off)"
+msgstr ""
+
+#: src/epggrab/module/xmltv.c:1089
 msgid ""
 "Try to obtain channel numbers from the display-name xml tag. If the first "
 "word is number, it is used as the channel number."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:773
+#: src/dvr/dvr_autorec.c:884
 msgid "Tue"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:226
-msgid "Tune before DiseqC"
-msgstr ""
-
-#: src/wizard.c:566
-msgid "Tuner"
-msgstr ""
-
-#: src/input/mpegts/satip/satip_frontend.c:211
-msgid "Tuner bind IP address"
-msgstr ""
-
-#: src/input/mpegts/satip/satip.c:224 src/input/mpegts/satip/satip.c:391
-msgid "Tuner configuration"
-msgstr ""
-
-#: src/input/mpegts/satip/satip.c:225
-msgid "Tuner configuration."
-msgstr ""
-
-#: src/streaming.c:461
-msgid "Tuning failed"
+#: src/transcoding/codec/codecs/libs/libx26x.c:183
+#: src/transcoding/codec/codecs/libs/libx26x.c:282
+#: src/transcoding/codec/codecs/libs/libvpx.c:130
+msgid "Tune"
 msgstr ""
 
 #: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:264
+msgid "Tune before DiseqC"
+msgstr ""
+
+#: src/transcoding/codec/codecs/libs/libx26x.c:184
+msgid "Tune the encoding params (cf. x264 --fullhelp)."
+msgstr ""
+
+#: src/transcoding/codec/codecs/libs/libvpx.c:131
+msgid "Tune the encoding to a specific scenario."
+msgstr ""
+
+#: src/wizard.c:568
+msgid "Tuner"
+msgstr ""
+
+#: src/wizard.c:670
+msgid "Tuner and Network"
+msgstr ""
+
+#: src/input/mpegts/satip/satip_frontend.c:340
+msgid "Tuner bind IP address"
+msgstr ""
+
+#: src/input/mpegts/satip/satip.c:267 src/input/mpegts/satip/satip.c:458
+msgid "Tuner configuration"
+msgstr ""
+
+#: src/input/mpegts/satip/satip.c:268
+msgid "Tuner configuration."
+msgstr ""
+
+#: src/streaming.c:483
+msgid "Tuning failed"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:302
 msgid "Turn off LNB when idle"
 msgstr ""
 
-#: src/config.c:2072
+#: src/config.c:2610
+msgid "Tvheadend model name for HDHomeRun Server Emulation"
+msgstr ""
+
+#: src/config.c:2204
 msgid "Tvheadend server name"
 msgstr ""
 
-#: src/epggrab/module.c:138
+#: src/epggrab/module.c:161 src/transcoding/codec/profile_class.c:259
 msgid "Type"
 msgstr ""
 
-#: src/service.c:237
+#: src/service.c:230
 msgid "Type override"
 msgstr ""
 
-#: src/input/mpegts/satip/satip_frontend.c:160
+#: src/input/mpegts/satip/satip_frontend.c:269
 msgid "UDP RTP port number (2 ports)"
 msgstr ""
 
-#: src/service.c:160
+#: src/tvhlog.c:187
+msgid "UDP Streamer"
+msgstr ""
+
+#: src/service.c:152
 msgid "UHD TV"
 msgstr ""
 
-#: src/profile.c:269
+#: src/profile.c:277
 msgid "UHD: ultra high definition"
 msgstr ""
 
-#: src/tvhlog.c:93
+#: src/tvhlog.c:102
 msgid "UPnP Protocol"
 msgstr ""
 
-#: src/tvhlog.c:90 src/wizard.c:817 src/dvr/dvr_db.c:3432
-#: src/input/mpegts/iptv/iptv.c:881 src/input/mpegts/iptv/iptv_mux.c:139
+#: src/tvhlog.c:99 src/wizard.c:826 src/dvr/dvr_db.c:4677
+#: src/input/mpegts/iptv/iptv.c:950 src/input/mpegts/iptv/iptv_mux.c:129
 msgid "URL"
 msgstr ""
 
-#: src/wizard.c:818
+#: src/input/mpegts/iptv/iptv_mux.c:155
+msgid "URL for comparison"
+msgstr ""
+
+#: src/wizard.c:827
 msgid "URL of the M3U playlist."
 msgstr ""
 
-#: src/main.c:849
+#: src/main.c:916
 msgid "URL with the SAT>IP server XML location"
 msgstr ""
 
-#: src/dvr/dvr_db.c:3433
+#: src/dvr/dvr_db.c:4678
 msgid "URL."
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:476
+#: src/input/mpegts/linuxdvb/linuxdvb_rotor.c:590
 msgid "USALS"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:481
+#: src/input/mpegts/dvb_support.c:559
 msgid "UTC"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:498
+#: src/input/mpegts/dvb_support.c:576
 msgid "UTC+ 1"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:499
+#: src/input/mpegts/dvb_support.c:577
 msgid "UTC+ 2"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:500
+#: src/input/mpegts/dvb_support.c:578
 msgid "UTC+ 3"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:501
+#: src/input/mpegts/dvb_support.c:579
 msgid "UTC+ 4"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:502
+#: src/input/mpegts/dvb_support.c:580
 msgid "UTC+ 4:30"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:503
+#: src/input/mpegts/dvb_support.c:581
 msgid "UTC+ 5"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:504
+#: src/input/mpegts/dvb_support.c:582
 msgid "UTC+ 5:30"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:505
+#: src/input/mpegts/dvb_support.c:583
 msgid "UTC+ 5:45"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:506
+#: src/input/mpegts/dvb_support.c:584
 msgid "UTC+ 6"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:507
+#: src/input/mpegts/dvb_support.c:585
 msgid "UTC+ 6:30"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:508
+#: src/input/mpegts/dvb_support.c:586
 msgid "UTC+ 7"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:509
+#: src/input/mpegts/dvb_support.c:587
 msgid "UTC+ 8"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:510
+#: src/input/mpegts/dvb_support.c:588
 msgid "UTC+ 8:45"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:511
+#: src/input/mpegts/dvb_support.c:589
 msgid "UTC+ 9"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:512
+#: src/input/mpegts/dvb_support.c:590
 msgid "UTC+ 9:30"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:513
+#: src/input/mpegts/dvb_support.c:591
 msgid "UTC+10"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:514
+#: src/input/mpegts/dvb_support.c:592
 msgid "UTC+10:30"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:515
+#: src/input/mpegts/dvb_support.c:593
 msgid "UTC+11"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:516
+#: src/input/mpegts/dvb_support.c:594
 msgid "UTC+12"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:517
+#: src/input/mpegts/dvb_support.c:595
 msgid "UTC+12:45"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:518
+#: src/input/mpegts/dvb_support.c:596
 msgid "UTC+13"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:519
+#: src/input/mpegts/dvb_support.c:597
 msgid "UTC+14"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:483
+#: src/input/mpegts/dvb_support.c:561
 msgid "UTC- 1"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:484
+#: src/input/mpegts/dvb_support.c:562
 msgid "UTC- 2"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:485
+#: src/input/mpegts/dvb_support.c:563
 msgid "UTC- 2:30"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:486
+#: src/input/mpegts/dvb_support.c:564
 msgid "UTC- 3"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:487
+#: src/input/mpegts/dvb_support.c:565
 msgid "UTC- 3:30"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:488
+#: src/input/mpegts/dvb_support.c:566
 msgid "UTC- 4"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:489
+#: src/input/mpegts/dvb_support.c:567
 msgid "UTC- 4:30"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:490
+#: src/input/mpegts/dvb_support.c:568
 msgid "UTC- 5"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:491
+#: src/input/mpegts/dvb_support.c:569
 msgid "UTC- 6"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:492
+#: src/input/mpegts/dvb_support.c:570
 msgid "UTC- 7"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:493
+#: src/input/mpegts/dvb_support.c:571
 msgid "UTC- 8"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:494
+#: src/input/mpegts/dvb_support.c:572
 msgid "UTC- 9"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:495
+#: src/input/mpegts/dvb_support.c:573
 msgid "UTC- 9:30"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:496
+#: src/input/mpegts/dvb_support.c:574
 msgid "UTC-10"
 msgstr ""
 
-#: src/input/mpegts/dvb_support.c:497
+#: src/input/mpegts/dvb_support.c:575
 msgid "UTC-11"
 msgstr ""
 
-#: src/tvhlog.c:88 src/input/mpegts/satip/satip.c:367
-#: src/input/mpegts/tvhdhomerun/tvhdhomerun.c:186
+#: src/tvhlog.c:97 src/input/mpegts/satip/satip.c:434
+#: src/input/mpegts/tvhdhomerun/tvhdhomerun.c:220
 msgid "UUID"
 msgstr ""
 
-#: src/htsp_server.c:1416
+#: src/htsp_server.c:1589
 msgid "Unable to get system UTC time"
 msgstr ""
 
-#: src/htsp_server.c:1409
+#: src/htsp_server.c:1582
 msgid "Unable to get system local time"
 msgstr ""
 
-#: src/htsp_server.c:1406
+#: src/htsp_server.c:1579
 msgid "Unable to get system time"
 msgstr ""
 
-#: src/htsp_server.c:722
+#: src/htsp_server.c:770
 msgid "Unable to open file"
 msgstr ""
 
-#: src/htsp_server.c:1384
+#: src/htsp_server.c:1557
 msgid "Unable to stat path"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:132
+#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:147
 msgid "Uncommitted"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:146
+#: src/input/mpegts/linuxdvb/linuxdvb_switch.c:161
 msgid "Uncommitted first"
 msgstr ""
 
-#: src/tvhlog.c:157
+#: src/tvhlog.c:169
 msgid "Unicable (EN50494)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:70
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:71
 msgid "Unicable I (EN50494)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:744
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:809
 msgid "Unicable I switch (universal LNB)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:77
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:79
 msgid "Unicable II (EN50607)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:750
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:816
 msgid "Unicable II switch (universal LNB)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1490
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:1604
 msgid "Unicable type"
 msgstr ""
 
-#: src/profile.c:252 src/dvr/dvr_db.c:2572
+#: src/profile.c:259 src/dvr/dvr_db.c:3503
 msgid "Unimportant"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:726
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:788
 msgid "Universal LNB only"
 msgstr ""
 
-#: src/satip/server.c:603
+#: src/descrambler/capmt.c:2699
+msgid "Universal tag order"
+msgstr ""
+
+#: src/satip/server.c:679
 msgid "Universally unique identifier. Read only."
 msgstr ""
 
-#: src/epggrab/module.c:60 src/dvr/dvr_timerec.c:95 src/dvr/dvr_config.c:708
+#: src/epggrab/module.c:57 src/dvr/dvr_timerec.c:84 src/dvr/dvr_config.c:734
 msgid "Unknown"
 msgstr ""
 
-#: src/htsp_server.c:2724
+#: src/htsp_server.c:2954
 msgid "Unknown file"
 msgstr ""
 
-#: src/streaming.c:488
+#: src/streaming.c:516
 #, c-format
 msgid "Unknown reason (%i)"
 msgstr ""
 
-#: src/timeshift.c:266
+#: src/timeshift.c:264
 msgid "Unlimited size"
 msgstr ""
 
-#: src/timeshift.c:232
+#: src/timeshift.c:230
 msgid "Unlimited time"
 msgstr ""
 
-#: src/profile.c:247
+#: src/ratinglabels.c:617
+msgid "Unprocessed rating 'age' received via DVB OTA EPG."
+msgstr ""
+
+#: src/profile.c:254
 msgid "Unset (default)"
 msgstr ""
 
-#: src/descrambler/cwc.c:1884
+#: src/transcoding/codec/profile_video_class.c:29
+msgid "Up & Down"
+msgstr ""
+
+#: src/transcoding/codec/profile_video_class.c:30
+msgid "Up (only)"
+msgstr ""
+
+#: src/descrambler/cclient.c:1424
 msgid "Update Entitlement Management Messages from one mux only."
 msgstr ""
 
-#: src/descrambler/cwc.c:1875
+#: src/descrambler/cclient.c:1414
 msgid "Update card (EMM)"
 msgstr ""
 
-#: src/epggrab.c:303
+#: src/epggrab.c:397
 msgid "Update channel icon"
 msgstr ""
 
-#: src/epggrab.c:279
+#: src/epggrab.c:373
 msgid "Update channel name"
 msgstr ""
 
-#: src/epggrab.c:291
+#: src/epggrab.c:385
 msgid "Update channel number"
 msgstr ""
 
-#: src/dvr/dvr_config.c:775
+#: src/dvr/dvr_config.c:842
 msgid "Update disabled"
 msgstr ""
 
-#: src/config.c:2282
+#: src/config.c:2724
 msgid "Update time"
 msgstr ""
 
-#: src/config.c:2305
+#: src/config.c:2747
 msgid "Update tolerance (ms)"
 msgstr ""
 
-#: src/epggrab/channel.c:780
+#: src/epggrab/channel.c:798
 msgid "Updated"
 msgstr ""
 
-#: src/descrambler/cwc.c:1883
+#: src/descrambler/cclient.c:1423
 msgid "Updates from one mux (EMM)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:646
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:699
 msgid ""
 "Upon start, Tvheadend doesn't know the last rotor position. This value "
 "defines the initial rotor movement. TVHeadend waits the specified time when "
 "the first movement is requested."
 msgstr ""
 
-#: src/main.c:498
+#: src/main.c:565
 #, c-format
 msgid "Usage: %s [OPTIONS]\n"
 msgstr ""
 
-#: src/input/mpegts/mpegts_mux.c:662
-msgid "Use AC-3 detection on the mux."
+#: src/input/mpegts/iptv/iptv_mux.c:97
+msgid "Use"
 msgstr ""
 
-#: src/channels.c:491 src/dvr/dvr_config.c:999
+#: src/input/mpegts/iptv/iptv.c:813 src/input/mpegts/iptv/iptv_mux.c:170
+msgid "Use A/V library"
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux.c:677
+msgid "Use AC-3 detection."
+msgstr ""
+
+#: src/channels.c:537 src/dvr/dvr_config.c:1399
 msgid ""
 "Use EITp/f to decide event start/stop. This is also known as \"Accurate "
 "Recording\". See Help for details."
 msgstr ""
 
-#: src/channels.c:490 src/dvr/dvr_config.c:998
+#: src/channels.c:536 src/dvr/dvr_config.c:1398
 msgid "Use EPG running state"
 msgstr ""
 
-#: src/config.c:2113
-msgid "Use HTTP digest authentication"
-msgstr ""
-
-#: src/profile.c:1230 src/profile.c:1512
+#: src/profile.c:1839 src/profile.c:2114
 msgid "Use WEBM format."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1277
+#: src/dvr/dvr_config.c:1363
 msgid "Use Windows-compatible filenames"
 msgstr ""
 
-#: src/main.c:865
+#: src/main.c:932
 msgid "Use XSPF playlist instead of M3U"
 msgstr ""
 
@@ -7986,9 +10092,15 @@ msgid ""
 "outdated and may cause scanning to take longer than usual."
 msgstr ""
 
-#: src/input/mpegts/mpegts_network_dvb.c:442
+#: src/input/mpegts/mpegts_network_dvb.c:475
 msgid ""
 "Use a pre-defined list of DAB muxes. Note: these lists can sometimes be "
+"outdated and may cause scanning to take longer than usual."
+msgstr ""
+
+#: src/input/mpegts/mpegts_network_dvb.c:452
+msgid ""
+"Use a pre-defined list of DTMB muxes. Note: these lists can sometimes be "
 "outdated and may cause scanning to take longer than usual."
 msgstr ""
 
@@ -8010,233 +10122,237 @@ msgid ""
 "outdated and may cause scanning to take longer than usual."
 msgstr ""
 
-#: src/input/mpegts/mpegts_network_dvb.c:396
+#: src/input/mpegts/mpegts_network_dvb.c:406
 msgid ""
 "Use a pre-defined list of ISDB-C muxes. Note: these lists can sometimes be "
 "outdated and may cause scanning to take longer than usual."
 msgstr ""
 
-#: src/input/mpegts/mpegts_network_dvb.c:419
+#: src/input/mpegts/mpegts_network_dvb.c:429
 msgid ""
 "Use a pre-defined list of ISDB-S muxes. Note: these lists can sometimes be "
 "outdated and may cause scanning to take longer than usual."
 msgstr ""
 
-#: src/input/mpegts/mpegts_network_dvb.c:373
+#: src/input/mpegts/mpegts_network_dvb.c:383
 msgid ""
 "Use a pre-defined list of ISDB-T muxes. Note: these lists can sometimes be "
 "outdated and may cause scanning to take longer than usual."
 msgstr ""
 
-#: src/profile.c:1715
+#: src/epggrab/module/xmltv.c:1115
+msgid "Use category instead of genre"
+msgstr ""
+
+#: src/epggrab/module.c:108
+msgid "Use default configuration"
+msgstr ""
+
+#: src/service_mapper.c:624 src/bouquet.c:759
+msgid "Use fuzzy mapping if merging same name"
+msgstr ""
+
+#: src/transcoding/codec/profile_video_class.c:215
+msgid "Use hardware acceleration for decoding if available."
+msgstr ""
+
+#: src/transcoding/codec/profile_audio_class.c:258
+msgid "Use only defined number of audio tracks at maximum."
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux.c:696
+msgid "Use only this service ID, filter out others."
+msgstr ""
+
+#: src/transcoding/codec/profile_audio_class.c:172
 msgid "Use original"
 msgstr ""
 
-#: src/config.c:2186
-msgid "Use packet backlog"
-msgstr ""
-
-#: src/input/mpegts/mpegts_network.c:225
+#: src/input/mpegts/mpegts_network.c:274
 msgid "Use service IDs as channel numbers"
 msgstr ""
 
-#: src/channels.c:1464
+#: src/channels.c:1801
 msgid "Use tag internally (don't expose to clients)."
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:226
+#: src/input/mpegts/mpegts_network.c:275
 msgid "Use the provider's service IDs as channel numbers."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1101
+#: src/dvr/dvr_config.c:1177
 msgid "Use this character set when setting filenames."
 msgstr ""
 
-#: src/dvr/dvr_config.c:1081
+#: src/dvr/dvr_config.c:1147
 msgid "Use x amount of storage space."
 msgstr ""
 
-#: src/streaming.c:446 src/dvr/dvr_db.c:645
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:536
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:600
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:175
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:233
+msgid "User Band Frequency (in MHz)."
+msgstr ""
+
+#: src/streaming.c:466
 msgid "User access error"
 msgstr ""
 
-#: src/htsp_server.c:1612 src/htsp_server.c:1709 src/htsp_server.c:1848
-#: src/htsp_server.c:1929 src/htsp_server.c:2075 src/htsp_server.c:2113
-#: src/htsp_server.c:2123 src/htsp_server.c:2149 src/htsp_server.c:2187
-#: src/htsp_server.c:2224 src/htsp_server.c:2234 src/htsp_server.c:2259
-#: src/htsp_server.c:2295 src/htsp_server.c:2338 src/htsp_server.c:2346
-#: src/htsp_server.c:2399 src/htsp_server.c:2708
+#: src/htsp_server.c:1785 src/htsp_server.c:1882 src/htsp_server.c:2005
+#: src/htsp_server.c:2114 src/htsp_server.c:2285 src/htsp_server.c:2323
+#: src/htsp_server.c:2333 src/htsp_server.c:2359 src/htsp_server.c:2397
+#: src/htsp_server.c:2434 src/htsp_server.c:2444 src/htsp_server.c:2469
+#: src/htsp_server.c:2505 src/htsp_server.c:2548 src/htsp_server.c:2556
+#: src/htsp_server.c:2609 src/htsp_server.c:2933
 msgid "User does not have access"
 msgstr ""
 
-#: src/htsp_server.c:1962
+#: src/htsp_server.c:2149
 msgid "User does not have access to channel"
 msgstr ""
 
-#: src/channels.c:421
+#: src/channels.c:456
 msgid "User icon"
 msgstr ""
 
-#: src/access.c:1461 src/access.c:1655 src/config.c:2081
+#: src/access.c:1558 src/access.c:1764
 msgid "User interface level"
 msgstr ""
 
-#: src/config.c:2104
-msgid "User interface quick tips (tooltips)"
-msgstr ""
-
-#: src/config.c:2247
-msgid "User language"
-msgstr ""
-
-#: src/streaming.c:448 src/dvr/dvr_db.c:647
+#: src/streaming.c:468
 msgid "User limit reached"
 msgstr ""
 
-#: src/wizard.c:403
+#: src/wizard.c:405
 msgid "User login"
 msgstr ""
 
-#: src/streaming.c:452
+#: src/streaming.c:472
 msgid "User request"
 msgstr ""
 
-#: src/access.c:1626 src/access.c:2039 src/wizard.c:442
-#: src/descrambler/cwc.c:1833
+#: src/access.c:1735 src/access.c:2273 src/wizard.c:444
+#: src/descrambler/cclient.c:1378
 msgid "Username"
 msgstr ""
 
-#: src/access.c:1627
+#: src/access.c:1736
 msgid "Username for the entry (login username)."
 msgstr ""
 
-#: src/access.c:2040
+#: src/access.c:2274
 msgid ""
 "Username of the entry (this should match a username from within the \"Access "
 "Entries\" tab)."
 msgstr ""
 
-#: src/access.c:1598
+#: src/access.c:1707
 msgid "Users - Access Entries"
 msgstr ""
 
-#: src/access.c:2173
+#: src/access.c:2431
 msgid "Users - IP Blocking"
 msgstr ""
 
-#: src/access.c:2020
+#: src/access.c:2254
 msgid "Users - Passwords"
 msgstr ""
 
-#: src/epg.c:2318
+#: src/tvhlog.c:183
+msgid "VA-API"
+msgstr ""
+
+#: src/transcoding/codec/codecs/vorbis.c:51
+#: src/transcoding/codec/codecs/libs/libtheora.c:60
+#: src/transcoding/codec/codecs/libs/libvorbis.c:79
+msgid "Variable bitrate (VBR) mode [0-10]."
+msgstr ""
+
+#: src/transcoding/codec/codecs/aac.c:99
+msgid "Variable bitrate (VBR) mode [0-2]."
+msgstr ""
+
+#: src/transcoding/codec/codecs/mpeg2video.c:60
+msgid "Variable bitrate (VBR) mode [0-31]."
+msgstr ""
+
+#: src/epg.c:1818
 msgid "Variety show"
 msgstr ""
 
-#: src/bouquet.c:1055
+#: src/bouquet.c:1082
 msgid "Verify the SSL certificate."
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:927
+#: src/input/mpegts/iptv/iptv.c:988
 msgid "Verify the peer's SSL."
 msgstr ""
 
-#: src/profile.c:1866
-msgid ""
-"Vertical resolution (height) of the output video stream. Horizontal "
-"resolution is adjusted automatically to preserve aspect ratio. When set to "
-"0, the input resolution is used."
+#: src/descrambler/cccam.c:1026
+msgid "Version"
 msgstr ""
 
-#: src/epg.c:2395
+#: src/epg.c:1895
 msgid "Video"
 msgstr ""
 
-#: src/esfilter.c:629
-msgid "Video Stream Filter"
+#: src/profile.c:2479
+msgid "Video codec profile"
 msgstr ""
 
-#: src/profile.c:1921
-msgid "Video bitrate (kb/s) (0=auto)"
+#: src/transcoding/codec/profile_video_class.c:224
+msgid "Video pixel format."
 msgstr ""
 
-#: src/profile.c:1898
-msgid "Video codec"
-msgstr ""
-
-#: src/profile.c:1910
-msgid "Video codec preset"
-msgstr ""
-
-#: src/profile.c:1911
-msgid "Video codec preset to use for transcoding."
-msgstr ""
-
-#: src/profile.c:1899
-msgid ""
-"Video codec to use for the transcode. \"Do not use\" will disable video "
-"output."
-msgstr ""
-
-#: src/access.c:1734
+#: src/access.c:1843
 msgid "Video recorder"
 msgstr ""
 
-#: src/access.c:1735
+#: src/access.c:1844
 msgid ""
 "Video recorder flags, allow/disallow access to video recorder functionality "
 "(including Autorecs), allow/disallow users to view other DVR entries, allow/"
 "disallow users to work with DVR entries of other users (remove, edit) etc."
 msgstr ""
 
-#: src/access.c:1548
+#: src/access.c:1655
 msgid "View all"
 msgstr ""
 
-#: src/streaming.c:582
+#: src/streaming.c:618
 msgid "Visually impaired commentary/audio description"
 msgstr ""
 
-#: src/profile.c:1318
+#: src/profile.c:1931
 msgid "Vorbis audio"
 msgstr ""
 
-#: src/profile.c:1229 src/profile.c:1511
+#: src/profile.c:1838 src/profile.c:2113
 msgid "WEBM"
 msgstr ""
 
-#: src/profile.c:1683
+#: src/profile.c:2266
 msgid "WEBM/av-lib"
 msgstr ""
 
-#: src/profile.c:1678
+#: src/profile.c:2261
 msgid "WEBM/built-in"
 msgstr ""
 
-#: src/profile.c:2299
-msgid "WEBTV profile H264/AAC/MPEG-TS"
-msgstr ""
-
-#: src/profile.c:2320
-msgid "WEBTV profile H264/AAC/Matroska"
-msgstr ""
-
-#: src/profile.c:2278
-msgid "WEBTV profile VP8/Vorbis/WEBM"
-msgstr ""
-
-#: src/dvr/dvr_db.c:633
+#: src/dvr/dvr_db.c:660
 msgid "Waiting for EPG running flag"
 msgstr ""
 
-#: src/dvr/dvr_db.c:625
+#: src/dvr/dvr_db.c:652
 msgid "Waiting for program start"
 msgstr ""
 
-#: src/dvr/dvr_db.c:623
+#: src/dvr/dvr_db.c:650
 msgid "Waiting for stream"
 msgstr ""
 
-#: src/input/mpegts/mpegts_input.c:338
+#: src/input/mpegts/mpegts_input.c:349
 msgid ""
 "Wake up the linked input whenever this adapter is used. The subscriptions "
 "are named as \"keep\". Note that this isn't normally needed, and is here "
@@ -8244,71 +10360,93 @@ msgid ""
 "otherwise lock the second tuner."
 msgstr ""
 
-#: src/epg.c:2282
+#: src/epg.c:1782
 msgid "War"
 msgstr ""
 
-#: src/epg.c:2342
+#: src/epg.c:1842
 msgid "Water sport"
 msgstr ""
 
-#: src/streaming.c:450
+#: src/streaming.c:470
 msgid "Weak stream"
 msgstr ""
 
-#: src/epg.c:2299
+#: src/epg.c:1799
 msgid "Weather report"
 msgstr ""
 
-#: src/tvhlog.c:165
+#: src/config.c:2175
+msgid "Web Interface Settings"
+msgstr ""
+
+#: src/tvhlog.c:177
 msgid "Web User Interface"
 msgstr ""
 
-#: src/access.c:1771 src/wizard.c:184
+#: src/access.c:1880 src/wizard.c:184
 msgid "Web interface"
 msgstr ""
 
-#: src/access.c:1451 src/access.c:1686
+#: src/access.c:1548 src/access.c:1795
 msgid "Web interface language"
 msgstr ""
 
-#: src/access.c:1687
+#: src/access.c:1796
 msgid "Web interface language."
 msgstr ""
 
-#: src/access.c:1696
+#: src/access.c:1805
 msgid "Web interface theme."
 msgstr ""
 
-#: src/access.c:1695
+#: src/access.c:1804
 msgid "Web theme"
 msgstr ""
 
-#: src/config.c:2032
-msgid "Web user interface"
-msgstr ""
-
-#: src/dvr/dvr_autorec.c:774
+#: src/dvr/dvr_autorec.c:885
 msgid "Wed"
 msgstr ""
 
-#: src/wizard.c:243 src/wizard.c:465
-msgid "Welcome - Tvheadend - your TV streaming server and video recorder"
+#: src/wizard.c:243
+msgid "Welcome"
 msgstr ""
 
-#: src/epg.c:2282
+#: src/epg.c:1782
 msgid "Western"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:691
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:744
 msgid "Western hemisphere (latitude direction)"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:692
+#: src/input/mpegts/linuxdvb/linuxdvb_satconf.c:745
 msgid "Western hemisphere (latitude direction)."
 msgstr ""
 
-#: src/input/mpegts/mpegts_network.c:208
+#: src/config.c:2584
+msgid ""
+"When Tvheadend is acting as an HDHomeRun Server (emulating an HDHomeRun "
+"device for downstream media devices to stream Live TV) then we tell clients "
+"that we have this number of tuners. This is necessary since some clients "
+"artificially limit connections based on tuner count, even though several "
+"channels may share a multiplex on one tuner. The HDHomeRun interface can not "
+"distinguish between different types of tuner in a mixed system with "
+"satellite, aerial and cable. The actual number or types of tuners used by "
+"Tvheadend is not affected by this value.  Tvheadend will allocate tuners "
+"automatically.  Set to zero for Tvheadend to use a default value."
+msgstr ""
+
+#: src/config.c:2611
+msgid ""
+"When Tvheadend is acting as an HDHomeRun Server (emulating an HDHomeRun "
+"device for downstream media devices to stream Live TV) then we use this as "
+"the type of HDHomeRun model number that we send to clients.  Some clients "
+"may require a specific model number to work.  Leave blank for Tvheadend to "
+"use a default."
+msgstr ""
+
+#: src/input/mpegts/mpegts_network.c:257
 msgid ""
 "When nothing else is happening Tvheadend will continuously rotate among all "
 "muxes and tune to them to verify that they are still working when the inputs "
@@ -8318,184 +10456,322 @@ msgid ""
 "issues for SAT>IP (limited number of PID filters)."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1026
+#: src/dvr/dvr_config.c:1063
+msgid ""
+"When scheduling an autorec, this option attempts to schedule at the earliest "
+"time and on the 'best' channel (such as channel with the most failover "
+"services). This is useful when multiple timeshift and repeat channels are "
+"available. Without this option autorecs may get scheduled on timeshift "
+"channels instead of on primary channels. This scheduling requires extra "
+"overhead so is disabled by default."
+msgstr ""
+
+#: src/dvr/dvr_autorec.c:1128
 msgid ""
 "When specified, this setting overrides the subdirectory rules (except the "
 "base directory) defined in the DVR configuration and puts all recordings "
 "done by this entry into the subdirectory named here. See Help for more info."
 msgstr ""
 
-#: src/input/mpegts/iptv/iptv.c:772
+#: src/input/mpegts/iptv/iptv.c:855
 msgid ""
 "When streaming a service (via http or htsp) Tvheadend will use the network "
 "with the highest streaming priority set here. See Help for details."
 msgstr ""
 
-#: src/dvr/dvr_autorec.c:1047
+#: src/dvr/dvr_autorec.c:1164
 msgid ""
 "When the fulltext is checked, the title pattern is matched against title, "
 "subtitle, summary and description."
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:249
+#: src/input/mpegts/mpegts_mux.c:704
+msgid "When the mux was created."
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux.c:712
+msgid "When the mux was successfully scanned for the first time."
+msgstr ""
+
+#: src/input/mpegts/mpegts_mux.c:720
+msgid "When the mux was successfully scanned."
+msgstr ""
+
+#: src/input/mpegts/mpegts_service.c:251
 msgid "When the service was first identified and recorded."
 msgstr ""
 
-#: src/input/mpegts/mpegts_service.c:257
+#: src/input/mpegts/mpegts_service.c:259
 msgid "When the service was last seen during a mux scan."
 msgstr ""
 
-#: src/epg.c:2343
+#: src/epg.c:1843
 msgid "Winter sports"
 msgstr ""
 
-#: src/timeshift.c:287
+#: src/timeshift.c:285
 msgid ""
 "With \"RAM only\" enabled, and when \"Maximum RAM size\" is reached, remove "
 "the oldest segment in the buffer instead of replacing it completely. Note, "
 "this may reduce the amount of rewind time."
 msgstr ""
 
-#: src/access.c:1852 src/access.c:2071 src/input/mpegts/mpegts_network.c:304
+#: src/access.c:1981 src/access.c:2327 src/input/mpegts/mpegts_network.c:353
 msgid "Wizard"
 msgstr ""
 
-#: src/descrambler/capmt.c:2367
+#: src/descrambler/capmt.c:2624
 msgid "Wrapper (capmt_ca.so)"
 msgstr ""
 
-#: src/esfilter.c:703 src/esfilter.c:798 src/esfilter.c:893 src/esfilter.c:988
-#: src/esfilter.c:1093 src/esfilter.c:1175
+#: src/esfilter.c:695 src/esfilter.c:791 src/esfilter.c:887 src/esfilter.c:982
+#: src/esfilter.c:1090 src/esfilter.c:1173
 msgid ""
 "Write a short message to log identifying the matched parameters. It is "
 "useful for debugging your setup or structure of incoming streams."
 msgstr ""
 
-#: src/epggrab.c:316
+#: src/epggrab.c:410
 msgid ""
 "Writes the current in-memory EPG database to disk every x hours, so should a "
 "crash/unexpected shutdown occur EPG data is saved periodically to the "
 "database (re-read on next startup). Set to 0 to disable."
 msgstr ""
 
-#: src/tvhlog.c:164
+#: src/epggrab.c:422
+msgid ""
+"Writes the current in-memory EPG database to disk shortly after an xmltv "
+"import has completed, so should a crash/unexpected shutdown occur EPG data "
+"is saved (re-read on next startup)."
+msgstr ""
+
+#: src/ratinglabels.c:640
+msgid "XML 'rating' tag value to match events received via XMLTV."
+msgstr ""
+
+#: src/ratinglabels.c:647
+msgid "XMLTV 'system' attribute to match events received via XMLTV."
+msgstr ""
+
+#: src/tvhlog.c:176
 msgid "XMLTV EPG Import"
 msgstr ""
 
-#: src/access.c:1397
+#: src/access.c:1563
+msgid "XMLTV output format"
+msgstr ""
+
+#: src/access.c:1494
 msgid "Yes"
 msgstr ""
 
-#: src/input/mpegts/satip/satip.c:288
+#: src/transcoding/codec/codecs/aac.c:83
+msgid "aac"
+msgstr ""
+
+#: src/input/mpegts/satip/satip.c:332
 msgid "addpids/delpids supported"
 msgstr ""
 
-#: src/profile.c:1802
-msgid "bd: nvenc(h264 / h265)"
+#: src/transcoding/codec/codecs/aac.c:71
+msgid "anmr: ANMR method (Not currently recommended)"
 msgstr ""
 
-#: src/profile.c:1806
-msgid "default: nvenc(h264 / h265)"
+#: src/transcoding/codec/profile_audio_class.c:252
+msgid "audio"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:142
+#: src/transcoding/codec/codecs/libs/libopus.c:65
+msgid "audio: Favor faithfulness to the input"
+msgstr ""
+
+#: src/transcoding/codec/codecs/libs/libvpx.c:57
+msgid "best"
+msgstr ""
+
+#: src/transcoding/codec/codecs/libs/libopus.c:54
+msgid "constrained: Use constrained VBR"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:563
+msgid "disabled"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:144
 msgid "en50494"
 msgstr ""
 
-#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:180
+#: src/input/mpegts/linuxdvb/linuxdvb_en50494.c:202
 msgid "en50607"
 msgstr ""
 
-#: src/profile.c:1794
-msgid "fast: h264 / h265 / qsv(h264 / h265)"
+#: src/transcoding/codec/codecs/aac.c:73
+msgid "fast: Constant quantizer (Not recommended)"
 msgstr ""
 
-#: src/profile.c:1793
-msgid "faster: h264 / h265 / qsv(h264)"
+#: src/transcoding/codec/codecs/flac.c:57
+msgid "flac"
 msgstr ""
 
-#: src/profile.c:1801
-msgid "hp: nvenc(h264 / h265)"
+#: src/transcoding/codec/codecs/libs/libvpx.c:58
+msgid "good"
 msgstr ""
 
-#: src/profile.c:1800
-msgid "hq: nvenc(h264 / h265)"
-msgstr ""
-
-#: src/dvr/dvr_db.c:2987
+#: src/dvr/dvr_db.c:4148
 msgid "hrs"
 msgstr ""
 
-#: src/main.c:926
+#: src/main.c:995
 #, c-format
 msgid "invalid option specified [%s]"
 msgstr ""
 
-#: src/tvhlog.c:149
+#: src/tvhlog.c:161
 msgid "libav / ffmpeg"
 msgstr ""
 
-#: src/profile.c:1803
-msgid "ll: nvenc(h264 / h265)"
+#: src/transcoding/codec/codecs/libs/libopus.c:76
+msgid "libopus"
 msgstr ""
 
-#: src/profile.c:1805
-msgid "llhp: nvenc(h264 / h265)"
+#: src/transcoding/codec/codecs/libs/libtheora.c:44
+msgid "libtheora"
 msgstr ""
 
-#: src/profile.c:1804
-msgid "llhq: nvenc(h264 / h265)"
+#: src/transcoding/codec/codecs/libs/libvorbis.c:63
+msgid "libvorbis"
 msgstr ""
 
-#: src/profile.c:1795
-msgid "medium: h264 / h265 / qsv(h264 / h265)"
+#: src/transcoding/codec/codecs/libs/libvpx.c:80
+msgid "libvpx"
 msgstr ""
 
-#: src/dvr/dvr_db.c:2988
+#: src/transcoding/codec/codecs/libs/libx26x.c:166
+msgid "libx264"
+msgstr ""
+
+#: src/transcoding/codec/codecs/libs/libx26x.c:265
+msgid "libx265"
+msgstr ""
+
+#: src/transcoding/codec/codecs/libs/libx26x.c:71
+msgid "libx26x"
+msgstr ""
+
+#: src/webui/webui.c:198
+msgid "logout"
+msgstr ""
+
+#: src/transcoding/codec/codecs/libs/libopus.c:66
+msgid "lowdelay: Restrict to only the lowest delay modes"
+msgstr ""
+
+#: src/dvr/dvr_db.c:4149
 msgid "min"
 msgstr ""
 
-#: src/dvr/dvr_db.c:2989
+#: src/dvr/dvr_db.c:4150
 msgid "mins"
 msgstr ""
 
-#: src/main.c:935
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:75
+msgid "module connected"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:74
+msgid "module init"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:73
+msgid "module present"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:76
+msgid "module ready"
+msgstr ""
+
+#: src/transcoding/codec/codecs/mp2.c:51
+msgid "mp2"
+msgstr ""
+
+#: src/transcoding/codec/codecs/mpeg2video.c:44
+msgid "mpeg2video"
+msgstr ""
+
+#: src/transcoding/codec/codecs/libs/libopus.c:52
+msgid "off: Use constant bit rate"
+msgstr ""
+
+#: src/transcoding/codec/codecs/libs/libopus.c:53
+msgid "on: Use variable bit rate"
+msgstr ""
+
+#: src/main.c:1004
 #, c-format
 msgid "option %s requires a value"
 msgstr ""
 
-#: src/profile.c:1799
-msgid "placebo: h264 / h265"
+#: src/transcoding/codec/codecs/libs/libvpx.c:69
+msgid "psnr"
 msgstr ""
 
-#: src/profile.c:1796
-msgid "slow: h264 / h265 / qsv(h264 / h265)"
+#: src/transcoding/codec/codecs/libs/libvpx.c:59
+msgid "realtime"
 msgstr ""
 
-#: src/profile.c:1797
-msgid "slower: h264 / h265 / qsv(h264)"
+#: src/webui/webui.c:209
+msgid "return"
 msgstr ""
 
-#: src/profile.c:1791
-msgid "superfast: h264 / h265"
+#: src/transcoding/codec/codecs/libs/libx26x.c:271
+msgid "set the x265 preset."
 msgstr ""
 
-#: src/main.c:898
+#: src/transcoding/codec/codecs/libs/libx26x.c:283
+msgid "set the x265 tune parameter."
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:71
+msgid "slot disabled"
+msgstr ""
+
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:72
+#: src/input/mpegts/linuxdvb/linuxdvb_ca.c:563
+msgid "slot empty"
+msgstr ""
+
+#: src/transcoding/codec/codecs/libs/libvpx.c:70
+msgid "ssim"
+msgstr ""
+
+#: src/webui/extjs.c:230
+msgid "towards project operating costs."
+msgstr ""
+
+#: src/main.c:965
 msgid "tsfile input (mux file)"
 msgstr ""
 
-#: src/input/mpegts/tvhdhomerun/tvhdhomerun.c:164
+#: src/input/mpegts/tvhdhomerun/tvhdhomerun.c:191
 msgid "tvhdhomerun client"
 msgstr ""
 
-#: src/profile.c:1790
-msgid "ultrafast: h264 / h265"
+#: src/transcoding/codec/codecs/aac.c:72
+msgid "twoloop: Two loop searching method"
 msgstr ""
 
-#: src/profile.c:1792
-msgid "veryfast: h264 / h265 / qsv(h264)"
+#: src/transcoding/codec/profile_video_class.c:178
+msgid "video"
 msgstr ""
 
-#: src/profile.c:1798
-msgid "veryslow: h264 / h265 / qsv(h264)"
+#: src/transcoding/codec/codecs/libs/libopus.c:64
+msgid "voip: Favor improved speech intelligibility"
+msgstr ""
+
+#: src/transcoding/codec/codecs/vorbis.c:45
+msgid "vorbis"
+msgstr ""
+
+#: src/channels.c:47
+msgid "{name-not-set}"
 msgstr ""


### PR DESCRIPTION
This PR updates the master English language translation templates against source code for the first time in almost seven years. As such the diff is large and the PR must not be merged until we see positive runtime reports.

The master templates are regenerated using `make intl` which fails due to broken dependencies on `src/version.c` and `src/docs_inc.c` not existing so a full build is required (which creates them) before `intl` can succeed. This needs to be resolved in a future PR before we can consider automating template udpates.