### PR TITLE
Fix handling of legacy configuration directories in debian/postinst

### DIFF
--- a/debian/tvheadend.postinst
+++ b/debian/tvheadend.postinst
@@ -13,11 +13,22 @@ configure)
         adduser --quiet --system --group --home /var/lib/tvheadend $HTS_USER
    fi
 
-   HTS_HOME=`getent passwd $HTS_USER | cut -d':' -f6`
+   HTS_HOMEDIR=`getent passwd $HTS_USER | cut -d':' -f6`
 
-   install -d -g ${HTS_USER} -o ${HTS_USER} "${HTS_HOME}/recordings"
+   # Handle previous configuration directory: If the HTS_USER home directory
+   # starts with /home/, append "/.hts/tvheadend" so the superuser
+   # configuration will go in the right place.
+   if [ -z "${HTS_HOMEDIR##/home/*}" ]; then
+        HTS_CONFDIR="$HTS_HOMEDIR/.hts/tvheadend"
+        echo >&2 "Legacy configuration directory $HTS_CONFDIR is in use."
+        install -d -g ${HTS_USER} -o ${HTS_USER} "${HTS_CONFDIR}"
+   else
+        HTS_CONFDIR="$HTS_HOMEDIR"
+   fi
 
-   HTS_SUPERUSERCONF="${HTS_HOME}/superuser"
+   install -d -g ${HTS_USER} -o ${HTS_USER} "${HTS_HOMEDIR}/recordings"
+
+   HTS_SUPERUSERCONF="${HTS_CONFDIR}/superuser"
    rm -f "${HTS_SUPERUSERCONF}"
    touch "${HTS_SUPERUSERCONF}"
    chmod 600 "${HTS_SUPERUSERCONF}"

--- a/debian/tvheadend.postinst
+++ b/debian/tvheadend.postinst
@@ -1,51 +1,50 @@
 #!/bin/sh -e
 
-HTS_USER=hts
+HTS_USER="hts"
 
 . /usr/share/debconf/confmodule
 db_version 2.0
 
 case "$1" in
 configure)
-
-   if ! getent passwd $HTS_USER >/dev/null; then
+    if ! getent passwd "$HTS_USER" >/dev/null; then
         echo >&2 "Creating user: $HTS_USER..."
-        adduser --quiet --system --group --home /var/lib/tvheadend $HTS_USER
-   fi
+        adduser --quiet --system --group --home /var/lib/tvheadend "$HTS_USER"
+    fi
 
-   HTS_HOMEDIR=`getent passwd $HTS_USER | cut -d':' -f6`
+    HTS_HOMEDIR="$(getent passwd "$HTS_USER" | cut -d':' -f6)"
 
-   # Handle previous configuration directory: If the HTS_USER home directory
-   # starts with /home/, append "/.hts/tvheadend" so the superuser
-   # configuration will go in the right place.
-   if [ -z "${HTS_HOMEDIR##/home/*}" ]; then
+    # Handle previous configuration directory: If the HTS_USER home directory
+    # starts with /home/, append "/.hts/tvheadend" so the superuser
+    # configuration will go in the right place.
+    if [ -z "${HTS_HOMEDIR##/home/*}" ]; then
         HTS_CONFDIR="$HTS_HOMEDIR/.hts/tvheadend"
         echo >&2 "Legacy configuration directory $HTS_CONFDIR is in use."
-        install -d -g ${HTS_USER} -o ${HTS_USER} "${HTS_CONFDIR}"
-   else
+        install -d -g "$HTS_USER" -o "$HTS_USER" "$HTS_CONFDIR"
+    else
         HTS_CONFDIR="$HTS_HOMEDIR"
-   fi
+    fi
 
-   install -d -g ${HTS_USER} -o ${HTS_USER} "${HTS_HOMEDIR}/recordings"
+    install -d -g "$HTS_USER" -o "$HTS_USER" "$HTS_HOMEDIR/recordings"
 
-   HTS_SUPERUSERCONF="${HTS_CONFDIR}/superuser"
-   rm -f "${HTS_SUPERUSERCONF}"
-   touch "${HTS_SUPERUSERCONF}"
-   chmod 600 "${HTS_SUPERUSERCONF}"
-   chown ${HTS_USER}:${HTS_USER} "${HTS_SUPERUSERCONF}"
+    HTS_SUPERUSERCONF="${HTS_CONFDIR}/superuser"
+    rm -f "$HTS_SUPERUSERCONF"
+    touch "$HTS_SUPERUSERCONF"
+    chmod 600 "$HTS_SUPERUSERCONF"
+    chown "$HTS_USER":"$HTS_USER" "$HTS_SUPERUSERCONF"
 
-   echo >>"${HTS_SUPERUSERCONF}" "{"
+    echo >>"$HTS_SUPERUSERCONF" "{"
 
-   if db_get tvheadend/admin_username; then
-       echo >>"${HTS_SUPERUSERCONF}" '"username": "'$RET'",'
-   fi
+    if db_get tvheadend/admin_username; then
+        echo >>"$HTS_SUPERUSERCONF" "\"username\": \"$RET\","
+    fi
 
-   if db_get tvheadend/admin_password; then
-       echo >>"${HTS_SUPERUSERCONF}" '"password": "'$RET'"'
-   fi
+    if db_get tvheadend/admin_password; then
+        echo >>"$HTS_SUPERUSERCONF" "\"password\": \"$RET\""
+    fi
     
-   echo >>"${HTS_SUPERUSERCONF}" "}"
-   ;;
+    echo >>"$HTS_SUPERUSERCONF" "}"
+    ;;
 esac
 
 db_stop

--- a/debian/tvheadend.postrm
+++ b/debian/tvheadend.postrm
@@ -1,15 +1,14 @@
 #!/bin/sh -e
 
-HTS_USER=hts
+HTS_USER="hts"
 
 . /usr/share/debconf/confmodule
 db_version 2.0
 
 case "$1" in
 purge)
-    if getent passwd $HTS_USER >/dev/null; then
-        HTS_HOME=`getent passwd $HTS_USER | cut -d':' -f6`
-        rm -rf "${HTS_HOME}"
+    if getent passwd "$HTS_USER" >/dev/null; then
+        rm -rf "$(getent passwd "$HTS_USER" | cut -d':' -f6)"
     fi
     db_purge
    ;;


### PR DESCRIPTION
Detect if the HTS user's home directory starts with "/home/", which
indicates the legacy configuration directory is in use, and use the
correct paths for the "recordings" directory and "superuser" file.
This prevents a useless files/directories from being created and
ensures that "dpkg-reconfigure tvheadend" still updates the
superuser credentials correctly.

Also, clean up several issues in the postinst and postrm scrips in a separate commit for ease of code review.