### PR TITLE
dvr: Fix incorrect usage of `strerror`

### DIFF
--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -4933,7 +4933,7 @@ dvr_entry_delete(dvr_entry_t *de)
       r = deferred_unlink(filename, rdir);
       if(r && r != -ENOENT)
         tvhwarn(LS_DVR, "Unable to remove file '%s' from disk -- %s",
-  	        filename, strerror(-errno));
+  	        filename, strerror(errno));
 
       cmd = de->de_config->dvr_postremove;
       if (cmd && cmd[0])


### PR DESCRIPTION
`strerror` takes the `errno` directly as its argument, negating it will result in an "Unknown error".