### PR TITLE
Add "recordings" to the backup exclude list

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1486,6 +1486,7 @@ dobackup(const char *oldver)
   const char *argv[] = {
     "/usr/bin/tar", "cjf", outfile,
     "--exclude", "backup",
+    "--exclude", "recordings",
     "--exclude", "epggrab/*.sock",
     "--exclude", "timeshift/buffer",
     "--exclude", "imagecache/meta",


### PR DESCRIPTION
Since https://github.com/tvheadend/tvheadend/pull/1540, enabled by https://github.com/tvheadend/tvheadend/pull/1535 and https://github.com/tvheadend/tvheadend/pull/1538, we have been storing the recordings in a subdirectory of the configuration directory by default.  Because of this, the recordings are getting stored in the configuration backup.  This causes the backups to take forever and fill the disk (see
https://github.com/tvheadend/tvheadend/issues/1625).  Instead, exclude the "recordings" directory from the backup to prevent this.

Fixes: #1625 