### PR TITLE
transcoding: access the codec name only when codec pointer is valid

### DIFF
--- a/src/transcoding/transcode/log.h
+++ b/src/transcoding/transcode/log.h
@@ -58,8 +58,8 @@
 #define tvh_context_log(self, level, fmt, ...) \
     do { \
         tvh_stream_log((self)->stream, (level), "[%s => %s]: " fmt, \
-            ((self)->iavctx) ? (self)->iavctx->codec->name : "<unknown>", \
-            ((self)->oavctx) ? (self)->oavctx->codec->name : "<unknown>", \
+            ((self)->iavctx && (self)->iavctx->codec) ? (self)->iavctx->codec->name : "<unknown>", \
+            ((self)->oavctx && (self)->oavctx->codec) ? (self)->oavctx->codec->name : "<unknown>", \
             ##__VA_ARGS__); \
     } while (0)
 


### PR DESCRIPTION
this fixes #1635