### PR TITLE
CI: Ensure we clone the whole repo

### DIFF
--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
We have to make sure we clone the whole repo, so that `git describe` works as expected. Without it, we get version 0.0.0, not what we want.