### PR TITLE
ci: update upload-artifact@v3 to upload-artifact@v4

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -51,7 +51,7 @@ jobs:
           DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre3-dev || DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre2-dev
           AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\ --enable-ffmpeg_static\ --enable-hdhomerun_static\ --python=python3 ./Autobuild.sh -p raspios
           support/cloudsmith.sh -n -p raspios -f '../tvheadend*.deb'
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Tvheadend-deb
         path: tvheadend*.deb
@@ -146,7 +146,7 @@ jobs:
             AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\ --enable-ffmpeg_static\ --enable-hdhomerun_static\ --python=python3 ./Autobuild.sh
             cp ../tvheadend*.deb /artifacts/
             support/cloudsmith.sh -n -f '../tvheadend*.deb'
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Tvheadend-deb
           path: artifacts/tvheadend*.deb
@@ -193,7 +193,7 @@ jobs:
         run: AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\ --enable-ffmpeg_static\ --enable-hdhomerun_static\ --python=python3 ./Autobuild.sh ${{ (startsWith(matrix.container, 'i386') && '-a i386') || '' }}
       - name: copy-result
         run: cp ../tvheadend*.deb .
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: startsWith(matrix.container, 'i386') != true
         with:
           name: Tvheadend-deb
@@ -225,7 +225,7 @@ jobs:
         run: ./configure --disable-dvbscan --disable-libfdkaac_static --disable-ffmpeg_static --disable-hdhomerun_static --disable-libfdkaac_static --disable-libopus_static --disable-libtheora_static --disable-libvorbis_static --disable-libvpx_static --disable-libx264_static --disable-libx265_static --enable-libfdkaac --enable-hdhomerun_client --enable-libsystemd_daemon --python=/usr/bin/python3 && make -C rpm build
       - name: copy-result
         run: cp rpm/RPMS/*/tvheadend*.rpm .
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Tvheadend-RPM
           path: tvheadend*.rpm

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -53,7 +53,7 @@ jobs:
           support/cloudsmith.sh -n -p raspios -f '../tvheadend*.deb'
     - uses: actions/upload-artifact@v4
       with:
-        name: Tvheadend-deb
+        name: Tvheadend-RPiOS-${{ matrix.arch }}
         path: tvheadend*.deb
         if-no-files-found: error
 
@@ -148,7 +148,7 @@ jobs:
             support/cloudsmith.sh -n -f '../tvheadend*.deb'
       - uses: actions/upload-artifact@v4
         with:
-          name: Tvheadend-deb
+          name: Tvheadend-CCX-${{ matrix.distro }}-${{ matrix.arch }}
           path: artifacts/tvheadend*.deb
           if-no-files-found: error
 
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: startsWith(matrix.container, 'i386') != true
         with:
-          name: Tvheadend-deb
+          name: Tvheadend-DEB-${{ matrix.distro }}
           path: tvheadend*.deb
           if-no-files-found: error
       - name: upload-cloudsmith
@@ -227,7 +227,7 @@ jobs:
         run: cp rpm/RPMS/*/tvheadend*.rpm .
       - uses: actions/upload-artifact@v4
         with:
-          name: Tvheadend-RPM
+          name: Tvheadend-RPM-${{ matrix.releasever }}
           path: tvheadend*.rpm
           if-no-files-found: error
       # - name: upload-cloudsmith

--- a/.github/workflows/build-cloudsmith.yml
+++ b/.github/workflows/build-cloudsmith.yml
@@ -52,7 +52,7 @@ jobs:
           DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre3-dev || DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y libpcre2-dev
           AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\ --enable-ffmpeg_static\ --enable-hdhomerun_static\ --python=python3 ./Autobuild.sh -p raspios
           support/cloudsmith.sh -p raspios -f '../tvheadend*.deb'
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Tvheadend-deb
         path: tvheadend*.deb
@@ -152,7 +152,7 @@ jobs:
             cp ../tvheadend*.deb /artifacts/
             if [ '${{ matrix.distro }}' = 'buster' ] && [ '${{ matrix.arch }}' = 'armv7' ]; then update-ca-certificates --fresh; fi
             support/cloudsmith.sh -f '../tvheadend*.deb'
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Tvheadend-deb
           path: artifacts/tvheadend*.deb
@@ -199,7 +199,7 @@ jobs:
         run: AUTOBUILD_CONFIGURE_EXTRA=--enable-ccache\ --enable-ffmpeg_static\ --enable-hdhomerun_static\ --python=python3 ./Autobuild.sh ${{ (startsWith(matrix.container, 'i386') && '-a i386') || '' }}
       - name: copy-result
         run: cp ../tvheadend*.deb .
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: startsWith(matrix.container, 'i386') != true
         with:
           name: Tvheadend-deb
@@ -236,7 +236,7 @@ jobs:
         run: ./configure --disable-dvbscan --disable-libfdkaac_static --disable-ffmpeg_static --disable-hdhomerun_static --disable-libfdkaac_static --disable-libopus_static --disable-libtheora_static --disable-libvorbis_static --disable-libvpx_static --disable-libx264_static --disable-libx265_static --enable-libfdkaac --enable-hdhomerun_client --enable-libsystemd_daemon --python=/usr/bin/python3 && make -C rpm build
       - name: copy-result
         run: cp rpm/RPMS/*/tvheadend*.rpm .
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Tvheadend-RPM
           path: tvheadend*.rpm


### PR DESCRIPTION
This should silence the following warnings during workflow runs:

 `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`