### PR TITLE
Replace single-bit signed integers with unsigned integers

### DIFF
--- a/src/http.h
+++ b/src/http.h
@@ -399,17 +399,17 @@ struct http_client {
   int          hc_refcnt;       /* callback protection - outside hc_mutex */
   int          hc_redirects;
   int          hc_result;
-  int          hc_shutdown:1;
-  int          hc_sending:1;
-  int          hc_einprogress:1;
-  int          hc_reconnected:1;
-  int          hc_keepalive:1;
-  int          hc_in_data:1;
-  int          hc_in_rtp_data:1;
-  int          hc_chunked:1;
-  int          hc_chunk_trails:1;
-  int          hc_handle_location:1; /* handle the redirection (location) requests */
-  int          hc_pause:1;
+  unsigned int hc_shutdown:1;
+  unsigned int hc_sending:1;
+  unsigned int hc_einprogress:1;
+  unsigned int hc_reconnected:1;
+  unsigned int hc_keepalive:1;
+  unsigned int hc_in_data:1;
+  unsigned int hc_in_rtp_data:1;
+  unsigned int hc_chunked:1;
+  unsigned int hc_chunk_trails:1;
+  unsigned int hc_handle_location:1; /* handle the redirection (location) requests */
+  unsigned int hc_pause:1;
 
   http_client_wcmd_t            *hc_wcmd;
   TAILQ_HEAD(,http_client_wcmd)  hc_wqueue;
@@ -425,8 +425,8 @@ struct http_client {
   int          hc_rtp_tcp;
   int          hc_rtcp_tcp;
   int          hc_rtcp_server_port;
-  int          hc_rtp_multicast:1;
-  int          hc_rtp_avpf:1;
+  unsigned int hc_rtp_multicast:1;
+  unsigned int hc_rtp_avpf:1;
   long         hc_rtsp_stream_id;
   int          hc_rtp_timeout;
   char        *hc_rtsp_user;


### PR DESCRIPTION
Single bit signed integers contain a single sign-byte and zero value bytes according to the C99 standard. This is not inteded here.