### PR TITLE
Show SeriesLink for AutoRecs

### DIFF
--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -1067,7 +1067,7 @@ tvheadend.autorec_editor = function(panel, index) {
 
     var list = 'name,title,fulltext,channel,start,start_window,weekdays,' +
                'record,tag,btype,content_type,cat1,cat2,cat3,minduration,maxduration,minyear,maxyear,minseason,maxseason,' +
-               'star_rating,dedup,directory,config_name,comment,pri';
+               'star_rating,dedup,directory,config_name,comment,pri,serieslink';
     var elist = 'enabled,start_extra,stop_extra,' +
                 (tvheadend.accessUpdate.admin ?
                 list + ',owner,creator' : list) + ',pri,retention,removal,maxcount,maxsched';
@@ -1116,6 +1116,7 @@ tvheadend.autorec_editor = function(panel, index) {
             maxseason:    { width: 100 },
             owner:        { width: 100 },
             creator:      { width: 200 },
+            serieslink:   { width: 100 },
             comment:      { width: 200 }
         },
         add: {
@@ -1133,7 +1134,7 @@ tvheadend.autorec_editor = function(panel, index) {
         del: true,
         list: 'enabled,name,title,fulltext,channel,tag,start,start_window,' +
               'weekdays,minduration,maxduration,record,btype,content_type,cat1,cat2,cat3' +
-              'star_rating,pri,dedup,directory,config_name,minseason,maxseason,minyear,maxyear,owner,creator,comment',
+              'star_rating,pri,dedup,directory,config_name,minseason,maxseason,minyear,maxyear,owner,creator,comment,serieslink',
         sort: {
           field: 'name',
           direction: 'ASC'


### PR DESCRIPTION
Allows the 'Series Link' field to be visible in the AutoRec WebUI.

https://tvheadend.org/d/8513-improvements-to-autorec-series-tracking-webui-indications

![1708394449-691767-image](https://github.com/tvheadend/tvheadend/assets/127641886/a32ca143-db7d-4a50-960a-c7a775a2e387)
![1708395088-49699-image](https://github.com/tvheadend/tvheadend/assets/127641886/6b9f9624-82e1-4142-85fc-705fc885fe24)
