### PR TITLE
Update OpenCollective donate link on Wizard

### DIFF
--- a/docs/wizard/channels.md
+++ b/docs/wizard/channels.md
@@ -1,13 +1,15 @@
 **You are now Finished**
 
-You may further customize your settings by editing channel numbers, etc.
+You may further customise your settings by editing channel numbers, etc.
 
 If you confirm this dialog, the default administrator account will be
-removed. Please then the use credentials you defined thru this wizard.
+removed. Please then the use credentials you defined through this wizard.
 
 If you require further help, check out
 [Tvheadend.org](http://tvheadend.org) or chat to us on
 [IRC](https://web.libera.chat/?nick=tvhhelp|?#hts).
 
 Thank you for using Tvheadend (and don't forget to
-[donate](http://tvheadend.org/projects/tvheadend/wiki/Donate))! :)
+[donate](https://opencollective.com/tvheadend/donate))! :)
+
+[![Donate to TVHeadEnd](static/img/opencollective.png)](https://opencollective.com/tvheadend/donate)

--- a/docs/wizard/channels2.md
+++ b/docs/wizard/channels2.md
@@ -1,10 +1,12 @@
 **You are now Finished**
 
-You may further customize your settings by editing channel numbers, etc.
+You may further customise your settings by editing channel numbers, etc.
 
 If you require further help, check out
 [Tvheadend.org](http://tvheadend.org) or chat to us on
 [IRC](https://web.libera.chat/?nick=tvhhelp|?#hts).
 
 Thank you for using Tvheadend (and don't forget to
-[donate](http://tvheadend.org/projects/tvheadend/wiki/Donate))! :)
+[donate](https://opencollective.com/tvheadend/donate))! :)
+
+[![Donate to Tvheadend](static/img/opencollective.png)](https://opencollective.com/tvheadend/donate)


### PR DESCRIPTION
Update the 'donate' link at the end of the setup wizard to point to OpenCollective.
Include logo with link.
![image](https://github.com/tvheadend/tvheadend/assets/127641886/bd69490a-b7e7-46a4-84ff-b5866b2b8a05)

