### PR TITLE
Improve autorec duplicate handling

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -356,7 +356,8 @@ typedef enum {
   DVR_AUTOREC_LRECORD_ONCE_PER_MONTH = 13,
   DVR_AUTOREC_LRECORD_ONCE_PER_WEEK = 10,
   DVR_AUTOREC_LRECORD_ONCE_PER_DAY = 11,
-  /* first free value == 15 */
+  DVR_AUTOREC_RECORD_DVR_PROFILE = 15,
+  /* first free value == 16 */
 } dvr_autorec_dedup_t;
 
 typedef enum {
@@ -764,9 +765,6 @@ int dvr_autorec_get_extra_time_pre( dvr_autorec_entry_t *dae );
 void dvr_autorec_completed( dvr_autorec_entry_t *dae, int error_code );
 
 uint32_t dvr_autorec_get_max_sched_count(dvr_autorec_entry_t *dae);
-
-htsmsg_t *
-dvr_autorec_entry_class_dedup_list ( void *o, const char *lang );
 
 /**
  *

--- a/src/dvr/dvr_autorec.c
+++ b/src/dvr/dvr_autorec.c
@@ -406,6 +406,7 @@ dvr_autorec_create(const char *uuid, htsmsg_t *conf)
   dae->dae_start = -1;
   dae->dae_start_window = -1;
   dae->dae_enabled = 1;
+  dae->dae_record = DVR_AUTOREC_RECORD_DVR_PROFILE;
   dae->dae_config = dvr_config_find_by_name_default(NULL);
   LIST_INSERT_HEAD(&dae->dae_config->dvr_autorec_entries, dae, dae_config_link);
 
@@ -996,10 +997,12 @@ dvr_autorec_entry_class_content_type_list(void *o, const char *lang)
   return m;
 }
 
-htsmsg_t *
+static htsmsg_t *
 dvr_autorec_entry_class_dedup_list ( void *o, const char *lang )
 {
   static const struct strtab tab[] = {
+    { N_("Use DVR configuration"),
+        DVR_AUTOREC_RECORD_DVR_PROFILE },
     { N_("Record all"),
         DVR_AUTOREC_RECORD_ALL },
     { N_("All: Record if EPG/XMLTV indicates it is a unique programme"),
@@ -1354,8 +1357,10 @@ const idclass_t dvr_autorec_entry_class = {
       .type     = PT_U32,
       .id       = "record",
       .name     = N_("Duplicate handling"),
-      .desc     = N_("Duplicate recording handling."),
-      .def.i    = DVR_AUTOREC_RECORD_ALL,
+      .desc     = N_("How to handle duplicate recordings. The 'Use DVR "
+                     "Configuration' value (the default) inherits the "
+                     "settings from the assigned DVR configuration"),
+      .def.i    = DVR_AUTOREC_RECORD_DVR_PROFILE,
       .doc      = prop_doc_duplicate_handling,
       .off      = offsetof(dvr_autorec_entry_t, dae_record),
       .list     = dvr_autorec_entry_class_dedup_list,

--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -190,7 +190,7 @@ dvr_config_create(const char *name, const char *uuid, htsmsg_t *conf)
   cfg->dvr_autorec_max_count = 50;
   cfg->dvr_format_tvmovies_subdir = strdup("tvmovies");
   cfg->dvr_format_tvshows_subdir = strdup("tvshows");
-  cfg->dvr_autorec_dedup = 0;
+  cfg->dvr_autorec_dedup = DVR_AUTOREC_RECORD_ALL;
 
   /* Muxer config */
   cfg->dvr_muxcnf.m_cache  = MC_CACHE_SYSTEM;
@@ -843,6 +843,44 @@ dvr_config_entry_class_update_window_list(void *o, const char *lang)
            24*3600, 60, lang);
 }
 
+static htsmsg_t *
+dvr_autorec_entry_class_record_list ( void *o, const char *lang )
+{
+  static const struct strtab tab[] = {
+    { N_("Record all"),
+        DVR_AUTOREC_RECORD_ALL },
+    { N_("All: Record if EPG/XMLTV indicates it is a unique programme"),
+        DVR_AUTOREC_RECORD_UNIQUE },
+    { N_("All: Record if different episode number"),
+        DVR_AUTOREC_RECORD_DIFFERENT_EPISODE_NUMBER },
+    { N_("All: Record if different subtitle"),
+        DVR_AUTOREC_RECORD_DIFFERENT_SUBTITLE },
+    { N_("All: Record if different description"),
+        DVR_AUTOREC_RECORD_DIFFERENT_DESCRIPTION },
+    { N_("All: Record once per month"),
+        DVR_AUTOREC_RECORD_ONCE_PER_MONTH },
+    { N_("All: Record once per week"),
+        DVR_AUTOREC_RECORD_ONCE_PER_WEEK },
+    { N_("All: Record once per day"),
+        DVR_AUTOREC_RECORD_ONCE_PER_DAY },
+    { N_("Local: Record if different episode number"),
+        DVR_AUTOREC_LRECORD_DIFFERENT_EPISODE_NUMBER },
+    { N_("Local: Record if different title"),
+        DVR_AUTOREC_LRECORD_DIFFERENT_TITLE },
+    { N_("Local: Record if different subtitle"),
+        DVR_AUTOREC_LRECORD_DIFFERENT_SUBTITLE },
+    { N_("Local: Record if different description"),
+        DVR_AUTOREC_LRECORD_DIFFERENT_DESCRIPTION },
+    { N_("Local: Record once per month"),
+        DVR_AUTOREC_LRECORD_ONCE_PER_MONTH },
+    { N_("Local: Record once per week"),
+        DVR_AUTOREC_LRECORD_ONCE_PER_WEEK },
+    { N_("Local: Record once per day"),
+        DVR_AUTOREC_LRECORD_ONCE_PER_DAY },
+  };
+  return strtab2htsmsg(tab, 1, lang);
+}
+
 static int
 dvr_config_class_pathname_set(void *o, const void *v)
 {
@@ -1428,11 +1466,11 @@ const idclass_t dvr_config_class = {
       .type     = PT_U32,
       .id       = "record",
       .name     = N_("Duplicate handling"),
-      .desc     = N_("Duplicate recording handling."),
+      .desc     = N_("How to handle duplicate recordings."),
       .def.i    = DVR_AUTOREC_RECORD_ALL,
       .doc      = prop_doc_duplicate_handling,
       .off      = offsetof(dvr_config_t, dvr_autorec_dedup),
-      .list     = dvr_autorec_entry_class_dedup_list,
+      .list     = dvr_autorec_entry_class_record_list,
       .opts     = PO_ADVANCED | PO_DOC_NLIST | PO_HIDDEN,
       .group    = 6,
     },

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1754,7 +1754,10 @@ static dvr_entry_t *_dvr_duplicate_event(dvr_entry_t *de)
   if (lang_str_empty(de->de_title))
     return NULL;
 
-  record = de->de_autorec->dae_record;
+  if (de->de_autorec->dae_record == DVR_AUTOREC_RECORD_DVR_PROFILE)
+    record = de->de_config->dvr_autorec_dedup;
+  else
+    record = de->de_autorec->dae_record;
 
   switch (record) {
     case DVR_AUTOREC_RECORD_ALL:


### PR DESCRIPTION
This PR merges #1330 with already-committed #1488. It adds an extra option "Use DVR Configuration" to the autorec edit screen; when selected (the default) the setting from the DVR Profile is used. Any later change to the DVR profile setting is applied to existing autorecs which do not have their own setting.