### PR TITLE
ci: added more info logging to cloudsmith.sh

### DIFF
--- a/support/cloudsmith.sh
+++ b/support/cloudsmith.sh
@@ -14,6 +14,12 @@ OS=""
 FILE=""
 DRYRUN="0"
 
+YELLOW='\033[1;33m'
+GREEN='\033[1;32m'
+CYAN='\033[1;36m'
+RED='\033[1;31m'
+NC='\033[0m'
+
 while getopts "t:p:f:n" OPTION
 do
     case $OPTION in
@@ -33,7 +39,7 @@ do
 done
 
 if [[ -z $FILE ]]; then
-    echo "No file specified"
+    echo -e "${RED}No file specified${NC}"
     exit 1
 fi
 
@@ -52,8 +58,8 @@ case $OSPREFIX$TARGET in
     37|38|39)
         OS="fedora";;
     40|41)
-        echo "Fedora 40 and 41 (current rawhide) are not (yet) supported by Cloudsmith" && exit;;
-    *) echo "OS $TARGET could not be recognized" && exit 1;;
+        echo -e "${YELLOW}Fedora 40 and 41 (current rawhide) are not (yet) supported by Cloudsmith${NC}" && exit;;
+    *) echo -e "${RED}OS $OSPREFIX$TARGET could not be recognized${NC}" && exit 1;;
 esac
 
 export LC_ALL=C.UTF-8
@@ -73,27 +79,53 @@ for package in "${FILEARRAY[@]}"; do
     PKGBASENAME=$(basename $package)
     # dryrun exit is performed as late as possible to catch any earlier potential issues
     if [ $DRYRUN = "1" ]; then
-        echo "DRYRUN MODE: Skip pushing $OS $TARGET package $package"
+        echo -e "\n${YELLOW}DRYRUN MODE: Skipped pushing $OS $TARGET package $package${NC}"
         continue
     fi
+    echo -e "\n${GREEN}Publishing $OS $TARGET package $package${NC}"
     # upload package to file upload endpoint
+    echo -e "\n${CYAN}Uploading file${NC}"
     curlUpload=$(
         curl \
+            -w "\n%{http_code}" \
             --upload-file $package \
             -u "$CLOUDSMITH_OWNER:$CLOUDSMITH_API_KEY" \
-            -H "Content-Sha256: $(sha256sum "$package" | cut -f1 -d' ')" \
+            -H "Content-Sha256: $(sha256sum "$package" | cut -f 1 -d ' ')" \
             https://upload.cloudsmith.io/$CLOUDSMITH_ORG/$CLOUDSMITH_REPO/$PKGBASENAME \
     )
+    uploadHTTPCode=$(tail -n1 <<< "$curlUpload")
+    uploadResponse=$(sed '$ d' <<< "$curlUpload")
+    if [ "$uploadHTTPCode" != "200" ]; then
+        echo -e "${RED}Error: received bad package upload response code${NC}"
+        echo -e "${CYAN}HTTP code:${NC}"
+        echo "$uploadHTTPCode"
+        echo -e "${CYAN}Response:${NC}"
+        echo "$uploadResponse"
+        exit 1
+    fi
     IDENTIFIER=$(echo $curlUpload | cut -f 4 -d '"')
     # finalize by POSTing to the create package endpoint
-    curl \
-        -X POST \
-        -H "Content-Type: application/json" \
-        -u "$CLOUDSMITH_OWNER:$CLOUDSMITH_API_KEY" \
-        -d "{
-                \"package_file\": \"$IDENTIFIER\",
-                \"distribution\": \"$OS/$TARGET\"
-            }" \
-        https://api-prd.cloudsmith.io/v1/packages/$CLOUDSMITH_ORG/$CLOUDSMITH_REPO/upload/$EXTENSION/
-    echo
+    echo -e "\n${CYAN}Creating package${NC}"
+    curlPkgCreate=$(
+        curl \
+            -X POST \
+            -w "\n%{http_code}" \
+            -H "Content-Type: application/json" \
+            -u "$CLOUDSMITH_OWNER:$CLOUDSMITH_API_KEY" \
+            -d "{
+                    \"package_file\": \"$IDENTIFIER\",
+                    \"distribution\": \"$OS/$TARGET\"
+                }" \
+            https://api-prd.cloudsmith.io/v1/packages/$CLOUDSMITH_ORG/$CLOUDSMITH_REPO/upload/$EXTENSION/
+    )
+    pkgCreateHTTPCode=$(tail -n1 <<< "$curlPkgCreate")
+    pkgCreateResponse=$(sed '$ d' <<< "$curlPkgCreate")
+    if [ "$pkgCreateHTTPCode" != "201" ]; then
+        echo -e "${RED}Error: received bad package create response code${NC}"
+        echo -e "${CYAN}HTTP code:${NC}"
+        echo "$pkgCreateHTTPCode"
+        echo -e "${CYAN}Response:${NC}"
+        echo "$pkgCreateResponse"
+        exit 1
+    fi
 done


### PR DESCRIPTION
- colors `echo` output for visibility
- exits with `1` if cloudflare API does not return success
- hides cloudsmith response unless there is an error