### PR TITLE
Add subsystems to JSON API.

### DIFF
--- a/src/api/api_config.c
+++ b/src/api/api_config.c
@@ -24,6 +24,12 @@
 #include "api.h"
 #include "config.h"
 
+//Needed to get the current trace/debug states for each subsystem.
+//Look in tvhlog.c for more details.
+#include "bitops.h"
+extern bitops_ulong_t           tvhlog_debug[TVHLOG_BITARRAY];  //TVHLOG_BITARRAY is defined in bitops.h
+extern bitops_ulong_t           tvhlog_trace[TVHLOG_BITARRAY];
+
 static int
 api_config_capabilities(access_t *perm, void *opaque, const char *op,
                         htsmsg_t *args, htsmsg_t **resp)
@@ -45,17 +51,78 @@ api_memoryinfo_grid
   }
 }
 
+//Return a list of trace/debug subsystems and their description.
+static int
+api_subsystems_grid
+ (access_t *perm, void *opaque, const char *op, htsmsg_t *args, htsmsg_t **resp)
+{
+
+  int     i;
+  int     counter = 0;
+  int     trace_count = 0;
+  int     debug_count = 0;
+
+  htsmsg_t *api_response;
+  htsmsg_t *api_item;
+
+  api_response = htsmsg_create_list();
+
+  tvhlog_subsys_t *ts = tvhlog_subsystems;
+
+  for (i = 1, ts++; i < LS_LAST; i++, ts++)
+  {
+    api_item = htsmsg_create_map();
+    htsmsg_add_u32(api_item, "id", i);
+    htsmsg_add_str(api_item, "subsystem", ts->name);
+    htsmsg_add_str(api_item, "description", _(ts->desc));
+
+    if(test_bit(i, tvhlog_trace))
+    {
+      trace_count++;
+      htsmsg_add_bool(api_item, "trace", 1);
+    }
+    else
+    {
+      htsmsg_add_bool(api_item, "trace", 0);
+    }
+
+    if(test_bit(i, tvhlog_debug))
+    {
+      debug_count++;
+      htsmsg_add_bool(api_item, "debug", 1);
+    }
+    else
+    {
+      htsmsg_add_bool(api_item, "debug", 0);
+    }
+
+    htsmsg_add_msg(api_response, NULL, api_item);
+
+    counter++;
+  }
+
+  *resp = htsmsg_create_map();
+
+  htsmsg_add_msg(*resp, "entries", api_response);
+  htsmsg_add_u32(*resp, "traceCount", trace_count);
+  htsmsg_add_u32(*resp, "debugCount", debug_count);
+  htsmsg_add_u32(*resp, "totalCount", counter);
+
+  return 0;
+}
+
 void
 api_config_init ( void )
 {
   static api_hook_t ah[] = {
-    { "config/capabilities", ACCESS_OR|ACCESS_WEB_INTERFACE|ACCESS_HTSP_INTERFACE, api_config_capabilities, NULL },
-    { "config/load",         ACCESS_ADMIN, api_idnode_load_simple, &config },
-    { "config/save",         ACCESS_ADMIN, api_idnode_save_simple, &config },
-    { "tvhlog/config/load",  ACCESS_ADMIN, api_idnode_load_simple, &tvhlog_conf },
-    { "tvhlog/config/save",  ACCESS_ADMIN, api_idnode_save_simple, &tvhlog_conf },
-    { "memoryinfo/class",    ACCESS_ADMIN, api_idnode_class, (void *)&memoryinfo_class },
-    { "memoryinfo/grid",     ACCESS_ADMIN, api_idnode_grid, api_memoryinfo_grid },
+    { "config/capabilities",    ACCESS_OR|ACCESS_WEB_INTERFACE|ACCESS_HTSP_INTERFACE, api_config_capabilities, NULL },
+    { "config/load",            ACCESS_ADMIN, api_idnode_load_simple, &config },
+    { "config/save",            ACCESS_ADMIN, api_idnode_save_simple, &config },
+    { "tvhlog/config/load",     ACCESS_ADMIN, api_idnode_load_simple, &tvhlog_conf },
+    { "tvhlog/config/save",     ACCESS_ADMIN, api_idnode_save_simple, &tvhlog_conf },
+    { "tvhlog/subsystem/grid",  ACCESS_ADMIN, api_subsystems_grid, NULL },
+    { "memoryinfo/class",       ACCESS_ADMIN, api_idnode_class, (void *)&memoryinfo_class },
+    { "memoryinfo/grid",        ACCESS_ADMIN, api_idnode_grid, api_memoryinfo_grid },
     { NULL },
   };
 

--- a/src/bitops.h
+++ b/src/bitops.h
@@ -31,6 +31,8 @@ typedef uint32_t bitops_ulong_t;
 #define BIT_WORD(bit) ((bit) / BITS_PER_LONG)
 #define BIT_MASK(bit) (((bitops_ulong_t)1) << ((bit) % BITS_PER_LONG))
 
+#define TVHLOG_BITARRAY ((LS_LAST + (BITS_PER_LONG - 1)) / BITS_PER_LONG)  //For tvhlog.c and api/api_config.c
+
 static inline void set_bit(int bit, void *addr)
 {
   bitops_ulong_t *p = ((bitops_ulong_t *)addr) + BIT_WORD(bit);

--- a/src/tvhlog.c
+++ b/src/tvhlog.c
@@ -36,12 +36,11 @@
 #include "tcp.h"
 #include "webui/webui.h"
 
-#define TVHLOG_BITARRAY ((LS_LAST + (BITS_PER_LONG - 1)) / BITS_PER_LONG)
-
 int                      tvhlog_run;
 int                      tvhlog_level;
 int                      tvhlog_options;
 char                    *tvhlog_path;
+//TVHLOG_BITARRAY is defined in bitops.h
 bitops_ulong_t           tvhlog_debug[TVHLOG_BITARRAY];
 bitops_ulong_t           tvhlog_trace[TVHLOG_BITARRAY];
 pthread_t                tvhlog_tid;


### PR DESCRIPTION
Add the ability to extract the available subsystems and their descriptions via the JSON API.

https://tvheadend.org/d/8597-extracting-tvh-subsystems-via-the-json-api

Sample:
```
        {
            "id": 12,
            "subsystem": "fsmonitor",
            "description": "Filesystem monitor",
            "trace": false,
            "debug": false
        },
```
**id** - The internal ENUM for this subsystem.
**subsystem** - The name of the subsystem.
**description** - The locale-aware description of the subsystem.
**trace** - True if this subsystem is currently being traced.
**debug** - True if this subsystem is currently being debugged.
