### PR TITLE
configure: fix parsing args if values contain "="

### DIFF
--- a/configure
+++ b/configure
@@ -96,7 +96,7 @@ opt=
 val=
 for opt do
   val=${opt#*=}
-  opt=${opt%=*}
+  opt=${opt%%=*}
   opt=${opt#*--}
   case "$opt" in
     help)


### PR DESCRIPTION
Currently, when the value of an option passed to the configure script as argument contains an equal sign `=`, the part of the string up to the second equal sign is used as option. This commit changes how the string is split, so that always only the part up to the first equal sign is interpreted as option.

`${var%=*}` removes everything from the last equal sign, `${var%%=*}` removes everything from the first equal sign.

This allows to pass `CFLAGS`, which usually contain equal signs, like `--cflags="-march=armv6 -mfloat-abi=hard -mfpu=vfp"`.

For reference: https://github.com/tvheadend/tvheadend/issues/1665