### PR TITLE
Fix echo target for superuser file in Debian postinst

### DIFF
--- a/debian/tvheadend.postinst
+++ b/debian/tvheadend.postinst
@@ -57,17 +57,17 @@ configure)
     echo >>"$HTS_SUPERUSERCONF" "{"
 
     if db_get tvheadend/admin_username; then
-        JSONUSER=`escape_json_string $RET`
-        echo "\"username\": $JSONUSER,"
+        JSONUSER="$(escape_json_string "$RET")"
+        echo >>"$HTS_SUPERUSERCONF" "\"username\": $JSONUSER,"
         JSONUSER=""
     fi
 
     if db_get tvheadend/admin_password; then
-        JSONPASS=`escape_json_string $RET`
-        echo "\"password\": $JSONPASS"
+        JSONPASS="$(escape_json_string "$RET")"
+        echo >>"$HTS_SUPERUSERCONF" "\"password\": $JSONPASS"
         JSONPASS=""
     fi
-    
+
     echo >>"$HTS_SUPERUSERCONF" "}"
     ;;
 esac


### PR DESCRIPTION
aba5e60792177d6a2a867445559f4806973b3258 was causing the username and password to get printed to the console instead of being put in the correct file.  Also, use the modern $() syntax instead of `` and quote all variable assignments.