### PR TITLE
tvhdhomerun: Add ISDB to type check in tvhdhomerun_device_create

### DIFF
--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
@@ -329,6 +329,7 @@ static void tvhdhomerun_device_create(struct hdhomerun_discover_device_t *dInfo)
       type = dvb_str2type(override_type);
       if ( ! ( type == DVB_TYPE_C || type == DVB_TYPE_T ||
                type == DVB_TYPE_ATSC_T || type == DVB_TYPE_ATSC_C ||
+               type == DVB_TYPE_ISDB_T || type == DVB_TYPE_ISDB_C ||
                type == DVB_TYPE_CABLECARD ) ) {
         type = DVB_TYPE_C;
       }


### PR DESCRIPTION
This commit adds support for ISDB in the type check of the tvhdhomerun_device_create function in tvhdhomerun.c. This allows the function to handle ISDB type devices, which previously would have been changed to a DVB device on startup every time despite overrides.