### PR TITLE
dvr: Added missing directory to rerecord-entry

### DIFF
--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1480,6 +1480,7 @@ not_so_good:
   htsmsg_add_str2(conf, "owner", de->de_owner);
   htsmsg_add_str2(conf, "creator", de->de_creator);
   htsmsg_add_str(conf, "comment", buf);
+  htsmsg_add_str(conf, "directory", de->de_directory);
   de2 = dvr_entry_create_from_htsmsg(conf, e);
   htsmsg_destroy(conf);
 


### PR DESCRIPTION
Previously if you had a directory set on a recording and this recording needed to be rerecorded, the directory was not kept in the new entry.