### PR TITLE
Docker/Alpine: Remove USB group

### DIFF
--- a/Containerfile.alpine
+++ b/Containerfile.alpine
@@ -116,7 +116,6 @@ RUN apk add --no-cache \
     addgroup -S 'tvheadend' && \
     adduser -D -G 'tvheadend' -h '/var/lib/tvheadend' -s '/bin/nologin' -S 'tvheadend' && \
     adduser 'tvheadend' 'audio' && \
-    adduser 'tvheadend' 'usb' && \
     adduser 'tvheadend' 'video' && \
     install -d -m 775 -g 'tvheadend' -o 'tvheadend' '/var/lib/tvheadend/recordings' && \
     install -d -m 775 -g 'tvheadend' -o 'tvheadend' '/var/log/tvheadend'


### PR DESCRIPTION
The USB group has been removed from upstream alpine in commit bb00d0e4f345 ("main/alpine-baselayout: remove mem and usb group") which was a fixup on commit
f16d0754d601 ("main/alpine-baselayout: remove unused/moved users and groups")

Lets remove it here as well as we cannot join the group any longer.

Besides, device access is probably better managed with host specific udev rules.