### PR TITLE
XMLTV: Rating Labels: Use 'NONE' when 'system' attribute is missing

### DIFF
--- a/src/epggrab/module/xmltv.c
+++ b/src/epggrab/module/xmltv.c
@@ -474,12 +474,18 @@ static int _xmltv_parse_age_rating
         rating_system = NULL;
         if ((attrib = htsmsg_get_map(rating, "attrib"))){
           rating_system = htsmsg_get_str(attrib, "system");
-        }//END get the atrtibutes for the rating tag.
+        }//END get the attributes for the rating tag.
+        
+        //If no 'system' attribute was found, set a default one.
+        if(!rating_system)
+        {
+          rating_system = "NONE";
+        }
+
         //Look for sub-tags of the 'rating' tag
         if ((tags  = htsmsg_get_map(rating, "tags"))) {
           //Look the the 'value' tag containing the actual rating text
           if ((s1 = htsmsg_xml_get_cdata_str(tags, "value"))) {
-            //tvherror(LS_RATINGLABELS, "XMLTV got system: '%s' / '%s'", rating_system, s1);
 
             rl = ratinglabel_find_from_xmltv(rating_system, s1);
 


### PR DESCRIPTION
**Description**

See Issue: https://github.com/tvheadend/tvheadend/issues/1709

When processing XMLTV EPG data and rating labels are enabled, a missing 'system' attribute in the 'rating' tag results in a crash.

```
<rating system="DEMO">
	<value>TV-PG</value>
</rating>
```

**Resolution:**

If a rating tag is encountered without a 'system' attribute, the literal 'NONE' will be used instead.