### PR TITLE
dvr: Use safer htsmsg_add_str2 when copying de->de_directory

### DIFF
--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1480,7 +1480,7 @@ not_so_good:
   htsmsg_add_str2(conf, "owner", de->de_owner);
   htsmsg_add_str2(conf, "creator", de->de_creator);
   htsmsg_add_str(conf, "comment", buf);
-  htsmsg_add_str(conf, "directory", de->de_directory);
+  htsmsg_add_str2(conf, "directory", de->de_directory);
   de2 = dvr_entry_create_from_htsmsg(conf, e);
   htsmsg_destroy(conf);
 


### PR DESCRIPTION
de->de_directory may be null. htsmsg_add_str passes str unchecked to underlying strlen function. __strlen_avx2 will segfault if str is null.

htsmsg_add_str2 checks the value of args before passing them to htsmsg_add_str, which should prevent this.

Fixes #1712