### PR TITLE
[Rating Labels] Revise null value handling.

### DIFF
--- a/src/epggrab/module/xmltv.c
+++ b/src/epggrab/module/xmltv.c
@@ -476,12 +476,6 @@ static int _xmltv_parse_age_rating
           rating_system = htsmsg_get_str(attrib, "system");
         }//END get the attributes for the rating tag.
         
-        //If no 'system' attribute was found, set a default one.
-        if(!rating_system)
-        {
-          rating_system = "NONE";
-        }
-
         //Look for sub-tags of the 'rating' tag
         if ((tags  = htsmsg_get_map(rating, "tags"))) {
           //Look the the 'value' tag containing the actual rating text


### PR DESCRIPTION
Address issue [#1717](https://github.com/tvheadend/tvheadend/issues/1717).

Reverse PR [#1710](https://github.com/tvheadend/tvheadend/pull/1710).

Remove replacement values and allow 'authority' and 'country' to be null.

Allow XMLTV to be matched using only labels of the 'system' is not supplied.

Use null-safe htsmsg function when creating rating label objects.