### PR TITLE
Rework fullscreen request method detection

### DIFF
--- a/src/webui/static/tv.js
+++ b/src/webui/static/tv.js
@@ -264,16 +264,18 @@ tv.ui.VideoPlayer = Ext.extend(Ext.Panel, (function() {
         },
 
         fullscreen: function() {
-            var dom  = this.video.dom;
+            var dom = this.video.dom;
 
-            if(typeof dom.requestFullScreen !== 'undefined')
-                dom.requestFullScreen();
+            var requestMethod = dom.requestFullScreen ||
+                dom.mozRequestFullScreen ||
+                dom.webkitEnterFullscreen ||
+                dom.webkitRequestFullscreen ||
+                dom.webkitRequestFullScreen ||
+                dom.msRequestFullscreen;
 
-            else if(typeof dom.mozRequestFullScreen !== 'undefined')
-                dom.mozRequestFullScreen();
-
-            else if(typeof dom.webkitRequestFullScreen !== 'undefined')
-                dom.webkitEnterFullscreen();
+            if(requestMethod) {
+                requestMethod.apply( dom );
+            }
         },
 
         play: function() {


### PR DESCRIPTION
The `fullscreen` function in `tv.js` checks for `webkitRequestFullScreen`, but after confirming that it is available, it ends up calling `webkitEnterFullscreen` which does not exist.

This commit changes the fullscreen method detection to something I feel is more straightforward, keeps backwards compatibility (as `webkitEnterFullscreen` is still checked for existence and will be called if possible), and fixes the linked issue.

Fixes #1729 .