### PR TITLE
Add start timeout to streaming profile

### DIFF
--- a/src/profile.c
+++ b/src/profile.c
@@ -361,6 +361,17 @@ const idclass_t profile_class =
     },
     {
       .type     = PT_INT,
+      .id       = "timeout_start",
+      .name     = N_("Data start timeout (sec) (0=default)"),
+      .desc     = N_("The number of seconds to wait for data "
+                     "when stream is starting."),
+      .off      = offsetof(profile_t, pro_timeout_start),
+      .opts     = PO_EXPERT,
+      .def.i    = 0,
+      .group    = 1
+    },
+    {
+      .type     = PT_INT,
       .id       = "priority",
       .name     = N_("Default priority"),
       .desc     = N_("If no specific priority was requested. This "

--- a/src/profile.h
+++ b/src/profile.h
@@ -125,6 +125,7 @@ typedef struct profile {
   int pro_prio;
   int pro_fprio;
   int pro_timeout;
+  int pro_timeout_start;
   int pro_restart;
   int pro_contaccess;
   int pro_ca_timeout;


### PR DESCRIPTION
This allows overriding the hardcoded grace period of 20 seconds.
It should address the problems described in [1][2].

In addition, timeout code has been slightly refactored for readability and more debug logging.

[1] https://tvheadend.org/d/8330-increase-timeout-when-tuning-iptv-mux/2
[2] https://tvheadend.org/d/8158-several-problems-questions-about-using-tvheadend-starting-with-not-waiting-long-enoough-for-stream-to-begin