### PR TITLE
Update linuxdvb_satconf.c  description for lnb_poweroff - requires power save

### DIFF
--- a/src/input/mpegts/linuxdvb/linuxdvb_satconf.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_satconf.c
@@ -302,7 +302,8 @@ const idclass_t linuxdvb_satconf_class =
       .name     = N_("Turn off LNB when idle"),
       .desc     = N_("Switch off the power to the LNB when idle. Note: "
                      "this may cause interference with other devices "
-                     "when the LNB is powered back up."),
+                     "when the LNB is powered back up. "
+                     "'Power save' setting must also be enabled."),
       .off      = offsetof(linuxdvb_satconf_t, ls_lnb_poweroff),
       .opts     = PO_ADVANCED,
       .def.i    = 1


### PR DESCRIPTION
First of all: thanks for TVH. Great software!

This PR extends the description for "lnb poweroff when idle" to make it clear that lnb_poweroff also requires "power save" setting.

Background: I noticed my SAT multiswitch never going into standby mode thus using >10Watt of unnecessary power 24/7. I traced it down to one of my adapters not turning off LNB power. Took me some time of triaging to figure out that the "LNB Poweroff when idle" setting only works, if you also set the "power save" setting.  

In my opinion it is quite bad UI design to have a hidden dependency on some other option. I extended the description to make it clearer that there is a dependency. A better solution would probaby be to remove this dependency and have it always work, no matter if "power save" is set or not. 