### PR TITLE
fix bug in AAC channel layout configuration tab

### DIFF
--- a/src/transcoding/codec/profile_audio_class.c
+++ b/src/transcoding/codec/profile_audio_class.c
@@ -105,16 +105,16 @@ tvh_codec_audio_get_list_channel_layouts(TVHAudioCodec *self)
         else {
 #if LIBAVCODEC_VERSION_MAJOR > 59
             l = channel_layouts;
-            ADD_ENTRY(list, map, s64, l->u.mask, str, AUTO_STR);
-            while (l->nb_channels) {
+            ADD_ENTRY(list, map, s64, 0, str, AUTO_STR);
+            while (l->nb_channels < 32) {
                 if (!(map = htsmsg_create_map())) {
                     htsmsg_destroy(list);
                     list = NULL;
                     break;
                 }
                 l_buf[0] = '\0';
-                av_channel_layout_describe(l, l_buf, sizeof(l_buf));
-                ADD_ENTRY(list, map, s64, l->u.mask, str, l_buf);
+                if(av_channel_layout_describe(l, l_buf, sizeof(l_buf)) > 0)
+                    ADD_ENTRY(list, map, s64, l->u.mask, str, l_buf);
                 l++;
             }
 #else


### PR DESCRIPTION
There are few issues:
1. first entry in combo should be AUTO (with value 0) - in original code was set to 1 (and overwritten later)
2. l->nb_channel is not the best way to cycle though layouts available. At the end I think is accessing some region outside of the struct (because I see is lopped also after 7.1). The way I knew how to fix was to add the filter (l->nb_channels < 32). Maybe changing the while to for will be a better option.
3. av_channel_layout() is returning the length of the string ... we should use l_buf only when retuned value > 0 ... when is < 0 l_buf was not updated.