### PR TITLE
HTSP: Expose broadcast type in 'autorecEntryAdd' and 'autorecEntryUpdate'…

### DIFF
--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -51,7 +51,7 @@
 
 static void *htsp_server, *htsp_server_2;
 
-#define HTSP_PROTO_VERSION 38
+#define HTSP_PROTO_VERSION 39
 
 #define HTSP_ASYNC_OFF  0x00
 #define HTSP_ASYNC_ON   0x01
@@ -611,6 +611,8 @@ htsp_serierec_convert(htsp_connection_t *htsp, htsmsg_t *in, channel_t *ch, int 
       htsmsg_add_u32(conf, "record", !retval ? u32 : DVR_AUTOREC_RECORD_ALL);
     if (!(retval = htsmsg_get_u32(in, "maxCount", &u32)) || add)
       htsmsg_add_u32(conf, "maxcount", !retval ? u32 : 0);     // 0 = unlimited
+    if (!(retval = htsmsg_get_u32(in, "broadcastType", &u32)) || add)
+      htsmsg_add_u32(conf, "broadcastType", !retval ? u32 : 0); // 0 = all
     if (!(retval = htsmsg_get_s64(in, "startExtra", &s64)) || add)
       htsmsg_add_s64(conf, "start_extra", !retval ? (s64 < 0 ? 0 : s64)  : 0); // 0 = dvr config
     if (!(retval = htsmsg_get_s64(in, "stopExtra", &s64)) || add)
@@ -1222,6 +1224,7 @@ htsp_build_autorecentry(htsp_connection_t *htsp, dvr_autorec_entry_t *dae, const
   htsmsg_add_s64(out, "stopExtra",   dvr_autorec_get_extra_time_post(dae));
   htsmsg_add_u32(out, "dupDetect",   dae->dae_record);
   htsmsg_add_u32(out, "maxCount",    dae->dae_max_count);
+  htsmsg_add_u32(out, "broadcastType", dae->dae_btype);
 
   if(dae->dae_title) {
     htsmsg_add_str(out, "title",     dae->dae_title);


### PR DESCRIPTION
… Handle broadcast type in 'addAutorecEntry' and 'updateAutorecEntry'.

For implementation of feature request https://github.com/kodi-pvr/pvr.hts/issues/405 I need autorec broadcast type to be accessible via HTSP.