### PR TITLE
HTSP Updates for UUID and Rating Labels

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -249,8 +249,10 @@ typedef struct dvr_entry {
   //may have changed, so keep an absolute copy of the values at
   //the time of recording rather than pointing to a rating label
   //object that may no longer exist many years later.
-  char *de_rating_label_saved;    /* Saved rating label for once the recording has been completed*/
-  char *de_rating_icon_saved;     /* Saved rating icon full path (not image cache) for once the recording has been completed*/
+  char *de_rating_label_saved;       /* Saved rating label for after the recording has been completed*/
+  char *de_rating_icon_saved;        /* Saved rating icon full path (not image cache) for after the recording has been completed*/
+  char *de_rating_country_saved;     /* Saved rating country code for after the recording has been completed*/
+  char *de_rating_authority_saved;   /* Saved rating authority for after the recording has been completed*/
   ratinglabel_t *de_rating_label; /* 'Live' rating label object */
 
   int de_pri;

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -1221,6 +1221,15 @@ dvr_entry_create_from_htsmsg(htsmsg_t *conf, epg_broadcast_t *e)
         if(e->rating_label->rl_icon){
           htsmsg_add_str(conf, "rating_icon_saved", imagecache_get_propstr(e->rating_label->rl_icon, tbuf, sizeof(tbuf)));
         }
+
+        if(e->rating_label->rl_country){
+          htsmsg_add_str(conf, "rating_country_saved", e->rating_label->rl_country);
+        }
+
+        if(e->rating_label->rl_authority){
+          htsmsg_add_str(conf, "rating_authority_saved", e->rating_label->rl_authority);
+        }
+
       }
     }//END rating labels enabled.
 
@@ -3465,6 +3474,22 @@ dvr_entry_class_rating_set(void *o, const void *v)
         de->de_rating_icon_saved = strdup(rl->rl_icon);
     }
 
+    if(de->de_rating_authority_saved){
+        free(de->de_rating_authority_saved);
+    }
+
+    if(rl->rl_authority){
+        de->de_rating_authority_saved = strdup(rl->rl_authority);
+    }
+
+    if(de->de_rating_country_saved){
+        free(de->de_rating_country_saved);
+    }
+
+    if(rl->rl_country){
+        de->de_rating_country_saved = strdup(rl->rl_country);
+    }
+
     return 1;
   }//END we got an RL object.
 
@@ -4073,6 +4098,53 @@ dvr_entry_class_rating_label_get(void *o)
   }
   return &prop_ptr;
 }
+
+static const void *
+dvr_entry_class_rating_authority_get(void *o)
+{
+  dvr_entry_t *de = (dvr_entry_t *)o;
+  ratinglabel_t *rl = de->de_rating_label;
+  if (rl == NULL) {
+    prop_ptr = "";
+    if(de->de_rating_authority_saved){
+        prop_ptr = de->de_rating_authority_saved;
+    }
+  } else {
+    if(de->de_sched_state == DVR_SCHEDULED){
+      prop_ptr = rl->rl_authority;
+    }
+    else
+    {
+      prop_ptr = de->de_rating_authority_saved;
+    }
+
+  }
+  return &prop_ptr;
+}
+
+static const void *
+dvr_entry_class_rating_country_get(void *o)
+{
+  dvr_entry_t *de = (dvr_entry_t *)o;
+  ratinglabel_t *rl = de->de_rating_label;
+  if (rl == NULL) {
+    prop_ptr = "";
+    if(de->de_rating_country_saved){
+        prop_ptr = de->de_rating_country_saved;
+    }
+  } else {
+    if(de->de_sched_state == DVR_SCHEDULED){
+      prop_ptr = rl->rl_country;
+    }
+    else
+    {
+      prop_ptr = de->de_rating_country_saved;
+    }
+
+  }
+  return &prop_ptr;
+}
+
 
 static const void *
 dvr_entry_class_duplicate_get(void *o)
@@ -4791,6 +4863,22 @@ const idclass_t dvr_entry_class = {
       .off      = offsetof(dvr_entry_t, de_rating_icon_saved),
       .opts     = PO_RDONLY | PO_NOUI,
     },
+    {
+      .type     = PT_STR,
+      .id       = "rating_authority_saved",
+      .name     = N_("Saved Rating Authority"),
+      .desc     = N_("Saved parental rating authority for once recording is complete."),
+      .off      = offsetof(dvr_entry_t, de_rating_authority_saved),
+      .opts     = PO_RDONLY | PO_NOUI,
+    },
+    {
+      .type     = PT_STR,
+      .id       = "rating_country_saved",
+      .name     = N_("Saved Rating Country"),
+      .desc     = N_("Saved parental rating country for once recording is complete."),
+      .off      = offsetof(dvr_entry_t, de_rating_country_saved),
+      .opts     = PO_RDONLY | PO_NOUI,
+    },
     //This needs to go after the 'saved' properties because loading the RL object
     //can refresh the 'saved' objects for scheduled entries.
     {
@@ -4810,6 +4898,22 @@ const idclass_t dvr_entry_class = {
       .name     = N_("Rating Icon"),
       .desc     = N_("Rating Icon URL."),
       .get      = dvr_entry_class_rating_icon_url_get,
+      .opts     = PO_HIDDEN | PO_RDONLY | PO_NOSAVE | PO_NOUI,
+    },
+    {
+      .type     = PT_STR,
+      .id       = "rating_authority",
+      .name     = N_("Rating Authority"),
+      .desc     = N_("Rating Authority."),
+      .get      = dvr_entry_class_rating_authority_get,
+      .opts     = PO_HIDDEN | PO_RDONLY | PO_NOSAVE | PO_NOUI,
+    },
+    {
+      .type     = PT_STR,
+      .id       = "rating_country",
+      .name     = N_("Rating Country"),
+      .desc     = N_("Rating Country."),
+      .get      = dvr_entry_class_rating_country_get,
       .opts     = PO_HIDDEN | PO_RDONLY | PO_NOSAVE | PO_NOUI,
     },
     {

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -869,6 +869,11 @@ htsp_build_channel(channel_t *ch, const char *method, htsp_connection_t *htsp)
   htsmsg_t *services = htsmsg_create_list();
 
   htsmsg_add_u32(out, "channelId", channel_get_id(ch));
+
+  if (htsp->htsp_version > 40){
+    htsmsg_add_str(out, "channelIdStr", idnode_uuid_as_str(&ch->ch_id, buf));
+  }
+
   htsmsg_add_u32(out, "channelNumber", channel_get_major(chnum));
   if (channel_get_minor(chnum))
     htsmsg_add_u32(out, "channelNumberMinor", channel_get_minor(chnum));
@@ -934,6 +939,11 @@ htsp_build_tag(htsp_connection_t *htsp, channel_tag_t *ct, const char *method, i
   htsmsg_t *members = include_channels ? htsmsg_create_list() : NULL;
 
   htsmsg_add_u32(out, "tagId", htsp_channel_tag_get_identifier(ct));
+
+  if (htsp->htsp_version > 40){
+    htsmsg_add_str(out, "tagIdStr", idnode_uuid_as_str(&ct->ct_id, buf));
+  }
+
   htsmsg_add_u32(out, "tagIndex", ct->ct_index);
 
   htsmsg_add_str(out, "tagName", ct->ct_name);
@@ -969,6 +979,10 @@ htsp_build_dvrentry(htsp_connection_t *htsp, dvr_entry_t *de, const char *method
   const char *str;
 
   htsmsg_add_u32(out, "id", idnode_get_short_uuid(&de->de_id));
+
+  if (htsp->htsp_version > 40){
+    htsmsg_add_str(out, "idStr", idnode_uuid_as_str(&de->de_id, ubuf));
+  }
 
   if (!statsonly) {
     htsmsg_add_u32(out, "enabled", de->de_enabled >= 1 ? 1 : 0);

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -51,7 +51,7 @@
 
 static void *htsp_server, *htsp_server_2;
 
-#define HTSP_PROTO_VERSION 40
+#define HTSP_PROTO_VERSION 41
 
 #define HTSP_ASYNC_OFF  0x00
 #define HTSP_ASYNC_ON   0x01
@@ -1049,8 +1049,22 @@ htsp_build_dvrentry(htsp_connection_t *htsp, dvr_entry_t *de, const char *method
                   htsmsg_add_str(out, "ratingIcon", str);
               }//END got an imagecache location
             }//END icon not null
-          }
-        }
+
+            //The authority and country are added for Kodi's parentalRatingSource field.
+            //Kodi looks for the authority first and if that is not present, then it uses the country.
+            //There could be no label, but there could be an age.  The authority &
+            //country could still be useful.
+            if (htsp->htsp_version > 40){
+                if(de->de_rating_label->rl_authority){
+                  htsmsg_add_str(out, "ratingAuthority", de->de_rating_label->rl_authority);
+                }//END authority saved not null
+
+                if(de->de_rating_label->rl_country){
+                  htsmsg_add_str(out, "ratingCountry", de->de_rating_label->rl_country);
+                }//END country saved not null
+            }//END ver > 40
+          }//END rating label not null
+        }//END this is a scheduled recording.
         else
         {
           if(de->de_rating_label_saved){
@@ -1065,8 +1079,19 @@ htsp_build_dvrentry(htsp_connection_t *htsp, dvr_entry_t *de, const char *method
                   htsmsg_add_str(out, "ratingIcon", str);
               }//END got an imagecache location
             }//END icon not null
+
+            if (htsp->htsp_version > 40){
+              if(de->de_rating_authority_saved){
+                htsmsg_add_str(out, "ratingAuthority", de->de_rating_authority_saved);
+              }//END authority saved not null
+
+              if(de->de_rating_country_saved){
+                htsmsg_add_str(out, "ratingCountry", de->de_rating_country_saved);
+              }//END country saved not null
+            }//END version > 40
+
           }
-        }
+        }//END this is not a scheduled recording.
       }//END processing rating labels is enabled
     }
 
@@ -1416,6 +1441,16 @@ htsp_build_event
                 htsmsg_add_str(out, "ratingIcon", str);
             }//END got an imagecache location
           }//END icon not null
+
+          if (htsp->htsp_version > 40){
+              if(e->rating_label->rl_authority){
+                htsmsg_add_str(out, "ratingAuthority", e->rating_label->rl_authority);
+              }//END authority saved not null
+
+              if(e->rating_label->rl_country){
+                htsmsg_add_str(out, "ratingCountry", e->rating_label->rl_country);
+              }//END country saved not null
+          }
         }//END rating label not null
     }//END parental labels enabled.
   }//END HTSP version check

--- a/src/ratinglabels.c
+++ b/src/ratinglabels.c
@@ -533,6 +533,22 @@ ratinglabel_class_save(idnode_t *self, char *filename, size_t fsize)
                 de->de_rating_icon_saved = NULL;
             }
 
+            //If this RL has a country, save that, else, ensure that the recording's RL country is empty.
+            if(rl->rl_icon){
+                de->de_rating_country_saved = strdup(rl->rl_country);
+            }
+            else {
+                de->de_rating_country_saved = NULL;
+            }
+
+            //If this RL has an authority, save that, else, ensure that the recording's RL authority is empty.
+            if(rl->rl_icon){
+                de->de_rating_authority_saved = strdup(rl->rl_authority);
+            }
+            else {
+                de->de_rating_authority_saved = NULL;
+            }
+
             dvr_entry_changed(de);       //Save this recording and push it out to clients.
             foundCount++;
         }//END we matched the RL


### PR DESCRIPTION
1) UUID
For existing message types that use a u32 ID field, for example `channelAdd`, `tagAdd` and `dvrEntryAdd`, add full UUID as a 32 character string for interoperability with objects returned via the HTSP JSON proxy APIs.

2) Rating Labels
a) Add the country and authority values to HTSP messages carrying parental rating labels.
b) Add the saved country and authority values to completed recordings.
This is so that clients (like Kodi) can use the rating properties held by TVH to interpret their own rating labels if required.

3) HTSP version increased to 41.