### PR TITLE
Fixup updating comment in _dvr_entry_update. Only overwrite existing …

### DIFF
--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -2569,9 +2569,9 @@ static dvr_entry_t *_dvr_entry_update
   }
 
   /* Comment */
-  if (strcmp(de->de_comment ?: "", comment ?: "")) {
+  if (comment && strcmp(de->de_comment ?: "", comment)) {
     free(de->de_comment);
-    de->de_comment = comment ? strdup(comment) : NULL;
+    de->de_comment = strdup(comment);
     save |= DVR_UPDATED_COMMENT;
   }
 


### PR DESCRIPTION
…comment if new comment is not NULL. Follows the same logic now as other updates done in this function.

This small functional regression sneaked in with https://github.com/tvheadend/tvheadend/pull/1754.