### PR TITLE
Fix - Audio transcoding not working #1663

### DIFF
--- a/src/transcoding/transcode/helpers.c
+++ b/src/transcoding/transcode/helpers.c
@@ -81,14 +81,15 @@ tvh_context_helper_find(struct TVHContextHelpers *list, const AVCodec *codec)
 
 /* decoders ================================================================= */
 
-/* shared by H264, AAC and VORBIS */
+/* shared by H264, THEORA, AAC, VORBIS and OPUS */
 static int
 tvh_extradata_open(TVHContext *self, AVDictionary **opts)
 {
     size_t extradata_size = 0;
 
     if (!(extradata_size = pktbuf_len(self->input_gh))) {
-        return AVERROR(EAGAIN);
+        // most audio streams don't have input_gh
+        return 0;
     }
     if (extradata_size >= TVH_INPUT_BUFFER_MAX_SIZE) {
         tvh_context_log(self, LOG_ERR, "extradata too big");


### PR DESCRIPTION
src/transcoding/transcode/helpers.c  : pktbuf_len(self->input_gh)) will be 0 (empty) so will return error -11 (AVERROR(EAGAIN) for audio streams.