### PR TITLE
update audio abuffersink from deprecated channel_layouts to ch_layouts

### DIFF
--- a/src/transcoding/codec/codecs/aac.c
+++ b/src/transcoding/codec/codecs/aac.c
@@ -22,16 +22,17 @@
 
 
 /* aac ====================================================================== */
-
+// see aacenc_profiles[] ffmpeg-7.0/libavcodec/aacenctab.h + AV_PROFILE_UNKNOWN
 static const AVProfile aac_profiles[] = {
-    { FF_PROFILE_AAC_MAIN, "Main" },
-    { FF_PROFILE_AAC_LOW,  "LC" },
-    { FF_PROFILE_AAC_LTP,  "LTP" },
-    { FF_PROFILE_UNKNOWN },
+    { FF_AV_PROFILE_AAC_MAIN,      "Main" },
+    { FF_AV_PROFILE_AAC_LOW,       "LC" },
+    { FF_AV_PROFILE_AAC_LTP,       "LTP" },
+    { FF_AV_PROFILE_MPEG2_AAC_LOW, "MPEG2_LC" },
+    { FF_AV_PROFILE_UNKNOWN },
 };
 
 #if LIBAVCODEC_VERSION_MAJOR > 59
-// see aac_chan_configs in ffmpeg-6.0/libavcodec/aacenctab.h
+// see aac_normal_chan_layouts[7] in ffmpeg-7.0/libavcodec/aacenctab.h + NULL termination
 static const AVChannelLayout aac_channel_layouts[] = {
     AV_CHANNEL_LAYOUT_MONO,
     AV_CHANNEL_LAYOUT_STEREO,
@@ -40,6 +41,7 @@ static const AVChannelLayout aac_channel_layouts[] = {
     AV_CHANNEL_LAYOUT_5POINT0_BACK,
     AV_CHANNEL_LAYOUT_5POINT1_BACK,
     AV_CHANNEL_LAYOUT_7POINT1,
+    { 0 },
 };
 #else
 // see aac_chan_configs in ffmpeg-3.0.2/libavcodec/aacenctab.h

--- a/src/transcoding/codec/codecs/libs/libx26x.c
+++ b/src/transcoding/codec/codecs/libs/libx26x.c
@@ -116,13 +116,13 @@ tvh_codec_profile_libx265_destroy(TVHCodecProfile *_self)
 #include <x264.h>
 
 static const AVProfile libx264_profiles[] = {
-    { FF_PROFILE_H264_BASELINE, "Baseline" },
-    { FF_PROFILE_H264_MAIN,     "Main" },
-    { FF_PROFILE_H264_HIGH,     "High" },
-    { FF_PROFILE_H264_HIGH_10,  "High 10" },
-    { FF_PROFILE_H264_HIGH_422, "High 4:2:2" },
-    { FF_PROFILE_H264_HIGH_444, "High 4:4:4" },
-    { FF_PROFILE_UNKNOWN },
+    { FF_AV_PROFILE_H264_BASELINE, "Baseline" },
+    { FF_AV_PROFILE_H264_MAIN,     "Main" },
+    { FF_AV_PROFILE_H264_HIGH,     "High" },
+    { FF_AV_PROFILE_H264_HIGH_10,  "High 10" },
+    { FF_AV_PROFILE_H264_HIGH_422, "High 4:2:2" },
+    { FF_AV_PROFILE_H264_HIGH_444, "High 4:4:4" },
+    { FF_AV_PROFILE_UNKNOWN },
 };
 
 

--- a/src/transcoding/codec/codecs/libs/nvenc.c
+++ b/src/transcoding/codec/codecs/libs/nvenc.c
@@ -52,8 +52,6 @@
 #define NV_ENC_HEVC_PROFILE_MAIN_10 			    1
 #define NV_ENC_HEVC_PROFILE_REXT			        2
 
-#define NV_ENC_PROFILE_UNKNOWN                      FF_PROFILE_UNKNOWN
-
 #define NV_ENC_LEVEL_AUTOSELECT                     0
 
 #define NV_ENC_LEVEL_H264_1                         10
@@ -217,7 +215,7 @@ static const codec_profile_class_t codec_profile_nvenc_class = {
                 .get_opts = codec_profile_class_profile_get_opts,
                 .off      = offsetof(tvh_codec_profile_nvenc_t, nvenc_profile),
                 .list     = codec_profile_nvenc_class_profile_list,
-                .def.i    = NV_ENC_PROFILE_UNKNOWN,
+                .def.i    = FF_AV_PROFILE_UNKNOWN,
             },
             {
                 .type     = PT_INT,
@@ -279,7 +277,7 @@ static const AVProfile nvenc_h264_profiles[] = {
     { NV_ENC_H264_PROFILE_MAIN,                 "Main" },
     { NV_ENC_H264_PROFILE_HIGH,                 "High" },
     { NV_ENC_H264_PROFILE_HIGH_444P,            "High 444P" },
-    { NV_ENC_PROFILE_UNKNOWN },
+    { FF_AV_PROFILE_UNKNOWN },
 };
 
 static int
@@ -323,7 +321,7 @@ tvh_codec_profile_nvenc_h264_open(tvh_codec_profile_nvenc_t *self,
         AV_DICT_SET(opts, "level", s, 0);
     }
 
-    if (self->nvenc_profile != NV_ENC_PROFILE_UNKNOWN &&
+    if (self->nvenc_profile != FF_AV_PROFILE_UNKNOWN &&
         (s = val2str(self->nvenc_profile, profiletab)) != NULL) {
         AV_DICT_SET(opts, "profile", s, 0);
     }
@@ -406,7 +404,7 @@ static const AVProfile nvenc_hevc_profiles[] = {
     { NV_ENC_HEVC_PROFILE_MAIN,    "Main" },
     { NV_ENC_HEVC_PROFILE_MAIN_10, "Main 10" },
     { NV_ENC_HEVC_PROFILE_REXT, "Rext" },
-    { NV_ENC_PROFILE_UNKNOWN },
+    { FF_AV_PROFILE_UNKNOWN },
 };
 
 static int
@@ -443,7 +441,7 @@ tvh_codec_profile_nvenc_hevc_open(tvh_codec_profile_nvenc_t *self,
         AV_DICT_SET(opts, "level", s, 0);
         }
 
-    if (self->nvenc_profile != NV_ENC_PROFILE_UNKNOWN &&
+    if (self->nvenc_profile != FF_AV_PROFILE_UNKNOWN &&
         (s = val2str(self->nvenc_profile, profiletab)) != NULL) {
         AV_DICT_SET(opts, "profile", s, 0);
         }

--- a/src/transcoding/codec/codecs/libs/vaapi.c
+++ b/src/transcoding/codec/codecs/libs/vaapi.c
@@ -590,10 +590,10 @@ static const codec_profile_class_t codec_profile_vaapi_class = {
 /* h264_vaapi =============================================================== */
 
 static const AVProfile vaapi_h264_profiles[] = {
-    { FF_PROFILE_H264_CONSTRAINED_BASELINE, "Constrained Baseline" },
-    { FF_PROFILE_H264_MAIN,                 "Main" },
-    { FF_PROFILE_H264_HIGH,                 "High" },
-    { FF_PROFILE_UNKNOWN },
+    { FF_AV_PROFILE_H264_CONSTRAINED_BASELINE, "Constrained Baseline" },
+    { FF_AV_PROFILE_H264_MAIN,                 "Main" },
+    { FF_AV_PROFILE_H264_HIGH,                 "High" },
+    { FF_AV_PROFILE_UNKNOWN },
 };
 
 static int
@@ -915,10 +915,10 @@ TVHVideoCodec tvh_codec_vaapi_h264 = {
 /* hevc_vaapi =============================================================== */
 
 static const AVProfile vaapi_hevc_profiles[] = {
-    { FF_PROFILE_HEVC_MAIN, "Main" },
-    { FF_PROFILE_HEVC_MAIN_10, "Main 10" },
-    { FF_PROFILE_HEVC_REXT, "Rext" },
-    { FF_PROFILE_UNKNOWN },
+    { FF_AV_PROFILE_HEVC_MAIN,     "Main" },
+    { FF_AV_PROFILE_HEVC_MAIN_10,  "Main 10" },
+    { FF_AV_PROFILE_HEVC_REXT,     "Rext" },
+    { FF_AV_PROFILE_UNKNOWN },
 };
 
 static int
@@ -1230,7 +1230,7 @@ TVHVideoCodec tvh_codec_vaapi_hevc = {
 /* vp8_vaapi =============================================================== */
 
 static const AVProfile vaapi_vp8_profiles[] = {
-    { FF_PROFILE_UNKNOWN },
+    { FF_AV_PROFILE_UNKNOWN },
 };
 
 static int
@@ -1538,7 +1538,7 @@ TVHVideoCodec tvh_codec_vaapi_vp8 = {
 /* vp9_vaapi =============================================================== */
 
 static const AVProfile vaapi_vp9_profiles[] = {
-    { FF_PROFILE_UNKNOWN },
+    { FF_AV_PROFILE_UNKNOWN },
 };
 
 static int

--- a/src/transcoding/codec/internals.h
+++ b/src/transcoding/codec/internals.h
@@ -162,6 +162,69 @@ tvh_codecs_register(void);
 void
 tvh_codecs_forget(void);
 
+/* ffmpeg constants */
+#if LIBAVCODEC_VERSION_MAJOR > 59
+// **** AUDIO ****
+// aac
+#define FF_AV_PROFILE_AAC_MAIN                  AV_PROFILE_AAC_MAIN
+#define FF_AV_PROFILE_AAC_LOW                   AV_PROFILE_AAC_LOW
+#define FF_AV_PROFILE_AAC_LTP                   AV_PROFILE_AAC_LTP
+#define FF_AV_PROFILE_MPEG2_AAC_LOW             AV_PROFILE_MPEG2_AAC_LOW
+// **** VIDEO ****
+// vp9
+#define FF_AV_PROFILE_VP9_0                     AV_PROFILE_VP9_0
+#define FF_AV_PROFILE_VP9_1                     AV_PROFILE_VP9_1
+#define FF_AV_PROFILE_VP9_2                     AV_PROFILE_VP9_2
+#define FF_AV_PROFILE_VP9_3                     AV_PROFILE_VP9_3
+// h265
+#define FF_AV_PROFILE_HEVC_MAIN                 AV_PROFILE_HEVC_MAIN
+#define FF_AV_PROFILE_HEVC_MAIN_10              AV_PROFILE_HEVC_MAIN_10
+#define FF_AV_PROFILE_HEVC_REXT                 AV_PROFILE_HEVC_REXT
+// h264
+#define FF_AV_PROFILE_H264_BASELINE             AV_PROFILE_H264_BASELINE
+#define FF_AV_PROFILE_H264_CONSTRAINED_BASELINE AV_PROFILE_H264_CONSTRAINED_BASELINE
+#define FF_AV_PROFILE_H264_MAIN                 AV_PROFILE_H264_MAIN
+#define FF_AV_PROFILE_H264_HIGH                 AV_PROFILE_H264_HIGH
+#define FF_AV_PROFILE_H264_HIGH_10              AV_PROFILE_H264_HIGH_10
+#define FF_AV_PROFILE_H264_HIGH_422             AV_PROFILE_H264_HIGH_422
+#define FF_AV_PROFILE_H264_HIGH_444             AV_PROFILE_H264_HIGH_444
+// mpeg2
+#define FF_AV_PROFILE_MPEG2_MAIN                AV_PROFILE_MPEG2_MAIN
+#define FF_AV_PROFILE_MPEG2_SIMPLE              AV_PROFILE_MPEG2_SIMPLE
+// common
+#define FF_AV_PROFILE_UNKNOWN                   AV_PROFILE_UNKNOWN
+#else
+// **** AUDIO ****
+// aac
+#define FF_AV_PROFILE_AAC_MAIN                  FF_PROFILE_AAC_MAIN
+#define FF_AV_PROFILE_AAC_LOW                   FF_PROFILE_AAC_LOW
+#define FF_AV_PROFILE_AAC_LTP                   FF_PROFILE_AAC_LTP
+#define FF_AV_PROFILE_MPEG2_AAC_LOW             FF_PROFILE_MPEG2_AAC_LOW
+// **** VIDEO ****
+// vp9
+#define FF_AV_PROFILE_VP9_0                     FF_PROFILE_VP9_0
+#define FF_AV_PROFILE_VP9_1                     FF_PROFILE_VP9_1
+#define FF_AV_PROFILE_VP9_2                     FF_PROFILE_VP9_2
+#define FF_AV_PROFILE_VP9_3                     FF_PROFILE_VP9_3
+// h265
+#define FF_AV_PROFILE_HEVC_MAIN                 FF_PROFILE_HEVC_MAIN
+#define FF_AV_PROFILE_HEVC_MAIN_10              FF_PROFILE_HEVC_MAIN_10
+#define FF_AV_PROFILE_HEVC_REXT                 FF_PROFILE_HEVC_REXT
+// h264
+#define FF_AV_PROFILE_H264_BASELINE             FF_PROFILE_H264_BASELINE
+#define FF_AV_PROFILE_H264_CONSTRAINED_BASELINE FF_PROFILE_H264_CONSTRAINED_BASELINE
+#define FF_AV_PROFILE_H264_MAIN                 FF_PROFILE_H264_MAIN
+#define FF_AV_PROFILE_H264_HIGH                 FF_PROFILE_H264_HIGH
+#define FF_AV_PROFILE_H264_HIGH_10              FF_PROFILE_H264_HIGH_10
+#define FF_AV_PROFILE_H264_HIGH_422             FF_PROFILE_H264_HIGH_422
+#define FF_AV_PROFILE_H264_HIGH_444             FF_PROFILE_H264_HIGH_444
+// mpeg2
+#define FF_AV_PROFILE_MPEG2_MAIN                FF_PROFILE_MPEG2_MAIN
+#define FF_AV_PROFILE_MPEG2_SIMPLE              FF_PROFILE_MPEG2_SIMPLE
+// common
+#define FF_AV_PROFILE_UNKNOWN                   FF_PROFILE_UNKNOWN
+#endif
+
 
 /* codec_profile_class */
 
@@ -239,11 +302,8 @@ typedef struct tvh_codec_profile_audio {
     char *language3;
     int sample_fmt;
     int sample_rate;
-#if LIBAVCODEC_VERSION_MAJOR > 59
-    AVChannelLayout channel_layout;
-#else
+    // this variable will be used also as ch_layout_u_mask when LIBAVCODEC_VERSION_MAJOR > 59
     int64_t channel_layout;
-#endif
 } TVHAudioCodecProfile;
 
 

--- a/src/transcoding/codec/profile_class.c
+++ b/src/transcoding/codec/profile_class.c
@@ -51,8 +51,8 @@ tvh_codec_get_list_profiles(TVHCodec *self)
             list = NULL;
         }
         else {
-            ADD_ENTRY(list, map, s32, FF_PROFILE_UNKNOWN, str, AUTO_STR);
-            for (p = (AVProfile *)profiles; p->profile != FF_PROFILE_UNKNOWN; p++) {
+            ADD_ENTRY(list, map, s32, FF_AV_PROFILE_UNKNOWN, str, AUTO_STR);
+            for (p = (AVProfile *)profiles; p->profile != FF_AV_PROFILE_UNKNOWN; p++) {
                 if (!(map = htsmsg_create_map())) {
                     htsmsg_destroy(list);
                     list = NULL;
@@ -80,7 +80,7 @@ tvh_codec_profile_base_open(TVHCodecProfile *self, AVDictionary **opts)
 {
     AV_DICT_SET_TVH_REQUIRE_META(opts, 1);
     // profile
-    if (self->profile != FF_PROFILE_UNKNOWN) {
+    if (self->profile != FF_AV_PROFILE_UNKNOWN) {
         AV_DICT_SET_INT(opts, "profile", self->profile, 0);
     }
     return 0;
@@ -281,7 +281,7 @@ const codec_profile_class_t codec_profile_class = {
                 .get_opts = codec_profile_class_profile_get_opts,
                 .off      = offsetof(TVHCodecProfile, profile),
                 .list     = codec_profile_class_profile_list,
-                .def.i    = FF_PROFILE_UNKNOWN,
+                .def.i    = FF_AV_PROFILE_UNKNOWN,
             },
             {}
         }

--- a/src/transcoding/transcode/hwaccels/vaapi.c
+++ b/src/transcoding/transcode/hwaccels/vaapi.c
@@ -17,7 +17,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
+#include "../../codec/internals.h"
 #include "../internals.h"
 #include "vaapi.h"
 
@@ -154,11 +154,11 @@ tvhva_context_profile(TVHVAContext *self, AVCodecContext *avctx)
     switch (avctx->codec->id) {
         case AV_CODEC_ID_MPEG2VIDEO:
             switch (avctx->profile) {
-                case FF_PROFILE_UNKNOWN:
-                case FF_PROFILE_MPEG2_MAIN:
+                case FF_AV_PROFILE_UNKNOWN:
+                case FF_AV_PROFILE_MPEG2_MAIN:
                     check = VAProfileMPEG2Main;
                     break;
-                case FF_PROFILE_MPEG2_SIMPLE:
+                case FF_AV_PROFILE_MPEG2_SIMPLE:
                     check = VAProfileMPEG2Simple;
                     break;
                 default:
@@ -167,14 +167,14 @@ tvhva_context_profile(TVHVAContext *self, AVCodecContext *avctx)
             break;
         case AV_CODEC_ID_H264:
             switch (avctx->profile) {
-                case FF_PROFILE_UNKNOWN:
-                case FF_PROFILE_H264_HIGH:
+                case FF_AV_PROFILE_UNKNOWN:
+                case FF_AV_PROFILE_H264_HIGH:
                     check = VAProfileH264High;
                     break;
-                case FF_PROFILE_H264_CONSTRAINED_BASELINE:
+                case FF_AV_PROFILE_H264_CONSTRAINED_BASELINE:
                     check = VAProfileH264ConstrainedBaseline;
                     break;
-                case FF_PROFILE_H264_MAIN:
+                case FF_AV_PROFILE_H264_MAIN:
                     check = VAProfileH264Main;
                     break;
                 default:
@@ -183,12 +183,12 @@ tvhva_context_profile(TVHVAContext *self, AVCodecContext *avctx)
             break;
         case AV_CODEC_ID_HEVC:
             switch (avctx->profile) {
-                case FF_PROFILE_UNKNOWN:
-                case FF_PROFILE_HEVC_MAIN:
+                case FF_AV_PROFILE_UNKNOWN:
+                case FF_AV_PROFILE_HEVC_MAIN:
                     check = VAProfileHEVCMain;
                     break;
-                case FF_PROFILE_HEVC_MAIN_10:
-                case FF_PROFILE_HEVC_REXT:
+                case FF_AV_PROFILE_HEVC_MAIN_10:
+                case FF_AV_PROFILE_HEVC_REXT:
                     check = VAProfileHEVCMain10;
                     break;
                 default:
@@ -197,7 +197,7 @@ tvhva_context_profile(TVHVAContext *self, AVCodecContext *avctx)
             break;
         case AV_CODEC_ID_VP8:
             switch (avctx->profile) {
-                case FF_PROFILE_UNKNOWN:
+                case FF_AV_PROFILE_UNKNOWN:
                     check = VAProfileVP8Version0_3;
                     break;
                 default:
@@ -206,17 +206,17 @@ tvhva_context_profile(TVHVAContext *self, AVCodecContext *avctx)
             break;
         case AV_CODEC_ID_VP9:
             switch (avctx->profile) {
-                case FF_PROFILE_UNKNOWN:
-                case FF_PROFILE_VP9_0:
+                case FF_AV_PROFILE_UNKNOWN:
+                case FF_AV_PROFILE_VP9_0:
                     check = VAProfileVP9Profile0;
                     break;
-                case FF_PROFILE_VP9_1:
+                case FF_AV_PROFILE_VP9_1:
                     check = VAProfileVP9Profile1;
                     break;
-                case FF_PROFILE_VP9_2:
+                case FF_AV_PROFILE_VP9_2:
                     check = VAProfileVP9Profile2;
                     break;
-                case FF_PROFILE_VP9_3:
+                case FF_AV_PROFILE_VP9_3:
                     check = VAProfileVP9Profile3;
                     break;
                 default:

--- a/src/transcoding/transcode/internals.h
+++ b/src/transcoding/transcode/internals.h
@@ -56,6 +56,14 @@ typedef enum {
     OPEN_ENCODER_POST
 } TVHOpenPhase;
 
+#if LIBAVCODEC_VERSION_MAJOR > 59
+// this is needed to separate av_opt_set-s from _context_filters_apply_sink_options
+typedef enum {
+    AV_OPT_SET_UNKNOWN,
+    AV_OPT_SET_BIN,
+    AV_OPT_SET_STRING
+} av_opt_set_type;
+#endif
 
 /* TVHTranscoder ============================================================ */
 
@@ -177,7 +185,7 @@ void
 tvh_context_close(TVHContext *self, int flush);
 
 /* __VA_ARGS__ = NULL terminated list of sink options
-   sink option = (const char *name, const uint8_t *value, int size) */
+   sink option = (const char *name, av_opt_set_type opt_set_type, int size, const uint8_t *value) */
 int
 tvh_context_open_filters(TVHContext *self,
                          const char *source_name, const char *source_args,

--- a/src/transcoding/transcode/video.c
+++ b/src/transcoding/transcode/video.c
@@ -274,6 +274,15 @@ tvh_video_context_open_filters(TVHContext *self, AVDictionary **opts)
         return -1;
     }
 
+#if LIBAVCODEC_VERSION_MAJOR > 59
+    int ret = tvh_context_open_filters(self,
+        "buffer", source_args,                                  // source
+        strlen(filters) ? filters : "null",                     // filters
+        "buffersink",                                           // sink
+        "pix_fmts", AV_OPT_SET_BIN,                             // sink option: pix_fmt
+        sizeof(self->oavctx->pix_fmt), &self->oavctx->pix_fmt,
+        NULL);                                                  // _IMPORTANT!_
+#else
     int ret = tvh_context_open_filters(self,
         "buffer", source_args,              // source
         strlen(filters) ? filters : "null", // filters
@@ -281,6 +290,7 @@ tvh_video_context_open_filters(TVHContext *self, AVDictionary **opts)
         "pix_fmts", &self->oavctx->pix_fmt, // sink option: pix_fmt
         sizeof(self->oavctx->pix_fmt),
         NULL);                              // _IMPORTANT!_
+#endif
     str_clear(filters);
     return ret;
 }

--- a/src/webui/static/app/codec.js
+++ b/src/webui/static/app/codec.js
@@ -81,9 +81,9 @@ var codec_profile_forms = {
             AV_CH_LAYOUT_4POINT0           | 263   | 4
             AV_CH_LAYOUT_5POINT0_BACK      | 55    | 5
             AV_CH_LAYOUT_5POINT1_BACK      | 63    | 6
-            AV_CH_LAYOUT_7POINT1_WIDE_BACK | 255   | 8
+            AV_CH_LAYOUT_7POINT1           | 1599  | 8
         */
-        var channels = [0, 4, 3, 7, 263, 55, 63, -1, 255]
+        var channels = [0, 4, 3, 7, 263, 55, 63, 1599]
 
         function updateBitrate(bitrate_f, quality_f, samplerate_f, layout_f) {
             if (quality_f.getValue() > 0) {
@@ -93,10 +93,12 @@ var codec_profile_forms = {
             else {
                 var samplerate = samplerate_f.getValue() || 48000;
                 var layout = layout_f.getValue() || 3; // AV_CH_LAYOUT_STEREO
-                var max_bitrate = (6 * samplerate * channels.indexOf(layout)) / 1000;
-                bitrate_f.setMaxValue(max_bitrate);
-                if (bitrate_f.getValue() > max_bitrate) {
-                    bitrate_f.setValue(max_bitrate);
+                if (channels.indexOf(layout) >= 0) {
+                    var max_bitrate = (6 * samplerate * channels.indexOf(layout)) / 1000;
+                    bitrate_f.setMaxValue(max_bitrate);
+                    if (bitrate_f.getValue() > max_bitrate) {
+                        bitrate_f.setValue(max_bitrate);
+                    }
                 }
                 bitrate_f.setReadOnly(false);
             }


### PR DESCRIPTION
remove audio abuffersink options starting ffmpeg7 as recommended in ffmpeg-7.0/doc/examples/filter_audio.c line 177 --> "/* This filter takes no options. */"

Fixes: #1764