### PR TITLE
lovcombo-all.js: Fix autorec create/edit TypeError with Firefox 134

### DIFF
--- a/src/webui/static/lovcombo/lovcombo-all.js
+++ b/src/webui/static/lovcombo/lovcombo-all.js
@@ -297,7 +297,7 @@ Ext.ux.form.LovCombo = Ext.extend(Ext.ux.form.ComboAny, {
 				this.store.clearFilter();
 				this.store.each(function(r) {
 					var checked = !(!v.match(
-						 '(^|' + this.separator + ')' + RegExp.escape(r.get(this.valueField))
+						 '(^|' + this.separator + ')' + RegExp.escape(String(r.get(this.valueField)))
 						+'(' + this.separator + '|$)'))
 					;
 


### PR DESCRIPTION
Firefox 134 added the RegExp.escape() method
(https://tc39.es/proposal-regex-escaping/#sec-regexp.escape) with a standards-compliant implementation that throws TypeError if any value other than a String is passed in.  This differs from the existing polyfill that simply returns the argument unmodified if it isn't a String.  In TVHeadend, the day-of-the-week selector (as used in the Autorec and Timer configuration) uses Integers as keys for options, causing an Integer to get passed to RegExp.escape() on line 300 of lovcombo-all.js.  Because of the non-standards- compliant permissive behavior of the polyfill, this previously didn't cause an issue.  However, with Firefox 134 (and an upcoming version of Safari), the added standards-compliant method causes a TypeError to be thrown on every attempt to create or edit a timer or autorec, causing the edit window to not be shown.  To solve the issue, pass the response from r.get(this.valueField) through the String() constructor to ensure anything that gets passed in is a String.  This has been tested with Firefox and Chrome with both Integer and String keys.