### PR TITLE
Show recording file name on DVR info page

### DIFF
--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -77,6 +77,7 @@ tvheadend.dvrDetails = function(grid, index) {
         var age_rating = params[25].value;
         var rating_label = params[26].value;
         var rating_icon = params[27].value;
+        let filename = params[28].value;
         var content = '<div class="dvr-details-dialog">' +
         '<div class="dvr-details-dialog-background-image"></div>' +
         '<div class="dvr-details-dialog-content">';
@@ -153,6 +154,8 @@ tvheadend.dvrDetails = function(grid, index) {
             content += '<div class="x-epg-meta"><span class="x-epg-prefix">' + _('Status') + ':</span><span class="x-epg-desc">' + status + '</span></div>';
         if (filesize)
             content += '<div class="x-epg-meta"><span class="x-epg-prefix">' + _('File size') + ':</span><span class="x-epg-desc">' + parseInt(filesize / 1000000) + ' MB</span></div>';
+        if (filename && (tvheadend.uiviewlevel ? tvheadend.uiviewlevel : tvheadend.uilevel) !== 'basic')  // Only show for 'advanced' and 'expert' levels.
+            content += '<div class="x-epg-meta"><span class="x-epg-prefix">' + _('File name') + ':</span><span class="x-epg-desc">' + filename + '</span></div>';
         if (comment)
             content += '<div class="x-epg-meta"><span class="x-epg-prefix">' + _('Comment') + ':</span><span class="x-epg-desc">' + comment + '</span></div>';
         if (autorec_caption)
@@ -317,7 +320,7 @@ tvheadend.dvrDetails = function(grid, index) {
             list: 'channel_icon,disp_title,disp_subtitle,disp_summary,episode_disp,start_real,stop_real,' +
                   'duration,disp_description,status,filesize,comment,duplicate,' +
                   'autorec_caption,timerec_caption,image,copyright_year,credits,keyword,category,' +
-                  'first_aired,genre,channelname,fanart_image,broadcast,age_rating,rating_label,rating_icon',
+                  'first_aired,genre,channelname,fanart_image,broadcast,age_rating,rating_label,rating_icon,filename',
         },
         success: function(d) {
             d = json_decode(d);
@@ -624,7 +627,7 @@ tvheadend.dvr_upcoming = function(panel, index) {
         del: true,
         list: 'category,enabled,duplicate,disp_title,disp_extratext,episode_disp,' +
               'channel,image,copyright_year,start_real,stop_real,duration,pri,filesize,' +
-              'sched_status,errors,data_errors,config_name,owner,creator,comment,genre,broadcast,age_rating,rating_label',
+              'sched_status,errors,data_errors,config_name,owner,creator,comment,genre,broadcast,age_rating,rating_label,filename',
         columns: {
             disp_title: {
                 renderer: tvheadend.displayWithYearAndDuplicateRenderer(),
@@ -814,7 +817,7 @@ tvheadend.dvr_finished = function(panel, index) {
         del: false,
         list: 'disp_title,disp_extratext,episode_disp,channel,channelname,' +
               'start_real,stop_real,duration,filesize,copyright_year,' +
-              'sched_status,errors,data_errors,playcount,url,config_name,owner,creator,comment,age_rating,rating_label',
+              'sched_status,errors,data_errors,playcount,url,config_name,owner,creator,comment,age_rating,rating_label,filename',
         columns: {
             disp_title: {
                 renderer: tvheadend.displayWithYearRenderer(),
@@ -934,7 +937,7 @@ tvheadend.dvr_failed = function(panel, index) {
                      _('The associated file will be removed from storage.'),
         list: 'disp_title,disp_extratext,episode_disp,channel,channelname,' +
               'image,copyright_year,start_real,stop_real,duration,filesize,status,' +
-              'sched_status,errors,data_errors,playcount,url,config_name,owner,creator,comment,age_rating,rating_label',
+              'sched_status,errors,data_errors,playcount,url,config_name,owner,creator,comment,age_rating,rating_label,filename',
         columns: {
             disp_title: {
                 renderer: tvheadend.displayWithYearRenderer(),

--- a/src/webui/static/app/idnode.js
+++ b/src/webui/static/app/idnode.js
@@ -1221,6 +1221,7 @@ tvheadend.idnode_editor = function(_uilevel, item, conf)
             !conf.noUIlevel) {
             uilevelBtn = tvheadend.idnode_uilevel_menu(uilevel, function(l) {
                 uilevel = l;
+                tvheadend.uiviewlevel = l;
                 var values = panel.getForm().getFieldValues();
                 destroy();
                 build();
@@ -1572,6 +1573,7 @@ tvheadend.idnode_create = function(conf, onlyDefault, cloneValues)
             abuttons.uilevel = tvheadend.idnode_uilevel_menu(uilevel, function (l) {
                 values = panel.getForm().getFieldValues();
                 uilevel = l;
+                tvheadend.uiviewlevel = l;
                 createwin();
             });
             buttons.push('->');
@@ -2089,6 +2091,7 @@ tvheadend.idnode_grid = function(panel, conf)
         if (!tvheadend.uilevel_nochange && (!conf.uilevel || conf.uilevel !== 'expert')) {
             abuttons.uilevel = tvheadend.idnode_uilevel_menu(uilevel, function (l) {
                 uilevel = l;
+                tvheadend.uiviewlevel = l;
                 for (var i = 0; i < ifields.length; i++)
                     if (!ifields[i].noui) {
                         var h = ifields[i].get_hidden(uilevel);
@@ -2491,6 +2494,7 @@ tvheadend.idnode_form_grid = function(panel, conf)
         if (!tvheadend.uilevel_nochange && (!conf.uilevel || conf.uilevel !== 'expert')) {
             abuttons.uilevel = tvheadend.idnode_uilevel_menu(uilevel, function (l) {
                 uilevel = l;
+                tvheadend.uiviewlevel = l;
                 var values = null;
                 if (current)
                     values = current.editor.getForm().getFieldValues();
@@ -2925,6 +2929,7 @@ tvheadend.idnode_simple = function(panel, conf)
             if (l === uilevel)
                 return;
             uilevel = l;
+            tvheadend.uiviewlevel = l;
             if (!refresh)
                 return;
             var values = null;


### PR DESCRIPTION
In the DVR 'Information' window, show the full file name and path for recordings where the user 'interface level' or the 'UI grid view level' is higher than 'Basic'.

![image](https://github.com/user-attachments/assets/98249e65-d49f-4249-8439-9354d076f326)
