### PR TITLE
Global setting for 'Items per page'

### DIFF
--- a/docs/property/page_size.md
+++ b/docs/property/page_size.md
@@ -1,0 +1,11 @@
+:
+
+Option           | Description
+-----------------|------------
+**25**           | List 25 items per page.
+**50**           | List 50 items per page.
+**100**          | List 100 items per page.
+**200**          | List 200 items per page.
+**All**          | List all items on a single page.
+
+This setting can be overridden on a page-by-page basis using the drop-down box.

--- a/src/access.c
+++ b/src/access.c
@@ -1507,6 +1507,19 @@ theme_get_ui_list ( void *p, const char *lang )
   return strtab2htsmsg_str(tab, 1, lang);
 }
 
+htsmsg_t *
+page_size_get_ui_list ( void *p, const char *lang )
+{
+  static struct strtab tab[] = {
+    { "25",          25  },
+    { "50",          50  },
+    { "100",         100  },
+    { "200",         200  },
+    { N_("All"),     999999999 },
+  };
+  return strtab2htsmsg(tab, 1, lang);
+}
+
 static idnode_slist_t access_entry_class_change_slist[] = {
   {
     .id   = "change_rights",

--- a/src/access.h
+++ b/src/access.h
@@ -366,6 +366,7 @@ void access_done(void);
 htsmsg_t *language_get_list ( void *obj, const char *lang );
 htsmsg_t *language_get_ui_list ( void *obj, const char *lang );
 htsmsg_t *theme_get_ui_list ( void *obj, const char *lang );
+htsmsg_t *page_size_get_ui_list ( void *obj, const char *lang );
 htsmsg_t *user_get_userlist ( void *obj, const char *lang );
 
 #endif /* ACCESS_H_ */

--- a/src/config.c
+++ b/src/config.c
@@ -1780,6 +1780,7 @@ config_boot
   config.hdhomerun_ip = strdup("");
   config.local_ip = strdup("");
   config.local_port = 0;
+  config.page_size_ui = 50;
 
   /* Generate default */
   if (!path)
@@ -2164,6 +2165,7 @@ PROP_DOC(config_picon_path)
 PROP_DOC(config_picon_servicetype)
 PROP_DOC(viewlevel_config)
 PROP_DOC(themes)
+PROP_DOC(page_size)
 
 const idclass_t config_class = {
   .ic_snode      = &config.idnode,
@@ -2256,6 +2258,17 @@ const idclass_t config_class = {
       .doc    = prop_doc_themes,
       .list   = theme_get_ui_list,
       .off    = offsetof(config_t, theme_ui),
+      .opts   = PO_DOC_NLIST,
+      .group  = 2
+    },
+    {
+      .type   = PT_U32,
+      .id     = "page_size_ui",
+      .name   = N_("Items per page"),
+      .desc   = N_("The default web interface items per page."),
+      .doc    = prop_doc_page_size,
+      .list   = page_size_get_ui_list,
+      .off    = offsetof(config_t, page_size_ui),
       .opts   = PO_DOC_NLIST,
       .group  = 2
     },

--- a/src/config.h
+++ b/src/config.h
@@ -83,6 +83,7 @@ typedef struct config {
 #if ENABLE_VAAPI
   int enable_vainfo;
   #endif
+  uint32_t page_size_ui;
 } config_t;
 
 extern const idclass_t config_class;

--- a/src/webui/comet.c
+++ b/src/webui/comet.c
@@ -180,6 +180,7 @@ comet_access_update(http_connection_t *hc, comet_mailbox_t *cmb)
     }
   }
   htsmsg_add_str(m, "theme", access_get_theme(hc->hc_access));
+  htsmsg_add_u32(m, "page_size", config.page_size_ui);
   htsmsg_add_u32(m, "quicktips", config.ui_quicktips);
   htsmsg_add_u32(m, "chname_num", config.chname_num);
   htsmsg_add_u32(m, "chname_src", config.chname_src);

--- a/src/webui/static/app/config.js
+++ b/src/webui/static/app/config.js
@@ -44,7 +44,10 @@ tvheadend.baseconf = function(panel, index) {
             var n = data['theme_ui'];
             if (n !== tvheadend.theme)
               reload = 1;
-            var n = data['uilevel_nochange'] ? true : false;
+            var n = data['page_size_ui'];
+            if (n !== tvheadend.page_size)
+            reload = 1;
+              var n = data['uilevel_nochange'] ? true : false;
             if (n !== tvheadend.uilevel_nochange)
                 reload = 1;
             var n = data['ui_quicktips'] ? true : false;

--- a/src/webui/static/app/idnode.js
+++ b/src/webui/static/app/idnode.js
@@ -1741,6 +1741,8 @@ tvheadend.idnode_grid = function(panel, conf)
         if (conf.all) params['all'] = 1;
         if (conf.extraParams) conf.extraParams(params);
 
+        if(!params['limit']) params['limit'] = tvheadend.page_size;
+
         groupReader = new Ext.data.JsonReader({
             totalProperty: 'total',
             root: 'entries',
@@ -2036,7 +2038,7 @@ tvheadend.idnode_grid = function(panel, conf)
                 data: [[25, '25'], [50, '50'], [100, '100'],
                     [200, '200'], [999999999, _('All')]]
             }),
-            value: 50,
+            value: tvheadend.page_size,
             mode: 'local',
             forceSelection: false,
             triggerAction: 'all',

--- a/src/webui/static/app/tvheadend.js
+++ b/src/webui/static/app/tvheadend.js
@@ -694,7 +694,7 @@ tvheadend.loading = function(on) {
 tvheadend.PagingToolbarConf = function(conf, title, auto, count)
 {
   conf.width = 50;
-  conf.pageSize = 50;
+  conf.pageSize = tvheadend.page_size;
   conf.displayInfo = true;
                     /// {0} start, {1} end, {2} total, {3} title
   conf.displayMsg = _('{3} {0} - {1} of {2}').replace('{3}', title);
@@ -1024,6 +1024,7 @@ function accessUpdate(o) {
     tvheadend.chname_src = o.chname_src ? 1 : 0;
     tvheadend.date_mask = o.date_mask;
     tvheadend.label_formatting = o.label_formatting ? true : false;
+    tvheadend.page_size = o.page_size;
 
     if (o.uilevel_nochange)
         tvheadend.uilevel_nochange = true;


### PR DESCRIPTION
Add a global default setting for 'Items per page' for lists in the UI.

The value is set to 50 (the current UI default) unless changed by the user.  Once changed, every list page will be limited to the value specified.

Each list can still be individually set for the current session but will be reset to the new default for each new session.

![itemsPerPage](https://github.com/user-attachments/assets/c4778b60-2f13-4027-9238-e5d002228c13)
