### PR TITLE
Fix crash when updating 'disp_summary'

### DIFF
--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -3820,7 +3820,7 @@ dvr_entry_class_disp_summary_set(void *o, const void *v)
   const char *lang = idnode_lang(o);
   const char *s = "";
   v = tvh_str_default(v, "UnknownSummary");
-  if (de->de_subtitle)
+  if (de->de_summary)
     s = lang_str_get(de->de_summary, lang);
   if (strcmp(s, v)) {
     lang_str_set(&de->de_summary, v, lang);


### PR DESCRIPTION
Bug fix for issue: https://github.com/tvheadend/tvheadend/issues/1809

Code was testing for `de->de_subtitle` instead of `de->de_summary` when updating `de->de_summary`.