### PR TITLE
httpc.c: Fix HTTPS with OpenSSL 3.5

### DIFF
--- a/src/httpc.c
+++ b/src/httpc.c
@@ -1599,7 +1599,7 @@ http_client_connect
   tvh_mutex_init(&hc->hc_mutex, NULL);
   hc->hc_id      = atomic_add(&tally, 1);
   hc->hc_aux     = aux;
-  hc->hc_io_size = 1024;
+  hc->hc_io_size = 2048;
   hc->hc_rtsp_stream_id = -1;
   hc->hc_verify_peer = -1;
   hc->hc_bindaddr = bindaddr ? strdup(bindaddr) : NULL;


### PR DESCRIPTION
The TLS Client Hello message is larger in OpenSSL 3.5 and will not fit in the previous hc_io_size of 1024 bytes.  This causes the TLS Client Hello message to be truncated, resulting in HTTPS requests stalling and eventually timing out.  To fix this, increase hc_io_size to 2048 bytes.