### PR TITLE
Fix GCC 15+ format-truncation compile error by enlarging EPG language buffer

### DIFF
--- a/src/wizard.c
+++ b/src/wizard.c
@@ -145,7 +145,7 @@ static void hello_changed(idnode_t *in)
 {
   wizard_page_t *p = (wizard_page_t *)in;
   wizard_hello_t *w = p->aux;
-  char buf[32];
+  char buf[64];
   size_t l = 0;
   int save = 0;
 


### PR DESCRIPTION
GCC 15.1 introduces stricter checks around `snprintf`-like functions under `-Wformat-truncation`, even when the format string itself is under developer control. This triggers a false positive in `hello_changed()` when building with `-Werror=format-truncation`:

  error: ‘__builtin___snprintf_chk’ output may be truncated before the
  last format character [-Werror=format-truncation=]

  note: output between 1 and 33 bytes into a destination of size 32

This warning is triggered due to a theoretical edge case in `tvh_strlcatf()` where combining strings like `"en,fr,de"` could approach the buffer limit of 32 bytes. While truncation is unlikely in practice, the warning is still emitted aggressively by the new FORTIFY logic.

Increase the buffer from 32 to 64 bytes to silence the warning and ensure headroom. This avoids having to disable the diagnostic, while still keeping the logic and usage intact. This is a defensive fix with no behavioral change, and aligns with similar mitigations used in other projects facing the same issue with GCC >= 13 and especially 15+.

Tested with GCC 15.1.1, built cleanly.

Refs:
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108231
- https://gcc.gnu.org/onlinedocs/gcc-15.1.0/gcc/Warning-Options.html#index-Wformat-truncation