### PR TITLE
chore(build): remove x265 from unsupported platforms

### DIFF
--- a/Autobuild/bionic-aarch64.sh
+++ b/Autobuild/bionic-aarch64.sh
@@ -1,2 +1,3 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --disable-libx265_static --disable-libx265"
 source Autobuild/aarch64.sh
 source Autobuild/bionic.sh

--- a/Autobuild/buster-aarch64.sh
+++ b/Autobuild/buster-aarch64.sh
@@ -1,2 +1,3 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --disable-libx265_static --disable-libx265"
 source Autobuild/aarch64.sh
 source Autobuild/buster.sh

--- a/Autobuild/focal-aarch64.sh
+++ b/Autobuild/focal-aarch64.sh
@@ -1,2 +1,3 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --disable-libx265_static --disable-libx265"
 source Autobuild/aarch64.sh
 source Autobuild/focal.sh

--- a/Autobuild/raspiosbookworm-armv7l.sh
+++ b/Autobuild/raspiosbookworm-armv7l.sh
@@ -1,3 +1,4 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --disable-libx265_static --disable-libx265"
 source Autobuild/armv7l.sh
 EXTRA_X265_CMAKE_OPTS="${EXTRA_X265_CMAKE_OPTS:-} -DCROSS_COMPILE_ARM=0"
 source Autobuild/raspiosbookworm.sh

--- a/Autobuild/stretch-aarch64.sh
+++ b/Autobuild/stretch-aarch64.sh
@@ -1,2 +1,3 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --disable-libx265_static --disable-libx265"
 source Autobuild/aarch64.sh
 source Autobuild/stretch.sh

--- a/Autobuild/xenial-aarch64.sh
+++ b/Autobuild/xenial-aarch64.sh
@@ -1,2 +1,3 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --disable-libx265_static --disable-libx265"
 source Autobuild/aarch64.sh
 source Autobuild/xenial.sh


### PR DESCRIPTION
Please have a look before merging, I'm not sure if this way of excluding is how it should be made. I'd prefer avoiding the redundancy, but it might be necessary because there's no "common denominator" for the combinations.