### PR TITLE
Add Sub-Title Processing Options for DVB OTA EPG

### DIFF
--- a/src/input/mpegts.h
+++ b/src/input/mpegts.h
@@ -545,6 +545,11 @@ struct mpegts_mux
 #define PREFCAPID_ON       1
 #define PREFCAPID_FORCE    2
 
+#define SVC_PROCESS_SUBTITLE_NONE     0
+#define SVC_PROCESS_SUBTITLE_DESC     1
+#define SVC_PROCESS_SUBTITLE_APPEND   2
+#define SVC_PROCESS_SUBTITLE_PREPEND  3
+
 /* Service */
 struct mpegts_service
 {
@@ -574,6 +579,8 @@ struct mpegts_service
   char    *s_dvb_cridauth;
   uint16_t s_dvb_servicetype;
   int      s_dvb_ignore_eit;
+  int      s_dvb_subtitle_processing;       //Various options for replacing/augmenting the desc from the sub-title
+  int      s_dvb_ignore_matching_subtitle;  //Ignore the sub-title if same as title
   char    *s_dvb_charset;
   uint16_t s_dvb_prefcapid;
   int      s_dvb_prefcapid_lock;

--- a/src/input/mpegts/mpegts_service.c
+++ b/src/input/mpegts/mpegts_service.c
@@ -82,6 +82,18 @@ mpegts_service_pref_capid_lock_list ( void *o, const char *lang )
    return strtab2htsmsg(tab, 1, lang);
 }
 
+static htsmsg_t *
+mpegts_service_subtitle_procesing ( void *o, const char *lang )
+{
+  static const struct strtab tab[] = {
+    { N_("None"),                         SVC_PROCESS_SUBTITLE_NONE    }, //No processing.
+    { N_("Save in Description"),          SVC_PROCESS_SUBTITLE_DESC    }, //Save the sub-title in the desc if desc is empty.
+    { N_("Append to Description"),        SVC_PROCESS_SUBTITLE_APPEND  }, //Append, but if the desc is empty, just replace.
+    { N_("Prepend to Description"),       SVC_PROCESS_SUBTITLE_PREPEND }, //Prepend, but if the desc is empty, just replace.
+  };
+   return strtab2htsmsg(tab, 1, lang);
+}
+
 CLASS_DOC(mpegts_service)
 
 const idclass_t mpegts_service_class =
@@ -197,6 +209,28 @@ const idclass_t mpegts_service_class =
       .desc     = N_("Enable or disable ignoring of Event Information "
                      "Table (EIT) data for this service."),
       .off      = offsetof(mpegts_service_t, s_dvb_ignore_eit),
+      .opts     = PO_EXPERT,
+    },
+    {
+      .type     = PT_INT,
+      .id       = "dvb_subtitle_processing",
+      .name     = N_("DVB Sub-title Processing"),
+      .desc     = N_("Select action to be taken with the Sub-title "
+                     "provided by the broadcaster: None; Save in Description; "
+                     "Append to Description; Prepend to Description. "
+                     "If the Description is empty, save, "
+                     "append and prepend will replace the Description."),
+      .off      = offsetof(mpegts_service_t, s_dvb_subtitle_processing),
+      .opts     = PO_EXPERT | PO_DOC_NLIST,
+      .list     = mpegts_service_subtitle_procesing,
+    },
+    {
+      .type     = PT_BOOL,
+      .id       = "dvb_ignore_matching_subtitle",
+      .name     = N_("Skip Sub-title matches Title"),
+      .desc     = N_("If the Sub-title and the Title contain identical content, "
+                     "ignore the Sub-title and only save the Title."),
+      .off      = offsetof(mpegts_service_t, s_dvb_ignore_matching_subtitle),
       .opts     = PO_EXPERT,
     },
     {


### PR DESCRIPTION
Provide a number of EPG Sub-title processing options on an individual service basis for EPG data received via the DVB OTA EPG grabber.

![image](https://github.com/user-attachments/assets/bc108039-a25a-4ec2-a6d2-0e3b9e902b48)

1) If the Title and Sub-title are identical, save an empty Sub-title.
2) When the EIT: EPG Grabber ‘Short EIT description’ is set to ‘Subtitle’:
![image](https://github.com/user-attachments/assets/9c59bec0-e6d4-41cd-a09c-c270c6058d3f)
a) If the Description is empty, save the Sub-title as the Description and save an empty Sub-total.  Do nothing if the Description is not empty.
b) If the Description is not empty, append the Sub-title to the Description and save an empty Sub-total.  If the Description is empty, proceed as per option 2a.
c) If the Description is not empty, prepend the Sub-title to the Description and save an empty Sub-total.  If the Description is empty, proceed as per option 2a.

Forum Discussion:  https://tvheadend.org/d/9110-dvb-ota-epg-grabber-store-sub-title-in-description