### PR TITLE
fix memory leak

### DIFF
--- a/src/transcoding/codec/profile_audio_class.c
+++ b/src/transcoding/codec/profile_audio_class.c
@@ -107,14 +107,14 @@ tvh_codec_audio_get_list_channel_layouts(TVHAudioCodec *self)
             l = channel_layouts;
             ADD_ENTRY(list, map, s64, 0, str, AUTO_STR);
             while (l->nb_channels != 0) {
-                if (!(map = htsmsg_create_map())) {
-                    htsmsg_destroy(list);
-                    list = NULL;
-                    break;
-                }
-                l_buf[0] = '\0';
-                if(av_channel_layout_describe(l, l_buf, sizeof(l_buf)) > 0)
+                if(av_channel_layout_describe(l, l_buf, sizeof(l_buf)) > 0) {
+                    if (!(map = htsmsg_create_map())) {
+                        htsmsg_destroy(list);
+                        list = NULL;
+                        break;
+                    }
                     ADD_ENTRY(list, map, s64, l->u.mask, str, l_buf);
+                }
                 l++;
             }
 #else
@@ -126,7 +126,6 @@ tvh_codec_audio_get_list_channel_layouts(TVHAudioCodec *self)
                         list = NULL;
                         break;
                     }
-                    l_buf[0] = '\0';
                     av_get_channel_layout_string(l_buf, sizeof(l_buf), 0, l);
                     ADD_ENTRY(list, map, s64, l, str, l_buf);
                 }


### PR DESCRIPTION
My understanding is that htsmsg_create_map() is allocating memory and ADD_ENTRY() is consuming that.
We should always have pairs of htsmsg_create_map() <--> ADD_ENTRY()
If we check the code (before update) - with GREEN is when LIBAVCODEC <= 59 and with RED when LIBAVCODEC > 59:

![before](https://github.com/user-attachments/assets/69f27629-5c8f-494a-8ff8-fc79bf657107)

GREEN has clear pairs: 1 <--> 2 and 3 <--> 4
RED has 1 <--> 2 , but 3 <--> 4 is only when 5 == TRUE 
When 5 == FALSE memory is allocated but is not consumed.

The fix proposal is:

![after](https://github.com/user-attachments/assets/c6f684d0-20e2-461d-a371-a7ab835ae646)

This will always guarantee (no matter what 5 will be) we have pairs:  1 <--> 2 and 3 <--> 4


Fixes: #1749 