### PR TITLE
fix dead error condition

### DIFF
--- a/src/transcoding/transcode/video.c
+++ b/src/transcoding/transcode/video.c
@@ -424,8 +424,6 @@ tvh_video_context_wrap(TVHContext *self, AVPacket *avpkt, th_pkt_t *pkt)
         case AV_PICTURE_TYPE_B:
             pkt->v.pkt_frametype = PKT_B_FRAME;
             break;
-        case AV_PICTURE_TYPE_NONE:
-            break;
         default:
             tvh_context_log(self, LOG_WARNING, "unknown picture type: %d",
                             pict_type);


### PR DESCRIPTION
Fixes coverity scan issues: 462150

practically is impossible to reach that code ... and default will generate the same outcome.

![462150](https://github.com/user-attachments/assets/e98cade6-f559-4d84-a511-449605bf7be6)
