### PR TITLE
Improve handling and diagnostics of transcoding errors

### DIFF
--- a/src/transcoding/transcode/context.c
+++ b/src/transcoding/transcode/context.c
@@ -474,7 +474,8 @@ tvh_context_decode(TVHContext *self, AVPacket *avpkt)
     if (!ret && !(ret = _context_decode(self, avpkt))) {
         ret = tvh_context_decode_packet(self, avpkt);
     }
-    return (ret == AVERROR(EAGAIN) || ret == AVERROR_INVALIDDATA) ? 0 : ret;
+    return (ret == AVERROR(EAGAIN) || ret == AVERROR_INVALIDDATA ||
+            ret == AVERROR(EIO)    || ret == AVERROR(EINVAL) ) ? 0 : ret;
 }
 
 

--- a/src/transcoding/transcode/stream.c
+++ b/src/transcoding/transcode/stream.c
@@ -164,7 +164,7 @@ int
 tvh_stream_handle(TVHStream *self, th_pkt_t *pkt)
 {
     if (pkt->pkt_payload && self->context) {
-        return (tvh_context_handle(self->context, pkt) < 0) ? -1 : 0;
+        return tvh_context_handle(self->context, pkt);
     }
     pkt_ref_inc(pkt);
     return tvh_transcoder_deliver(self->transcoder, pkt);


### PR DESCRIPTION
This pull request introduces two related improvements to Tvheadend's transcoding subsystem, specifically targeting robustness and diagnostics when using hardware-accelerated decoding (e.g., VAAPI).

The first change improves fault tolerance by treating certain hardware decoder errors (EIO, EINVAL) as recoverable. These errors are observed in real-world conditions (e.g., malformed streams or signal glitches) and are tolerated by FFmpeg without aborting the transcoding session. Aligning Tvheadend’s behavior with FFmpeg avoids unnecessary stream teardown, reducing disruption for both live playback and recordings.

The second change enhances visibility into transcoding failures by logging detailed information when packet processing fails. This includes the packet PTS, the underlying error code, and a descriptive message, with optional packet dumps if trace logging is enabled. These logs will aid significantly in diagnosing video dropout or hardware-specific decoding issues.

These changes do not modify core transcoder logic or error escalation rules elsewhere; they simply improve resilience and observability. For full technical rationale and testing methodology, please refer to the individual commit messages.