### PR TITLE
move filter_hw_denoise and filter_hw_sharpness to tvh_codec_profile_video

### DIFF
--- a/src/transcoding/codec.h
+++ b/src/transcoding/codec.h
@@ -92,9 +92,8 @@ struct tvh_codec_profile {
     double bit_rate;
     double qscale;
     int profile;
+    // to be moved when we remove ENABLE_FFMPEG4_TRANSCODING
     int low_power;
-    int filter_hw_denoise;
-    int filter_hw_sharpness;
     char *device; // for hardware acceleration
     LIST_ENTRY(tvh_codec_profile) link;
 };

--- a/src/transcoding/codec/internals.h
+++ b/src/transcoding/codec/internals.h
@@ -290,13 +290,59 @@ extern const codec_profile_class_t codec_profile_video_class;
 
 typedef struct tvh_codec_profile_video {
     TVHCodecProfile;
+    /**
+     * SW or HW deinterlace  (applies for decoding)
+     * @note
+     * int: 
+     * VALUE - deinterlace enable
+     * 
+     * - 0 - disabled
+     * 
+     * - 1 - enabled
+     */
     int deinterlace;
     int height;
-    int scaling_mode;   // 0 --> up&down; 1 --> up; 2 --> down
+    /**
+     * SW or HW scaling mode  (applies for decoding)
+     * @note
+     * int: 
+     * VALUE - scaling mode
+     * 
+     * - 0 - scaling up or down
+     * 
+     * - 1 - scaling only up
+     * 
+     * - 2 - scaling only down
+     */
+    int scaling_mode;
     int hwaccel;
     int hwaccel_details;
     int pix_fmt;
     int crf;
+#if ENABLE_HWACCELS
+    /**
+     * HW accel denoise filter (applies for decoding)
+     * @note
+     * int: 
+     * VALUE - hardware denoise
+     * 
+     * - 0 - disabled (not sent to ffmpeg)
+     * 
+     * - >0 - denoise level value (max value different per platform)
+     */
+    int filter_hw_denoise;
+    /**
+     * HW accel sharpness filter (applies for decoding)
+     * @note
+     * int: 
+     * VALUE - hardware sharpness
+     * 
+     * - 0 - disabled (not sent to ffmpeg)
+     * 
+     * - >0 - sharpness level value (max value different per platform)
+     */
+    int filter_hw_sharpness;
+#endif
     AVRational size;
 } TVHVideoCodecProfile;
 

--- a/src/transcoding/transcode/video.c
+++ b/src/transcoding/transcode/video.c
@@ -18,6 +18,7 @@
  */
 
 #include "internals.h"
+#include "../codec/internals.h"
 
 #if ENABLE_HWACCELS
 #include "hwaccels/hwaccels.h"
@@ -60,9 +61,9 @@ _video_filters_get_filters(TVHContext *self, AVDictionary **opts, char **filters
     if (tvh_context_get_int_opt(opts, "tvh_filter_deint", &filter_deint)) {
         return -1;
     }
-#if ENABLE_VAAPI
-    filter_denoise = self->profile->filter_hw_denoise;
-    filter_sharpness = self->profile->filter_hw_sharpness;
+#if ENABLE_HWACCELS
+    filter_denoise = ((TVHVideoCodecProfile *)self->profile)->filter_hw_denoise;
+    filter_sharpness = ((TVHVideoCodecProfile *)self->profile)->filter_hw_sharpness;
 #endif
     //  in --> out  |  download   |   upload 
     // -------------|-------------|------------


### PR DESCRIPTION
fixes: https://github.com/tvheadend/tvheadend/issues/1818
also fixes a logical define bug: filter_denoise and filter_sharpness should be transferred for all HW accels (not only for VAAPI)