### PR TITLE
intl: doc/js: change freenode references to Libera.Chat

### DIFF
--- a/intl/docs/tvheadend.doc.ach.po
+++ b/intl/docs/tvheadend.doc.ach.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.ady.po
+++ b/intl/docs/tvheadend.doc.ady.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.ar.po
+++ b/intl/docs/tvheadend.doc.ar.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.bg.po
+++ b/intl/docs/tvheadend.doc.bg.po
@@ -6947,7 +6947,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.cs.po
+++ b/intl/docs/tvheadend.doc.cs.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.da.po
+++ b/intl/docs/tvheadend.doc.da.po
@@ -6947,7 +6947,7 @@ msgid "and"
 msgstr "og"
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.de.po
+++ b/intl/docs/tvheadend.doc.de.po
@@ -6951,7 +6951,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.en_GB.po
+++ b/intl/docs/tvheadend.doc.en_GB.po
@@ -9726,10 +9726,10 @@ msgstr "and"
 
 #: src/docs_inc.c:1708
 msgid ""
-"and IRC (_#hts_ on _Libera_ ). If you don't have a client installed you can "
+"and IRC (_#hts_ on _Libera.Chat_ ). If you don't have a client installed you can "
 "use the"
 msgstr ""
-"and IRC (_#hts_ on _Libera_ ). If you don't have a client installed you can "
+"and IRC (_#hts_ on _Libera.Chat_ ). If you don't have a client installed you can "
 "use the"
 
 #: src/docs_inc.c:3491

--- a/intl/docs/tvheadend.doc.en_US.po
+++ b/intl/docs/tvheadend.doc.en_US.po
@@ -9726,10 +9726,10 @@ msgstr "and"
 
 #: src/docs_inc.c:1708
 msgid ""
-"and IRC (_#hts_ on _Libera_ ). If you don't have a client installed you can "
+"and IRC (_#hts_ on _Libera.Chat_ ). If you don't have a client installed you can "
 "use the"
 msgstr ""
-"and IRC (_#hts_ on _Libera_ ). If you don't have a client installed you can "
+"and IRC (_#hts_ on _Libera.Chat_ ). If you don't have a client installed you can "
 "use the"
 
 #: src/docs_inc.c:3491

--- a/intl/docs/tvheadend.doc.es.po
+++ b/intl/docs/tvheadend.doc.es.po
@@ -6948,7 +6948,7 @@ msgid "and"
 msgstr "y"
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.et.po
+++ b/intl/docs/tvheadend.doc.et.po
@@ -6947,7 +6947,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.fa.po
+++ b/intl/docs/tvheadend.doc.fa.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.fi.po
+++ b/intl/docs/tvheadend.doc.fi.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.fr.po
+++ b/intl/docs/tvheadend.doc.fr.po
@@ -6947,7 +6947,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.he.po
+++ b/intl/docs/tvheadend.doc.he.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.hr.po
+++ b/intl/docs/tvheadend.doc.hr.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.hu.po
+++ b/intl/docs/tvheadend.doc.hu.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.it.po
+++ b/intl/docs/tvheadend.doc.it.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.ko.po
+++ b/intl/docs/tvheadend.doc.ko.po
@@ -6947,8 +6947,8 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
-msgstr "또는 IRC  (_#hts_ on _freenode_ )가 있습니다 -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
+msgstr "또는 IRC  (_#hts_ on _Libera.Chat_ )가 있습니다 -"
 
 #: src/docs_inc.c:3765
 msgid "api"

--- a/intl/docs/tvheadend.doc.lt.po
+++ b/intl/docs/tvheadend.doc.lt.po
@@ -7181,7 +7181,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:2900

--- a/intl/docs/tvheadend.doc.lv.po
+++ b/intl/docs/tvheadend.doc.lv.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.nl.po
+++ b/intl/docs/tvheadend.doc.nl.po
@@ -6947,7 +6947,7 @@ msgid "and"
 msgstr "en"
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.no.po
+++ b/intl/docs/tvheadend.doc.no.po
@@ -6947,7 +6947,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.pt.po
+++ b/intl/docs/tvheadend.doc.pt.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.ro.po
+++ b/intl/docs/tvheadend.doc.ro.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.ru.po
+++ b/intl/docs/tvheadend.doc.ru.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.sk.po
+++ b/intl/docs/tvheadend.doc.sk.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.sl.po
+++ b/intl/docs/tvheadend.doc.sl.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.sq.po
+++ b/intl/docs/tvheadend.doc.sq.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.sr.po
+++ b/intl/docs/tvheadend.doc.sr.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.sv.po
+++ b/intl/docs/tvheadend.doc.sv.po
@@ -6947,7 +6947,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.tr.po
+++ b/intl/docs/tvheadend.doc.tr.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.uk.po
+++ b/intl/docs/tvheadend.doc.uk.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.zh-Hans.po
+++ b/intl/docs/tvheadend.doc.zh-Hans.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/docs/tvheadend.doc.zh.po
+++ b/intl/docs/tvheadend.doc.zh.po
@@ -6946,7 +6946,7 @@ msgid "and"
 msgstr ""
 
 #: src/docs_inc.c:163
-msgid "and IRC (_#hts_ on _freenode_ ) -"
+msgid "and IRC (_#hts_ on _Libera.Chat_ ) -"
 msgstr ""
 
 #: src/docs_inc.c:3765

--- a/intl/js/tvheadend.js.ach.po
+++ b/intl/js/tvheadend.js.ach.po
@@ -2014,7 +2014,7 @@ msgstr ""
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.ady.po
+++ b/intl/js/tvheadend.js.ady.po
@@ -2014,7 +2014,7 @@ msgstr ""
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.ar.po
+++ b/intl/js/tvheadend.js.ar.po
@@ -2014,7 +2014,7 @@ msgstr ""
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.bg.po
+++ b/intl/js/tvheadend.js.bg.po
@@ -2018,7 +2018,7 @@ msgstr "от {0}"
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.cs.po
+++ b/intl/js/tvheadend.js.cs.po
@@ -2328,7 +2328,7 @@ msgstr "z {0}"
 #: src/webui/static/app/tvheadend.js:590
 msgid ""
 "or join the [IRC channel on "
-"libera](https://web.libera.chat/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.da.po
+++ b/intl/js/tvheadend.js.da.po
@@ -2018,7 +2018,7 @@ msgstr "af {0}"
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.de.po
+++ b/intl/js/tvheadend.js.de.po
@@ -2337,7 +2337,7 @@ msgstr "von {0}"
 #: src/webui/static/app/tvheadend.js:590
 msgid ""
 "or join the [IRC channel on "
-"libera](https://web.libera.chat/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.en_GB.po
+++ b/intl/js/tvheadend.js.en_GB.po
@@ -2344,10 +2344,10 @@ msgstr "of {0}"
 #: src/webui/static/app/tvheadend.js:590
 msgid ""
 "or join the [IRC channel on "
-"libera](https://web.libera.chat/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 "or join the [IRC channel on "
-"libera](https://web.libera.chat/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 
 #: src/webui/static/app/i18n-post.js:217
 msgid "true"

--- a/intl/js/tvheadend.js.en_US.po
+++ b/intl/js/tvheadend.js.en_US.po
@@ -2344,10 +2344,10 @@ msgstr "of {0}"
 #: src/webui/static/app/tvheadend.js:590
 msgid ""
 "or join the [IRC channel on "
-"libera](https://web.libera.chat/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 "or join the [IRC channel on "
-"libera](https://web.libera.chat/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 
 #: src/webui/static/app/i18n-post.js:217
 msgid "true"

--- a/intl/js/tvheadend.js.es.po
+++ b/intl/js/tvheadend.js.es.po
@@ -2339,7 +2339,7 @@ msgstr "de {0}"
 #: src/webui/static/app/tvheadend.js:590
 msgid ""
 "or join the [IRC channel on "
-"libera](https://web.libera.chat/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.et.po
+++ b/intl/js/tvheadend.js.et.po
@@ -2326,7 +2326,7 @@ msgstr "{0}st"
 #: src/webui/static/app/tvheadend.js:590
 msgid ""
 "or join the [IRC channel on "
-"libera](https://web.libera.chat/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.fa.po
+++ b/intl/js/tvheadend.js.fa.po
@@ -2014,7 +2014,7 @@ msgstr ""
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.fi.po
+++ b/intl/js/tvheadend.js.fi.po
@@ -2017,7 +2017,7 @@ msgstr ""
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.fr.po
+++ b/intl/js/tvheadend.js.fr.po
@@ -2344,7 +2344,7 @@ msgstr "sur {0}"
 #: src/webui/static/app/tvheadend.js:590
 msgid ""
 "or join the [IRC channel on "
-"libera](https://web.libera.chat/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.he.po
+++ b/intl/js/tvheadend.js.he.po
@@ -2017,7 +2017,7 @@ msgstr "של {0}"
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.hr.po
+++ b/intl/js/tvheadend.js.hr.po
@@ -2016,7 +2016,7 @@ msgstr "od {0}"
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.hu.po
+++ b/intl/js/tvheadend.js.hu.po
@@ -2332,7 +2332,7 @@ msgstr "{0}-ból"
 #: src/webui/static/app/tvheadend.js:590
 msgid ""
 "or join the [IRC channel on "
-"libera](https://web.libera.chat/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.it.po
+++ b/intl/js/tvheadend.js.it.po
@@ -2331,7 +2331,7 @@ msgstr "di {0}"
 #: src/webui/static/app/tvheadend.js:590
 msgid ""
 "or join the [IRC channel on "
-"libera](https://web.libera.chat/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.ko.po
+++ b/intl/js/tvheadend.js.ko.po
@@ -2321,7 +2321,7 @@ msgstr "전체 {0}"
 #: src/webui/static/app/tvheadend.js:590
 msgid ""
 "or join the [IRC channel on "
-"libera](https://web.libera.chat/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.lt.po
+++ b/intl/js/tvheadend.js.lt.po
@@ -2015,7 +2015,7 @@ msgstr "iš {0}"
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.lv.po
+++ b/intl/js/tvheadend.js.lv.po
@@ -2015,7 +2015,7 @@ msgstr "no {0}"
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.nl.po
+++ b/intl/js/tvheadend.js.nl.po
@@ -2330,7 +2330,7 @@ msgstr "Voeg {0} toe"
 #: src/webui/static/app/tvheadend.js:590
 msgid ""
 "or join the [IRC channel on "
-"libera](https://web.libera.chat/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.no.po
+++ b/intl/js/tvheadend.js.no.po
@@ -2015,7 +2015,7 @@ msgstr "av {0}"
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.pl.po
+++ b/intl/js/tvheadend.js.pl.po
@@ -2348,10 +2348,10 @@ msgstr "z {0}"
 #: src/webui/static/app/tvheadend.js:590
 msgid ""
 "or join the [IRC channel on "
-"libera](https://web.libera.chat/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 "lub dołącz do [kanału IRC na "
-"libera](https://web.libera.chat/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 
 #: src/webui/static/app/i18n-post.js:217
 msgid "true"

--- a/intl/js/tvheadend.js.pt.po
+++ b/intl/js/tvheadend.js.pt.po
@@ -2336,7 +2336,7 @@ msgstr "de {0}"
 #: src/webui/static/app/tvheadend.js:590
 msgid ""
 "or join the [IRC channel on "
-"libera](https://web.libera.chat/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.ro.po
+++ b/intl/js/tvheadend.js.ro.po
@@ -2014,7 +2014,7 @@ msgstr ""
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.ru.po
+++ b/intl/js/tvheadend.js.ru.po
@@ -2016,7 +2016,7 @@ msgstr "из {0}"
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.sk.po
+++ b/intl/js/tvheadend.js.sk.po
@@ -2014,7 +2014,7 @@ msgstr ""
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.sl.po
+++ b/intl/js/tvheadend.js.sl.po
@@ -2015,7 +2015,7 @@ msgstr ""
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.sq.po
+++ b/intl/js/tvheadend.js.sq.po
@@ -2014,7 +2014,7 @@ msgstr ""
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.sr.po
+++ b/intl/js/tvheadend.js.sr.po
@@ -2014,7 +2014,7 @@ msgstr ""
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.sv.po
+++ b/intl/js/tvheadend.js.sv.po
@@ -2015,7 +2015,7 @@ msgstr ""
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.tr.po
+++ b/intl/js/tvheadend.js.tr.po
@@ -2015,7 +2015,7 @@ msgstr ""
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.uk.po
+++ b/intl/js/tvheadend.js.uk.po
@@ -2015,7 +2015,7 @@ msgstr "з {0}"
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.zh-Hans.po
+++ b/intl/js/tvheadend.js.zh-Hans.po
@@ -2014,7 +2014,7 @@ msgstr ""
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217

--- a/intl/js/tvheadend.js.zh.po
+++ b/intl/js/tvheadend.js.zh.po
@@ -2014,7 +2014,7 @@ msgstr ""
 #: src/webui/static/app/tvheadend.js:251
 msgid ""
 "or join the [IRC channel on "
-"freenode](https://kiwiirc.com/client/chat.freenode.net/?nick=tvhhelp|?#hts)."
+"Libera.Chat](https://web.libera.chat/#hts)."
 msgstr ""
 
 #: src/webui/static/app/i18n-post.js:217


### PR DESCRIPTION
This updates the master doc templates to correctly reference `Libera.Chat` not just `Libera` and then bulk-changes the downstream translations to match (as translators aren't making them). It also updates the web-chat URL link to one that works `https://web.libera.chat/#hts` as the current (temporary) one is invalid.