### PR TITLE
ci: disable coverity on forks

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   coverity:
+    if: ${{ secrets.COVERITY_SCAN_TOKEN != '' }}
     runs-on: ubuntu-latest
     environment: Coverity
     steps:


### PR DESCRIPTION
Add an `if` clause so coverity only runs on our main repo and not personal forks. This should stop the weekly email telling me the action on my fork failed.