### PR TITLE
remove coded_width and coded_height from encoding

### DIFF
--- a/src/transcoding/transcode/video.c
+++ b/src/transcoding/transcode/video.c
@@ -224,8 +224,6 @@ tvh_video_context_open_encoder(TVHContext *self, AVDictionary **opts)
     }
 
 #if ENABLE_HWACCELS
-    self->oavctx->coded_width = self->oavctx->width;
-    self->oavctx->coded_height = self->oavctx->height;
 #if ENABLE_FFMPEG4_TRANSCODING
     // hwaccel is the user input for Hardware acceleration from Codec parameteres
     int hwaccel = -1;


### PR DESCRIPTION
according to AVCodecContext documentation this is only used for decoding, oavctx is used for encoding

![image](https://github.com/user-attachments/assets/9f5500c1-22f6-4094-98e4-8c26f082505a)
