### PR TITLE
User's DVR Configuration profile not used when scheduling recordings via HTSP

### DIFF
--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -2042,13 +2042,12 @@ htsp_method_addDvrEntry(htsp_connection_t *htsp, htsmsg_t *in)
   conf = htsmsg_create_map();
   htsmsg_copy_field(conf, "enabled", in, NULL);
   s = htsmsg_get_str(in, "configName");
-  if (s) {
-    dvr_conf = dvr_config_find_by_uuid(s);
-    if (dvr_conf == NULL)
-      dvr_conf = dvr_config_find_by_name(s);
+  dvr_conf = dvr_config_find_by_list(htsp->htsp_granted_access->aa_dvrcfgs, s);
     if (dvr_conf)
+  {
       htsmsg_add_uuid(conf, "config_name", &dvr_conf->dvr_id.in_uuid);
   }
+  
   htsmsg_copy_field(conf, "start_extra", in, "startExtra");
   htsmsg_copy_field(conf, "stop_extra", in, "stopExtra");
   htsmsg_copy_field(conf, "pri", in, "priority");


### PR DESCRIPTION
When scheduling a recording via HTSP (Kodi client), the '(Default profile)' is used instead of the user's nominated DVR Configuration profile.  However, when the same operation with the same user is performed via the WebUI, the correct profile was used.

Align the HTSP DVR Configuration profile selection process with the process used in the equivalent JSON API function [dvr_config_find_by_list()].

https://github.com/tvheadend/tvheadend/blob/42ed6affc42ef06e427fb8b1465532a4489e182c/src/api/api_dvr.c#L145C1-L147C64

Tested by scheduling a recording from Kodi with the same user, with and without a nominated DVR profile.  Please note, the HTSP connection retains its previous settings until reauthenticated.

Fixes: #1855
Supersedes: #1443