### PR TITLE
Add Scene Markers to recordings at scheduled EPG event start/stop times

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -115,6 +115,7 @@ typedef struct dvr_config {
   int dvr_episode_in_title;
   int dvr_clean_title;
   int dvr_tag_files;
+  int dvr_create_scene_markers;
   int dvr_skip_commercials;
   int dvr_subtitle_in_title;
   int dvr_windows_compatible_filenames;
@@ -635,6 +636,8 @@ const char *dvr_get_filename(dvr_entry_t *de);
 
 int64_t dvr_get_filesize(dvr_entry_t *de, int flags);
 
+int dvr_get_files_details(dvr_entry_t *de, time_t *files_start, time_t *files_stop, int *files_count);
+
 int64_t dvr_entry_claenup(dvr_entry_t *de, int64_t requiredBytes);
 
 void dvr_entry_set_rerecord(dvr_entry_t *de, int cmd);
@@ -881,6 +884,7 @@ void dvr_entry_trace_time2_(const char *file, int line,
  *
  */
 
+void dvr_create_recording_scene_markers(dvr_entry_t *de);
 void dvr_init(void);
 void dvr_config_init(void);
 

--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -180,6 +180,7 @@ dvr_config_create(const char *name, const char *uuid, htsmsg_t *conf)
   cfg->dvr_removal_days = DVR_RET_REM_FOREVER;
   cfg->dvr_clone = 1;
   cfg->dvr_tag_files = 1;
+  cfg->dvr_create_scene_markers = 1;
   cfg->dvr_skip_commercials = 1;
   dvr_charset_update(cfg, intlconv_filesystem_charset());
   cfg->dvr_warm_time = 30;
@@ -1415,6 +1416,16 @@ const idclass_t dvr_config_class = {
                      "that support metadata (if possible)."),
       .off      = offsetof(dvr_config_t, dvr_tag_files),
       .opts     = PO_ADVANCED,
+      .def.i    = 1,
+      .group    = 5,
+    },
+    {
+      .type     = PT_BOOL,
+      .id       = "create-scene-markers",
+      .name     = N_("Create scene markers"),
+      .desc     = N_("Create scene markers in recordings "
+                     "based on the EPG start/stop times when available."),
+      .off      = offsetof(dvr_config_t, dvr_create_scene_markers),
       .def.i    = 1,
       .group    = 5,
     },

--- a/src/dvr/dvr_cutpoints.c
+++ b/src/dvr/dvr_cutpoints.c
@@ -185,20 +185,40 @@ done:
  *
  * // TODO: possibly could be better with some sort of auto-detect
  */
+
+/* DMC 2025 Notes
+ *
+ * I did some testing with Kodi mixing 'sm' and 'edl' records.
+ * The combined records do NOT need to be sorted, overlapping
+ * records of different types work fine from different files.
+ * However, in Kodi, mixing types within files can have unpredictable results.
+ * Keeping type 2 (scene markers) and type 3 (skip) in different files works.
+ * Kodi does not attempt to load cutpoints for 'radio' recordings.
+ */
+
 static struct {
   const char *ext;
   int        (*parse) (const char *path, dvr_cutpoint_list_t *, void *);
   void       *opaque;
+  int        merge;  //Allow merging.  If this parser has data, do not stop there.
 } dvr_cutpoint_parsers[] = {
+  {
+    .ext    = "sm",               // This is just an 'edl' file with an 'sm' extension containing
+    .parse  = dvr_parse_file,     // scene markers.  This is done first so that the results can be
+    .opaque = dvr_parse_edl,      // merged with following edl or txt skip records.
+    .merge  = 1,
+  },
   {
     .ext    = "txt",
     .parse  = dvr_parse_file,
     .opaque = dvr_parse_comskip,
+    .merge  = 0,
   },
   {
     .ext    = "edl",
     .parse  = dvr_parse_file,
     .opaque = dvr_parse_edl,
+    .merge  = 0,
   },
 };
 
@@ -212,6 +232,7 @@ dvr_get_cutpoint_list (dvr_entry_t *de)
   char *path, *sptr;
   const char *filename;
   dvr_cutpoint_list_t *cuts;
+  int found_count = 0;
 
   /* Check this is a valid recording */
   assert(de != NULL);
@@ -248,11 +269,18 @@ dvr_get_cutpoint_list (dvr_entry_t *de)
     /* Try parsing */
     if (dvr_cutpoint_parsers[i].parse(path, cuts,
                                       dvr_cutpoint_parsers[i].opaque) != -1)
-      break;
-  }
+    {
+      found_count++;
+      if(!dvr_cutpoint_parsers[i].merge)
+      {
+        break;
+      }
+    }
+  }//END loop through parsers
 
   /* Cleanup */
-  if (i >= ARRAY_SIZE(dvr_cutpoint_parsers)) {
+  if (found_count == 0)
+  {
     dvr_cutpoint_list_destroy(cuts);
     return NULL;
   }


### PR DESCRIPTION
Once a recording finishes, create an ‘sm’ file containing Scene Marker 'cut points' based on the EPG scheduled start/stop times and the actual recording start/stop times.  This will allow for easier navigation when skipping pre-padding to find the start of the recorded programme.

It should look something like this:

```
|-Warm-Up-|-Pre-Pad-|------EPG-Event------|--Post-Pad--|
|----------------Service-Subscription------------------|
          |--------------Recording---------------------|
                    ^                     ^
              Scene Marker A        Scene Marker B
```

These ‘sm’ files are in ‘edl’ format and will be deleted by TVH when the main recording file is deleted.  Even though the file is in edl format, the use of a separate ‘sm’ file, dedicated to scene markers, was selected to enable interoperability with existing external utilities.  For example, comskip, can already produce ‘edl’ files for TVH recordings.

The quantity and location of scene markers will vary depending upon how much of the scheduled EPG event time is covered by the recording file.

None - The recording covers neither the start nor the end of the scheduled EPG time.
One - The recording covers either the start (Scene Marker A) or the end (Scene Marker B) of the scheduled EPG time, but not both.
Two - The recording covers both the start and end (both Scene Markers A & B) of the scheduled EPG time.