### PR TITLE
linuxdvb_adapter: increase MAX_DEV_OPEN_ATTEMPTS to 50

### DIFF
--- a/src/input/mpegts/linuxdvb/linuxdvb_adapter.c
+++ b/src/input/mpegts/linuxdvb/linuxdvb_adapter.c
@@ -43,7 +43,7 @@
 #define CI_PATH  "%s/ci%d"
 #define SEC_PATH "%s/sec%d"
 
-#define MAX_DEV_OPEN_ATTEMPTS 20
+#define MAX_DEV_OPEN_ATTEMPTS 50
 
 /* ***************************************************************************
  * DVB Adapter


### PR DESCRIPTION
This fixes 2 issues with my TBS 5520SE and TBS 5930 USB devices. 
Issue 1: no adapters present in tvh after a system reboot. Tvh required a delayed start (wait for frontend init).
Issue 2: no adapters present in tvh after physically disconnecting/reconnecting the adapter. Tvh required a restart.