### PR TITLE
version: stop using tilde between build and githash

### DIFF
--- a/support/version
+++ b/support/version
@@ -16,7 +16,7 @@ if [ -d ".git" ]; then
     VER=$(cd "$(dirname "$0")/.."; git describe --match "v*" 2> /dev/null)
     [ -z "$VER" ] && VER="0.0.0-unknown"
   fi
-  VER=$(echo $VER | sed "s/^v//" | sed "s/-\([0-9]*\)-\(g[0-9a-f]*\)/-\1~\2/")
+  VER=$(echo $VER | sed "s/^v//" | sed "s/-\([0-9]*\)-\(g[0-9a-f]*\)/-\1-\2/")
 elif [ -f "$(dirname "$0")/../debian/changelog" ]; then
   VER=$(head -1 "$(dirname "$0")/../debian/changelog" | awk '{ print $2 }' | tr -d '()' | cut -d '-' -f 1-2)
 elif [ -r "$(dirname "$0")/../rpm/version" ]; then
@@ -25,7 +25,7 @@ else
   VER=$(basename $(realpath $(dirname "$0")/..) | sed -e 's/^tvheadend-//' | sed -e 's/^tvheadend-v//')
   case $VER in
   [1-9]*\.[0-9]*) ;;
-  *) VER="0.0.0~unknown" ;;
+  *) VER="0.0.0-unknown" ;;
   esac
 fi
 


### PR DESCRIPTION
The tilde that separates githash in e.g. `tvheadend-4.3-2432~g0af87f13f` causes formatting issues in the forum and other locations that use markdown, so this is a naeive/blind attempt at changes to use a hyphen instead. I have no means of test building from current vacation location so let's see if CI builds? and if not, what failure messages show up.