### PR TITLE
dvb_psi_pmt: Don't recognize all extension descriptors as AC-4 audio

### DIFF
--- a/src/input/mpegts/dvb.h
+++ b/src/input/mpegts/dvb.h
@@ -167,7 +167,7 @@ struct lang_str;
 #define DVB_DESC_CRID                 0x76
 #define DVB_DESC_EAC3                 0x7A
 #define DVB_DESC_AAC                  0x7C
-#define DVB_DESC_AC4                  0x7F
+#define DVB_DESC_EXTENSION            0x7F
 
 #define DVB_DESC_BSKYB_LCN            0xB1
 

--- a/src/input/mpegts/dvb_psi_pmt.c
+++ b/src/input/mpegts/dvb_psi_pmt.c
@@ -249,6 +249,7 @@ dvb_psi_parse_pmt
   int tt_position;
   int video_stream;
   int rds_uecp;
+  int ac4;
   int pcr_shared = 0;
   const char *lang;
   uint8_t audio_type, audio_version;
@@ -311,6 +312,7 @@ dvb_psi_parse_pmt
     composition_id = -1;
     ancillary_id = -1;
     rds_uecp = 0;
+    ac4 = 0;
     position = 0;
     tt_position = 1000;
     lang = NULL;
@@ -439,8 +441,14 @@ dvb_psi_parse_pmt
           hts_stream_type = SCT_EAC3;
         break;
 
-      case DVB_DESC_AC4:
-        if(estype == 0x06 || estype == 0x81)
+      case DVB_DESC_EXTENSION:
+        if(dlen < 1)
+          break;
+
+        if(ptr[0] == 0x15) /* descriptor_tag_extension : AC-4 */
+          ac4 = 1;
+
+        if((estype == 0x06 || estype == 0x81) && ac4)
           hts_stream_type = SCT_AC4;
         break;
 


### PR DESCRIPTION
A few of my channels are incorrectly showing up with AC-4 audio streams on Tvheadend's "Service details" screen. These tracks really are AC-3.

I believe that is a bug introduced in #1479, which originally added AC-4 support. This code looks for a DVB descriptor with _tag value_ `0x7f`, but according to [ETSI EN 300 468](https://www.etsi.org/deliver/etsi_en/300400_300499/300468/01.18.01_60/en_300468v011801p.pdf), that is not the _AC-4 descriptor_ but the _extension descriptor_. Tvheadend's `DVB_DESC_AC4` should thus be renamed to `DVB_DESC_EXTENSION`. Only if the extension descriptor's _extension tag value_ is `0x15` do we have an AC-4 descriptor.

Due to lack of an actual AC-4 broadcast, I cannot test my patch for correctness, but at least it stops marking streams with extension descriptors as AC-4.

My AC-3 streams do contain an extension descriptor, but its _extension tag value_ is `0x06`, corresponding to a _supplementary audio descriptor_. It should be easy enough to extend the code here to parse that descriptor too and extract the language and clean/hearing-impaired/visually-impaired classification.
