### PR TITLE
issues: misc. template updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,8 +10,7 @@ body:
       description: "What Tvheadend version are you using?"
       options:
         - v4.2 (unsupported)
-        - v4.3 (development)
-        - v4.4 (stable)
+        - v4.3 (stable)
     validations:
       required: true
   - type: input
@@ -35,9 +34,15 @@ body:
         - Debian 10 (Buster)
         - Debian 11 (Bullseye)
         - Debian 12 (Bookworm)
+        - Debian 13 (Trixie)
+        - Enterprise Linux 8
+        - Enterprise Linux 9
         - Fedora 37
         - Fedora 38
         - Fedora 39
+        - Fedora 40
+        - Fedora 41
+        - Fedora 42
         - Fedora Rawhide
         - FreeBSD (all)
         - Raspberry Pi OS (Buster)
@@ -50,6 +55,7 @@ body:
         - Ubuntu 18.04 (Bionic)
         - Ubuntu 20.04 (Focal)
         - Ubuntu 22.04 (Jammy)
+        - Ubuntu 24.04 (Noble)
         - Other..
       multiple: false
     validations:

--- a/.github/workflows/enforce-issue-template.yml
+++ b/.github/workflows/enforce-issue-template.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         issue-close-message: "@${issue.user.login} this issue was automatically closed because you are using an unsupported version"
-        issue-pattern: ".*### Tvheadend Version[\\r\\n]+v4\\.(3 \\(development\\)|4 \\(stable\\)).*"
+        issue-pattern: ".*### Tvheadend Version[\\r\\n]+v4\\.3 \\(stable\\).*"
     - name: Autoclose feature ideas which are not developed by the user
       if: startsWith(github.event.issue.title, '[FEATURE]:')
       uses: roots/issue-closer@v1.2


### PR DESCRIPTION
The current GitHub issue template claims v4.3 is `development` but we have declared it to be `stable` and v4.4 does not exist, so reflect that in the releases drop-list. Also update the distro drop-list with some newer items.