### PR TITLE
transcode: avoid multi-line encoder configuration log

### DIFF
--- a/src/transcoding/transcode/video.c
+++ b/src/transcoding/transcode/video.c
@@ -281,12 +281,10 @@ tvh_video_context_open_encoder(TVHContext *self, AVDictionary **opts)
     self->oavctx->sample_aspect_ratio = self->iavctx->sample_aspect_ratio;
 
     tvh_context_log(self, LOG_DEBUG,
-        "Encoder configuration:\n"
-        "  framerate:              %d/%d (%.3f fps)\n"
-        "  time_base:              %.0fHz\n"
-        "  frame duration:         %" PRId64 " ticks (%.6f sec)\n"
-        "  gop_size:               %d\n"
-        "  sample_aspect_ratio:    %d/%d",
+        "Encoder configuration: "
+        "framerate: %d/%d (%.3f fps),time_base: %.0fHz,"
+        "frame duration: %" PRId64 " ticks (%.6f sec),"
+        "gop_size: %d,sample_aspect_ratio: %d/%d",
         self->oavctx->framerate.num, self->oavctx->framerate.den, av_q2d(self->oavctx->framerate),
         av_q2d(av_inv_q(self->oavctx->time_base)),
         av_rescale_q(1, av_inv_q(self->oavctx->framerate), self->oavctx->time_base),


### PR DESCRIPTION
The encoder configuration debug message previously included embedded `\n` to print multiple lines. Following maintainer guidance discussed on Slack, update the log to output everything on a single line instead.

This keeps the configuration details (framerate, time base, frame duration, GOP size, sample aspect ratio) visible in one log entry, making it easier to grep and parse while staying consistent with the logging style.

This change is fallout from 0af87f1