### PR TITLE
add v4l2-m2m transcoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -540,6 +540,9 @@ endif
 ifeq ($(CONFIG_OMX),yes)
 LIBS-CODECS += omx
 endif
+ifeq ($(CONFIG_V4L2M2M),yes)
+LIBS-CODECS += v4l2-m2m
+endif
 SRCS-CODECS += $(foreach lib,$(LIBS-CODECS),src/transcoding/codec/codecs/libs/$(lib).c)
 
 #hwaccels

--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -107,9 +107,14 @@ FFNVCODEC_URL  = https://github.com/FFmpeg/nv-codec-headers/releases/download/n$
 FFNVCODEC_SHA1 = 74231bb5572ebde98652a26ce98ede7895b4c730
 
 FFMPEG         = ffmpeg-6.1.1
+#FFMPEG         = ffmpeg-pios-bookworm
 FFMPEG_TB      = $(FFMPEG).tar.bz2
+#FFMPEG_TB      = $(FFMPEG).tar.gz
 FFMPEG_URL     = https://ffmpeg.org/releases/$(FFMPEG_TB)
+#FFMPEG_URL     = https://github.com/RPi-Distro/ffmpeg/archive/refs/heads/pios/$(FFMPEG_TB)
+#FFMPEG_URL     = https://github.com/RPi-Distro/ffmpeg/archive/refs/heads/pios/bookworm.tar.gz
 FFMPEG_SHA1    = 157e7b0f6521142e1ebd786175e363e9f1b59312
+#FFMPEG_SHA1    = 0609ed6c4c7a2e42e3e8ac4e53c25a626e81f9da
 
 
 # ##############################################################################
@@ -647,6 +652,26 @@ ifeq (yes,$(CONFIG_OMX_RPI))
 EXTLIBS  += omx_rpi
 
 endif
+
+
+# ##############################################################################
+# V4L2M2M
+#
+
+ifeq (yes,$(CONFIG_V4L2M2M))
+
+EXTLIBS  += v4l2-m2m
+ENCODERS += h264_v4l2m2m
+HWACCELS += drm
+DECODERS += h264_v4l2m2m
+
+EXTLIBS  += libv4l2
+#EXTLIBS  += v4l2-request
+#EXTLIBS  += libudev
+EXTLIBS  += libdrm
+
+endif
+
 
 
 # ##############################################################################

--- a/configure
+++ b/configure
@@ -54,9 +54,10 @@ OPTIONS=(
   "libopus:yes"
   "libopus_static:yes"
   "nvenc:no"
-  "vaapi:auto"
+  "vaapi:no"
   "mmal:no"
   "omx:no"
+  "v4l2m2m:yes"
   "inotify:auto"
   "epoll:auto"
   "pcre:auto"
@@ -270,7 +271,7 @@ int test ( void )
 }' -lpthread
 
 check_cc_snippet qsort_r '
-#define _GNU_SOURCE
+#define __USE_GNU
 #include <stdlib.h>
 #define TEST test
 int test(void)
@@ -679,6 +680,13 @@ if enabled ffmpeg_static; then
       CFLAGS=$OLDCFLAGS
     fi
     check_cc_header OMX_Core omx || die "OpenMAX IL not found"
+  fi
+
+  # v4l2
+  if enabled v4l2m2m; then
+    check_pkg libv4l2 ">=1.22" || die "libv4l2 1.22 package not found"
+    check_pkg libdrm ">=2.4" || die "libdrm 2.4 package not found"
+    check_pkg libudev ">=252" || die "libudev 252 package not found"
   fi
 
 else

--- a/src/plumbing/globalheaders.c
+++ b/src/plumbing/globalheaders.c
@@ -238,7 +238,7 @@ headers_complete(globalheaders_t *gh)
        * - maximal timeout is reached without metadata
        */
       if(threshold || (qd[i] <= 0 && qd_max > (MAX_NOPKT_TIME * 90))) {
-	ssc->ssc_disabled = 1;
+	//ssc->ssc_disabled = 1;
         tvhdebug(LS_GLOBALHEADERS, "gh disable stream %d %s%s%s (PID %i) threshold %d qd %"PRId64" qd_max %"PRId64,
              ssc->es_index, streaming_component_type2txt(ssc->es_type),
              ssc->es_lang[0] ? " " : "", ssc->es_lang, ssc->es_pid,

--- a/src/transcoding/codec/codec.c
+++ b/src/transcoding/codec/codec.c
@@ -78,6 +78,9 @@ extern TVHCodec tvh_codec_nvenc_hevc;
 extern TVHCodec tvh_codec_omx_h264;
 #endif
 
+#if ENABLE_V4L2M2M
+extern TVHCodec tvh_codec_v4l2m2m_h264;
+#endif
 
 /* AVCodec ================================================================== */
 
@@ -327,6 +330,10 @@ tvh_codecs_register()
 
 #if ENABLE_OMX
     tvh_codec_register(&tvh_codec_omx_h264);
+#endif
+
+#if ENABLE_V4L2M2M
+    tvh_codec_register(&tvh_codec_v4l2m2m_h264);
 #endif
 }
 

--- a/src/transcoding/codec/codecs/libs/v4l2-m2m.c
+++ b/src/transcoding/codec/codecs/libs/v4l2-m2m.c
@@ -1,0 +1,101 @@
+/*
+ *  tvheadend - Codec Profiles
+ *
+ *  Copyright (C) 2016 Tvheadend
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "transcoding/codec/internals.h"
+
+
+/* v4l2m2m ====================================================================== */
+
+typedef struct {
+    TVHVideoCodecProfile;
+    char *libname;
+    char *libprefix;
+    int zerocopy;
+} tvh_codec_profile_v4l2m2m_t;
+
+
+static int
+tvh_codec_profile_v4l2m2m_open(tvh_codec_profile_v4l2m2m_t *self, AVDictionary **opts)
+{
+    AV_DICT_SET_FLAGS_GLOBAL_HEADER(opts);
+    // bit_rate
+    if (self->bit_rate) {
+        AV_DICT_SET_BIT_RATE(opts, self->bit_rate);
+    }
+
+    // max_b_frames
+    // Encoder does not support b-frames yet, setting to 0
+    // remove when b-frames handling in FFmpeg h264_v4l2m2m is fixed
+    AV_DICT_SET_INT(opts, "bf", 0, 0);
+
+
+//ffmpeg -hide_banner -h encoder=h264_v4l2m2m
+// Encoder h264_v4l2m2m [V4L2 mem2mem H.264 encoder wrapper]:
+//    General capabilities: delay hardware
+//    Threading capabilities: none
+// h264_v4l2m2m_encoder AVOptions:
+//  -num_output_buffers <int>        E..V....... Number of buffers in the output context (from 0 to INT_MAX) (default 0)
+//  -num_capture_buffers <int>        E..V....... Number of buffers in the capture context (from 8 to INT_MAX) (default 8)
+
+    return 0;
+}
+
+
+static const codec_profile_class_t codec_profile_v4l2m2m_class = {
+    {
+        .ic_super   = (idclass_t *)&codec_profile_video_class,
+        .ic_class   = "codec_profile_v4l2m2m",
+        .ic_caption = N_("v4l2m2m_h264"),
+        .ic_properties = (const property_t[]){
+            {
+                .type     = PT_DBL,
+                .id       = "bit_rate",
+                .name     = N_("Bitrate (kb/s) (0=auto)"),
+                .desc     = N_("Constant bitrate (CBR) mode."),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(TVHCodecProfile, bit_rate),
+                .def.d    = 0,
+            },
+            {}
+        }
+    },
+    .open = (codec_profile_open_meth)tvh_codec_profile_v4l2m2m_open,
+};
+
+
+/* h264_v4l2m2m ================================================================= */
+
+static void
+tvh_codec_profile_v4l2m2m_destroy(TVHCodecProfile *_self)
+{
+    tvh_codec_profile_v4l2m2m_t *self = (tvh_codec_profile_v4l2m2m_t *)_self;
+    tvh_codec_profile_video_destroy(_self);
+    free(self->libname);
+    free(self->libprefix);
+}
+
+TVHVideoCodec tvh_codec_v4l2m2m_h264 = {
+    .name    = "h264_v4l2m2m",
+    .size    = sizeof(tvh_codec_profile_v4l2m2m_t),
+    .idclass = &codec_profile_v4l2m2m_class,
+    .profile_init = tvh_codec_profile_video_init,
+    .profile_destroy = tvh_codec_profile_v4l2m2m_destroy,
+};

--- a/src/transcoding/codec/internals.h
+++ b/src/transcoding/codec/internals.h
@@ -129,6 +129,9 @@
 #if ENABLE_MMAL
 #define HWACCEL_PRIORITIZE_MMAL  3
 #endif
+#if ENABLE_V4L2M2M
+#define HWACCEL_PRIORITIZE_V4L2M2M  4
+#endif
 
 #define DEINT_RATE_FRAME         0
 #define DEINT_RATE_FIELD         1

--- a/src/transcoding/codec/profile_video_class.c
+++ b/src/transcoding/codec/profile_video_class.c
@@ -47,6 +47,9 @@ hwaccel_get_list( void *o, const char *lang )
 #if ENABLE_MMAL
         { N_("prioritize MMAL"),                    HWACCEL_PRIORITIZE_MMAL},
 #endif
+#if ENABLE_V4L2M2M
+        { N_("prioritize V4L2"),                    HWACCEL_PRIORITIZE_V4L2M2M},
+#endif
     };
     return strtab2htsmsg(tab, 1, lang);
 }

--- a/src/transcoding/transcode/stream.c
+++ b/src/transcoding/transcode/stream.c
@@ -63,7 +63,7 @@ tvh_stream_setup(TVHStream *self, TVHCodecProfile *profile, tvh_ssc_t *ssc)
                        streaming_component_type2txt(ssc->es_type));
         return -1;
     }
-#if ENABLE_MMAL | ENABLE_NVENC | ENABLE_VAAPI
+#if ENABLE_V4L2M2M | ENABLE_MMAL | ENABLE_NVENC | ENABLE_VAAPI
     int hwaccel = -1;
     int hwaccel_details = -1;
     if (SCT_ISVIDEO(ssc->es_type)) {
@@ -71,6 +71,15 @@ tvh_stream_setup(TVHStream *self, TVHCodecProfile *profile, tvh_ssc_t *ssc)
             ((hwaccel_details = tvh_codec_profile_video_get_hwaccel_details(profile)) < 0)) {
             return -1;
         }
+#if ENABLE_V4L2M2M
+        if (idnode_is_instance(&profile->idnode, (idclass_t *)&codec_profile_video_class) &&
+            hwaccel &&
+            ((hwaccel_details == HWACCEL_AUTO && strstr(profile->codec_name, "v4l2")) || hwaccel_details == HWACCEL_PRIORITIZE_V4L2M2M)) {
+            if (icodec_id == AV_CODEC_ID_H264) {
+                icodec = avcodec_find_decoder_by_name("h264_v4l2m2m");
+            }
+        }
+#endif
 #if ENABLE_MMAL
         if (idnode_is_instance(&profile->idnode, (idclass_t *)&codec_profile_video_class) &&
             hwaccel &&
@@ -116,7 +125,7 @@ tvh_stream_setup(TVHStream *self, TVHCodecProfile *profile, tvh_ssc_t *ssc)
         }
 #endif
     }
-#endif // from ENABLE_MMAL | ENABLE_NVENC | ENABLE_VAAPI
+#endif // from ENABLE_V4L2M2M | ENABLE_MMAL | ENABLE_NVENC | ENABLE_VAAPI
     if (!icodec && !(icodec = avcodec_find_decoder(icodec_id))) {
         tvh_stream_log(self, LOG_ERR, "failed to find decoder for '%s'",
                        streaming_component_type2txt(ssc->es_type));

--- a/src/webui/static/app/codec.js
+++ b/src/webui/static/app/codec.js
@@ -35,7 +35,7 @@ function update_deinterlace_vaapi_mode(form) {
     if (form.findField('deinterlace_vaapi_mode')) {
         const hwaccel = form.findField('hwaccel').getValue();
         const deinterlace = form.findField('deinterlace').getValue();
-        const hwaccelDetails = form.findField('hwaccel_details').getValue(); // 0=AUTO, 1=VAAPI, 2=NVDEC, 3=MMAL
+        const hwaccelDetails = form.findField('hwaccel_details').getValue(); // 0=AUTO, 1=VAAPI, 2=NVDEC, 3=MMAL, 4=V4L2
 
         const disableDeintVaapiMode = !hwaccel || !deinterlace || (hwaccelDetails !== 0 && hwaccelDetails !== 1);
         form.findField('deinterlace_vaapi_mode').setDisabled(disableDeintVaapiMode);


### PR DESCRIPTION
I want to clarify that is not final, encoding is not working (decoding is working).
Unfortunately I got stuck for more than one month on this point ... I am afraid I need help.
The encoding is generating a corrupted output (as you can see in the picture) and I had to comment the removal of the stream from globalheaders (for investigation purpose): src/plumbing/globalheaders.c line 241
The hardware used is raspberry pi 4 with latest raspbian OS 64 bit.
Note some libs are required on top of regular libs required to compile tvh-master.
`sudo apt install libudev-dev libdrm-dev`
`sudo apt install libv4l-dev`

<img width="1816" height="1442" alt="error" src="https://github.com/user-attachments/assets/f9a36322-bb42-406f-b653-299efc266c16" />
