### PR TITLE
remove deprecated ticks_per_frame

### DIFF
--- a/src/transcoding/transcode/video.c
+++ b/src/transcoding/transcode/video.c
@@ -270,8 +270,8 @@ tvh_video_context_open_encoder(TVHContext *self, AVDictionary **opts)
         self->iavctx->framerate = av_make_q(30, 1);
     }
     self->oavctx->framerate = av_mul_q(self->iavctx->framerate, (AVRational) { field_rate, 1 }); //take into account double rate i.e. field-based deinterlacers
-    self->oavctx->ticks_per_frame = (90000 * self->oavctx->framerate.den) / self->oavctx->framerate.num; // We assume 90kHz as timebase which is mandatory for MPEG-TS
-    ticks_per_frame = av_make_q(self->oavctx->ticks_per_frame, 1);
+    int ticks_per_frame_tmp = (90000 * self->oavctx->framerate.den) / self->oavctx->framerate.num; // We assume 90kHz as timebase which is mandatory for MPEG-TS
+    ticks_per_frame = av_make_q(ticks_per_frame_tmp, 1);
     self->oavctx->time_base = av_inv_q(av_mul_q(
         self->oavctx->framerate, ticks_per_frame));
     self->oavctx->gop_size = ceil(av_q2d(av_inv_q(av_mul_q(


### PR DESCRIPTION
- remove deprecated ticks_per_frame

<img width="820" height="333" alt="ticks_per_frame" src="https://github.com/user-attachments/assets/b2262ba8-f249-4c55-9a2a-08256f3f87b8" />
