### PR TITLE
Reinstate references to 'url'

### DIFF
--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -791,7 +791,7 @@ tvheadend.dvr_finished = function(panel, index) {
         del: false,
         list: 'disp_title,disp_extratext,episode_disp,channel,channelname,' +
               'start_real,stop_real,duration,filesize,copyright_year,' +
-              'sched_status,errors,data_errors,playcount,uri,config_name,owner,creator,comment,age_rating,rating_label,filename',
+              'sched_status,errors,data_errors,playcount,uri,url,config_name,owner,creator,comment,age_rating,rating_label,filename',
         columns: {
             disp_title: {
                 renderer: tvheadend.displayWithYearRenderer(),
@@ -911,7 +911,7 @@ tvheadend.dvr_failed = function(panel, index) {
                      _('The associated file will be removed from storage.'),
         list: 'disp_title,disp_extratext,episode_disp,channel,channelname,' +
               'image,copyright_year,start_real,stop_real,duration,filesize,status,' +
-              'sched_status,errors,data_errors,playcount,uri,config_name,owner,creator,comment,age_rating,rating_label,filename',
+              'sched_status,errors,data_errors,playcount,uri,url,config_name,owner,creator,comment,age_rating,rating_label,filename',
         columns: {
             disp_title: {
                 renderer: tvheadend.displayWithYearRenderer(),


### PR DESCRIPTION
PR #1915 changed references to 'url' to 'uri' in order to display CRID information for recordings. However 'url' is used to hold a link to the recording file which is used by the 'Download' button on the UI. Reinstate 'url' where this is relevant, ie for completed and failed recordings. Reported in https://tvheadend.org/d/9235-small-bug-in-43-2462g664cc1b62