### PR TITLE
doc: Fix docker tag usage in running the container

### DIFF
--- a/README.Docker.md
+++ b/README.Docker.md
@@ -16,7 +16,7 @@ $ git clone https://github.com/tvheadend/tvheadend
 Then, from within the repository
 
 ```sh
-docker image build
+docker image build \
     --rm \
     --tag 'tvheadend:issue-123' \
     './'
@@ -47,7 +47,7 @@ docker container run \
     --name 'TVHeadend_container_01' \
     --rm \
     --tty \
-    'ghcr.io/tvheadend/tvheadend:issue-123' \
+    'tvheadend:issue-123' \
     --firstrun
 ```
 
@@ -447,7 +447,7 @@ Instead, the `builder` container, an intermediate step, can be used instead
 and the source directory volume mounted herein.
 
 ```sh
-docker image build
+docker image build \
     --rm \
     --tag 'tvheadend:builder' \
     --target 'builder' \


### PR DESCRIPTION
When following the instructions, one first builds a container, using a specific tag, but then the instruction later use a (slightly) different tag when running, causing a failure.

This fixes that.

While here, Add proper line-continuation to the build entries.

No code changes as part of this commit.