### PR TITLE
debian: Enable IPv6 by default

### DIFF
--- a/debian/tvheadend.default
+++ b/debian/tvheadend.default
@@ -35,7 +35,7 @@ TVH_ADAPTERS=""
 
 # TVH_IPV6
 #   if set to 1 will enable IPv6 support
-TVH_IPV6=0
+TVH_IPV6=1
 
 # TVH_HTTP_PORT
 #   if set to "" will use binary default


### PR DESCRIPTION
With global IPv4 exhaustion and widespread IPv6 deployment by ISPs, enabling IPv6 by default ensures compatibility with modern dual-stack and IPv6-only networks.

If people wants to disable it, they can do it manuallly.

Fixes: https://github.com/tvheadend/tvheadend/issues/1854