### PR TITLE
Fixes coverity 637368

### DIFF
--- a/src/transcoding/codec/internals.h
+++ b/src/transcoding/codec/internals.h
@@ -155,13 +155,16 @@
 #define AV_DICT_SET_FLAGS_GLOBAL_HEADER(s, d) \
     AV_DICT_SET_FLAGS((s), (d), "+global_header")
 
+// Defines the maximum bitrate value to avoid exceeding int64_t limits after multiplication
+#define BITRATE_MAX ((double)((1ULL) << 53))
+
 #define AV_DICT_SET_BIT_RATE(s, d, v) \
     do { \
         int64_t bitrate = 0; \
-        if ((v) <= (INT64_MAX / 1000) && (v) >= 0) \
-            bitrate = (int64_t)((v) * 1000); \
+        if ((v) <= BITRATE_MAX && (v) >= 0.0) \
+            bitrate = (int64_t)((v) * 1000.0); \
         else \
-            tvherror_transcode((s), "bitrate value too large to fit in int64_t: %g or negative", (v) * 1000); \
+            tvherror_transcode((s), "bitrate value too large to fit in int64_t: %g or negative", (v) * 1000.0); \
         AV_DICT_SET_INT((s), (d), "b", bitrate, AV_DICT_DONT_OVERWRITE); \
     } while (0)
 


### PR DESCRIPTION
- threshold was defined as double representing the maximum representation that can fit in a int64_t later on
- number is ridiculously large so is only a theoretical limit.

<img width="1534" height="733" alt="637368" src="https://github.com/user-attachments/assets/6743cf3f-da1d-4df4-ac57-dcf328677c39" />
