### PR TITLE
Hack to fix New Zealand Freeview DVB-T OTA 7-day EPG.

### DIFF
--- a/data/conf/epggrab/eit/config
+++ b/data/conf/epggrab/eit/config
@@ -51,7 +51,7 @@
 
   "nz_freeview2": {
     "name": {
-      "eng": "New Zealand: Freeview Local"
+      "eng": "NZ: Freeview Terrestrial (DVB-T)"
     },
     "nit": {
       "Freeview ": {
@@ -63,22 +63,8 @@
     "prio": 5,
     "conv": "huffman",
     "hacks": {
-      "svc-net-lookup": 1
+      "translate-tsid": 1
     }
-  },
-
-  "nz_freeview1": {
-    "name": {
-      "eng": "New Zealand: Freeview Base"
-    },
-    "nit": {
-      "Freeview ": {
-        "onid": 8746,
-        "nbid": [ 13313, 13314, 13315, 13316 ]
-      }
-    },
-    "prio": 1,
-    "conv": "huffman"
   },
 
   "viasat_baltic": {

--- a/src/epggrab/module/eit.c
+++ b/src/epggrab/module/eit.c
@@ -1211,40 +1211,23 @@ _eit_callback
            mt->mt_name, sid, tsid, onid, seg);
 
  /*
- Notes for eroyee NZ DVB-T hack for full regional EPG in New Zealand.
+ DVB-T hack for full regional EPG in New Zealand.
  
- [Data] stream TSID for TVNZ and TVWorks is 0x19 and 0x1D respectively.
- This is NOT the  same as the network TSID for regional transmissions, 
- (see https://freeviewnz.tv/Media/o4pp5qwe/freeview-specification-2022-v15.pdf)
- which means that, without this hack, those outside of the Auckland region
- will only get now/next (p/f) EPG for TVNZ, TV3, Duke, Bravo, Eden etc.
+ [Data] stream TSID for TVNZ and TVWorks is 0x19 and 0x1D respectively, which is
+ NOT the  same as the network TSID for regional transmissions, limiting EPG for 
+ those outside of the Auckland region
+ (see https://freeviewnz.tv/Media/o4pp5qwe/freeview-specification-2022-v15.pdf).
+
+ Following translates the two Auckland-based stream TSIDs to the locally determined
+ NIT TSID for full 7-day EPG when the "NZ: Freeview Terrestrial (DVB-T)" module is used. 
  
- Therefore to fully populate the EPG we translate the two Auckland-based 
- stream TSIDs to the locally determined NIT TSID. This means we don't need
- to specify the region and it should 'just work'. At this point the code
- has not been tested outside of the southern region so YMMV!
- 
- May ultimately require a new Grabber module but for now use "NZ Freeview Local"
- which should provide the requisite scraping script and also sets the SVCNETLOOKUP
- flag which we're using here to ensure the TSID translation only occurs when this
- module is selected.
- 
- Note that, for some reason, 'svc-net-lookup' (from the 'Local' module "nz_freeview2") 
- was defined here as EXTRAMUXLOOKUP, which presumable means EIT_HACK_SVCNETLOOKUP, 
- called in the 'get service' code section and referred to as 'NZ Freesat', was 
- not working and could then be redundant? 
+ Note: NZ DVB-S users should utilise the standard "EIT Grabber" module.
  */
 
-  if ((hacks & EIT_HACK_SVCNETLOOKUP) != 0) {
+  if ((hacks & EIT_HACK_TRANSLATETSID) != 0) {
     mpegts_mux_t *dm = mt->mt_mux;
-    if (tsid == 0x19) {
-     tsid = dm->mm_tsid;
-    }
-    if (tsid == 0x1D) {
-     tsid = dm->mm_tsid;
-    }
+    tsid = dm->mm_tsid;
   }
-
 
   /* Register interest */
   if (tableid == 0x4e || (tableid >= 0x50 && tableid < 0x60) ||
@@ -1295,17 +1278,6 @@ _eit_callback
 
   /* Get service */
   svc = mpegts_mux_find_service(mm, sid);
-  if (!svc) {
-    /* NZ Freesat: use main data */
-    if (hacks & EIT_HACK_SVCNETLOOKUP) {
-      svc = mpegts_network_find_active_service(mm->mm_network, sid, &mm);
-      if (svc)
-        goto svc_ok;
-    }
-
-    tvhtrace(LS_TBL_EIT, "sid %i not found", sid);
-    goto done;
-  }
 
 svc_ok:
   if (map->om_first) {
@@ -1886,8 +1858,8 @@ static void eit_init_one ( const char *id, htsmsg_t *conf )
         priv->hacks |= EIT_HACK_INTEREST4E;
       else if (strcmp(htsmsg_field_name(f), "extra-mux-lookup") == 0)
         priv->hacks |= EIT_HACK_EXTRAMUXLOOKUP;
-      else if (strcmp(htsmsg_field_name(f), "svc-net-lookup") == 0)
-        priv->hacks |= EIT_HACK_SVCNETLOOKUP;
+      else if (strcmp(htsmsg_field_name(f), "translate-tsid") == 0)
+        priv->hacks |= EIT_HACK_TRANSLATETSID;
       else if (strcmp(htsmsg_field_name(f), "bat") == 0) {
         if (!(e = htsmsg_field_get_map(f))) continue;
         priv->bat_pid = htsmsg_get_s32_or_default(e, "pid", 0);


### PR DESCRIPTION
Presently, in New Zealand, those outside of the Auckland region DVB-T transmission will only get now/next OTA *EIT EPG for TVNZ, TV3, Duke, Bravo, Eden etc. This appears to be due to an anomaly with the way the TSID is handled between the Auckland and regional areas. Further detail is available from https://freeviewnz.tv/Media/o4pp5qwe/freeview-specification-2022-v15.pdf (note some broadcasts are not affected, eg. Sky and Eden+1).
 
In this hack, to fully populate the EPG we simply translate the two Auckland-based stream TSIDs to the locally determined NIT TSID. This means we shouldn't need to specify the region and it should 'just work'. At this point the code has not been tested outside of the southern region so YMMV. Testing in other regions, and Auckland, would be appreciated.

I believe it should also work (insofar as it would be 'neutral') for the Auckland region. If this proves to be the case we may be able to do away with one of the present New Zealand EPG modules. Presently the code uses the current "New Zealand: Freeview Local" module which should provide the requisite scraping script and also sets the SVCNETLOOKUP
 flag which we're using here to ensure the TSID translation _only_ occurs when this module is selected.

*New Zealand also broadcasts 7-day EPG information in an MHEG-5 stream. This can also be utilised with TVH, however it requires an additional grabber file and there is the possibility this stream will be removed eventually. Having 'native' EIT EPG mitigates this problem and provides an 'out of the box' solution.