### PR TITLE
added gop adjustment to vaapi, nvenc, libx26x and libvp

### DIFF
--- a/src/transcoding/codec/codecs/libs/libvpx.c
+++ b/src/transcoding/codec/codecs/libs/libvpx.c
@@ -136,6 +136,17 @@ static const codec_profile_class_t codec_profile_libvpx_class = {
                 .list     = codec_profile_libvpx_class_tune_list,
                 .def.i    = VP8_TUNE_PSNR,
             },
+            {
+                .type     = PT_INT,
+                .id       = "gop_size",     // Don't change
+                .name     = N_("GOP size"),
+                .desc     = N_("Sets the Group of Pictures (GOP) size in frame (default 0 is 3 sec.)"),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(TVHVideoCodecProfile, gop_size),
+                .intextra = INTEXTRA_RANGE(0, 1000, 1),
+                .def.i    = 0,
+            },
             {}
         }
     },

--- a/src/transcoding/codec/codecs/libs/libx26x.c
+++ b/src/transcoding/codec/codecs/libs/libx26x.c
@@ -91,6 +91,17 @@ static const codec_profile_class_t codec_profile_libx26x_class = {
                 .intextra = INTEXTRA_RANGE(0, 51, 1),
                 .def.i    = 0,
             },
+            {
+                .type     = PT_INT,
+                .id       = "gop_size",     // Don't change
+                .name     = N_("GOP size"),
+                .desc     = N_("Sets the Group of Pictures (GOP) size in frame (default 0 is 3 sec.)"),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(TVHVideoCodecProfile, gop_size),
+                .intextra = INTEXTRA_RANGE(0, 1000, 1),
+                .def.i    = 0,
+            },
             {}
         }
     },

--- a/src/transcoding/codec/codecs/libs/nvenc.c
+++ b/src/transcoding/codec/codecs/libs/nvenc.c
@@ -253,6 +253,17 @@ static const codec_profile_class_t codec_profile_nvenc_class = {
             },
             {
                 .type     = PT_INT,
+                .id       = "gop_size",     // Don't change
+                .name     = N_("GOP size"),
+                .desc     = N_("Sets the Group of Pictures (GOP) size in frame (default 0 is 3 sec.)"),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(TVHVideoCodecProfile, gop_size),
+                .intextra = INTEXTRA_RANGE(0, 1000, 1),
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_INT,
                 .id       = "rc",
                 .name     = N_("Rate control"),
                 .group    = 3,
@@ -332,7 +343,6 @@ tvh_codec_profile_nvenc_h264_open(tvh_codec_profile_nvenc_t *self,
     AV_DICT_SET_INT(LST_NVENC, opts, "qdiff", -1, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "qblur", -1, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "qcomp", -1, 0);
-    AV_DICT_SET_INT(LST_NVENC, opts, "g", 250, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "bf", 0, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "refs", 0, 0);
     return 0;
@@ -452,7 +462,6 @@ tvh_codec_profile_nvenc_hevc_open(tvh_codec_profile_nvenc_t *self,
     AV_DICT_SET_INT(LST_NVENC, opts, "qdiff", -1, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "qblur", -1, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "qcomp", -1, 0);
-    AV_DICT_SET_INT(LST_NVENC, opts, "g", 250, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "bf", 0, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "refs", 0, 0);
     return 0;

--- a/src/transcoding/codec/codecs/libs/vaapi.c
+++ b/src/transcoding/codec/codecs/libs/vaapi.c
@@ -338,7 +338,7 @@ static const codec_profile_class_t codec_profile_vaapi_class = {
                 .name     = N_("Device name"),
                 .desc     = N_("Device name (e.g. /dev/dri/renderD128)."),
                 .group    = 3,
-                .off      = offsetof(tvh_codec_profile_vaapi_t, device),
+                .off      = offsetof(TVHCodecProfile, device),
                 .list     = tvh_codec_profile_vaapi_device_list,
             },
             {
@@ -349,7 +349,7 @@ static const codec_profile_class_t codec_profile_vaapi_class = {
                 .group    = 3,
                 .opts     = PO_EXPERT,
                 .get_opts = codec_profile_class_get_opts,
-                .off      = offsetof(tvh_codec_profile_vaapi_t, low_power),
+                .off      = offsetof(TVHCodecProfile, low_power),
                 .def.i    = 0,
             },
             {
@@ -383,6 +383,17 @@ static const codec_profile_class_t codec_profile_vaapi_class = {
                 .get_opts = codec_profile_class_get_opts,
                 .off      = offsetof(tvh_codec_profile_vaapi_t, b_reference),
                 .list     = b_reference_get_list,
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "gop_size",     // Don't change
+                .name     = N_("GOP size"),
+                .desc     = N_("Sets the Group of Pictures (GOP) size in frame (default 0 is 3 sec.)"),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(TVHVideoCodecProfile, gop_size),
+                .intextra = INTEXTRA_RANGE(0, 1000, 1),
                 .def.i    = 0,
             },
             {
@@ -436,7 +447,7 @@ static const codec_profile_class_t codec_profile_vaapi_class = {
                 .desc     = N_("Target bitrate (0=skip).[if disabled will not send paramter to libav]"),
                 .group    = 3,
                 .get_opts = codec_profile_class_get_opts,
-                .off      = offsetof(tvh_codec_profile_vaapi_t, bit_rate),
+                .off      = offsetof(TVHCodecProfile, bit_rate),
                 .def.d    = 0,
             },
             {
@@ -476,7 +487,7 @@ static const codec_profile_class_t codec_profile_vaapi_class = {
                 .group    = 2,
                 .desc     = N_("Denoise only available with Hardware Acceleration (from 0 to 64, 0=skip, 0 default)"),
                 .get_opts = codec_profile_class_get_opts,
-                .off      = offsetof(tvh_codec_profile_vaapi_t, filter_hw_denoise),
+                .off      = offsetof(TVHVideoCodecProfile, filter_hw_denoise),
                 .intextra = INTEXTRA_RANGE(0, 64, 1),
                 .def.i    = 0,
             },
@@ -487,7 +498,7 @@ static const codec_profile_class_t codec_profile_vaapi_class = {
                 .group    = 2,
                 .desc     = N_("Sharpness only available with Hardware Acceleration (from 0 to 64, 0=skip, 44 default)"),
                 .get_opts = codec_profile_class_get_opts,
-                .off      = offsetof(tvh_codec_profile_vaapi_t, filter_hw_sharpness),
+                .off      = offsetof(TVHVideoCodecProfile, filter_hw_sharpness),
                 .intextra = INTEXTRA_RANGE(0, 64, 1),
                 .def.i    = 44,
             },
@@ -774,8 +785,6 @@ tvh_codec_profile_vaapi_h264_open(tvh_codec_profile_vaapi_t *self,
             }
             break;
     }
-    // force keyframe every 3 sec.
-    AV_DICT_SET(LST_VAAPI, opts, "force_key_frames", "expr:gte(t,n_forced*3)", AV_DICT_DONT_OVERWRITE);
     return 0;
 }
 
@@ -1078,8 +1087,6 @@ tvh_codec_profile_vaapi_hevc_open(tvh_codec_profile_vaapi_t *self,
             }
             break;
     }
-    // force keyframe every 3 sec.
-    AV_DICT_SET(LST_VAAPI, opts, "force_key_frames", "expr:gte(t,n_forced*3)", AV_DICT_DONT_OVERWRITE);
     return 0;
 }
 
@@ -1375,8 +1382,6 @@ tvh_codec_profile_vaapi_vp8_open(tvh_codec_profile_vaapi_t *self,
             }
             break;
     }
-    // force keyframe every 3 sec.
-    AV_DICT_SET(LST_VAAPI, opts, "force_key_frames", "expr:gte(t,n_forced*3)", AV_DICT_DONT_OVERWRITE);
     return 0;
 }
 
@@ -1693,8 +1698,6 @@ tvh_codec_profile_vaapi_vp9_open(tvh_codec_profile_vaapi_t *self,
             }
             break;
     }
-    // force keyframe every 3 sec.
-    AV_DICT_SET(LST_VAAPI, opts, "force_key_frames", "expr:gte(t,n_forced*3)", AV_DICT_DONT_OVERWRITE);
     return 0;
 }
 

--- a/src/transcoding/codec/internals.h
+++ b/src/transcoding/codec/internals.h
@@ -427,6 +427,17 @@ typedef struct tvh_codec_profile_video {
      * - 2 - scaling only down
      */
     int scaling_mode;
+    /**
+     * SW or HW gop size  (applies for encoding)
+     * @note
+     * int: 
+     * VALUE - gop size
+     * 
+     * - 0 - default gop size (3 sec)
+     * 
+     * - 1 --> 1000 - gop size in frames
+     */
+    int gop_size;
     int hwaccel;
     int hwaccel_details;
     int pix_fmt;

--- a/src/transcoding/transcode/video.c
+++ b/src/transcoding/transcode/video.c
@@ -225,6 +225,7 @@ tvh_video_context_open_encoder(TVHContext *self, AVDictionary **opts)
     AVRational ticks_per_frame;
     int deinterlace  = ((TVHVideoCodecProfile *)self->profile)->deinterlace;
     int field_rate = (deinterlace && ((TVHVideoCodecProfile *)self->profile)->deinterlace_field_rate) ? 2 : 1;
+    int gop_size = ((TVHVideoCodecProfile *)self->profile)->gop_size;
 
     if (tvh_context_get_int_opt(opts, "pix_fmt", &self->oavctx->pix_fmt) ||
         tvh_context_get_int_opt(opts, "width", &self->oavctx->width) ||
@@ -272,11 +273,16 @@ tvh_video_context_open_encoder(TVHContext *self, AVDictionary **opts)
     self->oavctx->framerate = av_mul_q(self->iavctx->framerate, (AVRational) { field_rate, 1 }); //take into account double rate i.e. field-based deinterlacers
     int ticks_per_frame_tmp = (90000 * self->oavctx->framerate.den) / self->oavctx->framerate.num; // We assume 90kHz as timebase which is mandatory for MPEG-TS
     ticks_per_frame = av_make_q(ticks_per_frame_tmp, 1);
-    self->oavctx->time_base = av_inv_q(av_mul_q(
-        self->oavctx->framerate, ticks_per_frame));
-    self->oavctx->gop_size = ceil(av_q2d(av_inv_q(av_mul_q(
-        self->oavctx->time_base, ticks_per_frame))));
-    self->oavctx->gop_size *= 3;
+    self->oavctx->time_base = av_inv_q(av_mul_q(self->oavctx->framerate, ticks_per_frame));
+    if (gop_size) {
+        // gop was set by the user
+        self->oavctx->gop_size = gop_size;
+    }
+    else {
+        // gop = 0 --> we use default of 3 sec.
+        self->oavctx->gop_size = ceil(av_q2d(av_inv_q(av_mul_q(self->oavctx->time_base, ticks_per_frame))));
+        self->oavctx->gop_size *= 3;
+    }
 
     self->oavctx->sample_aspect_ratio = self->iavctx->sample_aspect_ratio;
 


### PR DESCRIPTION
- fixed one bug: gop was always overwritten in video.c to 3 sec.
- vaapi and nvenc was trying to setup gop though AVDictionary.
- now each video codec can overwrite the default value of 3 sec.; except mpeg2video

vaapi has a indirect mechanism (using force_key_frames) to force a gop = 3 sec.
https://github.com/tvheadend/tvheadend/blob/7f9710c13742807e31672052f6e4ebebe8f857c5/src/transcoding/codec/codecs/libs/vaapi.c#L778
nvenc has a default value for gop (set with g = 250).
https://github.com/tvheadend/tvheadend/blob/7f9710c13742807e31672052f6e4ebebe8f857c5/src/transcoding/codec/codecs/libs/nvenc.c#L335

Both those values are overwritten in video.c:
https://github.com/tvheadend/tvheadend/blob/7f9710c13742807e31672052f6e4ebebe8f857c5/src/transcoding/transcode/video.c#L277

I consider this a bug (taking into account we overwrite the gop_size).

This PR will check if the user has selected a particular gop ... if it has, will use that gop_size; if not, will use the old implementation of 3 sec.
