### PR TITLE
Reorder retrieval logic of DVR recordings' images

### DIFF
--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -4220,10 +4220,10 @@ dvr_entry_class_channel_icon_url_get(void *o)
 const char *
 dvr_entry_get_image(const dvr_entry_t *de)
 {
-  if (de && de->de_bcast && de->de_bcast->image)
-    return de->de_bcast->image;
   if (de && de->de_image)
     return de->de_image;
+  if (de && de->de_bcast && de->de_bcast->image)
+    return de->de_bcast->image;
   return NULL;
 }
 


### PR DESCRIPTION
Closes #1992

Inverts the logic of retrieval of DVR recordings' images.

Previously the logic was :
1. Return the image tied to the recording's EPG event.
2. If (1.) doesn't exist, return the image tied to the recording.

Now:
1. Return the image tied to the recording.
2. If (1.) doesn't exist, return the image tied to the recording's EPG event.