### PR TITLE
Refactor and enhance NVENC codec profile options

### DIFF
--- a/src/transcoding/codec/codecs/libs/nvenc.c
+++ b/src/transcoding/codec/codecs/libs/nvenc.c
@@ -1,7 +1,7 @@
 /*
  *  tvheadend - Codec Profiles
  *
- *  Copyright (C) 2017 Tvheadend
+ *  Copyright (C) 2025 Tvheadend
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -21,11 +21,15 @@
 #include "transcoding/codec/internals.h"
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <ffnvcodec/nvEncodeAPI.h>
 
+#define PRESET_SKIP                  -1
+// matched with ffmpeg/libavcodec/nvenc.h line 120
 #define PRESET_DEFAULT               0
 #define PRESET_SLOW                  1
 #define PRESET_MEDIUM                2
 #define PRESET_FAST                  3
+#if NVENCAPI_MAJOR_VERSION < 10
 #define PRESET_HP                    4
 #define PRESET_HQ                    5
 #define PRESET_BD                    6
@@ -34,20 +38,33 @@
 #define PRESET_LOW_LATENCY_HP        9
 #define PRESET_LOSSLESS_DEFAULT      10
 #define PRESET_LOSSLESS_HP           11
+#else
+#define PRESET_P1                    12
+#define PRESET_P2                    13
+#define PRESET_P3                    14
+#define PRESET_P4                    15
+#define PRESET_P5                    16
+#define PRESET_P6                    17
+#define PRESET_P7                    18
+#endif
 
+// matched with src/webui/static/app/codec.js --> function filter_based_on_rc_nvenc(form)
 #define NV_ENC_PARAMS_RC_AUTO                  0
 #define NV_ENC_PARAMS_RC_CONSTQP               1
 #define NV_ENC_PARAMS_RC_VBR                   2
 #define NV_ENC_PARAMS_RC_CBR                   3
+#define NV_ENC_PARAMS_RC_VBR_MINQP             4   
 #define NV_ENC_PARAMS_RC_CBR_LD_HQ             8
 #define NV_ENC_PARAMS_RC_CBR_HQ                16
 #define NV_ENC_PARAMS_RC_VBR_HQ                32
 
+// matched with ffmpeg/libavcodec/nvenc.h
 #define NV_ENC_H264_PROFILE_BASELINE			    0
 #define NV_ENC_H264_PROFILE_MAIN			        1
 #define NV_ENC_H264_PROFILE_HIGH			        2
 #define NV_ENC_H264_PROFILE_HIGH_444P           	3
 
+// matched with ffmpeg/libavcodec/nvenc.h
 #define NV_ENC_HEVC_PROFILE_MAIN			        0
 #define NV_ENC_HEVC_PROFILE_MAIN_10 			    1
 #define NV_ENC_HEVC_PROFILE_REXT			        2
@@ -88,20 +105,101 @@
 #define NV_ENC_LEVEL_HEVC_61                        183
 #define NV_ENC_LEVEL_HEVC_62                        186
 
-#define AV_DICT_SET_CQ(d, v, a) \
-    AV_DICT_SET_INT(LST_NVENC, (d), "cq", (v) ? (v) : (a), AV_DICT_DONT_OVERWRITE)
-
+#define NV_ENC_TUNING_INFO_UNDEFINED                0   //< Undefined tuningInfo. Invalid value for encoding.
+#define NV_ENC_TUNING_INFO_HIGH_QUALITY             1   //< Tune presets for latency tolerant encoding.
+#define NV_ENC_TUNING_INFO_LOW_LATENCY              2   //< Tune presets for low latency streaming.
+#define NV_ENC_TUNING_INFO_ULTRA_LOW_LATENCY        3   //< Tune presets for ultra low latency streaming.
+#define NV_ENC_TUNING_INFO_LOSSLESS                 4   //< Tune presets for lossless encoding.
 
 /* nvenc ==================================================================== */
 
 typedef struct {
     TVHVideoCodecProfile;
-    int nvenc_profile;
+/**
+ * NVENC Constant QP [qp]
+ * @note
+ * int:
+ * VALUE - Constant QP value (1-51, 0=skip)
+ */
+    int qp;
+/**
+ * NVENC Selects which NVENC capable GPU to use. First GPU is 0, second is 1, and so on. [gpu]
+ * @note
+ * int:
+ * VALUE - GPU to use. First GPU is 0, second is 1, and so on. (from -2 to 15) (default any) (from 0 to 15, -1=any, -2=skip)
+ */
     int devicenum;
+/**
+ * NVENC Set the encoding preset [preset]
+ * @note
+ * int:
+ * VALUE - encoding preset (from 0 to 18) (default p4) (from ffmpeg/libavcodec/nvenc.h line 120, -1=skip)
+ */
     int preset;
+/**
+ * NVENC Set the encoding tuning info [tune]
+ * @note
+ * int:
+ * VALUE - encoding tuning info (from 1 to 4) (default skip) (from nvEncodeAPI.h, 0=skip)
+ */
+    int tune;
+/**
+ * NVENC Maximum bitrate [maxrate]
+ * @note
+ * double:
+ * VALUE - max bitrate in bps
+ */
+    double max_bit_rate;
+/**
+ * NVENC Maximum bitrate scale factor
+ * @note
+ * double:
+ * VALUE - max bitrate scale factor
+ */
+    double bit_rate_scale_factor;
+/**
+ * NVENC Override the preset rate-control method [rc]
+ * @note
+ * int:
+ * VALUE - rc mode accepted values (from 0 to 32) (default auto)
+ * Note: some rc modes are deprecated
+ */
     int rc;
+/**
+ * NVENC Set target quality level for constant quality mode in VBR rate control [cq]
+ * @note
+ * int:
+ * VALUE - quality level (0 to 51, 0 means automatic)
+ */
+    int cq;
+/**
+ * NVENC Set the encoding level restriction [level]
+ * @note
+ * int:
+ * VALUE - level restriction (from 0 to 62)
+ */
     int level;
-    int quality;
+/**
+ * NVENC Sets the lowest possible quantization level [qmin]
+ * @note
+ * int:
+ * VALUE - quantization restriction (from 0 to 51)
+ */
+    int qmin;
+/**
+ * NVENC Sets the highest possible quantization level [qmax]
+ * @note
+ * int:
+ * VALUE - quantization restriction (from 0 to 51)
+ */
+    int qmax;
+/**
+ * NVENC Sets the maximum allowed difference between the Quantization Parameter (QP) of consecutive frames [qdiff]
+ * @note
+ * int:
+ * VALUE - quantization restriction (from -1 to 69)
+ */
+    int qdiff;
 } tvh_codec_profile_nvenc_t;
 
 static int
@@ -113,83 +211,196 @@ tvh_codec_profile_nvenc_open(tvh_codec_profile_nvenc_t *self,
         {"slow",        PRESET_SLOW},
         {"medium",      PRESET_MEDIUM},
         {"fast",        PRESET_FAST},
-        {"hp",		PRESET_HP},
-        {"hq",		PRESET_HQ},
-        {"bd",		PRESET_BD},
-        {"ll",		PRESET_LOW_LATENCY_DEFAULT},
-        {"llhq",	PRESET_LOW_LATENCY_HQ},
-        {"llhp",	PRESET_LOW_LATENCY_HP},
+#if NVENCAPI_MAJOR_VERSION < 10
+        {"hp",		    PRESET_HP},
+        {"hq",		    PRESET_HQ},
+        {"bd",		    PRESET_BD},
+        {"ll",		    PRESET_LOW_LATENCY_DEFAULT},
+        {"llhq",	    PRESET_LOW_LATENCY_HQ},
+        {"llhp",	    PRESET_LOW_LATENCY_HP},
         {"lossless",	PRESET_LOSSLESS_DEFAULT},
         {"losslesshp",	PRESET_LOSSLESS_HP},
+#else
+        {"p1",          PRESET_P1},
+        {"p2",          PRESET_P2},
+        {"p3",          PRESET_P3},
+        {"p4",          PRESET_P4},
+        {"p5",          PRESET_P5},
+        {"p6",          PRESET_P6},
+        {"p7",          PRESET_P7},
+#endif
     };
     static const struct strtab rctab[] = {
         {"constqp",	      NV_ENC_PARAMS_RC_CONSTQP},
         {"vbr",           NV_ENC_PARAMS_RC_VBR},
         {"cbr",           NV_ENC_PARAMS_RC_CBR},
+#if NVENCAPI_MAJOR_VERSION < 10
+        {"vbr_minqp",     NV_ENC_PARAMS_RC_VBR_MINQP},
         {"cbr_ld_hq",     NV_ENC_PARAMS_RC_CBR_LD_HQ},
         {"cbr_hq",        NV_ENC_PARAMS_RC_CBR_HQ},
         {"vbr_hq",        NV_ENC_PARAMS_RC_VBR_HQ},
+#endif
     };
+#if NVENCAPI_MAJOR_VERSION >= 10
+    static const struct strtab tunetab[] = {
+        {"hq",	            NV_ENC_PARAMS_RC_CONSTQP},
+        {"ll",              NV_ENC_PARAMS_RC_VBR},
+        {"ull",             NV_ENC_PARAMS_RC_CBR},
+        {"lossless",        NV_ENC_PARAMS_RC_VBR_MINQP},
+    };
+#endif
     const char *s;
 
-    AV_DICT_SET_INT(LST_NVENC, opts, "gpu", MINMAX(self->devicenum, 0, 15), 0);
-    if (self->preset != PRESET_DEFAULT &&
-        (s = val2str(self->profile, presettab)) != NULL) {
-        AV_DICT_SET(LST_NVENC, opts, "preset", s, 0);
+    if (self->devicenum != -2) {
+        AV_DICT_SET_INT(LST_NVENC, opts, "gpu", self->devicenum, 0);
     }
+    if (self->preset != PRESET_SKIP &&
+        (s = val2str(self->preset, presettab)) != NULL) {
+            AV_DICT_SET(LST_NVENC, opts, "preset", s, 0);
+        }
+#if NVENCAPI_MAJOR_VERSION >= 10
+    if (self->tune != NV_ENC_TUNING_INFO_UNDEFINED &&
+        (s = val2str(self->tune, tunetab)) != NULL) {
+            AV_DICT_SET(LST_NVENC, opts, "tune", s, 0);
+        }
+#endif
     if (self->rc != NV_ENC_PARAMS_RC_AUTO &&
         (s = val2str(self->rc, rctab)) != NULL) {
-        AV_DICT_SET(LST_NVENC, opts, "rc", s, 0);
+            AV_DICT_SET(LST_NVENC, opts, "rc", s, 0);
+        }
+    
+    int int_bitrate = (int)((self->bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
+    int int_max_bitrate = (int)((self->max_bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
+    int int_qp = self->qp;
+    int int_cq = self->cq;
+    // disable fields based on rc mode to match the UI behavior
+    // skip and auto are not filtering
+    if (self->rc == NV_ENC_PARAMS_RC_VBR || self->rc == NV_ENC_PARAMS_RC_AUTO
+#if NVENCAPI_MAJOR_VERSION < 10
+        || self->rc == NV_ENC_PARAMS_RC_VBR_MINQP || self->rc == NV_ENC_PARAMS_RC_VBR_HQ
+#endif
+        ) {
+        // force max_bitrate to be >= with bitrate (to avoid crash)
+        if (int_bitrate > int_max_bitrate) {
+            tvherror_transcode(LST_NVENC, "Bitrate %d kbps is greater than Max bitrate %d kbps, increase Max bitrate to %d kbps", int_bitrate / 1024, int_max_bitrate / 1024, int_bitrate / 1024);
+            int_max_bitrate = int_bitrate;
+        }
+        if (int_bitrate) {
+            tvhinfo_transcode(LST_NVENC, "Bitrate = %d kbps; Max bitrate = %d kbps", int_bitrate / 1024, int_max_bitrate / 1024);
+        }
+        int_qp = 0; // disable qp setting
     }
-    if (self->bit_rate) {
-        AV_DICT_SET_BIT_RATE(LST_NVENC, opts, self->bit_rate);
+    else if(self->rc == NV_ENC_PARAMS_RC_CBR
+#if NVENCAPI_MAJOR_VERSION < 10
+            || self->rc == NV_ENC_PARAMS_RC_CBR_LD_HQ || self->rc == NV_ENC_PARAMS_RC_CBR_HQ
+#endif
+            ) {
+            // in CBR mode max_bitrate is ignored by nvenc, so we only use bitrate
+            if (int_bitrate) {
+                tvhinfo_transcode(LST_NVENC, "Bitrate = %d kbps", int_bitrate / 1024);
+            }
+            int_max_bitrate = 0; // disable max_bitrate setting
+            int_qp = 0;         // disable qp setting
+            int_cq = 0;         // disable cq setting
+        }
+        else if(self->rc == NV_ENC_PARAMS_RC_CONSTQP) {
+            // in CQP mode both bitrate and max_bitrate are ignored by nvenc, so we only use qp
+            int_bitrate = 0;    // disable bitrate setting
+            int_max_bitrate = 0; // disable max_bitrate setting
+            int_cq = 0;         // disable cq setting
+        }
+    if (int_bitrate) {
+        AV_DICT_SET_INT(LST_NVENC, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
     }
-    AV_DICT_SET_INT(LST_NVENC, opts, "quality", self->quality, 0);
+    if (int_max_bitrate) {
+        AV_DICT_SET_INT(LST_NVENC, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
+    }
+    if (int_qp) {
+        AV_DICT_SET_INT(LST_NVENC, opts, "qp", int_qp, 0);
+    }
+    if (int_cq) {
+        AV_DICT_SET_INT(LST_NVENC, opts, "cq", int_cq, 0);
+    }
+    
+    if (self->qmin) {
+        AV_DICT_SET_INT(LST_NVENC, opts, "qmin", self->qmin, 0);
+    }
+    if (self->qmax) {
+        AV_DICT_SET_INT(LST_NVENC, opts, "qmax", self->qmax, 0);
+    }
+    if (self->qdiff != -2) {
+        AV_DICT_SET_INT(LST_NVENC, opts, "qdiff", self->qdiff, 0);
+    }
     return 0;
 }
 
-static htsmsg_t *
-codec_profile_nvenc_class_profile_list(void *obj, const char *lang)
-{
-    TVHCodec *codec = tvh_codec_profile_get_codec(obj);
-    return tvh_codec_get_list(codec, profiles);
-}
 
 static htsmsg_t *
 codec_profile_nvenc_class_preset_list(void *obj, const char *lang)
 {
     static const struct strtab tab[] = {
-        {N_("Default"),		PRESET_DEFAULT},
-        {N_("Slow"),		PRESET_SLOW},
-        {N_("Medium"),		PRESET_MEDIUM},
-        {N_("Fast"),		PRESET_FAST},
-        {N_("HP"),		PRESET_HP},
-        {N_("HQ"),		PRESET_HQ},
-        {N_("BD"),		PRESET_BD},
-        {N_("Low latency"),	PRESET_LOW_LATENCY_DEFAULT},
-        {N_("Low latency HQ"),	PRESET_LOW_LATENCY_HQ},
-        {N_("Low latency HP"),	PRESET_LOW_LATENCY_HP},
-        {N_("Lossless"),	PRESET_LOSSLESS_DEFAULT},
-        {N_("Lossless HP"),	PRESET_LOSSLESS_HP},
+        {N_("skip"),                    PRESET_SKIP},
+        {N_("Default"),                 PRESET_DEFAULT},
+        {N_("Slow"),                    PRESET_SLOW},
+        {N_("Medium"),                  PRESET_MEDIUM},
+        {N_("Fast"),                    PRESET_FAST},
+#if NVENCAPI_MAJOR_VERSION < 10
+        {N_("HP"),                      PRESET_HP},
+        {N_("HQ"),                      PRESET_HQ},
+        {N_("BD"),                      PRESET_BD},
+        {N_("Low latency"),             PRESET_LOW_LATENCY_DEFAULT},
+        {N_("Low latency HQ"),          PRESET_LOW_LATENCY_HQ},
+        {N_("Low latency HP"),          PRESET_LOW_LATENCY_HP},
+        {N_("Lossless"),                PRESET_LOSSLESS_DEFAULT},
+        {N_("Lossless HP"),             PRESET_LOSSLESS_HP},
+#else
+        {N_("P1 (lowest quality)"),     PRESET_P1},
+        {N_("P2"),                      PRESET_P2},
+        {N_("P3"),                      PRESET_P3},
+        {N_("P4"),                      PRESET_P4},
+        {N_("P5"),                      PRESET_P5},
+        {N_("P6"),                      PRESET_P6},
+        {N_("P7 (highest quality)"),    PRESET_P7},
+#endif
     };
     return strtab2htsmsg(tab, 1, lang);
 }
+
+#if NVENCAPI_MAJOR_VERSION >= 10
+static htsmsg_t *
+codec_profile_nvenc_class_tune_list(void *obj, const char *lang)
+{
+    static const struct strtab tab[] = {
+        {N_("skip"),		        NV_ENC_TUNING_INFO_UNDEFINED},
+        {N_("High quality"),		NV_ENC_TUNING_INFO_HIGH_QUALITY},
+        {N_("Low latency"),	        NV_ENC_TUNING_INFO_LOW_LATENCY},
+        {N_("Ultra low latency"),	NV_ENC_TUNING_INFO_ULTRA_LOW_LATENCY},
+        {N_("Lossless"),	        NV_ENC_TUNING_INFO_LOSSLESS},
+    };
+    return strtab2htsmsg(tab, 1, lang);
+}
+#endif
 
 static htsmsg_t *
 codec_profile_nvenc_class_rc_list(void *obj, const char *lang)
 {
     static const struct strtab tab[] = {
-        {N_("Auto"),				  NV_ENC_PARAMS_RC_AUTO},
-        {N_("Constant QP mode"),      NV_ENC_PARAMS_RC_CONSTQP},
-        {N_("VBR mode"),   			  NV_ENC_PARAMS_RC_VBR},
-        {N_("CBR mode"), 	  		  NV_ENC_PARAMS_RC_CBR},
-        {N_("CBR LD HQ"),			  NV_ENC_PARAMS_RC_CBR_LD_HQ},
-        {N_("CBR High Quality"),	  NV_ENC_PARAMS_RC_CBR_HQ},
-        {N_("VBR High Quality"),   	  NV_ENC_PARAMS_RC_VBR_HQ},
+        {N_("auto"),                            NV_ENC_PARAMS_RC_AUTO},
+        {N_("Constant QP"),                     NV_ENC_PARAMS_RC_CONSTQP},
+        {N_("Variable Bitrate"),                NV_ENC_PARAMS_RC_VBR},
+        {N_("Constant Bitrate"),                NV_ENC_PARAMS_RC_CBR},
+#if NVENCAPI_MAJOR_VERSION < 10
+        {N_("VBR min Q (deprecated)"),          NV_ENC_PARAMS_RC_VBR_MINQP},
+        {N_("CBR LD HQ (deprecated)"),          NV_ENC_PARAMS_RC_CBR_LD_HQ},
+        {N_("CBR High Quality (deprecated)"),   NV_ENC_PARAMS_RC_CBR_HQ},
+        {N_("VBR High Quality (deprecated)"),   NV_ENC_PARAMS_RC_VBR_HQ},
+#endif
     };
     return strtab2htsmsg(tab, 1, lang);
 }
 
+// NOTE:
+// the names below are used in codec.js (/src/webui/static/app/codec.js)
 static const codec_profile_class_t codec_profile_nvenc_class = {
     {
         .ic_super      = (idclass_t *)&codec_profile_video_class,
@@ -198,28 +409,18 @@ static const codec_profile_class_t codec_profile_nvenc_class = {
         .ic_properties = (const property_t[]){
             {
                 .type     = PT_INT,
-                .id       = "devicenum",
+                .id       = "devicenum",     // Don't change
                 .name     = N_("GPU number"),
                 .group    = 3,
-                .desc     = N_("GPU number (starts with zero)."),
+                .desc     = N_("Select GPU number (from 0 to 15, -1=any, -2=skip)."),
                 .get_opts = codec_profile_class_get_opts,
                 .off      = offsetof(tvh_codec_profile_nvenc_t, devicenum),
+                .intextra = INTEXTRA_RANGE(-2, 15, 1),
+                .def.i    = -1,
             },
             {
                 .type     = PT_INT,
-                .id       = "profile",
-                .name     = N_("Profile"),
-                .desc     = N_("Profile."),
-                .group    = 4,
-                .opts     = PO_ADVANCED | PO_PHIDDEN,
-                .get_opts = codec_profile_class_profile_get_opts,
-                .off      = offsetof(tvh_codec_profile_nvenc_t, nvenc_profile),
-                .list     = codec_profile_nvenc_class_profile_list,
-                .def.i    = FF_AV_PROFILE_UNKNOWN,
-            },
-            {
-                .type     = PT_INT,
-                .id       = "preset",
+                .id       = "preset",     // Don't change
                 .name     = N_("Preset"),
                 .group    = 3,
                 .desc     = N_("Override the preset rate control."),
@@ -228,29 +429,19 @@ static const codec_profile_class_t codec_profile_nvenc_class = {
                 .list     = codec_profile_nvenc_class_preset_list,
                 .def.i    = PRESET_DEFAULT,
             },
-            {
-                .type     = PT_DBL,
-                .id       = "bit_rate",
-                .name     = N_("Bitrate (kb/s) (0=auto)"),
-                .desc     = N_("Target bitrate."),
-                .group    = 3,
-                .get_opts = codec_profile_class_get_opts,
-                .off      = offsetof(TVHCodecProfile, bit_rate),
-                .def.d    = 0,
-            },
+#if NVENCAPI_MAJOR_VERSION >= 10
             {
                 .type     = PT_INT,
-                .id       = "quality",
-                .name     = N_("Quality (0=auto)"),
-                .desc     = N_("Set encode quality (trades off against speed, "
-                               "higher is faster) [0-51]."),
-                .group    = 5,
-                .opts     = PO_EXPERT,
+                .id       = "tune",     // Don't change
+                .name     = N_("Tune"),
+                .group    = 3,
+                .desc     = N_("Set the encoding tuning info."),
                 .get_opts = codec_profile_class_get_opts,
-                .off      = offsetof(tvh_codec_profile_nvenc_t, quality),
-                .intextra = INTEXTRA_RANGE(0, 51, 1),
-                .def.i    = 0,
+                .off      = offsetof(tvh_codec_profile_nvenc_t, tune),
+                .list     = codec_profile_nvenc_class_tune_list,
+                .def.i    = PRESET_DEFAULT,
             },
+#endif
             {
                 .type     = PT_INT,
                 .id       = "gop_size",     // Don't change
@@ -264,14 +455,100 @@ static const codec_profile_class_t codec_profile_nvenc_class = {
             },
             {
                 .type     = PT_INT,
-                .id       = "rc",
-                .name     = N_("Rate control"),
+                .id       = "rc_mode",     // Don't change
+                .name     = N_("Rate control mode"),
                 .group    = 3,
                 .desc     = N_("Override the preset rate control."),
                 .opts     = PO_EXPERT,
                 .off      = offsetof(tvh_codec_profile_nvenc_t, rc),
                 .list     = codec_profile_nvenc_class_rc_list,
                 .def.i    = NV_ENC_PARAMS_RC_AUTO,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "qp",     // Don't change
+                .name     = N_("Constant QP"),
+                .group    = 3,
+                .desc     = N_("Fixed QP of P frames (from 0 to 51, 0=skip).[if disabled will not send parameter to libav]"),
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_nvenc_t, qp),
+                .intextra = INTEXTRA_RANGE(0, 51, 1),
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "qmin",     // Don't change
+                .name     = N_("Minimum QP"),
+                .group    = 5,
+                .desc     = N_("Minimum QP of P frames (from 0 to 51, 0=skip)"),
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_nvenc_t, qmin),
+                .intextra = INTEXTRA_RANGE(0, 51, 1),
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "qmax",     // Don't change
+                .name     = N_("Maximum QP"),
+                .group    = 5,
+                .desc     = N_("Maximum QP of P frames (from 0 to 51, 0=skip)"),
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_nvenc_t, qmax),
+                .intextra = INTEXTRA_RANGE(0, 51, 1),
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "qdiff",     // Don't change
+                .name     = N_("QP difference"),
+                .group    = 5,
+                .desc     = N_("Maximum QP change between adjacent frames (from -2 to 69, -1=default, -2=skip)"),
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_nvenc_t, qdiff),
+                .intextra = INTEXTRA_RANGE(-2, 69, 1),
+                .def.i    = -2,
+            },
+            {
+                .type     = PT_DBL,
+                .id       = "bit_rate",     // Don't change
+                .name     = N_("Bitrate (kb/s) (0=auto)"),
+                .desc     = N_("Target bitrate."),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(TVHCodecProfile, bit_rate),
+                .def.d    = 0,
+            },
+            {
+                .type     = PT_DBL,
+                .id       = "max_bit_rate",     // Don't change
+                .name     = N_("Max bitrate (kb/s)"),
+                .desc     = N_("Maximum bitrate (0=skip).[if disabled will not send parameter to libav]"),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_nvenc_t, max_bit_rate),
+                .def.d    = 0,
+            },
+            {
+                .type     = PT_DBL,
+                .id       = "bit_rate_scale_factor",     // Don't change
+                .name     = N_("Bitrate scale factor"),
+                .desc     = N_("Bitrate & Max bitrate scaler with resolution (0=no scale; 1=proportional_change). Relative to 480."),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_nvenc_t, bit_rate_scale_factor),
+                .def.d    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "cq",     // Don't change
+                .name     = N_("Quality (0=auto)"),
+                .desc     = N_("Set target quality level (0 to 51, 0 means automatic) for constant quality mode in VBR rate control."),
+                .group    = 3,
+                .opts     = PO_EXPERT,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_nvenc_t, cq),
+                .intextra = INTEXTRA_RANGE(0, 51, 1),
+                .def.i    = 0,
             },
             {}
         }
@@ -295,15 +572,8 @@ static int
 tvh_codec_profile_nvenc_h264_open(tvh_codec_profile_nvenc_t *self,
                                   AVDictionary **opts)
 {
-    static const struct strtab profiletab[] = {
-        {"baseline",    NV_ENC_H264_PROFILE_BASELINE},
-        {"main",        NV_ENC_H264_PROFILE_MAIN},
-        {"high",        NV_ENC_H264_PROFILE_HIGH},
-        {"high444p",    NV_ENC_H264_PROFILE_HIGH_444P},
-    };
- 
-    static const struct strtab leveltab[] = {
-        {"Auto",	      NV_ENC_LEVEL_AUTOSELECT},
+        static const struct strtab leveltab[] = {
+        {"auto",	      NV_ENC_LEVEL_AUTOSELECT},
         {"1.0",           NV_ENC_LEVEL_H264_1},
         {"1.0b",          NV_ENC_LEVEL_H264_1b},
         {"1.1",           NV_ENC_LEVEL_H264_11},
@@ -320,9 +590,11 @@ tvh_codec_profile_nvenc_h264_open(tvh_codec_profile_nvenc_t *self,
         {"4.2",           NV_ENC_LEVEL_H264_42},
         {"5.0",           NV_ENC_LEVEL_H264_5},
         {"5.1",           NV_ENC_LEVEL_H264_51},
+#if NVENCAPI_MAJOR_VERSION >= 10
         {"6.0",           NV_ENC_LEVEL_H264_6},
         {"6.1",           NV_ENC_LEVEL_H264_61},
         {"6.2",           NV_ENC_LEVEL_H264_62},
+#endif
     };
 
     const char *s;
@@ -332,15 +604,7 @@ tvh_codec_profile_nvenc_h264_open(tvh_codec_profile_nvenc_t *self,
         AV_DICT_SET(LST_NVENC, opts, "level", s, 0);
     }
 
-    if (self->nvenc_profile != FF_AV_PROFILE_UNKNOWN &&
-        (s = val2str(self->nvenc_profile, profiletab)) != NULL) {
-        AV_DICT_SET(LST_NVENC, opts, "profile", s, 0);
-    }
-    
     // ------ Set Defaults ---------
-    AV_DICT_SET_INT(LST_NVENC, opts, "qmin", -1, 0);
-    AV_DICT_SET_INT(LST_NVENC, opts, "qmax", -1, 0);
-    AV_DICT_SET_INT(LST_NVENC, opts, "qdiff", -1, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "qblur", -1, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "qcomp", -1, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "bf", 0, 0);
@@ -352,7 +616,7 @@ static htsmsg_t *
 codec_profile_nvenc_class_level_list_h264(void *obj, const char *lang)
 {
     static const struct strtab tab[] = {
-        {N_("Auto"),	      NV_ENC_LEVEL_AUTOSELECT},
+        {N_("auto"),	      NV_ENC_LEVEL_AUTOSELECT},
         {N_("1.0"),           NV_ENC_LEVEL_H264_1},
         {N_("1.0b"),          NV_ENC_LEVEL_H264_1b},
         {N_("1.1"),           NV_ENC_LEVEL_H264_11},
@@ -369,13 +633,17 @@ codec_profile_nvenc_class_level_list_h264(void *obj, const char *lang)
         {N_("4.2"),           NV_ENC_LEVEL_H264_42},
         {N_("5.0"),           NV_ENC_LEVEL_H264_5},
         {N_("5.1"),           NV_ENC_LEVEL_H264_51},
+#if NVENCAPI_MAJOR_VERSION >= 10
         {N_("6.0"),           NV_ENC_LEVEL_H264_6},
         {N_("6.1"),           NV_ENC_LEVEL_H264_61},
         {N_("6.2"),           NV_ENC_LEVEL_H264_62},
+#endif
     };
     return strtab2htsmsg(tab, 1, lang);
 }
 
+// NOTE:
+// the names below are used in codec.js (/src/webui/static/app/codec.js)
 static const codec_profile_class_t codec_profile_nvenc_h264_class = {
     {
         .ic_super      = (idclass_t *)&codec_profile_nvenc_class,
@@ -384,9 +652,9 @@ static const codec_profile_class_t codec_profile_nvenc_h264_class = {
         .ic_properties = (const property_t[]){
             {
                 .type     = PT_INT,
-                .id       = "level",
+                .id       = "level",     // Don't change
                 .name     = N_("Level"),
-                .group    = 4,
+                .group    = 5,
                 .desc     = N_("Override the preset level."),
                 .opts     = PO_EXPERT,
                 .off      = offsetof(tvh_codec_profile_nvenc_t, level),
@@ -405,6 +673,8 @@ TVHVideoCodec tvh_codec_nvenc_h264 = {
     .size     = sizeof(tvh_codec_profile_nvenc_t),
     .idclass  = &codec_profile_nvenc_h264_class,
     .profiles = nvenc_h264_profiles,
+    .profile_init = tvh_codec_profile_video_init,
+    .profile_destroy = tvh_codec_profile_video_destroy,
 };
 
 
@@ -421,14 +691,8 @@ static int
 tvh_codec_profile_nvenc_hevc_open(tvh_codec_profile_nvenc_t *self,
                                   AVDictionary **opts)
 {
-    static const struct strtab profiletab[] = {
-        {"main",        NV_ENC_HEVC_PROFILE_MAIN},
-        {"main10",      NV_ENC_HEVC_PROFILE_MAIN_10},
-        {"rext",        NV_ENC_HEVC_PROFILE_REXT},
-    };
-
     static const struct strtab leveltab[] = {
-        {"Auto",	   NV_ENC_LEVEL_AUTOSELECT},
+        {"auto",	   NV_ENC_LEVEL_AUTOSELECT},
         {"1.0",           NV_ENC_LEVEL_HEVC_1},
         {"2.0",           NV_ENC_LEVEL_HEVC_2},
         {"2.1",           NV_ENC_LEVEL_HEVC_21},
@@ -439,9 +703,11 @@ tvh_codec_profile_nvenc_hevc_open(tvh_codec_profile_nvenc_t *self,
         {"5.0",           NV_ENC_LEVEL_HEVC_5},
         {"5.1",           NV_ENC_LEVEL_HEVC_51},
         {"5.2",           NV_ENC_LEVEL_HEVC_52},
+#if NVENCAPI_MAJOR_VERSION >= 10
         {"6.0",           NV_ENC_LEVEL_HEVC_6},
         {"6.1",           NV_ENC_LEVEL_HEVC_61},
         {"6.2",           NV_ENC_LEVEL_HEVC_62},
+#endif
     };
 
     const char *s;
@@ -451,15 +717,7 @@ tvh_codec_profile_nvenc_hevc_open(tvh_codec_profile_nvenc_t *self,
         AV_DICT_SET(LST_NVENC, opts, "level", s, 0);
         }
 
-    if (self->nvenc_profile != FF_AV_PROFILE_UNKNOWN &&
-        (s = val2str(self->nvenc_profile, profiletab)) != NULL) {
-        AV_DICT_SET(LST_NVENC, opts, "profile", s, 0);
-        }
-    
     // ------ Set Defaults ---------
-    AV_DICT_SET_INT(LST_NVENC, opts, "qmin", -1, 0);
-    AV_DICT_SET_INT(LST_NVENC, opts, "qmax", -1, 0);
-    AV_DICT_SET_INT(LST_NVENC, opts, "qdiff", -1, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "qblur", -1, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "qcomp", -1, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "bf", 0, 0);
@@ -471,7 +729,7 @@ static htsmsg_t *
 codec_profile_nvenc_class_level_list_hevc(void *obj, const char *lang)
 {
     static const struct strtab tab[] = {
-        {N_("Auto"),	      NV_ENC_LEVEL_AUTOSELECT},
+        {N_("auto"),	      NV_ENC_LEVEL_AUTOSELECT},
         {N_("1.0"),           NV_ENC_LEVEL_HEVC_1},
         {N_("2.0"),           NV_ENC_LEVEL_HEVC_2},
         {N_("2.1"),           NV_ENC_LEVEL_HEVC_21},
@@ -482,13 +740,17 @@ codec_profile_nvenc_class_level_list_hevc(void *obj, const char *lang)
         {N_("5.0"),           NV_ENC_LEVEL_HEVC_5},
         {N_("5.1"),           NV_ENC_LEVEL_HEVC_51},
         {N_("5.2"),           NV_ENC_LEVEL_HEVC_52},
+#if NVENCAPI_MAJOR_VERSION >= 10
         {N_("6.0"),           NV_ENC_LEVEL_HEVC_6},
         {N_("6.1"),           NV_ENC_LEVEL_HEVC_61},
         {N_("6.2"),           NV_ENC_LEVEL_HEVC_62},
+#endif
     };
     return strtab2htsmsg(tab, 1, lang);
 }
 
+// NOTE:
+// the names below are used in codec.js (/src/webui/static/app/codec.js)
 static const codec_profile_class_t codec_profile_nvenc_hevc_class = {
     {
         .ic_super      = (idclass_t *)&codec_profile_nvenc_class,
@@ -497,9 +759,9 @@ static const codec_profile_class_t codec_profile_nvenc_hevc_class = {
         .ic_properties = (const property_t[]){
             {
                 .type     = PT_INT,
-                .id       = "level",
+                .id       = "level",     // Don't change
                 .name     = N_("Level"),
-                .group    = 4,
+                .group    = 5,
                 .desc     = N_("Override the preset level."),
                 .opts     = PO_EXPERT,
                 .off      = offsetof(tvh_codec_profile_nvenc_t, level),


### PR DESCRIPTION
- leverage ffnvcodec/nvEncodeAPI.h constants
- update the presets with new introduced values (P1-P7)
- update presets deprecated with proper values
- bring nvenc closer to vaapi format: qp, maxrate, bit_rate_scale_factor
- defined new set of variables for new settings (with docstrincs)
- update the avDictionary set from string to integer
- updated the order of the settings to match the vaapi order
- consolidated common settings for h264 and hevc
- applied filters from vaapi to nvenc for rc_mode setting

CoPilot change log:
Updated NVENC codec profile handling to support new presets, rate control modes, and tuning options, with improved mapping to ffmpeg/libavcodec/nvenc.h and nvEncodeAPI.h. Added new fields for QP, bitrate scaling, and max bitrate, and restructured the UI logic in codec.js to dynamically enable or disable relevant fields based on selected rate control mode. Improved code documentation and maintainability, and updated copyright.

removed profile from nvenc.c because is handled by profile_class.c:
static int
tvh_codec_profile_base_open(TVHCodecProfile *self, AVDictionary **opts)
{
    AV_DICT_SET_TVH_REQUIRE_META(LST_NONE, opts, 1);
    // profile
    if (self->profile != FF_AV_PROFILE_UNKNOWN) {
        AV_DICT_SET_INT(LST_CODEC, opts, "profile", self->profile, 0);
    }
    return 0;
}

replaced quality with cq (because nvenc doesn't have quality)