### PR TITLE
update to ffmpeg 7.1.3 (with patch for vaapi)

### DIFF
--- a/Autobuild/trusty.sh
+++ b/Autobuild/trusty.sh
@@ -1,3 +1,3 @@
-AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --nowerror"
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --nowerror --disable-ffmpeg_static"
 DEBDIST=trusty
 source Autobuild/debian.sh

--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -106,10 +106,10 @@ FFNVCODEC_TB   = $(FFNVCODEC).tar.gz
 FFNVCODEC_URL  = https://github.com/FFmpeg/nv-codec-headers/releases/download/n$(FFNVCODEC_VER)/nv-codec-headers-$(FFNVCODEC_VER).tar.gz
 FFNVCODEC_SHA1 = 74231bb5572ebde98652a26ce98ede7895b4c730
 
-FFMPEG         = ffmpeg-6.1.1
+FFMPEG         = ffmpeg-7.1.3
 FFMPEG_TB      = $(FFMPEG).tar.bz2
 FFMPEG_URL     = https://ffmpeg.org/releases/$(FFMPEG_TB)
-FFMPEG_SHA1    = 157e7b0f6521142e1ebd786175e363e9f1b59312
+FFMPEG_SHA1    = 1aba57070ed172fac4f5a648a260e44dabbca0a4
 
 
 # ##############################################################################
@@ -615,6 +615,7 @@ EXTLIBS  += vaapi
 ENCODERS += h264_vaapi hevc_vaapi vp8_vaapi vp9_vaapi
 HWACCELS += mpeg2_vaapi h264_vaapi hevc_vaapi vp9_vaapi
 FILTERS  += deinterlace_vaapi scale_vaapi denoise_vaapi sharpness_vaapi
+FFMPEG_DIFFS += ffmpeg.vaapi.diff ffmpeg.vaapi2.diff
 
 endif
 

--- a/support/patches/ffmpeg.vaapi.diff
+++ b/support/patches/ffmpeg.vaapi.diff
@@ -1,0 +1,13 @@
+# Patch is fixing: https://github.com/tvheadend/tvheadend/issues/1833
+diff -urN ../ffmpeg-7.1.3.orig/libavcodec/hw_base_encode.c ./libavcodec/hw_base_encode.c
+--- ../ffmpeg-7.1.3.orig/libavcodec/hw_base_encode.c    2023-04-03 00:53:26.000000000 +0200
++++ ./libavcodec/hw_base_encode.c    2023-04-03 07:46:36.641867975 +0200
+@@ -504,7 +504,7 @@ static int hw_base_encode_send_frame(AVCodecContext *avctx, FFHWBaseEncodeContex
+ 
+         // Fix timestamps if we hit end-of-stream before the initial decode
+         // delay has elapsed.
+-        if (ctx->input_order <= ctx->decode_delay)
++        if (ctx->input_order <= ctx->decode_delay && ctx->pic_end)
+             ctx->dts_pts_diff = ctx->pic_end->pts - ctx->first_pts;
+     }
+ 

--- a/support/patches/ffmpeg.vaapi2.diff
+++ b/support/patches/ffmpeg.vaapi2.diff
@@ -1,0 +1,34 @@
+# Patch is fixing: https://github.com/tvheadend/tvheadend/issues/1869
+# is combining two commits:
+#
+# Commit 1:
+# From: David Rosca <nowrep@gmail.com>
+# Date: Tue, 15 Oct 2024 16:49:41 +0200
+# Subject: hw_base_encode: Free pictures on close
+#
+# Fixes leaking recon surfaces with VAAPI.
+#
+# Commit 2:
+# From: Marvin Scholz <epirat07@gmail.com>
+# Date: Thu, 17 Oct 2024 20:23:40 +0200
+# Subject: avcodec/hw_base_encode: fix use after free on close
+#
+# The way the linked list of images was freed caused a
+# use after free, by accessing pic->next after pic was
+# already freed.
+#
+diff --urN ../ffmpeg-7.1.1/libavcodec/hw_base_encode.c ./libavcodec/hw_base_encode.c
+--- ../ffmpeg-7.1.1/libavcodec/hw_base_encode.c
++++ ./libavcodec/hw_base_encode.c
+@@ -804,6 +804,11 @@ int ff_hw_base_encode_init(AVCodecContext *avctx, FFHWBaseEncodeContext *ctx)
+
+ int ff_hw_base_encode_close(FFHWBaseEncodeContext *ctx)
+ {
++    for (FFHWBaseEncodePicture *pic = ctx->pic_start, *next_pic = pic; pic; pic = next_pic) {
++        next_pic = pic->next;
++        base_encode_pic_free(pic);
++    }
++
+     av_fifo_freep2(&ctx->encode_fifo);
+
+     av_frame_free(&ctx->frame);


### PR DESCRIPTION
- update to ffmpeg 7.1.3 (with patch for vaapi)

this PR is implementing the changes from: https://github.com/tvheadend/tvheadend/issues/1869 and https://github.com/tvheadend/tvheadend/issues/1833
Thank you @jahutchi 