### PR TITLE
Fix buffer and other minor leaks

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -46,6 +46,7 @@ api_register ( const api_hook_t *hook )
   t = RB_INSERT_SORTED(&api_hook_tree, api_skel, link, ah_cmp);
   if (t) {
     tvherror(LS_API, "trying to re-register subsystem");
+    free(api_skel);
   } else {
     SKEL_USED(api_skel);
   }

--- a/src/htsmsg.c
+++ b/src/htsmsg.c
@@ -1154,8 +1154,10 @@ htsmsg_field_get_msg ( htsmsg_field_t *f, int islist )
         free((void*)f->hmf_str);
       }
       l = f->hmf_msg  = malloc(sizeof(htsmsg_t));
-      if (l == NULL)
+      if (l == NULL) {
+        htsmsg_destroy(m);
         return NULL;
+      }
       f->hmf_type     = m->hm_islist ? HMF_LIST : HMF_MAP;
       f->hmf_flags   |= HMF_ALLOCED;
       l->hm_islist    = m->hm_islist;

--- a/src/input/mpegts/iptv/iptv_auto.c
+++ b/src/input/mpegts/iptv/iptv_auto.c
@@ -162,7 +162,7 @@ iptv_auto_network_process_m3u_item(iptv_network_t *in,
   }
 
   if (urlparse(url, &u))
-    return;
+    goto end;
   if (u.host == NULL || u.host[0] == '\0')
     goto end;
 

--- a/src/input/mpegts/iptv/iptv_http.c
+++ b/src/input/mpegts/iptv/iptv_http.c
@@ -598,7 +598,6 @@ iptv_http_start
   im->im_data = hp;
   sbuf_init(&hp->m3u_sbuf);
   sbuf_init(&hp->key_sbuf);
-  sbuf_init_fixed(&im->mm_iptv_buffer, IPTV_BUF_SIZE);
   iptv_input_mux_started(hp->mi, im, 1);
   http_client_register(hc);          /* register to the HTTP thread */
   r = http_client_simple(hc, u);


### PR DESCRIPTION
- Fixes a major memory leak in iptv_http where &im->mm_iptv_buffer was initialized twice, with the second initialization not freeing the original data, causing the reference to be lost. This could cause gigabytes of memory to leak over time due to the buffer.
- Fixes some other minor leaks.