### PR TITLE
make reset counters a global option; fix linuxdvb mux lock after failed tuning; other improvements

### DIFF
--- a/src/channels.c
+++ b/src/channels.c
@@ -131,13 +131,15 @@ channel_class_autoname_set ( void *obj, const void *p )
 {
   channel_t *ch = (channel_t *)obj;
   const char *s;
+  char *chan_name;
   int b = *(int *)p;
   if (ch->ch_autoname != b) {
     if (b == 0 && tvh_str_default(ch->ch_name, NULL) == NULL) {
       s = channel_get_name(ch, NULL);
       if (s) {
+        chan_name = strdup(s);
         free(ch->ch_name);
-        ch->ch_name = strdup(s);
+        ch->ch_name = chan_name;
       } else {
         return 0;
       }

--- a/src/config.c
+++ b/src/config.c
@@ -2746,6 +2746,17 @@ const idclass_t config_class = {
       .group  = 8,
     },
     {
+      .type   = PT_BOOL,
+      .id     = "auto_clear_input_counters",
+      .name   = N_("Automatically clear input error counters"),
+      .desc   = N_("Periodically resets input error counters "
+                   "(when a new mux starts for the target tuner). "
+                   "Note that previous counters will be lost."),
+      .off    = offsetof(config_t, auto_clear_input_counters),
+      .opts   = PO_EXPERT,
+      .group  = 8,
+    },
+    {
       .type   = PT_STR,
       .id     = "muxconfpath",
       .name   = N_("DVB scan files path"),

--- a/src/config.h
+++ b/src/config.h
@@ -65,6 +65,7 @@ typedef struct config {
   uint32_t descrambler_buffer;
   int caclient_ui;
   int parser_backlog;
+  int auto_clear_input_counters;
   int epg_compress;
   uint32_t epg_cut_window;
   uint32_t epg_update_window;

--- a/src/input/mpegts/iptv/iptv.c
+++ b/src/input/mpegts/iptv/iptv.c
@@ -576,6 +576,7 @@ iptv_input_thread ( void *aux )
       if ((n = im->im_handler->read(mi, im)) < 0) {
         tvherror(LS_IPTV, "read() error %s", strerror(errno));
         im->im_handler->stop(mi, im);
+        tvh_mutex_unlock(&iptv_lock);
         break;
       }
       r = iptv_input_recv_packets(im, n);

--- a/src/input/mpegts/iptv/iptv_http.c
+++ b/src/input/mpegts/iptv/iptv_http.c
@@ -473,7 +473,6 @@ url:
         free(hp->hls_url_after_key);
         hp->hls_url_after_key = url;
         url = strdup(s);
-        free(absolute_key_url);
         hc->hc_data_complete = iptv_http_complete_key;
         sbuf_reset(&hp->key_sbuf, 32);
       }
@@ -487,6 +486,7 @@ new_m3u:
     iptv_http_reconnect(hc, url);
 end:
     free(url);
+    free(absolute_key_url);
 fin:
     htsmsg_destroy(m);
   } else {

--- a/src/input/mpegts/mpegts_mux.c
+++ b/src/input/mpegts/mpegts_mux.c
@@ -27,6 +27,7 @@
 #include "profile.h"
 #include "dvb_charset.h"
 #include "epggrab.h"
+#include "config.h"
 
 #include <assert.h>
 
@@ -268,6 +269,11 @@ mpegts_mux_instance_start
   tvhdebug(LS_MPEGTS, "%s - started", mm->mm_nicename);
   mm->mm_start_monoclock = mclk();
   mi->mi_started_mux(mi, mmi);
+
+  /* Reset Error Counters */
+  if (config.auto_clear_input_counters && mmi->tii_clear_stats) {
+    mmi->tii_clear_stats((tvh_input_instance_t *)mmi);
+  }
 
   /* Event handler */
   mpegts_fire_event(mm, ml_mux_start);

--- a/src/input/mpegts/mpegts_mux.c
+++ b/src/input/mpegts/mpegts_mux.c
@@ -1295,12 +1295,16 @@ void
 mpegts_mux_save ( mpegts_mux_t *mm, htsmsg_t *c, int refs )
 {
   mpegts_service_t *ms;
+  mpegts_mux_instance_t *mmi;
   htsmsg_t *root = !refs ? htsmsg_create_map() : c;
   htsmsg_t *services = !refs ? htsmsg_create_map() : htsmsg_create_list();
   htsmsg_t *e;
   char ubuf[UUID_HEX_SIZE];
 
   idnode_save(&mm->mm_id, root);
+  LIST_FOREACH(mmi, &mm->mm_instances, mmi_mux_link) {
+    mmi->mmi_tune_failed = 0;
+  }
   LIST_FOREACH(ms, &mm->mm_services, s_dvb_mux_link) {
     if (refs) {
       htsmsg_add_uuid(services, NULL, &ms->s_id.in_uuid);


### PR DESCRIPTION
- linuxdvb: Fixes mux becoming unusable after editing its configuration due to EINVAL caused by incorrect tuning options.
- make the auto-reset counters option global, allowing the user to enable it on demand.
- fix several missing locks and memory leaks detected by Coverity (CID-352140, CID-470910, CID-551184)