### PR TITLE
clean up low_power from vaapi

### DIFF
--- a/src/transcoding/codec.h
+++ b/src/transcoding/codec.h
@@ -92,8 +92,6 @@ struct tvh_codec_profile {
     double bit_rate;
     double qscale;
     int profile;
-    // to be moved when we remove ENABLE_FFMPEG4_TRANSCODING
-    int low_power;
     char *device; // for hardware acceleration
     LIST_ENTRY(tvh_codec_profile) link;
 };

--- a/src/transcoding/codec/codecs/libs/vaapi.c
+++ b/src/transcoding/codec/codecs/libs/vaapi.c
@@ -349,7 +349,7 @@ static const codec_profile_class_t codec_profile_vaapi_class = {
                 .group    = 3,
                 .opts     = PO_EXPERT,
                 .get_opts = codec_profile_class_get_opts,
-                .off      = offsetof(TVHCodecProfile, low_power),
+                .off      = offsetof(tvh_codec_profile_vaapi_t, low_power),
                 .def.i    = 0,
             },
             {

--- a/src/transcoding/codec/internals.h
+++ b/src/transcoding/codec/internals.h
@@ -477,6 +477,13 @@ typedef struct {
     int qp;
     int quality;
     int global_quality;
+/**
+ * VAAPI async_depth - Maximum processing parallelism. Increase this to improve single channel performance. [async_depth]
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#toc-VAAPI-encoders
+ * @note
+ * int:
+ * VALUE - number of async_depth is used by VAAPI encoder
+ */
     int async_depth;
 /**
  * VAAPI Encoder availablity.
@@ -515,21 +522,19 @@ typedef struct {
  * VAAPI Maximum bitrate [maxrate]
  * https://www.ffmpeg.org/ffmpeg-codecs.html#toc-VAAPI-encoders
  * @note
- * int:
+ * double:
  * VALUE - max bitrate in bps
  */
     double max_bit_rate;
 /**
- * VAAPI Maximum bitrate [maxrate]
- * https://www.ffmpeg.org/ffmpeg-codecs.html#toc-VAAPI-encoders
+ * VAAPI Bitrate scale factor [not ffmpeg parameter]
  * @note
  * double:
- * VALUE - max bitrate in bps
+ * VALUE - bitrate scale factor relative to 480p resolution
  */
     double bit_rate_scale_factor;
 /**
  * VAAPI Platform hardware [not ffmpeg parameter]
- * https://www.ffmpeg.org/ffmpeg-codecs.html#toc-VAAPI-encoders
  * @note
  * int:
  * 0 - Unconstrained (useful for debug)
@@ -537,12 +542,49 @@ typedef struct {
  * 2 - AMD
  */
     int platform;
+/**
+ * VAAPI Low power - Some drivers/platforms offer a second encoder for some codecs intended to use less power than the default encoder [low_power]
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#toc-VAAPI-encoders
+ * @note
+ * int:
+ * 0 - disabled
+ * 1 - enabled
+ */
+    int low_power;
 
     int loop_filter_level;
     int loop_filter_sharpness;
     double buff_factor;
+/**
+ * VAAPI Rate Control Mode - Set the rate control mode to use. A given driver may only support a subset of modes [rc_mode]
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#toc-VAAPI-encoders
+ * @note
+ * int:
+ * 0 - auto
+ * 1 - CQP
+ * 2 - CBR
+ * 3 - VBR
+ * 4 - ICQ
+ * 5 - QVBR
+ * 6 - AVBR
+ */
     int rc_mode;
+/**
+ * VAAPI hevc_vaapi Tier - Set general_tier_flag. This may affect the level chosen for the stream if it is not explicitly specified [tier]
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#toc-VAAPI-encoders
+ * @note
+ * int:
+ * 0 - Main
+ * 1 - High
+ */
     int tier;
+/**
+ * VAAPI Level - Set level (level_idc)  [level]
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#toc-VAAPI-encoders
+ * @note
+ * int:
+ * VALUE - from -99 to 255 (default -99: auto)
+ */
     int level;
     int qmin;
     int qmax;


### PR DESCRIPTION
- low power should be moved from tvh_codec_profile to tvh_codec_profile_vaapi_t after  https://github.com/tvheadend/tvheadend/pull/1996