### PR TITLE
fixes crash when user is forcing pix_fmt or when codec is not available

### DIFF
--- a/src/transcoding/codec/profile_video_class.c
+++ b/src/transcoding/codec/profile_video_class.c
@@ -86,6 +86,38 @@ deinterlace_enable_auto_get_list( void *o, const char *lang )
     return strtab2htsmsg(tab, 1, lang);
 }
 
+/* Internal =================================================================  */
+
+static int
+_is_pix_fmt_available(TVHVideoCodec *self, int pix_fmt)
+{
+    const enum AVPixelFormat *p;
+
+    if (!self) {
+        tvhwarn(LS_CODEC, "tvh_codec_video is not available");
+        return 0;
+    }
+    // if 'auto' is selected we exit with 1
+    if (pix_fmt == AV_PIX_FMT_NONE) {
+        return 1;
+    }
+    // check if pix_fmt is in the supported list
+    if (self->pix_fmts) {
+        for (p = self->pix_fmts; *p != AV_PIX_FMT_NONE; p++) {
+            if (*p == pix_fmt) {
+                return 1;
+            }
+        }
+    }
+    // not found: we report and exit with 0
+    const char *pix_fmt_name = av_get_pix_fmt_name(pix_fmt);
+    if (pix_fmt_name) {
+        tvhwarn(LS_CODEC, "pixel format '%s' is not available", pix_fmt_name);
+    } else {
+        tvhwarn(LS_CODEC, "pixel format '%d' is not available", pix_fmt);
+    }
+    return 0;
+}
 
 /* TVHCodec ================================================================= */
 
@@ -178,6 +210,10 @@ tvh_codec_profile_video_open(TVHVideoCodecProfile *self, AVDictionary **opts)
         AV_DICT_SET_INT(LST_VIDEO, opts, "crf", self->crf, AV_DICT_DONT_OVERWRITE);
     }
     // pix_fmt
+    TVHVideoCodec *codec = (TVHVideoCodec *)tvh_codec_profile_get_codec((TVHCodecProfile *)self);
+    if (!codec || !_is_pix_fmt_available(codec, self->pix_fmt)) {
+        return -1;
+    }
     AV_DICT_SET_PIX_FMT(LST_VIDEO, opts, self->pix_fmt, AV_PIX_FMT_YUV420P);
     return 0;
 }

--- a/src/transcoding/transcode/context.c
+++ b/src/transcoding/transcode/context.c
@@ -271,10 +271,18 @@ tvh_context_open(TVHContext *self, TVHOpenPhase phase)
     switch (phase) {
         case OPEN_DECODER:
             avctx = self->iavctx;
+            if (!avctx->codec) {
+                tvh_context_log(self, LOG_ERR, "no decoder available");
+                return AVERROR(EINVAL);
+            }
             helper = tvh_decoder_helper_find(avctx->codec);
             break;
         case OPEN_ENCODER:
             avctx = self->oavctx;
+            if (!avctx->codec) {
+                tvh_context_log(self, LOG_ERR, "no encoder available");
+                return AVERROR(EINVAL);
+            }
             helper = self->helper = tvh_encoder_helper_find(avctx->codec);
             ret = tvh_codec_profile_open(self->profile, &opts);
             break;


### PR DESCRIPTION
- fixes https://github.com/tvheadend/tvheadend/issues/1980
- in context.c I added two checks to ensure we don't search for a helper if codec is not available and is not trying to open (tvh_codec_profile_open()) --> this will create a panic.
- in order to avoid getting to that 'late point decision'; at am also checking if pix_fmt is available in ffmpeg before calling.
- if the user will try to force (from web interface) a different pix_fmt some warnings will be printed and video will not open.