### PR TITLE
config.c: disable HDHomeRun configuration when not built in

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2560,6 +2560,7 @@ const idclass_t config_class = {
       .opts   = PO_EXPERT,
       .group  = 5
     },
+#if ENABLE_HDHOMERUN_CLIENT
     {
       .type   = PT_STR,
       .id     = "hdhomerun_ip",
@@ -2604,6 +2605,8 @@ const idclass_t config_class = {
       .opts   = PO_HIDDEN | PO_EXPERT,
       .group  = 6
     },
+#endif
+#if ENABLE_HDHOMERUN_SERVER
     {
       .type   = PT_U32,
       .id     = "hdhomerun_server_tuner_count",
@@ -2624,11 +2627,7 @@ const idclass_t config_class = {
                    "Set to zero for Tvheadend to use a default value."
                   ),
       .off    = offsetof(config_t, hdhomerun_server_tuner_count),
-      .opts   = PO_EXPERT
-#if !ENABLE_HDHOMERUN_SERVER
-      | PO_PHIDDEN
-#endif
-      ,
+      .opts   = PO_EXPERT,
       .group  = 6,
     },
     {
@@ -2644,11 +2643,7 @@ const idclass_t config_class = {
                    "for Tvheadend to use a default."
                   ),
       .off    = offsetof(config_t, hdhomerun_server_model_name),
-      .opts   = PO_EXPERT
-#if !ENABLE_HDHOMERUN_SERVER
-      | PO_PHIDDEN
-#endif
-      ,
+      .opts   = PO_EXPERT,
       .group  = 6,
     },
     {
@@ -2660,13 +2655,10 @@ const idclass_t config_class = {
                    "to be used on some media servers."
                   ),
       .off    = offsetof(config_t, hdhomerun_server_enable),
-      .opts   = PO_EXPERT
-#if !ENABLE_HDHOMERUN_SERVER
-      | PO_PHIDDEN
-#endif
-,
+      .opts   = PO_EXPERT,
       .group  = 6
     },
+#endif
     {
       .type   = PT_INT,
       .id     = "rtsp_udp_min_port",
@@ -2700,6 +2692,7 @@ const idclass_t config_class = {
     },
     {
       .type   = PT_INT,
+      .intextra = INTEXTRA_RANGE(1, 128, 1),
       .id     = "iptv_tpool",
       .name   = N_("IPTV threads"),
       .desc   = N_("Set the number of threads for IPTV to split load "


### PR DESCRIPTION
Hide HDHomeRun configuration when support is not enabled at build time