### PR TITLE
api: switch bandwidth readings to bps to match subscription behaviour

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -25,7 +25,7 @@
 #include "redblack.h"
 #include "access.h"
 
-#define TVH_API_VERSION 19
+#define TVH_API_VERSION 20
 
 /*
  * Command hook

--- a/src/input.c
+++ b/src/input.c
@@ -140,7 +140,8 @@ tvh_input_stream_create_msg
   htsmsg_add_s32(m, "snr", st->stats.snr);
   htsmsg_add_u32(m, "snr_scale", st->stats.snr_scale);
   htsmsg_add_u32(m, "unc", st->stats.unc);
-  htsmsg_add_u32(m, "bps", st->stats.bps);
+  htsmsg_add_s64(m, "bps", atomic_get_u64(&st->stats.bytes_avg) * 8);
+  htsmsg_add_s64(m, "total", atomic_get_u64(&st->stats.total_bytes));
   htsmsg_add_u32(m, "te", st->stats.te);
   htsmsg_add_u32(m, "cc", st->stats.cc);
   htsmsg_add_u32(m, "ec_bit", st->stats.ec_bit);

--- a/src/input.h
+++ b/src/input.h
@@ -52,7 +52,9 @@ struct tvh_input_stream_stats
               ///<  - SCALE DECIBEL  : 0.0001 dB units.
   int ber;    ///< bit error rate (driver/vendor specific value!)
   int unc;    ///< number of uncorrected blocks
-  int bps;    ///< bandwidth (bps)
+  uint64_t bytes_avg; ///< average bytes per second
+  uint64_t total_bytes; ///< total bytes since the input started
+  uint64_t total_bytes_prev; ///< total bytes since the input started, minus 1 second
   int cc;     ///< number of continuity errors
   int te;     ///< number of transport errors
 

--- a/src/input/mpegts.h
+++ b/src/input/mpegts.h
@@ -819,6 +819,8 @@ void mpegts_input_close_service ( mpegts_input_t *mi, mpegts_service_t *s );
 
 void mpegts_input_status_timer ( void *p );
 
+void input_add_bytes(tvh_input_stream_stats_t *ss, size_t bytes);
+
 int mpegts_input_grace ( mpegts_input_t * mi, mpegts_mux_t * mm );
 
 int mpegts_input_is_enabled ( mpegts_input_t * mi, mpegts_mux_t *mm, int flags, int weight );

--- a/src/input/mpegts/mpegts_input.c
+++ b/src/input/mpegts/mpegts_input.c
@@ -1609,7 +1609,7 @@ done:
 
   /* Bandwidth monitoring */
   llen = tsb - mpkt->mp_data;
-  atomic_add(&mmi->tii_stats.bps, llen);
+  input_add_bytes(&mmi->tii_stats, llen);
   mm->mm_input_pos += llen;
   return llen;
 }
@@ -1919,7 +1919,8 @@ mpegts_input_stream_status
   st->stats.unc   = atomic_get(&mmi->tii_stats.unc);
   st->stats.cc    = atomic_get(&mmi->tii_stats.cc);
   st->stats.te    = atomic_get(&mmi->tii_stats.te);
-  st->stats.bps   = atomic_exchange(&mmi->tii_stats.bps, 0) * 8;
+  st->stats.bytes_avg = atomic_get_u64(&mmi->tii_stats.bytes_avg);
+  st->stats.total_bytes = atomic_get_u64(&mmi->tii_stats.total_bytes);
 }
 
 void
@@ -2039,9 +2040,17 @@ mpegts_input_status_timer ( void *p )
   htsmsg_t *e;
   int64_t subs = 0;
 
+  mtimer_arm_rel(&mi->mi_status_timer, mpegts_input_status_timer, mi, sec2mono(1));
+
   tvh_mutex_lock(&mi->mi_output_lock);
   LIST_FOREACH(mmi, &mi->mi_mux_active, mmi_active_link) {
     memset(&st, 0, sizeof(st));
+    /* Store the difference between total bytes from the last round */
+    uint64_t bytes_curr = atomic_get_u64(&mmi->tii_stats.total_bytes);
+    uint64_t bytes_prev = atomic_exchange_u64(&mmi->tii_stats.total_bytes_prev, bytes_curr);
+
+    atomic_set_u64(&mmi->tii_stats.bytes_avg, bytes_curr - bytes_prev);
+
     mpegts_input_stream_status(mmi, &st);
     e = tvh_input_stream_create_msg(&st);
     htsmsg_add_u32(e, "update", 1);
@@ -2050,8 +2059,19 @@ mpegts_input_status_timer ( void *p )
     tvh_input_stream_destroy(&st);
   }
   tvh_mutex_unlock(&mi->mi_output_lock);
-  mtimer_arm_rel(&mi->mi_status_timer, mpegts_input_status_timer, mi, sec2mono(1));
   mpegts_input_dbus_notify(mi, subs);
+}
+
+/* **************************************************************************
+ * Input control
+ * *************************************************************************/
+
+/**
+ * Update byte count
+ */
+void input_add_bytes(tvh_input_stream_stats_t *ss, size_t bytes)
+{
+  atomic_add_u64(&ss->total_bytes, bytes);
 }
 
 /* **************************************************************************

--- a/src/subscriptions.c
+++ b/src/subscriptions.c
@@ -1091,8 +1091,8 @@ subscription_create_msg(th_subscription_t *s, const char *lang)
     htsmsg_add_str(m, "service", s->ths_dvrfile ?: "");
   }
 
-  htsmsg_add_u32(m, "in", atomic_get(&s->ths_bytes_in_avg));
-  htsmsg_add_u32(m, "out", atomic_get(&s->ths_bytes_out_avg));
+  htsmsg_add_s64(m, "in", atomic_get_u64(&s->ths_bytes_in_avg) * 8);
+  htsmsg_add_s64(m, "out", atomic_get_u64(&s->ths_bytes_out_avg) * 8);
   htsmsg_add_s64(m, "total_in", atomic_get_u64(&s->ths_total_bytes_in));
   htsmsg_add_s64(m, "total_out", atomic_get_u64(&s->ths_total_bytes_out));
 
@@ -1119,8 +1119,8 @@ subscription_status_callback ( void *p )
     uint64_t out_curr = atomic_get_u64(&s->ths_total_bytes_out);
     uint64_t out_prev = atomic_exchange_u64(&s->ths_total_bytes_out_prev, out_curr);
 
-    atomic_set(&s->ths_bytes_in_avg, (int)(in_curr - in_prev));
-    atomic_set(&s->ths_bytes_out_avg, (int)(out_curr - out_prev));
+    atomic_set_u64(&s->ths_bytes_in_avg, in_curr - in_prev);
+    atomic_set_u64(&s->ths_bytes_out_avg, out_curr - out_prev);
 
     htsmsg_t *m = subscription_create_msg(s, NULL);
     htsmsg_add_u32(m, "updateEntry", 1);

--- a/src/subscriptions.h
+++ b/src/subscriptions.h
@@ -103,8 +103,8 @@ typedef struct th_subscription {
   uint64_t ths_total_bytes_out; /* total bytes since the subscription started */
   uint64_t ths_total_bytes_in_prev; /* total bytes since the subscription started, minus 1 second */
   uint64_t ths_total_bytes_out_prev; /* total bytes since the subscription started, minus 1 second */
-  int ths_bytes_in_avg; /* Average bytes in per second */
-  int ths_bytes_out_avg; /* Average bytes out per second */
+  uint64_t ths_bytes_in_avg; /* Average bytes in per second */
+  uint64_t ths_bytes_out_avg; /* Average bytes out per second */
 
   streaming_target_t ths_input;
 

--- a/src/webui/static/app/status.js
+++ b/src/webui/static/app/status.js
@@ -72,7 +72,7 @@ tvheadend.status_subs = function(panel, index)
         tvheadend.comet.on('subscriptions', update);
 
         function renderBw(value, meta, record) {
-            var txt = parseInt(value / 125);
+            var txt = Math.round(value / 1000);
             meta.attr = 'style="cursor:alias;"';
             return '<span class="x-linked">&nbsp;</span>' + txt;
         }
@@ -190,7 +190,7 @@ tvheadend.status_subs = function(panel, index)
             {
                 width: 50,
                 id: 'in',
-                header: _("Input (kb/s)"),
+                header: _("Input (kbps)"),
                 dataIndex: 'in',
                 sortable: true,
                 listeners: { click: { fn: clicked } },
@@ -199,7 +199,7 @@ tvheadend.status_subs = function(panel, index)
             {
                 width: 50,
                 id: 'out',
-                header: _("Output (kb/s)"),
+                header: _("Output (kbps)"),
                 dataIndex: 'out',
                 sortable: true,
                 listeners: { click: { fn: clicked } },
@@ -372,7 +372,7 @@ tvheadend.status_streams = function(panel, index)
         tvheadend.comet.on('input_status', update);
 
         function renderBw(value, meta, record) {
-            var txt = parseInt(value / 1024);
+            var txt = Math.round(value / 1000);
             meta.attr = 'style="cursor:alias;"';
             return '<span class="x-linked">&nbsp;</span>' + txt;
         }
@@ -440,7 +440,7 @@ tvheadend.status_streams = function(panel, index)
             },
             {
                 width: 50,
-                header: _("Bandwidth (kb/s)"),
+                header: _("Bandwidth (kbps)"),
                 dataIndex: 'bps',
                 sortable: true,
                 renderer: renderBw,
@@ -918,13 +918,13 @@ tvheadend.subscription_bw_monitor = function(id) {
                 return;
             }
 
-            var input = Math.round(r.data['in'] / 125);
-            var output = Math.round(r.data.out / 125);
+            var input = Math.round(r.data['in'] / 1000);
+            var output = Math.round(r.data.out / 1000);
             var ratio = new Number(r.data['in'] / r.data.out).toPrecision(3);
 
-            win.setTitle(r.data.channel);
-            inputLbl.setText(_('In') + ': ' + input + ' kb/s');
-            outputLbl.setText(_('Out') + ': ' + output + ' kb/s');
+            win.setTitle(r.data.channel ?? r.data.service);
+            inputLbl.setText(_('In') + ': ' + input + ' kbps');
+            outputLbl.setText(_('Out') + ': ' + output + ' kbps');
             comprLbl.setText(_('Compression ratio') + ': ' + ratio);
 
             inputSeries.append(new Date().getTime(), input);
@@ -1010,8 +1010,8 @@ tvheadend.stream_bw_monitor = function(id) {
             }
 
             win.setTitle(r.data.input + ' (' + r.data.stream + ')');
-            var input = Math.round(r.data.bps / 1024);
-            inputLbl.setText(_('Input') + ': ' + input + ' kb/s');
+            var input = Math.round(r.data.bps / 1000);
+            inputLbl.setText(_('Input') + ': ' + input + ' kbps');
             inputSeries.append(new Date().getTime(), input);
         }
     };


### PR DESCRIPTION
I detected that the bitrate values provided by `http://{tvh_url}/api/status/inputs` were not correct when compared to those from `http://{tvh_url}/api/status/subscriptions`. I noticed that the values provided in subscriptions are measured as a one-second median, while inputs report them as instantaneous values.

Although this does not sound problematic at first, when querying the API the raw input values are extremely sporadic, with strange bitrate peaks, which makes them inconsistent and unreliable. This issue becomes even more noticeable when comparing data between two inputs. After performing the calculations, you will also notice in the next lines that the data units are not the same for similar metrics, which makes interpretation even more confusing.

Current Input state:
```{
[...]
"bps":150400, << kb/s?
[...]
},
```

New Input state:
```{
[...]
"bps":3540416, << bps
"total":645827940, << added
[...]
}
```

Current Subscription state:
```{
[...]
"in":4074336, << Bytes/s?
"out":4074336, << Bytes/s?
"total_in":325892172, << informative, no changes
"total_out":325892172, <<  informative, no changes
[...]
}
```

New Subscription state:
```{
[...]
"in":4957184, << bps
"out":4957184, << bps
"total_in":710134844, << informative, no changes
"total_out":710134844, <<  informative, no changes
[...]
}
```

Summary of changes:
- Added average bitrate measured per second to inputs, using the same approach as subscriptions (check https://github.com/tvheadend/tvheadend/commit/26dabb7a78b8791357a2e2a6e226e9d4963f1177).
- Added total data counters to inputs, allowing external APIs to measure data consumption (MB, GB, TB...) per input, similar to how subscriptions leverage the previously added total_bytes value (check https://github.com/tvheadend/tvheadend/commit/50f950c6f909e9213ad44832f7ce7ed488598887).
- Ensured that all bitrate values are reported in bits per second (bps) in API responses. Previously, one value was reported in kbps and another in bytes per second.
- Changed the web interface display to kbps, which is better suited for streaming and network measurement and is the conventional unit in streaming contexts.
- Leveraged the service name for bandwidth monitoring when the channel name is not available.