### PR TITLE
autobuild: missing trixie support for arm64 and armhf

### DIFF
--- a/Autobuild/trixie-aarch64.sh
+++ b/Autobuild/trixie-aarch64.sh
@@ -1,0 +1,3 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --disable-libx265_static --disable-libx265"
+source Autobuild/aarch64.sh
+source Autobuild/trixie.sh

--- a/Autobuild/trixie-armv7l.sh
+++ b/Autobuild/trixie-armv7l.sh
@@ -1,0 +1,3 @@
+AUTOBUILD_CONFIGURE_EXTRA="${AUTOBUILD_CONFIGURE_EXTRA:-} --disable-libx265_static --disable-libx265"
+source Autobuild/armv7l.sh
+source Autobuild/trixie.sh


### PR DESCRIPTION
Add missing Trixie support for Raspberry Pi aarch64/armhf OS
```
root@pi:~/tvheadend# AUTOBUILD_CONFIGURE_EXTRA==--enable-ccache\ --disable-hdhomerun_client\ --enable-ccdebug ./Autobuild.sh
OS identified using lsb_release command
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
target trixie-aarch64 not supported
```