### PR TITLE
fix free of self->device in vaapi.c

### DIFF
--- a/src/transcoding/codec/codecs/libs/vaapi.c
+++ b/src/transcoding/codec/codecs/libs/vaapi.c
@@ -522,6 +522,18 @@ static const codec_profile_class_t codec_profile_vaapi_class = {
 };
 
 
+static void
+tvh_codec_profile_vaapi_destroy(TVHCodecProfile *_self)
+{
+    tvh_codec_profile_vaapi_t *self = (tvh_codec_profile_vaapi_t *)_self;
+    if (self->device){
+        free(self->device);
+        self->device = NULL;
+    }
+    tvh_codec_profile_video_destroy(_self);
+}
+
+
 /* h264_vaapi =============================================================== */
 
 static const AVProfile vaapi_h264_profiles[] = {
@@ -841,7 +853,7 @@ TVHVideoCodec tvh_codec_vaapi_h264 = {
     .idclass  = &codec_profile_vaapi_h264_class,
     .profiles = vaapi_h264_profiles,
     .profile_init = tvh_codec_profile_video_init,
-    .profile_destroy = tvh_codec_profile_video_destroy,
+    .profile_destroy = tvh_codec_profile_vaapi_destroy,
 };
 
 
@@ -1154,7 +1166,7 @@ TVHVideoCodec tvh_codec_vaapi_hevc = {
     .idclass  = &codec_profile_vaapi_hevc_class,
     .profiles = vaapi_hevc_profiles,
     .profile_init = tvh_codec_profile_video_init,
-    .profile_destroy = tvh_codec_profile_video_destroy,
+    .profile_destroy = tvh_codec_profile_vaapi_destroy,
 };
 
 
@@ -1461,7 +1473,7 @@ TVHVideoCodec tvh_codec_vaapi_vp8 = {
     .idclass  = &codec_profile_vaapi_vp8_class,
     .profiles = vaapi_vp8_profiles,
     .profile_init = tvh_codec_profile_video_init,
-    .profile_destroy = tvh_codec_profile_video_destroy,
+    .profile_destroy = tvh_codec_profile_vaapi_destroy,
 };
 
 /* vp9_vaapi =============================================================== */
@@ -1788,5 +1800,5 @@ TVHVideoCodec tvh_codec_vaapi_vp9 = {
     .idclass  = &codec_profile_vaapi_vp9_class,
     .profiles = vaapi_vp9_profiles,
     .profile_init = tvh_codec_profile_video_init,
-    .profile_destroy = tvh_codec_profile_video_destroy,
+    .profile_destroy = tvh_codec_profile_vaapi_destroy,
 };

--- a/src/transcoding/codec/profile.c
+++ b/src/transcoding/codec/profile.c
@@ -273,6 +273,11 @@ tvh_codec_profile_video_init(TVHCodecProfile *_self, htsmsg_t *conf)
 void
 tvh_codec_profile_video_destroy(TVHCodecProfile *_self)
 {
+    TVHVideoCodecProfile *self = (TVHVideoCodecProfile *)_self;
+    if (self){
+        free(self);
+        self = NULL;
+    }
 }
 
 int


### PR DESCRIPTION
- fix free of self->device in vaapi.c
- fix free of TVHVideoCodecProfile
- this PR is bringing vaapi.c to the same implementation as libx26x.c 