### PR TITLE
Fix CMake build error with latest CMake 4.0 release

### DIFF
--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -63,6 +63,7 @@ LIBX265_TB     = $(LIBX265).tar.gz
 LIBX265_URL    = https://ftp.videolan.org/pub/videolan/x265/$(LIBX265_TB)
 LIBX265_SHA1   = 11880a3aa9e4ee618f539a2d6a8ece0ea442f505
 LIBX265_DIFFS  = libx265.pic.diff
+LIBX265_DIFFS  += libx265.CMake4.diff
 LIBX265_DIFFS  += libx265-silence.patch
 LIBX265_DIFFS  += libx265-substring.patch
 LIBX265_DIFFS  += libx265-armv9.patch

--- a/support/patches/libx265.CMake4.diff
+++ b/support/patches/libx265.CMake4.diff
@@ -1,0 +1,44 @@
+diff -urN ../x265_4.1/source/CMakeLists.txt ./source/CMakeLists.txt
+--- ../x265_4.1/source/CMakeLists.txt	2026-02-21 21:21:19.467544361 -0800
++++ ./source/CMakeLists.txt	2026-02-21 21:26:27.597691907 -0800
+@@ -6,18 +6,14 @@
+         FORCE)
+ endif()
+ message(STATUS "cmake version ${CMAKE_VERSION}")
+-if(POLICY CMP0025)
+-    cmake_policy(SET CMP0025 OLD) # report Apple's Clang as just Clang
+-endif()
++
+ if(POLICY CMP0042)
+     cmake_policy(SET CMP0042 NEW) # MACOSX_RPATH
+ endif()
+-if(POLICY CMP0054)
+-    cmake_policy(SET CMP0054 OLD) # Only interpret if() arguments as variables or keywords when unquoted
+-endif()
++
+ 
+ project (x265)
+-cmake_minimum_required (VERSION 2.8.8) # OBJECT libraries require 2.8.8
++cmake_minimum_required (VERSION 2.8.8...3.10) # OBJECT libraries require 2.8.8
+ include(CheckIncludeFiles)
+ include(CheckFunctionExists)
+ include(CheckSymbolExists)
+@@ -168,7 +164,7 @@
+   add_definitions(-DMACOS=1)
+ endif()
+ 
+-if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
++if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang")
+     set(CLANG 1)
+ endif()
+ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
+@@ -723,6 +719,9 @@
+     if(ARM OR CROSS_COMPILE_ARM)
+     # compile ARM arch asm files here
+         enable_language(ASM)
++        if(APPLE)
++            set(ARM_ARGS ${ARM_ARGS} -arch ${CMAKE_OSX_ARCHITECTURES})
++        endif()
+         foreach(ASM ${ARM_ASMS})
+ 			set(ASM_SRC ${CMAKE_CURRENT_SOURCE_DIR}/common/arm/${ASM})
+             list(APPEND ASM_SRCS ${ASM_SRC})


### PR DESCRIPTION
- Fix CMake build error with latest CMake 4.0 release
- initial info started from https://mailman.videolan.org/pipermail/x265-devel/2025-February/014251.html