### PR TITLE
channels: fix numeric sort order in channel dropdown lists

### DIFF
--- a/src/channels.c
+++ b/src/channels.c
@@ -253,9 +253,14 @@ channel_class_get_list(void *o, const char *lang)
   htsmsg_add_str(m, "type",  "api");
   htsmsg_add_str(m, "uri",   "channel/list");
   htsmsg_add_str(m, "event", "channel");
+  htsmsg_add_str(m, "stype", "none");
   htsmsg_add_u32(p, "all",  1);
-  if (config.chname_num)
+  if (config.chname_num) {
     htsmsg_add_u32(p, "numbers", 1);
+    htsmsg_add_str(p, "sort", "numname");
+  } else {
+    htsmsg_add_str(p, "sort", "name");
+  }
   if (config.chname_src)
     htsmsg_add_u32(p, "sources", 1);
   htsmsg_add_msg(m, "params", p);


### PR DESCRIPTION
## Problem

Channel dropdowns (e.g. "Reuse EPG from" in channel configuration, and
channel selectors in DVR, autorec, timerec and service mapper) were
displaying channels in the wrong order when channel numbers are enabled
in the general configuration.

With channel numbers enabled, channel names are prefixed with their
number, e.g. "1 BBC One", "2 BBC Two", "10 ITV". The ExtJS data store
was re-sorting these alphabetically after loading, producing
"1 ...", "10 ...", "2 ..." instead of the correct numeric sequence.

## Root Cause

The channel property descriptor built by `channel_class_get_list()` in
`src/channels.c` lacked an `stype` field. In `idnode.js`,
`idnode_get_enum()` defaults to `Ext.data.SortTypes.asUCString`
(alphabetical) when no `stype` is specified, overriding the order
delivered by the server.

Note that the channel filter bar (`tvheadend.getChannels()`) was
unaffected because it explicitly passes `stype: 'none'` — this fix
applies the same treatment to the property descriptor path.

## Fix

Two changes to `channel_class_get_list()`:

1. Add `stype=none` to the descriptor to prevent client-side
   re-sorting, preserving the order delivered by the server.

2. Explicitly request the appropriate sort from the API:
   - `sort=numname` when channel numbers are enabled, so channels
     are ordered numerically by number then name.
   - `sort=name` when channel numbers are disabled, preserving the
     existing alphabetical-by-name behaviour for users who have
     chosen not to display channel numbers.

## Testing

Verified with channel numbers both enabled and disabled.