### PR TITLE
[WebUI] Option to hide seconds in DVR Dialogue.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1779,6 +1779,7 @@ config_boot
   config.iptv_tpool_count = 2;
   config.date_mask = strdup("");
   config.label_formatting = 0;
+  config.dvr_show_seconds = 1;
   config.hdhomerun_ip = strdup("");
   config.local_ip = strdup("");
   config.local_port = 0;
@@ -2355,6 +2356,17 @@ const idclass_t config_class = {
       .desc   = N_("Custom date mask like (%yyyy-%M-%dd %h:%m:%s)"),
       .opts   = PO_ADVANCED,
       .off    = offsetof(config_t, date_mask),
+      .group  = 2,
+    },
+    {
+      .type   = PT_BOOL,
+      .id     = "dvr_show_seconds",
+      .name   = N_("Show DVR seconds"),
+      .desc   = N_("Show seconds in the DVR entry add/edit dialogue window. "
+                   "If disabled, existing seconds can not be edited and "
+                   "new entries will have seconds set to zero."),
+      .opts   = PO_ADVANCED,
+      .off    = offsetof(config_t, dvr_show_seconds),
       .group  = 2,
     },
     {

--- a/src/config.c
+++ b/src/config.c
@@ -1779,6 +1779,7 @@ config_boot
   config.iptv_tpool_count = 2;
   config.date_mask = strdup("");
   config.label_formatting = 0;
+  config.dvr_show_seconds = 1;
   config.hdhomerun_ip = strdup("");
   config.local_ip = strdup("");
   config.local_port = 0;
@@ -2395,6 +2396,17 @@ const idclass_t config_class = {
       .off    = offsetof(config_t, default_tab),
       .opts   = PO_DOC_NLIST,
       .group  = 2
+    },
+    {
+      .type   = PT_BOOL,
+      .id     = "dvr_show_seconds",
+      .name   = N_("Show DVR seconds"),
+      .desc   = N_("Show seconds in the DVR entry add/edit dialogue window. "
+                   "If disabled, existing seconds can not be edited and "
+                   "new entries will have seconds set to zero."),
+      .opts   = PO_ADVANCED,
+      .off    = offsetof(config_t, dvr_show_seconds),
+      .group  = 2,
     },
     {
       .type   = PT_BOOL,

--- a/src/config.h
+++ b/src/config.h
@@ -72,6 +72,7 @@ typedef struct config {
   int iptv_tpool_count;
   char *date_mask;
   int label_formatting;
+  int dvr_show_seconds;
   uint32_t ticket_expires;
   char *hdhomerun_ip;
   char *local_ip;

--- a/src/webui/comet.c
+++ b/src/webui/comet.c
@@ -186,6 +186,7 @@ comet_access_update(http_connection_t *hc, comet_mailbox_t *cmb)
   htsmsg_add_u32(m, "chname_src", config.chname_src);
   htsmsg_add_str(m, "date_mask", config.date_mask);
   htsmsg_add_u32(m, "label_formatting", config.label_formatting);
+  htsmsg_add_u32(m, "dvr_show_seconds", config.dvr_show_seconds);
   if (!access_noacl)
     htsmsg_add_str(m, "username", username);
   if (hc->hc_peer_ipstr)

--- a/src/webui/comet.c
+++ b/src/webui/comet.c
@@ -193,9 +193,8 @@ comet_access_update(http_connection_t *hc, comet_mailbox_t *cmb)
   htsmsg_add_u32(m, "chname_src", config.chname_src);
   htsmsg_add_str(m, "date_mask", config.date_mask);
   htsmsg_add_u32(m, "label_formatting", config.label_formatting);
-  
   htsmsg_add_u32(m, "default_tab", default_tab);
-  
+  htsmsg_add_u32(m, "dvr_show_seconds", config.dvr_show_seconds);
   if (!access_noacl)
     htsmsg_add_str(m, "username", username);
   if (hc->hc_peer_ipstr)

--- a/src/webui/static/app/idnode.js
+++ b/src/webui/static/app/idnode.js
@@ -786,9 +786,9 @@ tvheadend.idnode_editor_field = function(f, conf)
                     value: value,
                     disabled: false,
                     width: 300,
-                    timeFormat: 'H:i:s',
+                    timeFormat: tvheadend.dvr_show_seconds ? 'H:i:s' : 'H:i',
                     timeConfig: {
-                        altFormats: 'H:i:s',
+                        altFormats: 'H:i:s|H:i',
                         allowBlank: true,
                         increment: 10
                     },

--- a/src/webui/static/app/tvheadend.js
+++ b/src/webui/static/app/tvheadend.js
@@ -13,6 +13,7 @@ tvheadend.docs_toc = null;
 tvheadend.doc_history = [];
 tvheadend.doc_win = null;
 tvheadend.date_mask = '';
+tvheadend.dvr_show_seconds = true;
 tvheadend.label_formatting = false;
 tvheadend.language = window.navigator.userLanguage || window.navigator.language;
 
@@ -1028,6 +1029,7 @@ function accessUpdate(o) {
     tvheadend.chname_num = o.chname_num ? 1 : 0;
     tvheadend.chname_src = o.chname_src ? 1 : 0;
     tvheadend.date_mask = o.date_mask;
+    tvheadend.dvr_show_seconds = o.dvr_show_seconds ? true : false;
     tvheadend.label_formatting = o.label_formatting ? true : false;
     tvheadend.page_size = o.page_size;
 

--- a/src/webui/static/app/tvheadend.js
+++ b/src/webui/static/app/tvheadend.js
@@ -41,6 +41,7 @@ tvheadend.docs_toc = null;
 tvheadend.doc_history = [];
 tvheadend.doc_win = null;
 tvheadend.date_mask = '';
+tvheadend.dvr_show_seconds = true;
 tvheadend.label_formatting = false;
 tvheadend.language = window.navigator.userLanguage || window.navigator.language;
 tvheadend.default_tab = CONFIG_DEFAULT_TAB_EPG;
@@ -1057,6 +1058,7 @@ function accessUpdate(o) {
     tvheadend.chname_num = o.chname_num ? 1 : 0;
     tvheadend.chname_src = o.chname_src ? 1 : 0;
     tvheadend.date_mask = o.date_mask;
+    tvheadend.dvr_show_seconds = o.dvr_show_seconds ? true : false;
     tvheadend.label_formatting = o.label_formatting ? true : false;
     tvheadend.page_size = o.page_size;
     tvheadend.default_tab = o.default_tab ? o.default_tab : CONFIG_DEFAULT_TAB_EPG;


### PR DESCRIPTION
Provide a configuration option in the 'Web Interface Settings' section to allow/suppress the display of seconds in the add/edit DVR entry dialogue window.

<img width="473" height="488" alt="image" src="https://github.com/user-attachments/assets/3f7ac7de-016a-48a1-8898-118b499560c0" />

When enabled, seconds are displayed in the time input field and the drop-down list.

<img width="564" height="276" alt="image" src="https://github.com/user-attachments/assets/a83300f6-71d9-4f92-ab69-63e61a72c69c" />

When disabled, display of seconds is suppressed in the time input field and the drop-down list.  Seconds will always be set to '00'.

<img width="563" height="261" alt="image" src="https://github.com/user-attachments/assets/b39506c2-0628-40bb-9d15-ed878a50dacb" />

If a DVR entry with seconds is edited when seconds display is suppressed, its seconds will be set to '00.

https://tvheadend.org/d/9372-remove-seconds-to-the-time-displayed-in-the-drop-down-menu-of-the-dvr