### PR TITLE
Fix environment variable syntax in Docker compose yaml

### DIFF
--- a/README.Docker.md
+++ b/README.Docker.md
@@ -415,7 +415,7 @@ services:
     devices:
       - /dev/dvb/
     environment:
-      - TZ: 'Europe/Amsterdam'
+      - TZ='Europe/Amsterdam'
     volumes:
       - tvheadend:/var/lib/tvheadend:rw
       - /export/recordings:/var/lib/tvheadend/recordings:rw


### PR DESCRIPTION
fix env var syntax to prevent error:
services.tvheadend.environment.[0]: unexpected type map[string]interface {}
