### PR TITLE
[WebUI] Option to set default tab by system and user.

### DIFF
--- a/docs/property/change_parameters.md
+++ b/docs/property/change_parameters.md
@@ -21,6 +21,9 @@ Option                     | Description/Properties
 **Web interface language** | *Web interface language*.
 **Theme**                  | *Theme*.
 **User interface level**   | *User interface level*.
+**XMLTV output format**    | *Output format for XMLTV*.
+**HTSP output format**     | *Output format for HTSP*.
+**Default tab**            | *Default tab on the Web interface*.
 
 The above table displays the *Change parameters* option name and the fields that it 
 applies to, as shown in add/edit dialog(s).

--- a/src/access.c
+++ b/src/access.c
@@ -294,6 +294,7 @@ access_copy(access_t *src)
     dst->aa_auth = strdup(src->aa_auth);
   dst->aa_xmltv_output_format = src->aa_xmltv_output_format;
   dst->aa_htsp_output_format = src->aa_htsp_output_format;
+  dst->aa_default_tab = src->aa_default_tab;
   return dst;
 }
 
@@ -695,6 +696,11 @@ access_update(access_t *a, access_entry_t *ae)
     a->aa_xmltv_output_format = ae->ae_xmltv_output_format;
   if (ae->ae_change_htsp_output_format)
     a->aa_htsp_output_format = ae->ae_htsp_output_format;
+
+  if (ae->ae_change_default_tab) {
+    a->aa_default_tab = ae->ae_default_tab;
+  }
+
 }
 
 /**
@@ -1126,6 +1132,7 @@ access_entry_create(const char *uuid, htsmsg_t *conf)
     ae->ae_change_rights  = 1;
     ae->ae_change_xmltv_output_format = 1;
     ae->ae_change_htsp_output_format = 1;
+    ae->ae_change_default_tab = CONFIG_DEFAULT_TAB_SYSTEM;
     ae->ae_htsp_streaming = 1;
     ae->ae_htsp_dvr       = 1;
     ae->ae_all_dvr        = 1;
@@ -1581,6 +1588,11 @@ static idnode_slist_t access_entry_class_change_slist[] = {
     .name = N_("HTSP output format"),
     .off  = offsetof(access_entry_t, ae_change_htsp_output_format),
   },
+  {
+    .id   = "change_default_tab",
+    .name = N_("Default tab"),
+    .off  = offsetof(access_entry_t, ae_change_default_tab),
+  },
   {}
 };
 
@@ -1810,6 +1822,15 @@ const idclass_t access_entry_class = {
       .list     = language_get_ui_list,
       .off      = offsetof(access_entry_t, ae_lang_ui),
       .opts     = PO_ADVANCED,
+    },
+    {
+      .type     = PT_U32,
+      .id       = "default_tab",
+      .name     = N_("Default tab"),
+      .desc     = N_("Set the default start-up tab.  'EPG' is the default tab."),
+      .list     = config_class_default_tab_list,
+      .off      = offsetof(access_entry_t, ae_default_tab),
+      .opts     = PO_DOC_NLIST | PO_ADVANCED,
     },
     {
       .type     = PT_STR,

--- a/src/access.h
+++ b/src/access.h
@@ -142,6 +142,9 @@ typedef struct access_entry {
   int ae_htsp_output_format;
   int ae_change_htsp_output_format;
 
+  uint32_t ae_default_tab;
+  int ae_change_default_tab;
+
   int ae_dvr;
   int ae_htsp_dvr;
   int ae_all_dvr;
@@ -174,6 +177,8 @@ LIST_HEAD(access_entry_list, access_entry);
 
 extern const idclass_t access_entry_class;
 
+extern htsmsg_t *config_class_default_tab_list ( void *o, const char *lang );
+
 typedef struct access {
   char     *aa_username;
   char     *aa_representative;
@@ -198,6 +203,7 @@ typedef struct access {
   int       aa_uilevel_nochange;
   char     *aa_theme;
   char     *aa_auth;
+  uint32_t  aa_default_tab;
 } access_t;
 
 TAILQ_HEAD(access_ticket_queue, access_ticket);

--- a/src/config.c
+++ b/src/config.c
@@ -2135,6 +2135,35 @@ config_class_http_auth_algo_list ( void *o, const char *lang )
   return strtab2htsmsg(tab, 1, lang);
 }
 
+htsmsg_t *
+config_class_default_tab_list ( void *o, const char *lang )
+{
+  static const struct strtab tab[] = {
+    { N_("System Default"),        CONFIG_DEFAULT_TAB_SYSTEM },
+    { N_("EPG"),                   CONFIG_DEFAULT_TAB_EPG },
+    { N_("DVR-Upcoming/Current"),  CONFIG_DEFAULT_TAB_DVR_UPCOMING },
+    { N_("DVR-Finished"),          CONFIG_DEFAULT_TAB_DVR_FINISHED },
+    { N_("DVR-Failed"),            CONFIG_DEFAULT_TAB_DVR_FAILED },
+    { N_("DVR-Removed"),           CONFIG_DEFAULT_TAB_DVR_REMOVED },
+    { N_("DVR-Autorecs"),          CONFIG_DEFAULT_TAB_DVR_AUTORECS },
+    { N_("DVR-Timers"),            CONFIG_DEFAULT_TAB_DVR_TIMERS },
+    { N_("Config-General"),        CONFIG_DEFAULT_TAB_CFG_GENERAL },
+    { N_("Config-Users"),          CONFIG_DEFAULT_TAB_CFG_USERS },
+    { N_("Config-DVB Inputs"),     CONFIG_DEFAULT_TAB_CFG_DVB },
+    { N_("Config-Channel/EPG"),    CONFIG_DEFAULT_TAB_CFG_CHANNEL },
+    { N_("Config-Stream"),         CONFIG_DEFAULT_TAB_CFG_STREAM },
+    { N_("Config-Recording"),      CONFIG_DEFAULT_TAB_CFG_REC },
+    { N_("Config-CAs"),            CONFIG_DEFAULT_TAB_CFG_CA },
+    { N_("Config-Debugging"),      CONFIG_DEFAULT_TAB_CFG_DEBUG },
+    { N_("Status-Stream"),         CONFIG_DEFAULT_TAB_STATUS_STREAM },
+    { N_("Status-Subscriptions"),  CONFIG_DEFAULT_TAB_STATUS_SUBS },
+    { N_("Status-Connections"),    CONFIG_DEFAULT_TAB_STATUS_CONN },
+    { N_("Status-Service Mapper"), CONFIG_DEFAULT_TAB_STATUS_SVC },
+    { N_("About"),                 CONFIG_DEFAULT_TAB_ABOUT },
+  };
+  return strtab2htsmsg(tab, 1, lang);
+}
+
 #if ENABLE_MPEGTS_DVB
 static void
 config_muxconfpath_notify_cb(void *opaque, int disarmed)
@@ -2356,6 +2385,16 @@ const idclass_t config_class = {
       .opts   = PO_ADVANCED,
       .off    = offsetof(config_t, date_mask),
       .group  = 2,
+    },
+    {
+      .type   = PT_U32,
+      .id     = "default_tab",
+      .name   = N_("Default tab"),
+      .desc   = N_("Set the default start-up tab.  'EPG' is the system default tab."),
+      .list   = config_class_default_tab_list,
+      .off    = offsetof(config_t, default_tab),
+      .opts   = PO_DOC_NLIST,
+      .group  = 2
     },
     {
       .type   = PT_BOOL,

--- a/src/config.h
+++ b/src/config.h
@@ -85,6 +85,7 @@ typedef struct config {
   int enable_vainfo;
   #endif
   uint32_t page_size_ui;
+  uint32_t default_tab;
 } config_t;
 
 extern const idclass_t config_class;
@@ -99,5 +100,28 @@ const char *config_get_server_name ( void );
 const char *config_get_http_server_name ( void );
 const char *config_get_language    ( void );
 const char *config_get_language_ui ( void );
+
+#define CONFIG_DEFAULT_TAB_SYSTEM         0
+#define CONFIG_DEFAULT_TAB_EPG            1
+#define CONFIG_DEFAULT_TAB_DVR_UPCOMING  10
+#define CONFIG_DEFAULT_TAB_DVR_FINISHED  11
+#define CONFIG_DEFAULT_TAB_DVR_FAILED    12
+#define CONFIG_DEFAULT_TAB_DVR_REMOVED   13
+#define CONFIG_DEFAULT_TAB_DVR_AUTORECS  14
+#define CONFIG_DEFAULT_TAB_DVR_TIMERS    15
+#define CONFIG_DEFAULT_TAB_CFG_GENERAL   20
+#define CONFIG_DEFAULT_TAB_CFG_USERS     21
+#define CONFIG_DEFAULT_TAB_CFG_DVB       22
+#define CONFIG_DEFAULT_TAB_CFG_CHANNEL   23
+#define CONFIG_DEFAULT_TAB_CFG_STREAM    24
+#define CONFIG_DEFAULT_TAB_CFG_REC       25
+#define CONFIG_DEFAULT_TAB_CFG_CA        26
+#define CONFIG_DEFAULT_TAB_CFG_DEBUG     27
+#define CONFIG_DEFAULT_TAB_STATUS_STREAM 30
+#define CONFIG_DEFAULT_TAB_STATUS_SUBS   31
+#define CONFIG_DEFAULT_TAB_STATUS_CONN   32
+#define CONFIG_DEFAULT_TAB_STATUS_SVC    33
+#define CONFIG_DEFAULT_TAB_ABOUT         40
+
 
 #endif /* __TVH_CONFIG__H__ */

--- a/src/webui/comet.c
+++ b/src/webui/comet.c
@@ -161,6 +161,7 @@ comet_access_update(http_connection_t *hc, comet_mailbox_t *cmb)
   int dvr = !http_access_verify(hc, ACCESS_RECORDER);
   int admin = !http_access_verify(hc, ACCESS_ADMIN);
   const char *s;
+  uint32_t default_tab = config.default_tab;
 
   htsmsg_add_str(m, "notificationClass", "accessUpdate");
 
@@ -178,6 +179,12 @@ comet_access_update(http_connection_t *hc, comet_mailbox_t *cmb)
       if (config.uilevel_nochange)
         htsmsg_add_u32(m, "uilevel_nochange", config.uilevel_nochange);
     }
+    
+    if(hc->hc_access->aa_default_tab != CONFIG_DEFAULT_TAB_SYSTEM)
+    {
+      default_tab = hc->hc_access->aa_default_tab;
+    }
+
   }
   htsmsg_add_str(m, "theme", access_get_theme(hc->hc_access));
   htsmsg_add_u32(m, "page_size", config.page_size_ui);
@@ -186,6 +193,9 @@ comet_access_update(http_connection_t *hc, comet_mailbox_t *cmb)
   htsmsg_add_u32(m, "chname_src", config.chname_src);
   htsmsg_add_str(m, "date_mask", config.date_mask);
   htsmsg_add_u32(m, "label_formatting", config.label_formatting);
+  
+  htsmsg_add_u32(m, "default_tab", default_tab);
+  
   if (!access_noacl)
     htsmsg_add_str(m, "username", username);
   if (hc->hc_peer_ipstr)

--- a/src/webui/static/app/acleditor.js
+++ b/src/webui/static/app/acleditor.js
@@ -8,10 +8,10 @@ tvheadend.acleditor = function(panel, index)
                'lang,webui,uilevel,uilevel_nochange,admin,' +
                'streaming,profile,conn_limit_type,conn_limit,' +
                'dvr,dvr_config,channel_min,channel_max,' +
-	       'channel_tag_exclude,channel_tag,comment';
+	       'channel_tag_exclude,channel_tag,default_tab,comment';
 
     var list2 = 'enabled,username,password,prefix,change,' +
-                'lang,webui,themeui,langui,uilevel,uilevel_nochange,admin,' +
+                'lang,webui,themeui,langui,default_tab,uilevel,uilevel_nochange,admin,' +
                 'streaming,profile,conn_limit_type,conn_limit,' +
                 'dvr,htsp_anonymize,dvr_config,' +
                 'channel_min,channel_max,channel_tag_exclude,' +

--- a/src/webui/static/app/dvr.js
+++ b/src/webui/static/app/dvr.js
@@ -1201,5 +1201,17 @@ tvheadend.dvr = function(panel, index) {
     tvheadend.dvr_removed(p, 3);
     tvheadend.autorec_editor(p, 4);
     tvheadend.timerec_editor(p, 5);
+
+    if (tvheadend.default_tab >= CONFIG_DEFAULT_TAB_DVR_FIRST &&
+        tvheadend.default_tab <= CONFIG_DEFAULT_TAB_DVR_LAST) {
+        if ((tvheadend.uilevel !== 'expert') && (tvheadend.default_tab > CONFIG_DEFAULT_TAB_DVR_FAILED)) {
+            // The 'removed' tab is only shown for expert users,
+            // so shuffle the remaining tabs along one.
+            p.setActiveTab(tvheadend.default_tab - CONFIG_DEFAULT_TAB_DVR_FIRST - 1);
+        } else {
+            p.setActiveTab(tvheadend.default_tab - CONFIG_DEFAULT_TAB_DVR_FIRST);
+        }
+    }
+
     return p;
 }

--- a/src/webui/static/app/status.js
+++ b/src/webui/static/app/status.js
@@ -833,7 +833,13 @@ tvheadend.status = function() {
     tvheadend.status_subs(panel);
     tvheadend.status_conns(panel);
     tvheadend.service_mapper_status(panel);
-    return panel;
+
+    if (tvheadend.default_tab >= CONFIG_DEFAULT_TAB_STATUS_FIRST &&
+        tvheadend.default_tab <= CONFIG_DEFAULT_TAB_STATUS_LAST) {
+        panel.setActiveTab(tvheadend.default_tab - CONFIG_DEFAULT_TAB_STATUS_FIRST);
+    }
+
+        return panel;
 };
 
 

--- a/src/webui/static/app/tvheadend.js
+++ b/src/webui/static/app/tvheadend.js
@@ -1,3 +1,31 @@
+const CONFIG_DEFAULT_TAB_SYSTEM        = 0;
+const CONFIG_DEFAULT_TAB_EPG           = 1;
+const CONFIG_DEFAULT_TAB_DVR_FIRST     = 10;
+const CONFIG_DEFAULT_TAB_DVR_UPCOMING  = 10;
+const CONFIG_DEFAULT_TAB_DVR_FINISHED  = 11;
+const CONFIG_DEFAULT_TAB_DVR_FAILED    = 12;
+const CONFIG_DEFAULT_TAB_DVR_REMOVED   = 13;
+const CONFIG_DEFAULT_TAB_DVR_AUTORECS  = 14;
+const CONFIG_DEFAULT_TAB_DVR_TIMERS    = 15;
+const CONFIG_DEFAULT_TAB_DVR_LAST      = 19;
+const CONFIG_DEFAULT_TAB_CFG_FIRST     = 20;
+const CONFIG_DEFAULT_TAB_CFG_GENERAL   = 20;
+const CONFIG_DEFAULT_TAB_CFG_USERS     = 21;
+const CONFIG_DEFAULT_TAB_CFG_DVB       = 22;
+const CONFIG_DEFAULT_TAB_CFG_CHANNEL   = 23;
+const CONFIG_DEFAULT_TAB_CFG_STREAM    = 24;
+const CONFIG_DEFAULT_TAB_CFG_REC       = 25;
+const CONFIG_DEFAULT_TAB_CFG_CA        = 26;
+const CONFIG_DEFAULT_TAB_CFG_DEBUG     = 27;
+const CONFIG_DEFAULT_TAB_CFG_LAST      = 29;
+const CONFIG_DEFAULT_TAB_STATUS_FIRST  = 30;
+const CONFIG_DEFAULT_TAB_STATUS_STREAM = 30;
+const CONFIG_DEFAULT_TAB_STATUS_SUBS   = 31;
+const CONFIG_DEFAULT_TAB_STATUS_CONN   = 32;
+const CONFIG_DEFAULT_TAB_STATUS_SVC    = 33;
+const CONFIG_DEFAULT_TAB_STATUS_LAST   = 39;
+const CONFIG_DEFAULT_TAB_ABOUT         = 40;
+
 tvheadend.dynamic = true;
 tvheadend.accessupdate = null;
 tvheadend.capabilities = null;
@@ -15,6 +43,7 @@ tvheadend.doc_win = null;
 tvheadend.date_mask = '';
 tvheadend.label_formatting = false;
 tvheadend.language = window.navigator.userLanguage || window.navigator.language;
+tvheadend.default_tab = CONFIG_DEFAULT_TAB_EPG;
 
 // Use en-US if browser language detection fails.
 if (!tvheadend.language || !/\S/.test(tvheadend.language)) {
@@ -1030,6 +1059,7 @@ function accessUpdate(o) {
     tvheadend.date_mask = o.date_mask;
     tvheadend.label_formatting = o.label_formatting ? true : false;
     tvheadend.page_size = o.page_size;
+    tvheadend.default_tab = o.default_tab ? o.default_tab : CONFIG_DEFAULT_TAB_EPG;
 
     if (o.uilevel_nochange)
         tvheadend.uilevel_nochange = true;
@@ -1059,6 +1089,12 @@ function accessUpdate(o) {
     if (o.dvr == true && tvheadend.dvrpanel == null) {
         tvheadend.dvrpanel = tvheadend.dvr();
         panel.add(tvheadend.dvrpanel);
+
+        if (tvheadend.default_tab >= CONFIG_DEFAULT_TAB_DVR_FIRST &&
+            tvheadend.default_tab <= CONFIG_DEFAULT_TAB_DVR_LAST)
+            {
+                panel.setActiveTab(1);
+            }
     }
 
     if (o.admin == true && tvheadend.confpanel == null) {
@@ -1192,8 +1228,23 @@ function accessUpdate(o) {
             cp.add(dbg);
         }
 
+        //Set the default config sub-panel
+        if (tvheadend.default_tab >= CONFIG_DEFAULT_TAB_CFG_FIRST &&
+            tvheadend.default_tab <= CONFIG_DEFAULT_TAB_CFG_LAST)
+            {
+                cp.setActiveTab(tvheadend.default_tab - CONFIG_DEFAULT_TAB_CFG_FIRST);
+            }
+
         /* Finish */
         panel.add(cp);
+
+        //Also set the main config tab to default on level 1
+        //if one of the child tabs is the system default.
+        if (tvheadend.default_tab >= CONFIG_DEFAULT_TAB_CFG_FIRST &&
+            tvheadend.default_tab <= CONFIG_DEFAULT_TAB_CFG_LAST) {
+            panel.setActiveTab(panel.items.indexOf(cp));
+        }
+
         tvheadend.confpanel = cp;
         cp.doLayout();
     }
@@ -1201,6 +1252,11 @@ function accessUpdate(o) {
     if (o.admin == true && tvheadend.statuspanel == null) {
         tvheadend.statuspanel = new tvheadend.status;
         panel.add(tvheadend.statuspanel);
+
+        if (tvheadend.default_tab >= CONFIG_DEFAULT_TAB_STATUS_FIRST &&
+            tvheadend.default_tab <= CONFIG_DEFAULT_TAB_STATUS_LAST) {
+            panel.setActiveTab(panel.items.indexOf(tvheadend.statuspanel));
+        }
     }
 
     if (tvheadend.aboutPanel == null) {
@@ -1213,6 +1269,10 @@ function accessUpdate(o) {
             autoLoad: 'about.html'
         });
         panel.add(tvheadend.aboutPanel);
+
+        if (tvheadend.default_tab === CONFIG_DEFAULT_TAB_ABOUT) {
+            panel.setActiveTab(panel.items.indexOf(tvheadend.aboutPanel));
+        }
     }
 
     panel.doLayout();


### PR DESCRIPTION
Provide a configuration option in the 'Web Interface Settings' section that allows the selection of a system-wide default tab from the first two levels of tabs.

<img width="613" height="489" alt="image" src="https://github.com/user-attachments/assets/485b43df-d60a-488c-b9d8-105b4f575da0" />

If no system-wide default tab is selected, the default start-up tab remains 'EPG'.

Individual users can also be assigned a default tab.  The user's default tab takes priority over the system-wide setting when enabled in the 'Change parameters' user setting.

<img width="547" height="739" alt="image" src="https://github.com/user-attachments/assets/00352549-369d-44c3-adbf-f20d0bece0bd" />

If the user does not have access to the default tab, either by direct selection or inheritance, the user will see 'EPG' as their default tab.

The following tabs are available to be selected as default:

- System Default (EPG)
- EPG
- DVR-Upcomming/Current
- DVR-Finished
- DVR-Failed
- DVR-Removed
- DVR-Autorecs
- DVR-Timers
- Config-General
- Config-Users
- Config-DVB Inputs
- Config-Channel/EPG
- Config-Stream
- Config-Recording
- Config-CAs
- Config-Debugging
- Status-Stream
- Status-Subscriptions
- Status-Connections
- Status-Service Mapper
- About