### PR TITLE
 idnode.c: unlock idnode on failed uuid_set

### DIFF
--- a/src/idnode.c
+++ b/src/idnode.c
@@ -113,6 +113,7 @@ idnode_insert(idnode_t *in, const char *uuid, const idclass_t *class, int flags)
 
     if (uuid_set(&u, uuid)) {
       in->in_class = NULL;
+      idnode_unlock();
       return -1;
     }
     uuid_duplicate(&in->in_uuid, &u);


### PR DESCRIPTION
I've observed a startup failure when I had a stale .tmp file in my muxes folder. This patch seems to be an improvement.