### PR TITLE
update filter to format required by ffmpeg8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -545,6 +545,9 @@ SRCS-CODECS += $(foreach lib,$(LIBS-CODECS),src/transcoding/codec/codecs/libs/$(
 #hwaccels
 ifeq ($(CONFIG_HWACCELS),yes)
 SRCS-HWACCELS += src/transcoding/transcode/hwaccels/hwaccels.c
+ifeq ($(CONFIG_NVENC),yes)
+SRCS-HWACCELS += src/transcoding/transcode/hwaccels/nv.c
+endif
 ifeq ($(CONFIG_VAAPI),yes)
 SRCS-HWACCELS += src/transcoding/transcode/hwaccels/vaapi.c
 endif

--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -41,7 +41,7 @@ ENCODERS       = mpeg2video mp2 aac vorbis flac
 MUXERS         = mpegts matroska mp4
 DEMUXERS       = mpegts matroska hls flv live_flv
 BSFS           = h264_mp4toannexb hevc_mp4toannexb
-FILTERS        = yadif format hwupload hwdownload scale null aresample anull
+FILTERS        = yadif format hwupload hwdownload scale null aresample aformat asetpts anull
 HWACCELS       =
 
 NASM_VER       = 2.16.03
@@ -108,9 +108,13 @@ FFNVCODEC_URL  = https://github.com/FFmpeg/nv-codec-headers/releases/download/n$
 FFNVCODEC_SHA1 = 74231bb5572ebde98652a26ce98ede7895b4c730
 
 FFMPEG         = ffmpeg-6.1.1
+#FFMPEG         = ffmpeg-7.1.3
+#FFMPEG         = ffmpeg-8.0.1
 FFMPEG_TB      = $(FFMPEG).tar.bz2
 FFMPEG_URL     = https://ffmpeg.org/releases/$(FFMPEG_TB)
 FFMPEG_SHA1    = 157e7b0f6521142e1ebd786175e363e9f1b59312
+#FFMPEG_SHA1    = 1aba57070ed172fac4f5a648a260e44dabbca0a4
+#FFMPEG_SHA1    = c2f6d5fcbd3068c1c8b5af867dfa6809c456e6b4
 
 
 # ##############################################################################

--- a/src/api/api_service.c
+++ b/src/api/api_service.c
@@ -87,7 +87,7 @@ api_service_streams_get_one ( elementary_stream_t *es, int use_filter )
   } else if (SCT_ISVIDEO(es->es_type)) {
     htsmsg_add_u32(e, "width",          es->es_width);
     htsmsg_add_u32(e, "height",         es->es_height);
-    htsmsg_add_u32(e, "duration",       es->es_frame_duration);
+    htsmsg_add_u32(e, "duration",       ((es->es_frame_duration > INT_MAX) ? INT_MAX : (int)es->es_frame_duration));
     htsmsg_add_u32(e, "aspect_num",     es->es_aspect_num);
     htsmsg_add_u32(e, "aspect_den",     es->es_aspect_den);
   } else if (es->es_type == SCT_CA) {

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -1490,7 +1490,7 @@ dvr_rec_start(dvr_entry_t *de, const streaming_start_t *ss)
 
       htsmsg_add_u32(e, "width",      ssc->es_width);
       htsmsg_add_u32(e, "height",     ssc->es_height);
-      htsmsg_add_u32(e, "duration",   ssc->es_frame_duration);
+      htsmsg_add_u32(e, "duration",   ((ssc->es_frame_duration > INT_MAX) ? INT_MAX : (int)ssc->es_frame_duration));
       htsmsg_add_u32(e, "aspect_num", ssc->es_aspect_num);
       htsmsg_add_u32(e, "aspect_den", ssc->es_aspect_den);
     } else {

--- a/src/esstream.h
+++ b/src/esstream.h
@@ -22,6 +22,9 @@
 
 #include "descrambler/descrambler.h"
 #include "input/mpegts/dvb.h"
+#if ENABLE_LIBAV
+#include <libavutil/rational.h>
+#endif
 
 /**
  *
@@ -93,13 +96,23 @@ struct elementary_info {
   int16_t es_pid;
   int es_type;
 
-  int es_frame_duration;
+  int64_t es_frame_duration;
 
+  // temporary used for each field
+  int es_width_2b;
+  int es_height_2b;
+  int es_width_12b;
+  int es_height_12b;
+
+  // store the final width,height (after 2bits+12bits concatenation)
   int es_width;
   int es_height;
 
   uint16_t es_aspect_num;
   uint16_t es_aspect_den;
+#if ENABLE_LIBAV
+  AVRational es_sample_aspect_ratio;
+#endif
 
   char es_lang[4];           /* ISO 639 2B 3-letter language code */
   uint8_t es_audio_type;     /* Audio type */

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -4199,7 +4199,7 @@ htsp_stream_deliver(htsp_subscription_t *hs, th_pkt_t *pkt)
     htsmsg_add_s64(m, "dts", dts);
   }
 
-  uint32_t dur = hs->hs_90khz ? pkt->pkt_duration : ts_rescale(pkt->pkt_duration, 1000000);
+  uint32_t dur = (uint32_t) (hs->hs_90khz ? ((pkt->pkt_duration > INT_MAX) ? INT_MAX : (int)pkt->pkt_duration) : ts_rescale(pkt->pkt_duration, 1000000));
   htsmsg_add_u32(m, "duration", dur);
 
   /**
@@ -4323,7 +4323,8 @@ htsp_subscription_start(htsp_subscription_t *hs, const streaming_start_t *ss)
       if(ssc->es_height)
         htsmsg_add_u32(c, "height", ssc->es_height);
       if(ssc->es_frame_duration)
-        htsmsg_add_u32(c, "duration", hs->hs_90khz ? ssc->es_frame_duration :
+      
+        htsmsg_add_u32(c, "duration", hs->hs_90khz ? ((ssc->es_frame_duration > INT_MAX) ? INT_MAX : (int)ssc->es_frame_duration) :
                        ts_rescale(ssc->es_frame_duration, 1000000));
       if (ssc->es_aspect_num)
         htsmsg_add_u32(c, "aspect_num", ssc->es_aspect_num);

--- a/src/muxer/muxer_libav.c
+++ b/src/muxer/muxer_libav.c
@@ -175,14 +175,10 @@ lav_muxer_add_stream(lav_muxer_t *lm,
     c->time_base.num = 1;
     c->time_base.den = 25;
 
-    c->sample_aspect_ratio.num = ssc->es_aspect_num;
-    c->sample_aspect_ratio.den = ssc->es_aspect_den;
-
-    if (lm->m_config.m_type == MC_AVMP4) {
-      /* this is a whole hell */
-      AVRational ratio = { c->height, c->width };
-      c->sample_aspect_ratio = av_mul_q(c->sample_aspect_ratio, ratio);
-    }
+    // to be removed when we remove has_support_for_filter2
+    tvhinfo(LS_LIBAV,  "Muxer: sample aspect ratio = %d/%d", ssc->es_sample_aspect_ratio.num, ssc->es_sample_aspect_ratio.den);
+    c->sample_aspect_ratio.num = ssc->es_sample_aspect_ratio.num;
+    c->sample_aspect_ratio.den = ssc->es_sample_aspect_ratio.den;
 
     avcodec_parameters_from_context(st->codecpar, c);
     st->sample_aspect_ratio.num = c->sample_aspect_ratio.num;

--- a/src/packet.c
+++ b/src/packet.c
@@ -182,7 +182,7 @@ pkt_trace_(const char *file, int line, int subsys, th_pkt_t *pkt,
   snprintf(buf, sizeof(buf),
            "%s%spkt stream %d %s%s%s"
            " pcr %s dts %s pts %s"
-           " dur %d len %zu err %i%s%s",
+           " dur %"PRId64" len %zu err %i%s%s",
            fmt ? fmt : "",
            fmt ? " (" : "",
            pkt->pkt_componentindex,

--- a/src/packet.h
+++ b/src/packet.h
@@ -53,7 +53,7 @@ typedef struct th_pkt {
   int64_t pkt_dts;
   int64_t pkt_pts;
   int64_t pkt_pcr;
-  int pkt_duration;
+  int64_t pkt_duration;
   int pkt_refcount;
 
   uint8_t pkt_type;
@@ -68,6 +68,9 @@ typedef struct th_pkt {
 
       uint16_t pkt_aspect_num;
       uint16_t pkt_aspect_den;
+#if ENABLE_LIBAV
+      AVRational pkt_sample_aspect_ratio;
+#endif
     } v;
     struct {
       uint8_t pkt_keyframe;

--- a/src/parsers/parser_h264.c
+++ b/src/parsers/parser_h264.c
@@ -444,6 +444,11 @@ h264_decode_slice_header(parser_es_t *st, bitstream_t *bs, int *pkttype,
     parser_set_stream_vparam(st, width, height, d);
 
   if (sps->aspect_num && sps->aspect_den) {
+#if ENABLE_LIBAV
+    // save SAR
+    st->es_sample_aspect_ratio.num = sps->aspect_num;
+    st->es_sample_aspect_ratio.den = sps->aspect_den;
+#endif
     width  *= sps->aspect_num;
     height *= sps->aspect_den;
     if (width && height) {
@@ -452,6 +457,11 @@ h264_decode_slice_header(parser_es_t *st, bitstream_t *bs, int *pkttype,
       st->es_aspect_den = height / v;
     }
   } else {
+#if ENABLE_LIBAV
+    // save SAR
+    st->es_sample_aspect_ratio.num = 0;
+    st->es_sample_aspect_ratio.den = 1;
+#endif
     st->es_aspect_num = 0;
     st->es_aspect_den = 1;
   }

--- a/src/parsers/parser_hevc.c
+++ b/src/parsers/parser_hevc.c
@@ -1713,6 +1713,11 @@ hevc_decode_slice_header(parser_es_t *st, bitstream_t *bs, int *pkttype)
     parser_set_stream_vparam(st, width, height, d);
 
   if (sps->vui.sar.num && sps->vui.sar.den) {
+#if ENABLE_LIBAV
+    // save SAR
+    st->es_sample_aspect_ratio.num = sps->vui.sar.num;
+    st->es_sample_aspect_ratio.den = sps->vui.sar.den;
+#endif
     width  *= sps->vui.sar.num;
     height *= sps->vui.sar.den;
     if (width && height) {
@@ -1721,6 +1726,11 @@ hevc_decode_slice_header(parser_es_t *st, bitstream_t *bs, int *pkttype)
       st->es_aspect_den = height / v;
     }
   } else {
+#if ENABLE_LIBAV
+    // save SAR
+    st->es_sample_aspect_ratio.num = 0;
+    st->es_sample_aspect_ratio.den = 1;
+#endif
     st->es_aspect_num = 0;
     st->es_aspect_den = 1;
   }

--- a/src/parsers/parsers.c
+++ b/src/parsers/parsers.c
@@ -144,6 +144,10 @@ deliver:
   if (SCT_ISVIDEO(pkt->pkt_type)) {
     pkt->v.pkt_aspect_num = st->es_aspect_num;
     pkt->v.pkt_aspect_den = st->es_aspect_den;
+#if ENABLE_LIBAV
+    pkt->v.pkt_sample_aspect_ratio.num = st->es_sample_aspect_ratio.num;
+    pkt->v.pkt_sample_aspect_ratio.den = st->es_sample_aspect_ratio.den;
+#endif
   }
 
   /* Forward packet */
@@ -1100,12 +1104,11 @@ parse_mpeg2video_pic_start(parser_t *t, parser_es_t *st, int *frametype,
  *
  */
 void
-parser_set_stream_vparam(parser_es_t *st, int width, int height,
-                         int duration)
+parser_set_stream_vparam(parser_es_t *st, int width, int height, int64_t duration)
 {
   int need_save = 0;
 
-  tvhtrace(LS_PARSER, "vparam %02d: w=%d h=%d d=%d (old w=%d h=%d d=%d meta=%d)",
+  tvhtrace(LS_PARSER, "vparam %02d: w=%d h=%d d=%"PRId64" (old w=%d h=%d d=%"PRId64" meta=%d)",
            st->es_index, width, height, duration, st->es_width, st->es_height,
            st->es_frame_duration, st->es_meta_change);
   if(st->es_width == 0 && st->es_height == 0 && st->es_frame_duration < 2) {
@@ -1131,13 +1134,35 @@ parser_set_stream_vparam(parser_es_t *st, int width, int height,
   }
 }
 
+static void
+parser_combine_stream_vparam(parser_es_t *st, int64_t duration) {
 
+  int width  = (st->es_width_2b  << 12) | (st->es_width_12b  & 0xFFFu);
+  int height = (st->es_height_2b << 12) | (st->es_height_12b & 0xFFFu);
+#if ENABLE_LIBAV
+  /* CALCULATE SAR 
+     Now that we have the intended display area, we can refine the SAR 
+     calculation if we already have the DAR from the 0xB3 header. */
+  if (st->es_aspect_num && st->es_aspect_den && width > 0 && height > 0) {
+    // SAR = (DAR_num * display_height) / (DAR_den * display_width)
+    uint32_t sample_aspect_ratio_num = st->es_aspect_num * height;
+    uint32_t sample_aspect_ratio_den = st->es_aspect_den * width;
+    // Note: You should simplify this fraction via GCD.
+    uint32_t v = gcdU32(sample_aspect_ratio_num, sample_aspect_ratio_den);
+    st->es_sample_aspect_ratio.num = sample_aspect_ratio_num / v;
+    st->es_sample_aspect_ratio.den = sample_aspect_ratio_den / v;
+  }
+#endif
+  parser_set_stream_vparam(st, width, height, duration);
+}
+
+/* Standard MPEG-2 DAR table: {numerator, denominator} */
 static const uint8_t mpeg2_aspect[16][2]={
-    {0,1},
-    {1,1},
-    {4,3},
-    {16,9},
-    {221,100},
+    {0,1},      /* Reserved */
+    {1,1},      /* Square Pixels (SAR is 1:1, DAR depends on W/H) */
+    {4,3},      /* 4:3 DAR */
+    {16,9},     /* 16:9 DAR */
+    {221,100},  /* 2.21:1 DAR */
     {0,1},
     {0,1},
     {0,1},
@@ -1153,35 +1178,200 @@ static const uint8_t mpeg2_aspect[16][2]={
 
 
 /**
- * Parse mpeg2video sequence start
+ * @brief Parses the MPEG-2 Video Sequence Header to extract stream metadata.
+ *
+ * This function reads the mandatory fixed-length fields of an MPEG-2 sequence 
+ * start code. It populates the elementary stream (ES) structure with 
+ * resolution, aspect ratio, and frame timing data.
+ *
+ * @param t   Pointer to the global parser state.
+ * @param st  Pointer to the stream-specific context where results are stored.
+ * @param bs  Pointer to the bitstream buffer currently being read.
+ * * @return int PARSER_APPEND on success, or PARSER_RESET if there is insufficient data.
  */
 static int
 parse_mpeg2video_seq_start(parser_t *t, parser_es_t *st,
                            bitstream_t *bs)
 {
-  int width, height, aspect, duration;
-
+  int aspect, duration;
+  /* 1. Check for minimum required bits. 
+     The Sequence Header core (up to VBV size) is 61 bits long.
+     If we have less, we return RESET to wait for more data. */
   if(bs->len < 61)
     return PARSER_RESET;
-  
-  width = read_bits(bs, 12);
-  height = read_bits(bs, 12);
+  /* 2. Read Resolution: 
+     Horizontal and Vertical sizes are 12 bits each in the MPEG-2 spec. */
+  st->es_width_12b = read_bits(bs, 12);
+  st->es_height_12b = read_bits(bs, 12);
+  /* 3. Read Aspect Ratio:
+     A 4-bit index used to determine the Sample or Display aspect ratio. */
   aspect = read_bits(bs, 4);
-
+  /* Look up the actual numerator/denominator from a predefined MPEG-2 table. */
   st->es_aspect_num = mpeg2_aspect[aspect][0];
   st->es_aspect_den = mpeg2_aspect[aspect][1];
-
+  /* 4. Read Frame Rate:
+     A 4-bit 'frame_rate_code'. This is mapped to a duration (likely in 90kHz ticks)
+     using the mpeg2video_framedurations lookup table. */
   duration = mpeg2video_framedurations[read_bits(bs, 4)];
-
+  /* 5. Skip Bit Rate and Marker:
+     - 18 bits for the bit_rate_value.
+     - 1 bit for the marker_bit (always '1' to prevent start-code emulation). */
   skip_bits(bs, 18);
   skip_bits(bs, 1);
   
 #if 0
+  /* Optional: Read VBV Buffer Size (10 bits).
+     VBV (Video Buffering Verifier) ensures the stream doesn't overflow the decoder buffer. */
   int v = read_bits(bs, 10) * 16 * 1024 / 8;
   st->es_vbv_size = v;
 #endif
+  /* 6. Commit Parameters:
+     Update the stream context with the newly parsed width, height, and duration. */
+  parser_combine_stream_vparam(st, duration);
+  /* Return APPEND to signal that parsing of this header is complete. */
+  return PARSER_APPEND;
+}
 
-  parser_set_stream_vparam(st, width, height, duration);
+
+/*
+ * parse_mpeg2video_seq_ext - Parse MPEG-2 sequence_extension (ISO/IEC 13818-2).
+ *
+ * extension_start_code_identifier: 0001 (0x1). Fixed-length syntax: 48 bits
+ * starting at the first bit of that 4-bit identifier (not counting the prior
+ * extension_start_code 0x000001B5 if the caller already consumed it).
+ *
+ * Bitstream layout (MSB-first, order must match the standard):
+ *   - extension_start_code_identifier (4)  -- consumed here via skip_bits(4)
+ *   - profile_and_level_indication (8)
+ *   - progressive_sequence (1)
+ *   - chroma_format (2)  -- value 00 is forbidden in conforming streams
+ *   - horizontal_size_extension (2)
+ *   - vertical_size_extension (2)
+ *   - bit_rate_extension (12)
+ *   - marker_bit (1)  -- shall be 1
+ *   - vbv_buffer_size_extension (8)
+ *   - low_delay (1)
+ *   - frame_rate_extension_n (2)
+ *   - frame_rate_extension_d (5)
+ *
+ * Preconditions:
+ *   - `bs` is positioned at the first bit of extension_start_code_identifier.
+ *   - At least 48 bits are available (returns PARSER_DROP if not).
+ *
+ * Coded picture size:
+ *   Combine with 12-bit horizontal_size_value / vertical_size_value from
+ *   sequence_header (0xB3): full width/height = (ext << 12) | value.
+ *   Extensions may be zero; the formula still applies.
+ *
+ * This implementation only refreshes width/height when either extension
+ * nibble is non-zero and is always applying the OR to achieve a one code
+ * path for all streams.
+ *
+ * Returns PARSER_APPEND on success, PARSER_DROP if the fixed extension
+ * cannot be read in full.
+ */
+static int
+parse_mpeg2video_seq_ext(parser_t *t, parser_es_t *st, bitstream_t *bs)
+{
+  /* 1. Check for minimum required bits. 
+     The Sequence Extension (0x1) is 48 bits long.
+     If we have less, we return PARSER_DROP to wait for more data. */
+  if(bs->len < 48)
+    return PARSER_DROP;
+  /* Skip the 4-bit ID we already read (0x1) */
+  skip_bits(bs, 4); 
+
+  skip_bits(bs, 8); // skip profile_and_level_indication
+  skip_bits(bs, 1); // skip progressive_sequence
+  skip_bits(bs, 2); // skip chroma_format
+  
+  /* Horizontal/Vertical size extensions (2 bits each) 
+     These would be appended to the 12-bit values from 0xB3 */
+  st->es_width_2b  = read_bits(bs, 2);
+  st->es_height_2b = read_bits(bs, 2);
+  skip_bits(bs, 12); // skip bit_rate_extension
+  // marker always 1
+  skip_bits(bs, 1); // skip marker_bit; TODO: maybe we sould check if is '1'
+
+  skip_bits(bs, 8); // skip vbv_buffer_size_extension
+  skip_bits(bs, 1); // skip low_delay
+  skip_bits(bs, 2); // skip frame_rate_extension_n
+  skip_bits(bs, 5); // skip frame_rate_extension_d
+
+  // Update st-> values
+  if (st->es_width_2b || st->es_height_2b) {
+    /* Commit Parameters:
+      Update the stream context with the newly parsed width, height, and duration. */
+    parser_combine_stream_vparam(st, st->es_frame_duration);
+  }
+  
+  /* Return APPEND to signal that parsing of this header is complete. */
+  return PARSER_APPEND; 
+}
+
+
+/*
+ * Parse MPEG-2 sequence_display_extension (ISO/IEC 13818-2, sequence_display_extension).
+ *
+ * Preconditions:
+ *   - bs is positioned at the first bit of extension_start_code_identifier.
+ *   - That identifier is 0x2 (binary 0010) for sequence_display_extension; the caller
+ *     should verify extension_start_code (0x000001B5) and optionally the ID before calling.
+ *
+ * Syntax (fixed part only; no frame_center offsets — those are in picture_display_extension):
+ *   - video_format (3), colour_description (1)
+ *   - if colour_description: colour_primaries (8), transfer_characteristics (8),
+ *     matrix_coefficients (8)
+ *   - display_horizontal_size (14), marker_bit (1), display_vertical_size (14)
+ *
+ * Length: 37 bits without optional colour fields, 61 bits with them (not counting the
+ * 32-bit extension_start_code, which is outside this routine if already consumed).
+ *
+ * Returns PARSER_APPEND on success, PARSER_DROP if insufficient bits remain.
+ */
+static int
+parse_mpeg2video_display_ext(parser_t *t, parser_es_t *st, bitstream_t *bs)
+{
+  /* 1. Check for minimum required bits. 
+     The Display Extension (0x2) is between 37 bits and 61 bits long.
+     If we have less, we return RESET to wait for more data. */
+  if(bs->len < 37)
+    return PARSER_DROP;
+  /* Skip the 4-bit ID (0x2) */
+  skip_bits(bs, 4);
+
+  skip_bits(bs, 3); // skip video_format
+  int colour_description = read_bits(bs, 1);
+
+  if (colour_description) {
+    if (bs->len < 61)
+      return PARSER_DROP;
+    skip_bits(bs, 8); // skip primaries
+    skip_bits(bs, 8); // skip transfer
+    skip_bits(bs, 8); // skip matrix
+  } else {
+    if (bs->len < 37)
+      return PARSER_DROP;
+  }
+
+  /* Extract Display Sizes - 14 bits each */
+  int display_width  = read_bits(bs, 14);
+  skip_bits(bs, 1); // Marker bit; TODO: maybe we sould check if is '1'
+  int display_height = read_bits(bs, 14);
+
+  if (display_width > 0 && display_height > 0) {
+    // update raw fields of es_width and st->es_height
+    st->es_width_12b  = display_width  & 0xFFFu;
+    st->es_height_12b = display_height & 0xFFFu;
+    st->es_width_2b   = (display_width  & 0x3000u) >> 12;
+    st->es_height_2b  = (display_height & 0x3000u) >> 12;
+
+    /* 6. Commit Parameters:
+    Update the stream context with the newly parsed width, height, and duration. */
+    parser_combine_stream_vparam(st, st->es_frame_duration);
+  }
+
+  /* Return APPEND to signal that parsing of this header is complete. */
   return PARSER_APPEND;
 }
 
@@ -1229,6 +1419,21 @@ parser_global_data_move(parser_es_t *st, const uint8_t *data, size_t len, int re
  * 'steal' the st->es_buffer and use it as 'pkt' buffer
  *
  */
+/**
+ * @brief Main reassembly and parsing logic for MPEG-2 Video elementary streams.
+ *
+ * This function processes MPEG-2 start codes to reconstruct frames from slices.
+ * It handles metadata extraction (Sequence, GOP, Extensions) and manages the
+ * lifecycle of media packets (th_pkt_t), including timestamp extrapolation
+ * and payload "stealing" for efficiency.
+ *
+ * @param t               Pointer to the global parser state.
+ * @param st              Pointer to the stream-specific context.
+ * @param len             Length of the current start code's data.
+ * @param next_startcode  The lookahead start code (used to detect frame boundaries).
+ * @param sc_offset       Offset in the stream buffer where the current code starts.
+ * @return int            Parser directive (APPEND, DROP, HEADER, or RESET).
+ */
 static int
 parse_mpeg2video(parser_t *t, parser_es_t *st, size_t len,
                  uint32_t next_startcode, int sc_offset)
@@ -1237,15 +1442,16 @@ parse_mpeg2video(parser_t *t, parser_es_t *st, size_t len,
   bitstream_t bs;
   int frametype;
   th_pkt_t *pkt;
-
+  /* 0x1E0 is the PES start code for Video. If found, signal it's a header. */
   if(next_startcode == 0x1e0)
     return PARSER_HEADER;
-
+  /* Initialize bitstream reader, skipping the 4-byte start code prefix (00 00 01 XX) */
   init_rbits(&bs, buf + 4, (len - 4) * 8);
-
+  /* Switch on the last byte of the start code */
   switch(st->es_startcode & 0xff) {
   case 0xe0 ... 0xef:
-    /* System start codes for video */
+    /* 1. PES/System Start Codes:
+       If we find a PES header, parse it to extract PTS/DTS and reset. */
     if(len < 9)
       return PARSER_RESET;
 
@@ -1253,16 +1459,17 @@ parse_mpeg2video(parser_t *t, parser_es_t *st, size_t len,
     return PARSER_RESET;
 
   case 0x00:
-    /* Picture start code */
+    /* 2. Picture Start Code:
+       Start of a new frame. We need a valid duration before we can proceed. */
     if(st->es_frame_duration == 0)
       return PARSER_RESET;
-
+    /* Extract frame type (I, P, or B) from the picture header. */
     if(parse_mpeg2video_pic_start(t, st, &frametype, &bs) != PARSER_APPEND)
       return PARSER_RESET;
-
+    /* If there was a previous unfinished packet, release it. */
     if(st->es_curpkt != NULL)
       pkt_ref_dec(st->es_curpkt);
-
+    /* Allocate a new packet and populate it with current timing/metadata. */
     pkt = pkt_alloc(st->es_type, NULL, 0, st->es_curpts, st->es_curdts, t->prs_current_pcr);
     pkt->v.pkt_frametype = frametype;
     pkt->pkt_duration = st->es_frame_duration;
@@ -1274,13 +1481,15 @@ parse_mpeg2video(parser_t *t, parser_es_t *st, size_t len,
     if(st->es_curdts != PTS_UNSET)
       st->es_curdts += st->es_frame_duration;
 
-    /* PTS cannot be extrapolated (it's not linear) */
+    /* PTS is non-linear in MPEG-2 (due to B-frame reordering), so we can't extrapolate it. */
     st->es_curpts = PTS_UNSET; 
 
     break;
 
   case 0xb3:
-    /* Sequence start code */
+    /* 3. Sequence Header:
+       Contains critical stream info (Resolution, Aspect Ratio).
+       'parser_global_data_move' saves this as extradata/global header. */
     if(!st->es_buf.sb_err) {
       if(parse_mpeg2video_seq_start(t, st, &bs) != PARSER_APPEND)
         return PARSER_RESET;
@@ -1291,45 +1500,102 @@ parse_mpeg2video(parser_t *t, parser_es_t *st, size_t len,
     return PARSER_DROP;
 
   case 0xb5:
+    /* 4. Extension Header:
+       Check if it's a Sequence Extension (0x1) or Display Extension (0x2). */
     if(len < 5)
       return PARSER_RESET;
     switch(buf[4] >> 4) {
     case 0x1:
       // Sequence Extension
-      if(!st->es_buf.sb_err)
+      /* Fixed (~48 bits from first bit of ID, including marker_bit)*/
+      if(!st->es_buf.sb_err) {
+        if(parse_mpeg2video_seq_ext(t, st, &bs) != PARSER_APPEND)
+          return PARSER_RESET;
         parser_global_data_move(st, buf, len, 0);
+      }
       return PARSER_DROP;
     case 0x2:
       // Sequence Display Extension
-      if(!st->es_buf.sb_err)
+      /* Variable (depends on flags + number_of_frame_center_offsets and optional colour description)*/
+      if(!st->es_buf.sb_err) {
+        if(parse_mpeg2video_display_ext(t, st, &bs) != PARSER_APPEND)
+          return PARSER_RESET;
         parser_global_data_move(st, buf, len, 0);
+      }
       return PARSER_DROP;
+/* other information that can be added later on: 
+  TODO: add data in the future.
+    case 0x03:
+      // Quant Matrix Extension
+      // Variable (depends on which load_*_intra/non_intra flags are set → optional 8×64 matrices)
+      if(!st->es_buf.sb_err) {
+        parser_global_data_move(st, buf, len, 0);
+      }
+    case 0x04:
+      // Copyright extension
+      // Fixed (fixed-width fields)
+    case 0x05:
+      // Sequence scalable extension
+      // Fixed
+      if(!st->es_buf.sb_err) {
+        parser_global_data_move(st, buf, len, 0);
+      }
+    case 0x06:
+      // reserved
+    case 0x07:
+      // Picture display extension
+      // Variable (number_of_frame_center_offsets + repeated offset pairs)
+    case 0x08:
+      // Picture coding extension
+      // Fixed (long but fixed)
+    case 0x09:
+      // Picture spatial scalable extension
+      // Fixed
+    case 0x0A:
+      // Picture temporal scalable extension
+      // Fixed
+    case 0x0B:
+      // Camera parameter extension
+      // Fixed
+    case 0x0C:
+      // ITU-T T.35 extension
+      // Variable (length follows T.35 payload rules)
+    case 0x0D:
+    case 0x0E:
+      // reserved
+    case 0x0F:
+      // forbidden
+*/
     }
     break;
 
   case 0x01 ... 0xaf:
-    /* Slices */
-
+    /* 5. Slices:
+       These contain the actual macroblock data. We stay in this case until 
+       the 'next_startcode' indicates the end of the picture (a new pic or sequence). */
     if(next_startcode == 0x100 || next_startcode > 0x1af) {
-      /* Last picture slice (because next not a slice) */
+      /* This is the final slice of the current frame. */
       th_pkt_t *pkt = st->es_curpkt;
       size_t metalen = 0;
       if(pkt == NULL) {
         /* no packet, may've been discarded by sanity checks here */
         return PARSER_RESET;
       }
-
+      /* Attach accumulated global headers (SPS/PPS/GOP) to this packet's metadata. */
       if(st->es_global_data) {
         pkt->pkt_meta = pktbuf_make(st->es_global_data,
                                     metalen = st->es_global_data_len);
         st->es_global_data = NULL;
         st->es_global_data_len = 0;
       }
-
+      /* Check for stream errors before finalizing payload. */
       if (st->es_buf.sb_err) {
         pkt->pkt_err = st->es_buf.sb_err;
         st->es_buf.sb_err = 0;
       }
+      /* Payload handling:
+         If we have metadata, we must copy everything into a new buffer.
+         Otherwise, we "steal" the internal buffer to avoid a memory copy. */
       if (metalen) {
         pkt->pkt_payload = pktbuf_alloc(NULL, metalen + st->es_buf.sb_ptr - 4);
         memcpy(pktbuf_ptr(pkt->pkt_payload), pktbuf_ptr(pkt->pkt_meta), metalen);
@@ -1340,7 +1606,7 @@ parse_mpeg2video(parser_t *t, parser_es_t *st, size_t len,
         sbuf_steal_data(&st->es_buf);
       }
       pkt->pkt_duration = st->es_frame_duration;
-
+      /* Deliver the packet to the next stage of the pipeline. */
       if (st->es_priv) {
         if (!TAILQ_EMPTY(&st->es_backlog))
           parser_do_backlog(t, st, NULL, pkt->pkt_meta);
@@ -1357,19 +1623,22 @@ parse_mpeg2video(parser_t *t, parser_es_t *st, size_t len,
     break;
 
   case 0xb8:
-    // GOP header
+    /* 6. Group of Pictures (GOP) Header:
+       Store this as global data so it's prepended to the next I-frame. */
     if(!st->es_buf.sb_err)
       parser_global_data_move(st, buf, len, 0);
     return PARSER_DROP;
 
   case 0xb2:
-    // User data
+    /* 7. User Data:
+       Usually contains closed captions or hardware-specific info. 
+       Currently ignored by this switch. */
     break;
 
   default:
     break;
   }
-
+  /* Continue accumulating data until a frame boundary is hit. */
   return PARSER_APPEND;
 }
 

--- a/src/parsers/parsers.h
+++ b/src/parsers/parsers.h
@@ -134,7 +134,7 @@ void parse_mpeg_ts(parser_t *t, parser_es_t *st, const uint8_t *data,
 
 void parser_enqueue_packet(struct service *t, parser_es_t *st, th_pkt_t *pkt);
 
-void parser_set_stream_vparam(parser_es_t *st, int width, int height, int duration);
+void parser_set_stream_vparam(parser_es_t *st, int width, int height, int64_t duration);
 
 extern const unsigned int mpeg2video_framedurations[16];
 

--- a/src/plumbing/globalheaders.c
+++ b/src/plumbing/globalheaders.c
@@ -78,44 +78,91 @@ gh_flush(globalheaders_t *gh)
 
 
 /**
+ * @brief Initializes stream metadata and ensures a global header exists for the component.
  *
+ * This function extracts essential stream parameters (frame duration, audio channels, 
+ * sample rate, and video aspect ratio) from an incoming packet if they are not already 
+ * defined in the streaming start component (ssc).
+ * * It is primarily responsible for ensuring the 'ssc_gh' (Global Header/Extradata) is 
+ * populated. If the packet contains metadata (pkt_meta), it increments the reference 
+ * count and assigns it. 
+ * * Special Case: AAC/MP4A
+ * If an AAC stream lacks a global header, this function manually constructs a 2-byte 
+ * (or 5-byte for SBR) AudioSpecificConfig (AAC-LC) using the packet's sample rate 
+ * index and channel configuration. This is required for many decoders to initialize 
+ * correctly.
+ *
+ * @param ssc  The streaming start component context to be updated.
+ * @param pkt  The input packet containing raw media data and technical attributes.
+ *
+ * @note This function returns immediately if ssc->ssc_gh is already set.
  */
 static void
 apply_header(streaming_start_component_t *ssc, th_pkt_t *pkt)
 {
+  /* 1. Set the elementary stream (ES) frame duration if it hasn't been initialized 
+        yet (is 0) and the incoming packet has a valid duration. */
   if(ssc->es_frame_duration == 0 && pkt->pkt_duration != 0)
     ssc->es_frame_duration = pkt->pkt_duration;
-
+  /* 2. Audio-specific initialization: 
+        If the stream is an audio type and the channel count hasn't been set yet, 
+        copy the channel count and Sample Rate Indices (SRI) from the packet. */
   if(SCT_ISAUDIO(ssc->es_type) && !ssc->es_channels) {
     ssc->es_channels = pkt->a.pkt_channels;
     ssc->es_sri      = pkt->a.pkt_sri;
     ssc->es_ext_sri  = pkt->a.pkt_ext_sri;
   }
-
+  /* 3. Video-specific initialization:
+        If the stream is a video type and the packet contains aspect ratio information,
+        copy the Sample Aspect Ratio (SAR) and Elementary Stream Aspect Ratio to the component. */
   if(SCT_ISVIDEO(ssc->es_type)) {
     if(pkt->v.pkt_aspect_num && pkt->v.pkt_aspect_den) {
+#if ENABLE_LIBAV
+      ssc->es_sample_aspect_ratio.num = pkt->v.pkt_sample_aspect_ratio.num;
+      ssc->es_sample_aspect_ratio.den = pkt->v.pkt_sample_aspect_ratio.den;
+#endif
       ssc->es_aspect_num = pkt->v.pkt_aspect_num;
       ssc->es_aspect_den = pkt->v.pkt_aspect_den;
     }
   }
-
+  /* 4. Global Header (Extradata) Check:
+        If the streaming component already has a global header initialized, 
+        there is no further work to do. */
   if(ssc->ssc_gh != NULL)
     return;
-
+  /* 5. Apply existing packet metadata as the global header:
+        If the packet contains metadata, assign it to the component's global header 
+        and increment the reference counter for the packet buffer to prevent it from 
+        being freed prematurely. */
   if(pkt->pkt_meta != NULL) {
     ssc->ssc_gh = pkt->pkt_meta;
     pktbuf_ref_inc(ssc->ssc_gh);
     return;
   }
-
+  /* 6. Synthesize AAC AudioSpecificConfig:
+        If there was no packet metadata, but the stream is AAC/MP4A, we must manually 
+        generate the MPEG-4 AudioSpecificConfig header required by decoders. */
   if (ssc->es_type == SCT_MP4A || ssc->es_type == SCT_AAC) {
+    /* Allocate 5 bytes if an extended Sample Rate Index (SBR/HE-AAC) exists, otherwise 2 bytes. */
     ssc->ssc_gh = pktbuf_alloc(NULL, pkt->a.pkt_ext_sri ? 5 : 2);
     uint8_t *d = pktbuf_ptr(ssc->ssc_gh);
-
+    /* Hardcode the Audio Object Type to 2 (AAC-LC - Low Complexity) */
     const int profile = 2; /* AAC LC */
+    /* Byte 0: 
+       - Top 5 bits: Audio Object Type (profile << 3)
+       - Bottom 3 bits: Top 3 bits of the 4-bit Sample Rate Index (SRI) */
     d[0] = (profile << 3) | ((pkt->a.pkt_sri & 0xe) >> 1);
+    /* Byte 1:
+       - Top 1 bit: Bottom 1 bit of the 4-bit SRI
+       - Next 4 bits: Channel Configuration (channels << 3)
+       - Bottom 3 bits: 0 (Frame length, DependsOnCoreCoder, ExtensionFlag) */
     d[1] = ((pkt->a.pkt_sri & 0x1) << 7) | (pkt->a.pkt_channels << 3);
+    /* Bytes 2-4: SBR (Spectral Band Replication) Extension signaling for HE-AAC */
     if (pkt->a.pkt_ext_sri) { /* SBR extension */
+      /* Byte 4:
+         - Top 1 bit: 1 (signals SBR is present)
+         - Next 4 bits: The extended Sample Rate Index
+         - Bottom 3 bits: 0 */
       d[2] = 0x56;
       d[3] = 0xe5;
       d[4] = 0x80 | ((pkt->a.pkt_ext_sri - 1) << 3);
@@ -125,7 +172,27 @@ apply_header(streaming_start_component_t *ssc, th_pkt_t *pkt)
 
 
 /**
+ * @brief Validates if sufficient metadata has been collected to initialize the stream.
  *
+ * This function checks the streaming start component (ssc) to ensure that all 
+ * critical parameters required by decoders or muxers have been populated. 
+ * It prevents the stream from starting prematurely with incomplete headers.
+ *
+ * @param ssc           The streaming start component context to validate.
+ * @param not_so_picky  Flag to relax validation. If non-zero, the function will 
+ * ignore missing video dimensions (width/height) and aspect 
+ * ratios, which is useful for certain "raw" or passthrough 
+ * scenarios.
+ *
+ * @return int          Returns 1 if the metadata is complete and the stream can 
+ * proceed; returns 0 if more information is required.
+ *
+ * @note Validation criteria include:
+ * - Existence of frame duration for both audio and video.
+ * - Presence of audio channel configuration for audio streams.
+ * - (If picky) Presence of width, height, and aspect ratio for video streams.
+ * - Presence of a Global Header (extradata) if the codec type requires it 
+ * (checked via gh_require_meta).
  */
 static int
 header_complete(streaming_start_component_t *ssc, int not_so_picky)
@@ -153,47 +220,105 @@ header_complete(streaming_start_component_t *ssc, int not_so_picky)
 
 
 /**
+ * @brief Calculates the time duration (delay) represented by packets in the hold queue.
+ * * This function determines the time spread between the earliest and latest queued 
+ * packets for a specific stream component (identified by `index`). It does this by 
+ * scanning the queue from both ends to find the first and last packets belonging to 
+ * the target stream that have valid Decoding Time Stamps (DTS), and computing the 
+ * difference while accounting for timestamp wraparound.
  *
+ * @param gh Pointer to the global headers context containing the packet hold queue.
+ * @param index The elementary stream (ES) index to calculate the delay for.
+ * @return int64_t The calculated time difference (delay) in DTS units. Returns 0 if 
+ * valid timestamps aren't found, or 1 for special payloadless transcode packets.
  */
 static int64_t
 gh_queue_delay(globalheaders_t *gh, int index)
 {
+  /* Initialize pointers to the first (head) and last (tail) elements of the hold queue */
   th_pktref_t *f = TAILQ_FIRST(&gh->gh_holdq);
   th_pktref_t *l = TAILQ_LAST(&gh->gh_holdq, th_pktref_queue);
   streaming_start_component_t *ssc;
   int64_t diff;
+  int8_t found_f = 0, found_l = 0;
 
   /*
    * Find only packets which require the meta data. Ignore others.
    */
+  /*
+   * 1. Forward Search: Find the EARLIEST packet in the queue for this stream.
+   * Iterate from the front of the queue towards the back. We are looking for the 
+   * first packet that has a valid DTS and belongs to the requested stream index.
+   */
   while (f != l) {
     if (f->pr_pkt->pkt_dts != PTS_UNSET) {
+      /* Retrieve the stream component context using the packet's internal component index */
       ssc = streaming_start_component_find_by_index
               (gh->gh_ss, f->pr_pkt->pkt_componentindex);
-      if (ssc && ssc->es_index == index)
+      /* If the packet belongs to the requested elementary stream index, stop searching */
+      if (ssc && ssc->es_index == index){
+        found_f = 1;
         break;
+      }
     }
+    /* Move to the next packet in the queue */
     f = TAILQ_NEXT(f, pr_link);
   }
+  /*
+   * 2. Backward Search: Find the LATEST packet in the queue for this stream.
+   * Iterate from the back of the queue towards the front. Stop when we find the 
+   * last packet matching our stream index with a valid DTS.
+   */
   while (l != f) {
     if (l->pr_pkt->pkt_dts != PTS_UNSET) {
       ssc = streaming_start_component_find_by_index
               (gh->gh_ss, l->pr_pkt->pkt_componentindex);
-      if (ssc && ssc->es_index == index)
+      if (ssc && ssc->es_index == index){
+        found_l = 1;
         break;
+      }
     }
+    /* Move to the previous packet in the queue */
     l = TAILQ_PREV(l, th_pktref_queue, pr_link);
   }
-
+  /* * 3. Calculate Delay Difference:
+   * If both a first and last packet with valid timestamps were found, compute the delay.
+   */
   if (l->pr_pkt->pkt_dts != PTS_UNSET && f->pr_pkt->pkt_dts != PTS_UNSET) {
-    diff = (l->pr_pkt->pkt_dts & PTS_MASK) - (f->pr_pkt->pkt_dts & PTS_MASK);
+    /* Mask the DTS values (usually 33-bit for MPEG-TS) to drop overflow bits, 
+       then subtract the early timestamp from the late timestamp. */
+    if (found_f && found_l) {
+      /* Calculate raw difference */
+      diff = (l->pr_pkt->pkt_dts & PTS_MASK) - (f->pr_pkt->pkt_dts & PTS_MASK);
+    } else {
+        return 0;
+    }
+    /* Handle Timestamp Rollover/Wraparound: 
+       If the difference is negative, the timestamp counter rolled over its maximum 
+       value (PTS_MASK+1) between the first and last packet. Add the mask to correct it. */
     if (diff < 0)
-      diff += PTS_MASK;
+      /* When a 33-bit counter overflows (wraps around), it goes from the maximum value back to 0. 
+        The total number of unique values in that clock cycle is 233, which is PTS_MASK + 1.*/
+      diff += (int64_t)PTS_MASK + 1;
+    /*  The V4L2/Discontinuity Fix:
+        If the diff is greater than half the mask (roughly 13 hours),
+        it means f was actually significantly ahead of l. 
+        This is usually a startup discontinuity. */
+    if (diff > (PTS_MASK >> 1)) {
+      diff = 0; 
+    }
   } else {
+    /* If no valid matching packets were found, there is no determinable delay. */
     diff = 0;
   }
 
   /* special noop packet from transcoder, increase decision limit */
+  /* * 4. Edge Case - Empty Transcoder Packet:
+   * special noop packet from transcoder, increase decision limit.
+   * If the queue resolved to a single packet (first == last) and it has no actual 
+   * media payload, artificially return a delay of 1. This prevents the system from 
+   * treating it as a standard zero-delay scenario.
+   */
   if (l == f && l->pr_pkt->pkt_payload == NULL)
     return 1;
 

--- a/src/plumbing/tsfix.c
+++ b/src/plumbing/tsfix.c
@@ -596,7 +596,7 @@ tsfix_input_packet(tsfix_t *tf, streaming_message_t *sm)
     }
   }
 
-  int pdur = pkt->pkt_duration >> pkt->v.pkt_field;
+  int64_t pdur = pkt->pkt_duration >> pkt->v.pkt_field;
 
   if (pkt->pkt_dts == PTS_UNSET) {
     if (tfs->tfs_last_dts_in == PTS_UNSET) {
@@ -610,7 +610,7 @@ tsfix_input_packet(tsfix_t *tf, streaming_message_t *sm)
 
     if (pkt->pkt_payload != NULL || pkt->pkt_pts != PTS_UNSET) {
       pkt->pkt_dts = (tfs->tfs_last_dts_in + pdur) & PTS_MASK;
-      tvhtrace(LS_TSFIX, "%-12s DTS set to last %"PRId64" +%d == %"PRId64", PTS = %"PRId64,
+      tvhtrace(LS_TSFIX, "%-12s DTS set to last %"PRId64" +%"PRId64" == %"PRId64", PTS = %"PRId64,
 		streaming_component_type2txt(tfs->tfs_type),
 		tfs->tfs_last_dts_in, pdur, pkt->pkt_dts, pkt->pkt_pts);
     }

--- a/src/service.c
+++ b/src/service.c
@@ -1664,7 +1664,7 @@ void service_save ( service_t *t, htsmsg_t *m )
       if(st->es_height)
 	      htsmsg_add_u32(sub, "height", st->es_height);
       if(st->es_frame_duration)
-        htsmsg_add_u32(sub, "duration", st->es_frame_duration);
+        htsmsg_add_u32(sub, "duration", ((st->es_frame_duration > INT_MAX) ? INT_MAX : (int)st->es_frame_duration));
     }
 
     htsmsg_add_msg(list, NULL, sub);

--- a/src/timeshift.c
+++ b/src/timeshift.c
@@ -51,7 +51,7 @@ timeshift_packet_log0
   th_pkt_t *pkt = sm->sm_data;
   tvhtrace(LS_TIMESHIFT,
            "ts %d pkt %s - stream %d type %c pts %10"PRId64
-           " dts %10"PRId64" dur %10d len %6zu time %14"PRId64,
+           " dts %10"PRId64" dur %10"PRId64" len %6zu time %14"PRId64,
            ts->id, source,
            pkt->pkt_componentindex,
            SCT_ISVIDEO(pkt->pkt_type) ? pkt_frametype_to_char(pkt->v.pkt_frametype) : '-',

--- a/src/transcoding/codec.h
+++ b/src/transcoding/codec.h
@@ -93,6 +93,15 @@ struct tvh_codec_profile {
     double qscale;
     int profile;
     char *device; // for hardware acceleration
+    /**
+     * Support for tvh_context_open_filters2()
+     * @note
+     * int: 
+     * VALUE - support
+     * - 0 - no support (use tvh_context_open_filters())
+     * - 1 - has support for tvh_context_open_filters2()
+     */
+    int has_support_for_filter2;
     LIST_ENTRY(tvh_codec_profile) link;
 };
 

--- a/src/transcoding/codec/codecs/aac.c
+++ b/src/transcoding/codec/codecs/aac.c
@@ -67,14 +67,17 @@ typedef struct {
 static int
 tvh_codec_profile_aac_open(tvh_codec_profile_aac_t *self, AVDictionary **opts)
 {
+    TVHCodecProfile *p = (TVHCodecProfile *)self;
+
     // bit_rate or global_quality
-    if (self->bit_rate) {
-        AV_DICT_SET_BIT_RATE(LST_AAC, opts, self->bit_rate);
+    if (p->bit_rate) {
+        AV_DICT_SET_BIT_RATE(LST_AAC, opts, p->bit_rate);
     }
     else {
-        AV_DICT_SET_GLOBAL_QUALITY(LST_AAC, opts, self->qscale, 1);
+        AV_DICT_SET_GLOBAL_QUALITY(LST_AAC, opts, p->qscale, 1);
     }
     AV_DICT_SET(LST_AAC, opts, "aac_coder", self->coder, 0);
+    p->has_support_for_filter2 = 1;
     return 0;
 }
 

--- a/src/transcoding/codec/codecs/libs/libx26x.c
+++ b/src/transcoding/codec/codecs/libs/libx26x.c
@@ -141,17 +141,21 @@ static int
 tvh_codec_profile_libx264_open(tvh_codec_profile_libx26x_t *self,
                                AVDictionary **opts)
 {
+    TVHCodecProfile *p = (TVHCodecProfile *)self;
+    const TVHVideoCodecProfile *vp = (TVHVideoCodecProfile *)self;
+
     // bit_rate or crf
-    if (self->bit_rate) {
-        AV_DICT_SET_BIT_RATE(LST_LIBX26X, opts, self->bit_rate);
+    if (p->bit_rate) {
+        AV_DICT_SET_BIT_RATE(LST_LIBX26X, opts, p->bit_rate);
     }
     else {
-        AV_DICT_SET_CRF(LST_LIBX26X, opts, self->crf, 15);
+        AV_DICT_SET_CRF(LST_LIBX26X, opts, vp->crf, 15);
     }
     // params
     if (self->params && strlen(self->params)) {
         AV_DICT_SET(LST_LIBX26X, opts, "x264-params", self->params, 0);
     }
+    p->has_support_for_filter2 = 1;
     return 0;
 }
 
@@ -240,17 +244,21 @@ static int
 tvh_codec_profile_libx265_open(tvh_codec_profile_libx26x_t *self,
                                AVDictionary **opts)
 {
+    TVHCodecProfile *p = (TVHCodecProfile *)self;
+    TVHVideoCodecProfile *vp = (TVHVideoCodecProfile *)self;
+
     // bit_rate or crf
-    if (self->bit_rate) {
-        AV_DICT_SET_BIT_RATE(LST_LIBX26X, opts, self->bit_rate);
+    if (p->bit_rate) {
+        AV_DICT_SET_BIT_RATE(LST_LIBX26X, opts, p->bit_rate);
     }
     else {
-        AV_DICT_SET_CRF(LST_LIBX26X, opts, self->crf, 18);
+        AV_DICT_SET_CRF(LST_LIBX26X, opts, vp->crf, 18);
     }
     // params
     if (self->params && strlen(self->params)) {
         AV_DICT_SET(LST_LIBX26X, opts, "x265-params", self->params, 0);
     }
+    p->has_support_for_filter2 = 1;
     return 0;
 }
 

--- a/src/transcoding/codec/codecs/libs/nvenc.c
+++ b/src/transcoding/codec/codecs/libs/nvenc.c
@@ -345,6 +345,10 @@ tvh_codec_profile_nvenc_h264_open(tvh_codec_profile_nvenc_t *self,
     AV_DICT_SET_INT(LST_NVENC, opts, "qcomp", -1, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "bf", 0, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "refs", 0, 0);
+
+    // force keyframe at t=0, t=1s and t=2s (used for flashing the encoder)
+    AV_DICT_SET(LST_NVENC, opts, "force_key_frames", "expr:eq(t,0)+eq(t,1)+eq(t,2)", AV_DICT_DONT_OVERWRITE);
+    ((TVHCodecProfile *)self)->has_support_for_filter2 = 1;
     return 0;
 }
 
@@ -464,6 +468,10 @@ tvh_codec_profile_nvenc_hevc_open(tvh_codec_profile_nvenc_t *self,
     AV_DICT_SET_INT(LST_NVENC, opts, "qcomp", -1, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "bf", 0, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "refs", 0, 0);
+
+    // force keyframe at t=0, t=1s and t=2s (used for flashing the encoder)
+    AV_DICT_SET(LST_NVENC, opts, "force_key_frames", "expr:eq(t,0)+eq(t,1)+eq(t,2)", AV_DICT_DONT_OVERWRITE);
+    ((TVHCodecProfile *)self)->has_support_for_filter2 = 1;
     return 0;
 }
 

--- a/src/transcoding/codec/codecs/libs/vaapi.c
+++ b/src/transcoding/codec/codecs/libs/vaapi.c
@@ -93,6 +93,12 @@
     (vainfo_encoder_maxBfreames(VAINFO_##codec) << UI_MAX_B_FRAMES_OFFSET) + \
     (vainfo_encoder_maxQuality(VAINFO_##codec) << UI_MAX_QUALITY_OFFSET)
 
+enum CODEC{
+    H264 = 1,
+    HEVC = 2,
+    VP8 = 3,
+    VP9 = 4
+};
 /* hts ==================================================================== */
 
 static htsmsg_t *
@@ -224,6 +230,7 @@ typedef struct drm_version {
 
 #define DRM_IOCTL_VERSION _IOWR('d', 0x00, struct drm_version)
 
+/* internal ==================================================================== */
 
 static int
 probe_vaapi_device(const char *device, char *name, size_t namelen)
@@ -308,10 +315,244 @@ static int
 tvh_codec_profile_vaapi_open(tvh_codec_profile_vaapi_t *self,
                              AVDictionary **opts)
 {
+    const TVHVideoCodecProfile *vp = (TVHVideoCodecProfile *)self;
+    
     // pix_fmt
-    AV_DICT_SET_PIX_FMT(LST_VAAPI, opts, self->pix_fmt, AV_PIX_FMT_VAAPI);
+    AV_DICT_SET_PIX_FMT(LST_VAAPI, opts, vp->pix_fmt, AV_PIX_FMT_VAAPI);
     return 0;
 }
+
+/**
+ * Derive VAAPI encoder rate-control numbers from the UI profile and output height.
+ *
+ * Reads @c TVHCodecProfile::bit_rate (kb/s) and @c TVHVideoCodecProfile::size.den
+ * (treated here as the active picture height in pixels), together with
+ * @c tvh_codec_profile_vaapi_t::bit_rate_scale_factor, @c max_bit_rate, and
+ * @c buff_factor. All three outputs are integer values in the same “scaled kb/s”
+ * space the rest of this file uses when passing @c b / @c bufsize / @c maxrate into
+ * libav (see the @c *1024 / @c *2048 factors and the info log that divides by 1024).
+ *
+ * Resolution scaling: relative to a 480-line baseline, the effective target bitrate
+ * is multiplied by @c 1 + bit_rate_scale_factor * (height - 480) / 480 so higher
+ * resolutions increase requested rate and buffer size.
+ *
+ * Buffer size additionally scales by @c buff_factor (forced to @c 3 if unset or
+ * non-positive).
+ *
+ * If the computed average bitrate exceeds the computed max bitrate, logs an error
+ * and raises @p max_bitrate to @p bitrate so the pair is always consistent.
+ *
+ * @param self         VAAPI codec profile (also carries base @c TVHCodecProfile /
+ *                     @c TVHVideoCodecProfile fields).
+ * @param bitrate      Out: scaled average / target bitrate.
+ * @param buffer_size  Out: scaled VBV buffer size (@c bufsize).
+ * @param max_bitrate  Out: scaled peak / max rate; may be bumped up to @p *bitrate.
+ */
+static void
+compute_bitrates(tvh_codec_profile_vaapi_t *self, int *bitrate, int *buffer_size, int *max_bitrate){
+    const TVHCodecProfile *p = (TVHCodecProfile *)self;
+    const TVHVideoCodecProfile *vp = (TVHVideoCodecProfile *)self;
+
+    // to avoid issues we have this check:
+    if (self->buff_factor <= 0) {
+        self->buff_factor = 3;
+    }
+    *bitrate = (int)((p->bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(vp->size.den) - 480.0) / 480.0)));
+    *buffer_size = (int)((p->bit_rate) * 2048.0 * self->buff_factor * (1.0 + self->bit_rate_scale_factor * ((double)(vp->size.den) - 480.0) / 480));
+    *max_bitrate = (int)((self->max_bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(vp->size.den) - 480.0) / 480.0)));
+    // force max_bitrate to be >= with bitrate (to avoid crash)
+    if (*bitrate > *max_bitrate) {
+        tvherror_transcode(LST_VAAPI, "Bitrate %d kbps is greater than Max bitrate %d kbps, increase Max bitrate to %d kbps", 
+            *bitrate / 1024, *max_bitrate / 1024, *bitrate / 1024);
+        *max_bitrate = *bitrate;
+    }
+    tvhinfo_transcode(LST_VAAPI, "Bitrate = %d kbps; Buffer size = %d kbps; Max bitrate = %d kbps", 
+        *bitrate / 1024, *buffer_size / 1024, *max_bitrate / 1024);
+}
+
+/**
+ * Append “baseline” libavcodec / VAAPI encoder options for the unconstrained platform
+ * profile into @p opts.
+ *
+ * All entries use @c AV_DICT_DONT_OVERWRITE so existing dictionary keys win.
+ *
+ * Behavior by @p codec:
+ * - @c VP8 / @c VP9 — if @c loop_filter_level / @c loop_filter_sharpness are @c >= 0,
+ *   set @c loop_filter_level and @c loop_filter_sharpness respectively.
+ * - Any codec — if @c async_depth is non-zero, set @c async_depth.
+ * - @c H264 / @c HEVC — if @c level is not the sentinel @c -100, set @c level.
+ * - Any codec — if @c qmin / @c qmax are non-zero, set @c qmin / @c qmax.
+ *
+ * @param self  VAAPI profile carrying the tuning fields above.
+ * @param opts  Target option dictionary for @c avcodec_open2 (or helper that forwards it).
+ * @param codec Which elementary codec is being configured (@c H264, @c HEVC, @c VP8, @c VP9, …).
+ * @return      Always @c 0 (no failure path).
+ */
+static int
+setup_baseline_opts_unconstrained(const tvh_codec_profile_vaapi_t *self, AVDictionary **opts, enum CODEC codec){
+    if (codec == VP8 || codec == VP9) {
+        if (self->loop_filter_level >= 0) {
+            AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_level", self->loop_filter_level, AV_DICT_DONT_OVERWRITE);
+        }
+        if (self->loop_filter_sharpness >= 0) {
+            AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_sharpness", self->loop_filter_sharpness, AV_DICT_DONT_OVERWRITE);
+        }
+    }
+    if (self->async_depth) {
+        AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
+    }
+    if ((codec == H264 || codec == HEVC) &&
+        self->level != -100) {
+            AV_DICT_SET_INT(LST_VAAPI, opts, "level", self->level, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->qmin) {
+        AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->qmax) {
+        AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
+    }
+    return 0;
+}
+
+/**
+ * Push rate-control and fixed-QP libavcodec options into @p opts for the unconstrained
+ * VAAPI platform path.
+ *
+ * Uses @c AV_DICT_DONT_OVERWRITE on every key so callers can pre-seed the dictionary.
+ *
+ * - If the base profile has a non-zero @c bit_rate (@c TVHCodecProfile), sets
+ *   @c b to @p bitrate and @c bufsize to @p buffer_size (typically produced by
+ *   @ref compute_bitrates).
+ * - If @c max_bit_rate on the VAAPI profile is non-zero, sets @c maxrate to @p max_bitrate.
+ * - If @c qp on the VAAPI profile is non-zero, sets @c qp.
+ *
+ * @param self         VAAPI codec profile (and embedded @c TVHCodecProfile).
+ * @param opts         Encoder option dictionary.
+ * @param bitrate      Target average bitrate for @c b (same units as @ref compute_bitrates).
+ * @param buffer_size  VBV buffer size for @c bufsize.
+ * @param max_bitrate  Peak bitrate for @c maxrate.
+ * @return             Always @c 0 (no failure path in this helper).
+ */
+static int
+setup_bitrate_qp_opts_unconstrained(const tvh_codec_profile_vaapi_t *self, AVDictionary **opts, int bitrate, int buffer_size, int max_bitrate){
+    const TVHCodecProfile *p = (TVHCodecProfile *)self;
+
+    if (p->bit_rate) {
+        AV_DICT_SET_INT(LST_VAAPI, opts, "b", bitrate, AV_DICT_DONT_OVERWRITE);
+        AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", buffer_size, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->max_bit_rate) {
+        AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", max_bitrate, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->qp) {
+        AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+    }
+    return 0;
+}
+
+/**
+ * Layered helper for the unconstrained VAAPI platform: applies bitrate / QP options,
+ * then a few codec-specific toggles, then baseline tuning.
+ *
+ * Steps:
+ * 1. @ref setup_bitrate_qp_opts_unconstrained — forwards @p bitrate, @p buffer_size,
+ *    and @p max_bitrate into @c b / @c bufsize / @c maxrate (and optional @c qp).
+ * 2. @c HEVC only — if @c tier >= 0, sets @c tier.
+ * 3. If @c quality >= 0, sets @c quality.
+ * 4. @c VP8 / @c VP9 only — if @c global_quality >= 0, sets @c global_quality.
+ * 5. If @c low_power is non-zero, sets @c low_power.
+ * 6. @ref setup_baseline_opts_unconstrained — note: this is invoked with a hard-coded
+ *    @c H264 @p codec argument, not the outer @p codec, so VP9/HEVC baseline fields
+ *    (e.g. @c level / @c qmin) follow the H264 branch rules inside that helper.
+ *
+ * @param self         VAAPI profile.
+ * @param opts         Encoder option dictionary.
+ * @param codec        Elementary codec being opened (@c HEVC, @c VP8, @c VP9, …).
+ * @param bitrate      Passed through to @ref setup_bitrate_qp_opts_unconstrained.
+ * @param buffer_size  Passed through to @ref setup_bitrate_qp_opts_unconstrained.
+ * @param max_bitrate  Passed through to @ref setup_bitrate_qp_opts_unconstrained.
+ * @return             @c 0 on success; otherwise the first non-zero return from a callee
+ *                     (today only the baseline helper can propagate, and it always returns 0).
+ */
+static int
+setup_common_opts_unconstrained(const tvh_codec_profile_vaapi_t *self, AVDictionary **opts, enum CODEC codec, int bitrate, int buffer_size, int max_bitrate){
+    int ret = 0;
+
+    if ((ret = setup_bitrate_qp_opts_unconstrained(self, opts, bitrate, buffer_size, max_bitrate))) {
+        return ret;
+    }
+
+    if ((codec == HEVC) &&
+        self->tier >= 0) {
+            AV_DICT_SET_INT(LST_VAAPI, opts, "tier", self->tier, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->quality >= 0) {
+        AV_DICT_SET_INT(LST_VAAPI, opts, "quality", self->quality, AV_DICT_DONT_OVERWRITE);
+    }
+    if ((codec == VP8 || codec == VP9) &&
+        self->global_quality >= 0) {
+            AV_DICT_SET_INT(LST_VAAPI, opts, "global_quality", self->global_quality, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->low_power) {
+        AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
+    }
+    if ((ret = setup_baseline_opts_unconstrained(self, opts, codec))) {
+        return ret;
+    }
+    return 0;
+}
+
+/**
+ * Populate @p opts for @c VAAPI_ENC_PLATFORM_UNCONSTRAINED: “anything goes” mode for
+ * new platforms or debugging (invalid combinations are not filtered here).
+ *
+ * Does the following in order:
+ * - If @c b_reference is non-zero, set @c b_depth.
+ * - If @c desired_b_depth >= 0, set @c bf (max B-frames).
+ * - For @c VP8 or @c VP9, if @c super_frame is enabled, set @c bsf to
+ *   @c "vp9_raw_reorder,vp9_superframe" (per FFmpeg VAAPI VP9 notes).
+ * - Calls @ref setup_common_opts_unconstrained with a hard-coded @c H264 @c codec
+ *   argument for the inner layer—not the outer @p codec—so the common / baseline
+ *   branch behaves like the H264 path regardless of whether you are configuring
+ *   VP9, HEVC, etc. (worth revisiting if that is unintentional).
+ *
+ * @param self         VAAPI profile.
+ * @param opts         Encoder option dictionary.
+ * @param codec        Which codec is being set up (@c H264, @c HEVC, @c VP8, @c VP9, …);
+ *                     only affects the VP super-frame @c bsf branch today.
+ * @param bitrate      Passed through to @ref setup_common_opts_unconstrained.
+ * @param buffer_size  Passed through to @ref setup_common_opts_unconstrained.
+ * @param max_bitrate  Passed through to @ref setup_common_opts_unconstrained.
+ * @return             @c 0 on success, or the first non-zero return from the common
+ *                     helper (currently always @c 0 from downstream helpers).
+ */
+static int
+setup_opts_unconstrained(const tvh_codec_profile_vaapi_t *self, AVDictionary **opts, enum CODEC codec, int bitrate, int buffer_size, int max_bitrate){
+    int ret = 0;
+
+    // Uncontrained --> will allow any combination of parameters (valid or invalid)
+    // this mode is useful for future platform and for debugging.
+    if (self->b_reference) {
+        // b_depth
+        AV_DICT_SET_INT(LST_VAAPI, opts, "b_depth", self->b_reference, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->desired_b_depth >= 0) {
+        // max_b_frames
+        AV_DICT_SET_INT(LST_VAAPI, opts, "bf", self->desired_b_depth, AV_DICT_DONT_OVERWRITE);
+    }
+    if ((codec == VP8 || codec == VP9) &&
+        self->super_frame) {
+            // according to example from https://trac.ffmpeg.org/wiki/Hardware/VAAPI
+            // -bsf:v vp9_raw_reorder,vp9_superframe
+            AV_DICT_SET(LST_VAAPI, opts, "bsf", "vp9_raw_reorder,vp9_superframe", AV_DICT_DONT_OVERWRITE);
+    }
+    if ((ret = setup_common_opts_unconstrained(self, opts, codec, bitrate, buffer_size, max_bitrate))) {
+        return ret;
+    }
+    return 0;
+}
+
+/* external ==================================================================== */
 
 // NOTE:
 // the names below are used in codec.js (/src/webui/static/app/codec.js)
@@ -535,114 +776,22 @@ static int
 tvh_codec_profile_vaapi_h264_open(tvh_codec_profile_vaapi_t *self,
                                   AVDictionary **opts)
 {
-    // to avoid issues we have this check:
-    if (self->buff_factor <= 0) {
-        self->buff_factor = 3;
-    }
-    int int_bitrate = (int)((double)(self->bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
-    int int_buffer_size = (int)((double)(self->bit_rate) * 2048.0 * self->buff_factor * (1.0 + self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480));
-    int int_max_bitrate = (int)((double)(self->max_bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
-    // force max_bitrate to be >= with bitrate (to avoid crash)
-    if (int_bitrate > int_max_bitrate) {
-        tvherror_transcode(LST_VAAPI, "Bitrate %d kbps is greater than Max bitrate %d kbps, increase Max bitrate to %d kbps", int_bitrate / 1024, int_max_bitrate / 1024, int_bitrate / 1024);
-        int_max_bitrate = int_bitrate;
-    }
-    tvhinfo_transcode(LST_VAAPI, "Bitrate = %d kbps; Buffer size = %d kbps; Max bitrate = %d kbps", int_bitrate / 1024, int_buffer_size / 1024, int_max_bitrate / 1024);
-    // https://wiki.libav.org/Hardware/vaapi
-    // https://blog.wmspanel.com/2017/03/vaapi-libva-support-nimble-streamer.html
-    // to find available parameters use:
-    // ffmpeg -hide_banner -h encoder=h264_vaapi
-    // h264_vaapi AVOptions:
-    // -low_power         <boolean>    E..V....... Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
-    // -idr_interval      <int>        E..V....... Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
-    // -b_depth           <int>        E..V....... Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
-    // -rc_mode           <int>        E..V....... Set rate control mode (from 0 to 6) (default auto)
-    //    auto            0            E..V....... Choose mode automatically based on other parameters
-    //    CQP             1            E..V....... Constant-quality
-    //    CBR             2            E..V....... Constant-bitrate
-    //    VBR             3            E..V....... Variable-bitrate
-    //    ICQ             4            E..V....... Intelligent constant-quality
-    //    QVBR            5            E..V....... Quality-defined variable-bitrate
-    //    AVBR            6            E..V....... Average variable-bitrate
-    // -qp                <int>        E..V....... Constant QP (for P-frames; scaled by qfactor/qoffset for I/B) (from 0 to 52) (default 0)
-    // -quality           <int>        E..V....... Set encode quality (trades off against speed, higher is faster) (from -1 to INT_MAX) (default -1)
-    // -coder             <int>        E..V....... Entropy coder type (from 0 to 1) (default cabac)
-    //    cavlc           0            E..V.......
-    //    cabac           1            E..V.......
-    //    vlc             0            E..V.......
-    //    ac              1            E..V.......
-    // -aud               <boolean>    E..V....... Include AUD (default false)
-    // -sei               <flags>      E..V....... Set SEI to include (default identifier+timing+recovery_point)
-    //    identifier                   E..V....... Include encoder version identifier
-    //    timing                       E..V....... Include timing parameters (buffering_period and pic_timing)
-    //    recovery_point               E..V....... Include recovery points where appropriate
-    // -profile           <int>        E..V....... Set profile (profile_idc and constraint_set*_flag) (from -99 to 65535) (default -99)
-    //    constrained_baseline 578          E..V.......
-    //    main            77           E..V.......
-    //    high            100          E..V.......
-    // -level             <int>        E..V....... Set level (level_idc) (from -99 to 255) (default -99)
-    //    1               10           E..V.......
-    //    1.1             11           E..V.......
-    //    1.2             12           E..V.......
-    //    1.3             13           E..V.......
-    //    2               20           E..V.......
-    //    2.1             21           E..V.......
-    //    2.2             22           E..V.......
-    //    3               30           E..V.......
-    //    3.1             31           E..V.......
-    //    3.2             32           E..V.......
-    //    4               40           E..V.......
-    //    4.1             41           E..V.......
-    //    4.2             42           E..V.......
-    //    5               50           E..V.......
-    //    5.1             51           E..V.......
-    //    5.2             52           E..V.......
-    //    6               60           E..V.......
-    //    6.1             61           E..V.......
-    //    6.2             62           E..V.......
+    TVHCodecProfile *p = (TVHCodecProfile *)self;
+    int int_bitrate = 0;
+    int int_buffer_size = 0;
+    int int_max_bitrate = 0;
+    int ret = 0;
+
+    compute_bitrates(self, &int_bitrate, &int_buffer_size, &int_max_bitrate);
+
     if (self->rc_mode != VAAPI_ENC_PARAMS_RC_SKIP) {
         AV_DICT_SET_INT(LST_VAAPI, opts, "rc_mode", self->rc_mode, AV_DICT_DONT_OVERWRITE);
     }
     int tempSupport = 0;
     switch (self->platform) {
         case VAAPI_ENC_PLATFORM_UNCONSTRAINED:
-            // Uncontrained --> will allow any combination of parameters (valid or invalid)
-            // this mode is useful for future platform and for debugging.
-            if (self->b_reference) {
-                // b_depth
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b_depth", self->b_reference, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->desired_b_depth >= 0) {
-                // max_b_frames
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bf", self->desired_b_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->max_bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qp) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "quality", self->quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->low_power) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->level != -100) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "level", self->level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_opts_unconstrained(self, opts, H264, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                return ret;
             }
             break;
         case VAAPI_ENC_PLATFORM_INTEL:
@@ -673,15 +822,8 @@ tvh_codec_profile_vaapi_h264_open(tvh_codec_profile_vaapi_t *self,
                     // same like 0 but is not sending 'rc_mode'
                 case VAAPI_ENC_PARAMS_RC_AUTO:
                     // for auto --> let the driver decide as requested by documentation
-                    if (self->bit_rate) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-                    }
-                    if (self->max_bit_rate) {
-                            AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-                        }
-                    if (self->qp) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+                    if ((ret = setup_bitrate_qp_opts_unconstrained(self, opts, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                        return ret;
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_CONSTQP:
@@ -693,14 +835,14 @@ tvh_codec_profile_vaapi_h264_open(tvh_codec_profile_vaapi_t *self,
                     break;
                 case VAAPI_ENC_PARAMS_RC_CBR:
                     // for constant bitrate: CBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_VBR:
                     // for variable bitrate: VBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
@@ -708,18 +850,13 @@ tvh_codec_profile_vaapi_h264_open(tvh_codec_profile_vaapi_t *self,
                     break;
                 case VAAPI_ENC_PARAMS_RC_QVBR:
                     // for variable bitrate: QVBR we use bitrate + qp
-                    if (self->bit_rate && self->buff_factor) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-                    }
-                    if (self->qp) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+                    if ((ret = setup_bitrate_qp_opts_unconstrained(self, opts, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                        return ret;
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_AVBR:
                     // for variable bitrate: AVBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
                     }
@@ -737,54 +874,23 @@ tvh_codec_profile_vaapi_h264_open(tvh_codec_profile_vaapi_t *self,
             if (self->low_power) {
                 AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
             }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->level != -100) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "level", self->level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_baseline_opts_unconstrained(self, opts, H264))) {
+                return ret;
             }
             break;
         case VAAPI_ENC_PLATFORM_AMD:
             // AMD --> will allow any combination of parameters
             // I am unable to confirm this platform because I don't have the HW
             // Is only going to override bf to 0 (as highlited by the previous implementation)
-            if (self->bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->max_bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qp) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_common_opts_unconstrained(self, opts, H264, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                return ret;
             }
             AV_DICT_SET_INT(LST_VAAPI, opts, "bf", 0, 0);
-            if (self->quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "quality", self->quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->low_power) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->level != -100) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "level", self->level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
-            }
             break;
     }
+    // force keyframe at t=0 and t=1s (used for flashing the encoder)
+    AV_DICT_SET(LST_VAAPI, opts, "force_key_frames", "expr:eq(t,0)+eq(t,1)", AV_DICT_DONT_OVERWRITE);
+    p->has_support_for_filter2 = 1;
     return 0;
 }
 
@@ -858,106 +964,21 @@ static int
 tvh_codec_profile_vaapi_hevc_open(tvh_codec_profile_vaapi_t *self,
                                   AVDictionary **opts)
 {
-    // to avoid issues we have this check:
-    if (self->buff_factor <= 0) {
-        self->buff_factor = 3;
-    }
-    int int_bitrate = (int)((double)(self->bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
-    int int_buffer_size = (int)((double)(self->bit_rate) * 2048.0 * self->buff_factor * (1.0 + self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480));
-    int int_max_bitrate = (int)((double)(self->max_bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
-    // force max_bitrate to be >= with bitrate (to avoid crash)
-    if (int_bitrate > int_max_bitrate) {
-        tvherror_transcode(LST_VAAPI, "Bitrate %d kbps is greater than Max bitrate %d kbps, increase Max bitrate to %d kbps", int_bitrate / 1024, int_max_bitrate / 1024, int_bitrate / 1024);
-        int_max_bitrate = int_bitrate;
-    }
-    tvhinfo_transcode(LST_VAAPI, "Bitrate = %d kbps; Buffer size = %d kbps; Max bitrate = %d kbps", int_bitrate / 1024, int_buffer_size / 1024, int_max_bitrate / 1024);
-    // https://wiki.libav.org/Hardware/vaapi
-    // to find available parameters use:
-    // ffmpeg -hide_banner -h encoder=hevc_vaapi
-    //   h265_vaapi AVOptions:
-    // -low_power         <boolean>    E..V....... Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
-    // -idr_interval      <int>        E..V....... Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
-    // -b_depth           <int>        E..V....... Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
-    // -rc_mode           <int>        E..V....... Set rate control mode (from 0 to 6) (default auto)
-    //    auto            0            E..V....... Choose mode automatically based on other parameters
-    //    CQP             1            E..V....... Constant-quality
-    //    CBR             2            E..V....... Constant-bitrate
-    //    VBR             3            E..V....... Variable-bitrate
-    //    ICQ             4            E..V....... Intelligent constant-quality
-    //    QVBR            5            E..V....... Quality-defined variable-bitrate
-    //    AVBR            6            E..V....... Average variable-bitrate
-    // -qp                <int>        E..V....... Constant QP (for P-frames; scaled by qfactor/qoffset for I/B) (from 0 to 52) (default 0)
-    // -aud               <boolean>    E..V....... Include AUD (default false)
-    // -profile           <int>        E..V....... Set profile (general_profile_idc) (from -99 to 255) (default -99)
-    //    main            1            E..V.......
-    //    main10          2            E..V.......
-    //    rext            4            E..V.......
-    // -tier              <int>        E..V....... Set tier (general_tier_flag) (from 0 to 1) (default main)
-    //    main            0            E..V.......
-    //    high            1            E..V.......
-    // -level             <int>        E..V....... Set level (general_level_idc) (from -99 to 255) (default -99)
-    //    1               30           E..V.......
-    //    2               60           E..V.......
-    //    2.1             63           E..V.......
-    //    3               90           E..V.......
-    //    3.1             93           E..V.......
-    //    4               120          E..V.......
-    //    4.1             123          E..V.......
-    //    5               150          E..V.......
-    //    5.1             153          E..V.......
-    //    5.2             156          E..V.......
-    //    6               180          E..V.......
-    //    6.1             183          E..V.......
-    //    6.2             186          E..V.......
-    // -sei               <flags>      E..V....... Set SEI to include (default hdr)
-    //    hdr                          E..V....... Include HDR metadata for mastering display colour volume and content light level information
-    // -tiles             <image_size> E..V....... Tile columns x rows
+    TVHCodecProfile *p = (TVHCodecProfile *)self;
+    int int_bitrate = 0;
+    int int_buffer_size = 0;
+    int int_max_bitrate = 0;
+    int ret = 0;
+
+    compute_bitrates(self, &int_bitrate, &int_buffer_size, &int_max_bitrate);
 
     if (self->rc_mode != VAAPI_ENC_PARAMS_RC_SKIP) {
         AV_DICT_SET_INT(LST_VAAPI, opts, "rc_mode", self->rc_mode, AV_DICT_DONT_OVERWRITE);
     }
     switch (self->platform) {
         case VAAPI_ENC_PLATFORM_UNCONSTRAINED:
-            // Unconstrained --> will allow any combination of parameters (valid or invalid)
-            // this mode is useful for future platform and for debugging.
-            if (self->b_reference) {
-                // b_depth
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b_depth", self->b_reference, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->desired_b_depth >= 0) {
-                // max_b_frames
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bf", self->desired_b_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->max_bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qp) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->tier >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "tier", self->tier, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "quality", self->quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->low_power) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->level != -100) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "level", self->level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_opts_unconstrained(self, opts, HEVC, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                return ret;
             }
             break;
         case VAAPI_ENC_PLATFORM_INTEL:
@@ -975,15 +996,8 @@ tvh_codec_profile_vaapi_hevc_open(tvh_codec_profile_vaapi_t *self,
                     // same like 0 but is not sending 'rc_mode'
                 case VAAPI_ENC_PARAMS_RC_AUTO:
                     // for auto --> let the driver decide as requested by documentation
-                    if (self->bit_rate) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-                    }
-                    if (self->max_bit_rate) {
-                            AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-                        }
-                    if (self->qp) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+                    if ((ret = setup_bitrate_qp_opts_unconstrained(self, opts, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                        return ret;
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_CONSTQP:
@@ -995,14 +1009,14 @@ tvh_codec_profile_vaapi_hevc_open(tvh_codec_profile_vaapi_t *self,
                     break;
                 case VAAPI_ENC_PARAMS_RC_CBR:
                     // for constant bitrate: CBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_VBR:
                     // for variable bitrate: VBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
@@ -1010,18 +1024,13 @@ tvh_codec_profile_vaapi_hevc_open(tvh_codec_profile_vaapi_t *self,
                     break;
                 case VAAPI_ENC_PARAMS_RC_QVBR:
                     // for variable bitrate: QVBR we use bitrate + qp
-                    if (self->bit_rate && self->buff_factor) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-                    }
-                    if (self->qp) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+                    if ((ret = setup_bitrate_qp_opts_unconstrained(self, opts, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                        return ret;
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_AVBR:
                     // for variable bitrate: AVBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
                     }
@@ -1036,57 +1045,23 @@ tvh_codec_profile_vaapi_hevc_open(tvh_codec_profile_vaapi_t *self,
             if (self->low_power) {
                 AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
             }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->level != -100) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "level", self->level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_baseline_opts_unconstrained(self, opts, HEVC))) {
+                return ret;
             }
             break;
         case VAAPI_ENC_PLATFORM_AMD:
             // AMD --> will allow any combination of parameters
             // I am unable to confirm this platform because I don't have the HW
             // Is only going to override bf to 0 (as highlited by the previous implementation)
-            if (self->bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->max_bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qp) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_common_opts_unconstrained(self, opts, HEVC, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                return ret;
             }
             AV_DICT_SET_INT(LST_VAAPI, opts, "bf", 0, 0);
-            if (self->tier >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "tier", self->tier, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "quality", self->quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->low_power) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->level != -100) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "level", self->level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
-            }
             break;
     }
+    // force keyframe at t=0 and t=1s (used for flashing the encoder)
+    AV_DICT_SET(LST_VAAPI, opts, "force_key_frames", "expr:eq(t,0)+eq(t,1)", AV_DICT_DONT_OVERWRITE);
+    p->has_support_for_filter2 = 1;
     return 0;
 }
 
@@ -1168,85 +1143,21 @@ static int
 tvh_codec_profile_vaapi_vp8_open(tvh_codec_profile_vaapi_t *self,
                                   AVDictionary **opts)
 {
-    // to avoid issues we have this check:
-    if (self->buff_factor <= 0) {
-        self->buff_factor = 3;
-    }
-    int int_bitrate = (int)((double)(self->bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
-    int int_buffer_size = (int)((double)(self->bit_rate) * 2048.0 * self->buff_factor * (1.0 + self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480));
-    int int_max_bitrate = (int)((double)(self->max_bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
-    // force max_bitrate to be >= with bitrate (to avoid crash)
-    if (int_bitrate > int_max_bitrate) {
-        tvherror_transcode(LST_VAAPI, "Bitrate %d kbps is greater than Max bitrate %d kbps, increase Max bitrate to %d kbps", int_bitrate / 1024, int_max_bitrate / 1024, int_bitrate / 1024);
-        int_max_bitrate = int_bitrate;
-    }
-    tvhinfo_transcode(LST_VAAPI, "Bitrate = %d kbps; Buffer size = %d kbps; Max bitrate = %d kbps", int_bitrate / 1024, int_buffer_size / 1024, int_max_bitrate / 1024);
-    // https://wiki.libav.org/Hardware/vaapi
-    // to find available parameters use:
-    // ffmpeg -hide_banner -h encoder=vp8_vaapi
-    //   vp8_vaapi AVOptions:
-    // -low_power         <boolean>    E..V....... Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
-    // -idr_interval      <int>        E..V....... Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
-    // -b_depth           <int>        E..V....... Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
-    // -rc_mode           <int>        E..V....... Set rate control mode (from 0 to 6) (default auto)
-    //    auto            0            E..V....... Choose mode automatically based on other parameters
-    //    CQP             1            E..V....... Constant-quality
-    //    CBR             2            E..V....... Constant-bitrate
-    //    VBR             3            E..V....... Variable-bitrate
-    //    ICQ             4            E..V....... Intelligent constant-quality
-    //    QVBR            5            E..V....... Quality-defined variable-bitrate
-    //    AVBR            6            E..V....... Average variable-bitrate
-    // -loop_filter_level <int>        E..V....... Loop filter level (from 0 to 63) (default 16)
-    // -loop_filter_sharpness <int>        E..V....... Loop filter sharpness (from 0 to 15) (default 4)
+    TVHCodecProfile *p = (TVHCodecProfile *)self;
+    int int_bitrate = 0;
+    int int_buffer_size = 0;
+    int int_max_bitrate = 0;
+    int ret = 0;
+
+    compute_bitrates(self, &int_bitrate, &int_buffer_size, &int_max_bitrate);
 
     if (self->rc_mode != VAAPI_ENC_PARAMS_RC_SKIP) {
         AV_DICT_SET_INT(LST_VAAPI, opts, "rc_mode", self->rc_mode, AV_DICT_DONT_OVERWRITE);
     }
     switch (self->platform) {
         case VAAPI_ENC_PLATFORM_UNCONSTRAINED:
-            // Unconstrained --> will allow any combination of parameters (valid or invalid)
-            // this mode is useful for future platform and for debugging.
-            if (self->b_reference) {
-                // b_depth
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b_depth", self->b_reference, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->desired_b_depth >= 0) {
-                // max_b_frames
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bf", self->desired_b_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->max_bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qp) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "quality", self->quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->global_quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "global_quality", self->global_quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->low_power) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_level >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_level", self->loop_filter_level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_sharpness >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_sharpness", self->loop_filter_sharpness, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_opts_unconstrained(self, opts, VP8, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                return ret;
             }
             break;
         case VAAPI_ENC_PLATFORM_INTEL:
@@ -1270,15 +1181,8 @@ tvh_codec_profile_vaapi_vp8_open(tvh_codec_profile_vaapi_t *self,
                     // same like 0 but is not sending 'rc_mode'
                 case VAAPI_ENC_PARAMS_RC_AUTO:
                     // for auto --> let the driver decide as requested by documentation
-                    if (self->bit_rate) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-                    }
-                    if (self->max_bit_rate) {
-                            AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-                        }
-                    if (self->qp) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+                    if ((ret = setup_bitrate_qp_opts_unconstrained(self, opts, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                        return ret;
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_CONSTQP:
@@ -1290,14 +1194,14 @@ tvh_codec_profile_vaapi_vp8_open(tvh_codec_profile_vaapi_t *self,
                     break;
                 case VAAPI_ENC_PARAMS_RC_CBR:
                     // for constant bitrate: CBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_VBR:
                     // for variable bitrate: VBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
@@ -1305,18 +1209,13 @@ tvh_codec_profile_vaapi_vp8_open(tvh_codec_profile_vaapi_t *self,
                     break;
                 case VAAPI_ENC_PARAMS_RC_QVBR:
                     // for variable bitrate: QVBR we use bitrate + qp
-                    if (self->bit_rate && self->buff_factor) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-                    }
-                    if (self->qp) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+                    if ((ret = setup_bitrate_qp_opts_unconstrained(self, opts, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                        return ret;
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_AVBR:
                     // for variable bitrate: AVBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
                     }
@@ -1325,63 +1224,24 @@ tvh_codec_profile_vaapi_vp8_open(tvh_codec_profile_vaapi_t *self,
             if (self->low_power) {
                 AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
             }
-            if (self->loop_filter_level >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_level", self->loop_filter_level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_sharpness >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_sharpness", self->loop_filter_sharpness, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_baseline_opts_unconstrained(self, opts, VP8))) {
+                return ret;
             }
             break;
         case VAAPI_ENC_PLATFORM_AMD:
             // AMD --> will allow any combination of parameters
             // I am unable to confirm this platform because I don't have the HW
             // Is only going to override bf to 0 (as highlited by the previous implementation)
-            if (self->bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->max_bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qp) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_common_opts_unconstrained(self, opts, VP8, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                return ret;
             }
             AV_DICT_SET_INT(LST_VAAPI, opts, "bf", 0, 0);
-            if (self->quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "quality", self->quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->global_quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "global_quality", self->global_quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->low_power) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_level >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_level", self->loop_filter_level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_sharpness >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_sharpness", self->loop_filter_sharpness, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
-            }
+
             break;
     }
+    // force keyframe at t=0 and t=1s (used for flashing the encoder)
+    AV_DICT_SET(LST_VAAPI, opts, "force_key_frames", "expr:eq(t,0)+eq(t,1)", AV_DICT_DONT_OVERWRITE);
+    p->has_support_for_filter2 = 1;
     return 0;
 }
 
@@ -1474,90 +1334,21 @@ static int
 tvh_codec_profile_vaapi_vp9_open(tvh_codec_profile_vaapi_t *self,
                                   AVDictionary **opts)
 {
-    // to avoid issues we have this check:
-    if (self->buff_factor <= 0) {
-        self->buff_factor = 3;
-    }
-    int int_bitrate = (int)((double)(self->bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
-    int int_buffer_size = (int)((double)(self->bit_rate) * 2048.0 * self->buff_factor * (1.0 + self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480));
-    int int_max_bitrate = (int)((double)(self->max_bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
-    // force max_bitrate to be >= with bitrate (to avoid crash)
-    if (int_bitrate > int_max_bitrate) {
-        tvherror_transcode(LST_VAAPI, "Bitrate %d kbps is greater than Max bitrate %d kbps, increase Max bitrate to %d kbps", int_bitrate / 1024, int_max_bitrate / 1024, int_bitrate / 1024);
-        int_max_bitrate = int_bitrate;
-    }
-    tvhinfo_transcode(LST_VAAPI, "Bitrate = %d kbps; Buffer size = %d kbps; Max bitrate = %d kbps", int_bitrate / 1024, int_buffer_size / 1024, int_max_bitrate / 1024);
-    // https://wiki.libav.org/Hardware/vaapi
-    // to find available parameters use:
-    // ffmpeg -hide_banner -h encoder=vp9_vaapi
-    //   vp9_vaapi AVOptions:
-    // -low_power         <boolean>    E..V....... Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
-    // -idr_interval      <int>        E..V....... Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
-    // -b_depth           <int>        E..V....... Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
-    // -rc_mode           <int>        E..V....... Set rate control mode (from 0 to 6) (default auto)
-    //    auto            0            E..V....... Choose mode automatically based on other parameters
-    //    CQP             1            E..V....... Constant-quality
-    //    CBR             2            E..V....... Constant-bitrate
-    //    VBR             3            E..V....... Variable-bitrate
-    //    ICQ             4            E..V....... Intelligent constant-quality
-    //    QVBR            5            E..V....... Quality-defined variable-bitrate
-    //    AVBR            6            E..V....... Average variable-bitrate
-    // -loop_filter_level <int>        E..V....... Loop filter level (from 0 to 63) (default 16)
-    // -loop_filter_sharpness <int>        E..V....... Loop filter sharpness (from 0 to 15) (default 4)
+    TVHCodecProfile *p = (TVHCodecProfile *)self;
+    int int_bitrate = 0;
+    int int_buffer_size = 0;
+    int int_max_bitrate = 0;
+    int ret = 0;
+
+    compute_bitrates(self, &int_bitrate, &int_buffer_size, &int_max_bitrate);
 
     if (self->rc_mode != VAAPI_ENC_PARAMS_RC_SKIP) {
         AV_DICT_SET_INT(LST_VAAPI, opts, "rc_mode", self->rc_mode, AV_DICT_DONT_OVERWRITE);
     }
     switch (self->platform) {
         case VAAPI_ENC_PLATFORM_UNCONSTRAINED:
-            // Unconstrained --> will allow any combination of parameters (valid or invalid)
-            // this mode is useful for future platform and for debugging.
-            if (self->b_reference) {
-                // b_depth
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b_depth", self->b_reference, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->desired_b_depth >= 0) {
-                // max_b_frames
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bf", self->desired_b_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->super_frame) {
-                // according to example from https://trac.ffmpeg.org/wiki/Hardware/VAAPI
-                // -bsf:v vp9_raw_reorder,vp9_superframe
-                AV_DICT_SET(LST_VAAPI, opts, "bsf", "vp9_raw_reorder,vp9_superframe", AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->max_bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qp) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "quality", self->quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->global_quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "global_quality", self->global_quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->low_power) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_level >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_level", self->loop_filter_level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_sharpness >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_sharpness", self->loop_filter_sharpness, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_opts_unconstrained(self, opts, VP9, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                return ret;
             }
             break;
         case VAAPI_ENC_PLATFORM_INTEL:
@@ -1586,15 +1377,8 @@ tvh_codec_profile_vaapi_vp9_open(tvh_codec_profile_vaapi_t *self,
                     // same like 0 but is not sending 'rc_mode'
                 case VAAPI_ENC_PARAMS_RC_AUTO:
                     // for auto --> let the driver decide as requested by documentation
-                    if (self->bit_rate) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-                    }
-                    if (self->max_bit_rate) {
-                            AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-                        }
-                    if (self->qp) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+                    if ((ret = setup_bitrate_qp_opts_unconstrained(self, opts, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                        return ret;
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_CONSTQP:
@@ -1606,14 +1390,14 @@ tvh_codec_profile_vaapi_vp9_open(tvh_codec_profile_vaapi_t *self,
                     break;
                 case VAAPI_ENC_PARAMS_RC_CBR:
                     // for constant bitrate: CBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_VBR:
                     // for variable bitrate: VBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
@@ -1621,18 +1405,13 @@ tvh_codec_profile_vaapi_vp9_open(tvh_codec_profile_vaapi_t *self,
                     break;
                 case VAAPI_ENC_PARAMS_RC_QVBR:
                     // for variable bitrate: QVBR we use bitrate + qp
-                    if (self->bit_rate && self->buff_factor) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-                    }
-                    if (self->qp) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+                    if ((ret = setup_bitrate_qp_opts_unconstrained(self, opts, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                        return ret;
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_AVBR:
                     // for variable bitrate: AVBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
                     }
@@ -1641,63 +1420,23 @@ tvh_codec_profile_vaapi_vp9_open(tvh_codec_profile_vaapi_t *self,
             if (self->low_power) {
                 AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
             }
-            if (self->loop_filter_level >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_level", self->loop_filter_level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_sharpness >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_sharpness", self->loop_filter_sharpness, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_baseline_opts_unconstrained(self, opts, VP9))) {
+                return ret;
             }
             break;
         case VAAPI_ENC_PLATFORM_AMD:
             // AMD --> will allow any combination of parameters
             // I am unable to confirm this platform because I don't have the HW
             // Is only going to override bf to 0 (as highlited by the previous implementation)
-            if (self->bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->max_bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qp) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_common_opts_unconstrained(self, opts, VP9, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                return ret;
             }
             AV_DICT_SET_INT(LST_VAAPI, opts, "bf", 0, 0);
-            if (self->quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "quality", self->quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->global_quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "global_quality", self->global_quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->low_power) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_level >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_level", self->loop_filter_level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_sharpness >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_sharpness", self->loop_filter_sharpness, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
-            }
             break;
     }
+    // force keyframe at t=0 and t=1s (used for flashing the encoder)
+    AV_DICT_SET(LST_VAAPI, opts, "force_key_frames", "expr:eq(t,0)+eq(t,1)", AV_DICT_DONT_OVERWRITE);
+    p->has_support_for_filter2 = 1;
     return 0;
 }
 

--- a/src/transcoding/codec/internals.h
+++ b/src/transcoding/codec/internals.h
@@ -212,6 +212,11 @@
 #define VAAPI_DEINT_MODE_MADI    3
 #define VAAPI_DEINT_MODE_MCDI    4
 
+#define NVDEC_DEINT_MODE_SEND_FRAME                 0
+#define NVDEC_DEINT_MODE_SEND_FIELD                 1
+#define NVDEC_DEINT_MODE_SEND_FRAME_NONSPATIAL      2
+#define NVDEC_DEINT_MODE_SEND_FIELD_NONSPATIAL      3
+
 
 /* codec_profile_class ====================================================== */
 
@@ -415,6 +420,18 @@ typedef struct tvh_codec_profile_video {
      * 4 - Use the motion compensated deinterlacing algorithm
      */
     int deinterlace_vaapi_mode;
+
+    /**
+     * NVDEC Deinterlace mode [yadif_cuda mode parameter]
+     * https://ffmpeg.org/ffmpeg-filters.html#yadif_005fcuda
+     * @note
+     * int:
+     * 0 - send_frame: (default) Output one frame for each frame.
+     * 1 - send_field: Output one frame for each field. 
+     * 2 - send_frame_nospatial: Like send_frame, but it skips the spatial interlacing check.
+     * 3 - send_field_nospatial: Like send_field, but it skips the spatial interlacing check. 
+     */
+    int deinterlace_nvdec_mode;
 
     int height;
     /**

--- a/src/transcoding/codec/profile_class.c
+++ b/src/transcoding/codec/profile_class.c
@@ -316,6 +316,16 @@ const codec_profile_class_t codec_profile_class = {
                 .list     = codec_profile_class_profile_list,
                 .def.i    = FF_AV_PROFILE_UNKNOWN,
             },
+            {
+                .type     = PT_INT,
+                .id       = "has_support_for_filter2",
+                .name     = N_("has_support_for_filter2"),
+                .desc     = N_("has_support_for_filter2."),
+                .group    = 1,
+                .opts     = PO_ADVANCED | PO_PHIDDEN | PO_NOSAVE,
+                .off      = offsetof(TVHCodecProfile, has_support_for_filter2),
+                .def.i    = 0,
+            },
             {}
         }
     },

--- a/src/transcoding/codec/profile_video_class.c
+++ b/src/transcoding/codec/profile_video_class.c
@@ -66,6 +66,20 @@ deinterlace_vaapi_mode_get_list( void *o, const char *lang )
 }
 #endif
 
+#if ENABLE_NVENC
+static htsmsg_t *
+deinterlace_nvdec_mode_get_list( void *o, const char *lang )
+{
+    static const struct strtab tab[] = {
+        { N_("Send Frame Deinterlacing"),              NVDEC_DEINT_MODE_SEND_FRAME },
+        { N_("Send Field Deinterlacing"),              NVDEC_DEINT_MODE_SEND_FIELD },
+        { N_("Send Frame Nonspatia Deinterlacing"),    NVDEC_DEINT_MODE_SEND_FRAME_NONSPATIAL },
+        { N_("Send Field Nonspatia Deinterlacing"),    NVDEC_DEINT_MODE_SEND_FIELD_NONSPATIAL },
+    };
+    return strtab2htsmsg(tab, 1, lang);
+}
+#endif
+
 static htsmsg_t *
 deinterlace_field_rate_get_list( void *o, const char *lang )
 {
@@ -326,6 +340,19 @@ const codec_profile_class_t codec_profile_video_class = {
                 .opts     = PO_ADVANCED,
                 .off      = offsetof(TVHVideoCodecProfile, deinterlace_vaapi_mode),
                 .list     = deinterlace_vaapi_mode_get_list,
+                .def.i    = VAAPI_DEINT_MODE_DEFAULT,
+            },
+#endif
+#if ENABLE_NVENC
+            {
+                .type     = PT_INT,
+                .id       = "deinterlace_nvdev_mode",
+                .name     = N_("NVDEC Deinterlace mode"),
+                .desc     = N_("Mode to use for NVDEC Deinterlacing."),
+                .group    = 2,
+                .opts     = PO_ADVANCED,
+                .off      = offsetof(TVHVideoCodecProfile, deinterlace_nvdec_mode),
+                .list     = deinterlace_nvdec_mode_get_list,
                 .def.i    = VAAPI_DEINT_MODE_DEFAULT,
             },
 #endif

--- a/src/transcoding/transcode/audio.c
+++ b/src/transcoding/transcode/audio.c
@@ -80,6 +80,96 @@ _audio_context_sample_rate(TVHContext *self, AVDictionary **opts)
 
 
 #if LIBAVCODEC_VERSION_MAJOR > 59
+/**
+ * Build the libavfilter chain string used between @c abuffer and @c abuffersink
+ * for FFmpeg/libavcodec major version &gt; 59.
+ *
+ * The result is a comma-separated list of filter descriptions allocated into
+ * @p *filters (caller must free via whatever owns the graph string lifecycle).
+ *
+ * Pieces (in join order):
+ * - @c asetpts=N/SR/TB — normalizes PTS on the audio link (sample rate / time base).
+ * - Optional @c aresample=@<output_sample_rate@> when input and output sample rates
+ *   differ (in this source the condition is written as never taken; adjust if you
+ *   re-enable rate mismatch handling here).
+ * - Optional @c aformat=… when input and output differ in @c sample_fmt and/or
+ *   channel count: adds @c sample_fmts=… and/or @c channel_layouts=… as required
+ *   by the @c aformat filter.
+ *
+ * @param self    Transcode context; uses @c iavctx / @c oavctx sample format, rate,
+ *                and channel layout to decide which segments are needed.
+ * @param filters Receives a newly built filter string (e.g. from @c str_join), or
+ *                is left untouched on failure.
+ * @return        0 on success; -1 if a buffer would overflow or allocation/join fails.
+ */
+static int
+_audio_filters_get_filters(TVHContext *self, char **filters)
+{
+    char sample_rate[32];
+    char sample_fmt[32];
+    char obuf[64];
+    char channel_layouts[64];
+    char aformat[128];
+    char asetpts[24];
+    int aformat_tokens = 0;
+
+    // sample_rate
+    memset(sample_rate, 0, sizeof(sample_rate));
+    if ((self->iavctx->sample_rate != self->oavctx->sample_rate) &&
+        str_snprintf(sample_rate, sizeof(sample_rate), "aresample=%d",
+
+                    self->oavctx->sample_rate))
+        return -1;    
+
+    // https://ayosec.github.io/ffmpeg-filters-docs/8.1/Filters/Audio/aformat.html
+    // sample_fmt
+    memset(sample_fmt, 0, sizeof(sample_fmt));
+    if (self->iavctx->sample_fmt != self->oavctx->sample_fmt) {
+        if(str_snprintf(sample_fmt, sizeof(sample_fmt), "sample_fmts=%s",
+                     av_get_sample_fmt_name(self->oavctx->sample_fmt)))
+            return -1;
+        else 
+            aformat_tokens++; 
+    }
+
+    // channel_layouts
+    memset(channel_layouts, 0, sizeof(channel_layouts));
+    if (self->iavctx->ch_layout.nb_channels != self->oavctx->ch_layout.nb_channels) {
+        av_channel_layout_describe(&self->oavctx->ch_layout, obuf, sizeof(obuf));
+        if(str_snprintf(channel_layouts, sizeof(channel_layouts), "channel_layouts=%s", obuf)) 
+            return -1;
+        else 
+            aformat_tokens++; 
+    }
+
+    memset(aformat, 0, sizeof(aformat));
+    switch (aformat_tokens) {
+        case 2:
+            // we have to update both settings
+            if(str_snprintf(aformat, sizeof(aformat), "aformat=%s:%s", sample_fmt, channel_layouts))
+                return -1;
+            break;
+        case 1:
+            // we have to update only one setting
+            if(str_snprintf(aformat, sizeof(aformat), "aformat=%s%s", sample_fmt, channel_layouts)) 
+                return -1;
+            break;
+        default:
+            break;
+    }
+
+    memset(asetpts, 0, sizeof(asetpts));
+    // we have to timestamp
+    if(str_snprintf(asetpts, sizeof(asetpts), "asetpts=N/SR/TB"))
+        return -1;
+
+    // context filters
+    if (!(*filters = str_join(",", asetpts, sample_rate, aformat, NULL)))
+        return -1;
+    
+    return 0;
+}
+
 static void
 _audio_context_channel_layout(TVHContext *self, AVDictionary **opts, AVChannelLayout *dst)
 {
@@ -254,6 +344,18 @@ tvh_audio_context_open_encoder(TVHContext *self, AVDictionary **opts)
 static int
 tvh_audio_context_open_filters(TVHContext *self, AVDictionary **opts)
 {
+#if LIBAVCODEC_VERSION_MAJOR > 59
+    char *filters2 = NULL;
+
+    // filters
+    if (_audio_filters_get_filters(self, &filters2)) {
+        tvherror(LS_TRANSCODE, "filters: audio: function _audio_filters_get_filters() returned with error.");
+        str_clear(filters2);
+        return -1;
+    }
+    
+    tvhinfo(LS_TRANSCODE, "filters: audio: '%s'", filters2);
+#endif
     char source_args[128];
     char filters[16];
     char layout[32];
@@ -273,6 +375,9 @@ tvh_audio_context_open_filters(TVHContext *self, AVDictionary **opts)
             self->iavctx->sample_rate,
             av_get_sample_fmt_name(self->iavctx->sample_fmt),
             layout)) {
+#if LIBAVCODEC_VERSION_MAJOR > 59
+        str_clear(filters2);
+#endif
         return -1;
     }
 
@@ -284,27 +389,38 @@ tvh_audio_context_open_filters(TVHContext *self, AVDictionary **opts)
     memset(filters, 0, sizeof(filters));
     if (str_snprintf(filters, sizeof(filters), "%s",
                      (resample) ? "aresample" : "anull")) {
+#if LIBAVCODEC_VERSION_MAJOR > 59
+        str_clear(filters2);
+#endif
         return -1;
     }
 
 #if LIBAVCODEC_VERSION_MAJOR > 59
     char ch_layout[64];
     av_channel_layout_describe(&self->oavctx->ch_layout, ch_layout, sizeof(ch_layout));
-    
-    int ret = tvh_context_open_filters(self,
-        "abuffer", source_args,                           // source
-        filters,                                          // filters
-        "abuffersink",                                    // sink
-        "ch_layouts",   AV_OPT_SET_STRING,                // sink option: channel_layout
-        sizeof(ch_layout),
-        ch_layout,
-        "sample_fmts",  AV_OPT_SET_BIN,                   // sink option: sample_fmt
-        sizeof(self->oavctx->sample_fmt),
-        &self->oavctx->sample_fmt,
-        "sample_rates", AV_OPT_SET_BIN,                   // sink option: sample_rate
-        sizeof(self->oavctx->sample_rate),
-        &self->oavctx->sample_rate,
-        NULL);                                            // _IMPORTANT!_
+    int ret = -1;
+    if (self->profile->has_support_for_filter2)
+        ret = tvh_context_open_filters2(self,
+            "abuffer",                                             // source
+            (filters2 && filters2[0] != '\0') ? filters2 : "anull",// filters
+            "abuffersink"                                          // sink
+        );
+    else 
+        ret = tvh_context_open_filters(self,
+            "abuffer", source_args,                           // source
+            filters,                                          // filters
+            "abuffersink",                                    // sink
+            "ch_layouts",   AV_OPT_SET_STRING,                // sink option: channel_layout
+            sizeof(ch_layout),
+            ch_layout,
+            "sample_fmts",  AV_OPT_SET_BIN,                   // sink option: sample_fmt
+            sizeof(self->oavctx->sample_fmt),
+            &self->oavctx->sample_fmt,
+            "sample_rates", AV_OPT_SET_BIN,                   // sink option: sample_rate
+            sizeof(self->oavctx->sample_rate),
+            &self->oavctx->sample_rate,
+            NULL);                                            // _IMPORTANT!_
+    str_clear(filters2);
 #else
     int ret = tvh_context_open_filters(self,
         "abuffer", source_args,                           // source
@@ -317,26 +433,54 @@ tvh_audio_context_open_filters(TVHContext *self, AVDictionary **opts)
         "sample_rates", &self->oavctx->sample_rate,       // sink option: sample_rate
         sizeof(self->oavctx->sample_rate),
         NULL);                                            // _IMPORTANT!_
-#endif
     if (!ret) {
         av_buffersink_set_frame_size(self->oavfltctx, self->oavctx->frame_size);
     }
+#endif
     return ret;
 }
 
-
+/**
+ * Audio half of the transcoder open state machine: dispatches @p phase to the
+ * right setup step for the audio path.
+ *
+ * Handled phases:
+ * - PREPARE_ENCODER — set output sample format/rate/time base, channel layout,
+ *   and other @c AVCodecContext fields before filters/encoder open
+ *   (@c tvh_audio_context_open_encoder).
+ * - OPEN_FILTERS — build the libavfilter graph (@c abuffer → filters → @c abuffersink),
+ *   including resample/aformat when needed (@c tvh_audio_context_open_filters).
+ * - OPEN_ENCODER — runs after @c avcodec_open2 on the encoder in @c tvh_context_open:
+ *   refuses @c frame_size == 0, then fills @c self->delta (PTS step per encoded
+ *   frame in @c iavctx time base) and sets @c abuffersink frame size to match
+ *   the encoder frame size.
+ *
+ * Phases such as PREPARE_DECODER, OPEN_DECODER, and NOTIFY_GLOBALHEADER are not
+ * handled here; @c tvh_context_open invokes this callback only for encoder-side
+ * steps that the audio context owns. Unhandled @p phase is a no-op (returns 0).
+ *
+ * @param self  Transcode context (shared with generic open in @c context.c).
+ * @param phase Which open step is being executed (@c TVHOpenPhase).
+ * @param opts  Codec/profile options (used by @c PREPARE_ENCODER).
+ * @return      0 on success or no-op; negative @c AVERROR (e.g. @c EINVAL) if
+ *              the encoder reports @c frame_size == 0 in @c OPEN_ENCODER, or
+ *              any error returned by the encoder/filter helpers.
+ */
 static int
 tvh_audio_context_open(TVHContext *self, TVHOpenPhase phase, AVDictionary **opts)
 {
     switch (phase) {
-        case OPEN_ENCODER:
+        case PREPARE_ENCODER:
             return tvh_audio_context_open_encoder(self, opts);
-        case OPEN_ENCODER_POST:
+        case OPEN_FILTERS:
+            return tvh_audio_context_open_filters(self, opts);
+        case OPEN_ENCODER:
             self->delta = av_rescale_q_rnd(self->oavctx->frame_size,
                                            self->oavctx->time_base,
                                            self->iavctx->time_base,
                                            AV_ROUND_NEAR_INF|AV_ROUND_PASS_MINMAX);
-            return tvh_audio_context_open_filters(self, opts);
+            av_buffersink_set_frame_size(self->oavfltctx, self->oavctx->frame_size);
+            break;
         default:
             break;
     }
@@ -384,7 +528,9 @@ tvh_audio_context_ship(TVHContext *self, AVPacket *avpkt)
 static int
 tvh_audio_context_wrap(TVHContext *self, AVPacket *avpkt, th_pkt_t *pkt)
 {
-    pkt->pkt_duration   = avpkt->duration;
+    // only if packet duration is valid we passed on
+    if (avpkt->duration > 0)
+        pkt->pkt_duration = avpkt->duration;
 #if LIBAVCODEC_VERSION_MAJOR > 59
     pkt->a.pkt_channels = self->oavctx->ch_layout.nb_channels;
 #else

--- a/src/transcoding/transcode/context.c
+++ b/src/transcoding/transcode/context.c
@@ -19,6 +19,13 @@
 
 
 #include "internals.h"
+#if ENABLE_HWACCELS
+#include "hwaccels/hwaccels.h"
+#endif
+
+#if LIBAVCODEC_VERSION_MAJOR > 59
+#include <libavutil/avstring.h>
+#endif
 
 #include <libavutil/opt.h>
 
@@ -211,6 +218,111 @@ _context_meta(TVHContext *self, AVPacket *avpkt, th_pkt_t *pkt)
     return (self->require_meta < 0) ? -1 : 0;
 }
 
+#if LIBAVCODEC_VERSION_MAJOR > 59
+/**
+ * Builds a linear filter graph from a comma-separated string,
+ * injecting the hardware context where necessary.
+ * * @param graph The allocated AVFilterGraph
+ * @param filter_str The comma-separated filter string (e.g., "format=nv12,hwupload,scale")
+ * @param in_ctx The input filter context (e.g., the "buffer" filter)
+ * @param out_ctx The output filter context (e.g., the "buffersink" filter)
+ * @param hw_device_octx The hardware device context to inject
+ * @return 0 on success, negative AVERROR on failure
+ * NOTE: is not working with complex filters
+ */
+static int build_linear_hw_filter_graph(AVFilterGraph *graph, const char *filter_str, 
+                                 AVFilterContext *in_ctx, AVFilterContext *out_ctx, 
+                                 AVBufferRef *hw_device_octx) {
+    int ret = 0;
+    AVFilterContext *prev_ctx = in_ctx;
+    
+    // Duplicate the string because av_strtok modifies it
+    char *str_copy = av_strdup(filter_str);
+    if (!str_copy) return AVERROR(ENOMEM);
+
+    char *saveptr = NULL;
+    // Tokenize the string by commas
+    char *filter_token = av_strtok(str_copy, ",", &saveptr);
+
+    while (filter_token) {
+        char *filter_name = filter_token;
+        char *filter_args = NULL;
+
+        // Find the first '=' to split the filter name from its arguments
+        char *eq_ptr = strchr(filter_name, '=');
+        if (eq_ptr) {
+            *eq_ptr = '\0';       // Null-terminate the name
+            filter_args = eq_ptr + 1; // The rest is the arguments string
+        }
+
+        // 1. Find the filter by name
+        const AVFilter *filter = avfilter_get_by_name(filter_name);
+        if (!filter) {
+            // Log error: Filter not found
+            ret = AVERROR_FILTER_NOT_FOUND;
+            goto cleanup;
+        }
+
+        // 2. Create the filter (Allocates context AND calls init)
+        AVFilterContext *current_ctx = NULL;
+        
+        // --- THE CRITICAL INJECTION STEP ---
+        // If the filter requires a hardware context (like hwupload), we cannot use 
+        // avfilter_graph_create_filter directly because it calls init() immediately.
+        // Instead, we must use the two-step allocation/init process manually.
+        
+        current_ctx = avfilter_graph_alloc_filter(graph, filter, filter_name);
+        if (!current_ctx) {
+            ret = AVERROR(ENOMEM);
+            goto cleanup;
+        }
+
+        // Inject the hardware context BEFORE initialization
+        if (hw_device_octx && (strstr(filter->name, "hwupload") || strstr(filter->name, "hwmap"))) {
+            current_ctx->hw_device_ctx = av_buffer_ref(hw_device_octx);
+            if (!current_ctx->hw_device_ctx) {
+                ret = AVERROR(ENOMEM);
+                goto cleanup;
+            }
+        }
+
+        // Now initialize the filter with its arguments
+        ret = avfilter_init_str(current_ctx, filter_args);
+        if (ret < 0) {
+            // Log error: Failed to initialize filter
+            goto cleanup;
+        }
+
+        // 3. Link this filter to the previous one in the chain
+        if (prev_ctx) {
+            ret = avfilter_link(prev_ctx, 0, current_ctx, 0);
+            if (ret < 0) {
+                // Log error: Failed to link filters
+                goto cleanup;
+            }
+        }
+
+        prev_ctx = current_ctx;
+        
+        // Get the next filter token
+        filter_token = av_strtok(NULL, ",", &saveptr);
+    }
+
+    // Finally, link the last created filter to the output context (buffersink)
+    if (prev_ctx && out_ctx) {
+        ret = avfilter_link(prev_ctx, 0, out_ctx, 0);
+        if (ret < 0) {
+            // Log error: Failed to link to output
+            goto cleanup;
+        }
+    }
+
+cleanup:
+    av_free(str_copy);
+    return ret;
+}
+#endif
+
 
 static int
 _context_wrap(TVHContext *self, AVPacket *avpkt, th_pkt_t *pkt)
@@ -259,51 +371,203 @@ tvh_context_setup(TVHContext *self, const AVCodec *iavcodec, const AVCodec *oavc
 
 
 // open
-
+/**
+ * Central open step for a @c TVHContext: validates which @c AVCodecContext is in
+ * scope for @p phase, then runs the matching libav setup sequence.
+ *
+ * Phase 1 selects the working context and refuses to continue if no @c codec
+ * is bound:
+ * - Decoder phases (@c PREPARE_DECODER, @c OPEN_DECODER, @c NOTIFY_GLOBALHEADER)
+ *   use @c self->iavctx.
+ * - Encoder phases (@c PREPARE_ENCODER, @c OPEN_FILTERS, @c OPEN_ENCODER)
+ *   use @c self->oavctx.
+ *
+ * Phase 2 (per @p phase):
+ * - @c PREPARE_DECODER — read @c tvh_require_meta, call @c _context_open (media-type
+ *   hooks), then optional decoder @c helper->open.
+ * - @c OPEN_DECODER — @c avcodec_open2 on the decoder, then @c _context_open for
+ *   post-open work; logs options on success.
+ * - @c NOTIFY_GLOBALHEADER — @c _context_open only; frees @c self->temp_opts afterward.
+ * - @c PREPARE_ENCODER — profile @c tvh_codec_profile_open, @c tvh_require_meta,
+ *   @c _context_open, then optional encoder @c helper->open; stores @c self->helper.
+ * - @c OPEN_FILTERS — @c _context_open only (typically builds the libavfilter graph).
+ * - @c OPEN_ENCODER — @c avcodec_open2 on the encoder, then @c _context_open (e.g. audio
+ *   computes @c delta / sink frame size after @c frame_size is known); frees
+ *   @c self->temp_opts afterward.
+ *
+ * Intended call order for a full pipeline is implemented by @c tvh_context_open_decoder
+ * and @c tvh_context_open_encoder (decoder: prepare → open → notify; encoder:
+ * prepare → filters → encoder).
+ *
+ * @param self  Transcode context (decoder, encoder, profile, temp options).
+ * @param phase Which @c TVHOpenPhase step to execute.
+ * @return      0 on success; a negative @c AVERROR or other error code from the failing
+ *              libav or Tvheadend step; @c AVERROR(EINVAL) for unknown phase or missing codec.
+ */
 static int
 tvh_context_open(TVHContext *self, TVHOpenPhase phase)
 {
     AVCodecContext *avctx = NULL;
     TVHContextHelper *helper = NULL;
-    AVDictionary *opts = NULL;
     int ret = 0;
 
+    // Phase 1: we check that we have codecs
     switch (phase) {
+        case PREPARE_DECODER:
         case OPEN_DECODER:
+        case NOTIFY_GLOBALHEADER:
             avctx = self->iavctx;
             if (!avctx->codec) {
                 tvh_context_log(self, LOG_ERR, "no decoder available");
                 return AVERROR(EINVAL);
             }
-            helper = tvh_decoder_helper_find(avctx->codec);
             break;
+        case PREPARE_ENCODER:
+        case OPEN_FILTERS:
         case OPEN_ENCODER:
             avctx = self->oavctx;
             if (!avctx->codec) {
                 tvh_context_log(self, LOG_ERR, "no encoder available");
                 return AVERROR(EINVAL);
             }
-            helper = self->helper = tvh_encoder_helper_find(avctx->codec);
-            ret = tvh_codec_profile_open(self->profile, &opts);
             break;
         default:
-            tvh_context_log(self, LOG_ERR, "invalid open phase");
+            tvh_context_log(self, LOG_ERR, "invalid open phase: %d", (int)phase);
             ret = AVERROR(EINVAL);
             break;
     }
-    if (!ret) {
-        _context_print_opts(self, opts);
-        ret = tvh_context_get_int_opt(&opts, "tvh_require_meta",
-                                      &self->require_meta);
-        if (!ret && !(ret = _context_open(self, phase, &opts)) && // pre open
-            !(ret = (helper && helper->open) ? helper->open(self, &opts) : 0) && // pre open
-            !(ret = avcodec_open2(avctx, NULL, &opts))) { // open
-            ret = _context_open(self, phase + 1, &opts); // post open
-        }
-        _context_print_opts(self, opts);
+    // Phase 2: we call proper functions (according to the state machine)
+    switch (phase) {
+        case PREPARE_DECODER:
+            helper = tvh_decoder_helper_find(avctx->codec);
+            if (!(ret = tvh_context_get_int_opt(&self->temp_opts, "tvh_require_meta", &self->require_meta)) &&
+                !(ret = _context_open(self, phase, &self->temp_opts))){
+                ret = (helper && helper->open) ? helper->open(self, &self->temp_opts) : 0;
+            } else {
+                tvh_context_log(self, LOG_ERR, "OpenPhase PREPARE_DECODER returned error: %d", ret);
+            }
+            break;
+        case OPEN_DECODER:
+            if (!(ret = avcodec_open2(avctx, NULL, &self->temp_opts)) && 
+                !(ret = _context_open(self, phase, &self->temp_opts))){
+                // print the dict for decoder
+                _context_print_opts(self, self->temp_opts);
+            } else {
+                tvh_context_log(self, LOG_ERR, "OpenPhase OPEN_DECODER returned error: %d", ret);
+            }
+            break;
+        case NOTIFY_GLOBALHEADER:
+            if ((ret = _context_open(self, phase, &self->temp_opts))){
+                tvh_context_log(self, LOG_ERR, "OpenPhase NOTIFY_GLOBALHEADER returned error: %d", ret);
+            }
+            // we no longer need dict for decoder
+            if (self->temp_opts) {
+                av_dict_free(&self->temp_opts);
+                self->temp_opts = NULL;
+            }
+            break;
+        case PREPARE_ENCODER:
+            helper = self->helper = tvh_encoder_helper_find(avctx->codec);
+            if (!(ret = tvh_codec_profile_open(self->profile, &self->temp_opts)) &&
+                !(ret = tvh_context_get_int_opt(&self->temp_opts, "tvh_require_meta", &self->require_meta)) &&
+                !(ret = _context_open(self, phase, &self->temp_opts)) && // pre open
+                !(ret = (helper && helper->open) ? helper->open(self, &self->temp_opts) : 0)){  // pre open
+                // print the dict for decoder
+                _context_print_opts(self, self->temp_opts);
+            } else {
+                tvh_context_log(self, LOG_ERR, "OpenPhase PREPARE_ENCODER returned error: %d", ret);
+            }
+            break;
+        case OPEN_FILTERS:
+            if ((ret = _context_open(self, phase, &self->temp_opts))){
+                tvh_context_log(self, LOG_ERR, "OpenPhase OPEN_FILTERS returned error: %d", ret);
+            }
+            break;
+        case OPEN_ENCODER:
+            if (!(ret = avcodec_open2(avctx, NULL, &self->temp_opts)) && 
+                !(ret = _context_open(self, phase, &self->temp_opts))){
+                // print the dict for encoder
+                _context_print_opts(self, self->temp_opts);
+            } else {
+                tvh_context_log(self, LOG_ERR, "OpenPhase OPEN_ENCODER returned error: %d", ret);
+            }
+            // we no longer need dict for encoder
+            if (self->temp_opts) {
+                av_dict_free(&self->temp_opts);
+                self->temp_opts = NULL;
+            }
+            break;
+        default:
+            tvh_context_log(self, LOG_ERR, "invalid open phase: %d", (int)phase);
+            ret = AVERROR(EINVAL);
+            break;
     }
-    if (opts) {
-        av_dict_free(&opts);
+    return ret;     
+}
+
+/**
+ * Run the encoder-side open sequence for @p self in the correct order.
+ *
+ * Calls @ref tvh_context_open with:
+ * 1. @c PREPARE_ENCODER — profile and type-specific preparation (@c sample_fmt,
+ *    rates, layouts, bit rate / quality, HW hooks, etc.).
+ * 2. @c OPEN_FILTERS — build and configure the libavfilter graph feeding the encoder
+ *    (only if step 1 succeeds).
+ * 3. @c OPEN_ENCODER — @c avcodec_open2 on the output codec, then type-specific
+ *    post-open work (only if step 2 succeeds).
+ *
+ * On failure, logs which phase failed and returns that error; later phases are skipped.
+ *
+ * @param self Transcode context whose @c oavctx and filter graph are being set up.
+ * @return     0 if all three phases succeed; otherwise the first non-zero return value
+ *             from @ref tvh_context_open (typically a negative @c AVERROR).
+ */
+static int
+tvh_context_open_encoder(TVHContext *self){
+    int ret = 0;
+
+    if ((ret = tvh_context_open(self, PREPARE_ENCODER))){
+        tvh_context_log(self, LOG_ERR, "PREPARE_ENCODER returned error: %d", ret);
+    }
+    if (!(ret) && (ret = tvh_context_open(self, OPEN_FILTERS))){
+        tvh_context_log(self, LOG_ERR, "OPEN_FILTERS returned error: %d", ret);
+    }
+    if (!(ret) && (ret = tvh_context_open(self, OPEN_ENCODER))){
+        tvh_context_log(self, LOG_ERR, "OPEN_ENCODER returned error: %d", ret);
+    }
+    return ret;
+}
+
+/**
+ * Run the decoder-side open sequence for @p self in the correct order.
+ *
+ * Calls @c tvh_context_open with:
+ * 1. @c PREPARE_DECODER — type-specific decoder preparation and optional decoder
+ *    helper setup (@c _context_open plus @c helper->open when present).
+ * 2. @c OPEN_DECODER — @c avcodec_open2 on the input codec, then decoder post-open
+ *    (@c _context_open) if step 1 succeeded.
+ * 3. @c NOTIFY_GLOBALHEADER — global-header / extradata notification via
+ *    @c _context_open if step 2 succeeded; @c tvh_context_open then clears
+ *    @c self->temp_opts for the decoder path.
+ *
+ * On failure, logs which phase failed and returns that error; later phases are skipped.
+ *
+ * @param self Transcode context whose @c iavctx is being opened.
+ * @return     0 if all three phases succeed; otherwise the first non-zero return value
+ *             from @c tvh_context_open (typically a negative @c AVERROR).
+ */
+static int
+tvh_context_open_decoder(TVHContext *self){
+    int ret = 0;
+
+    if ((ret = tvh_context_open(self, PREPARE_DECODER))){
+        tvh_context_log(self, LOG_ERR, "PREPARE_DECODER returned error: %d", ret);
+    }
+    if (!(ret) && (ret = tvh_context_open(self, OPEN_DECODER))){
+        tvh_context_log(self, LOG_ERR, "OPEN_DECODER returned error: %d", ret);
+    }
+    if (!(ret) && (ret = tvh_context_open(self, NOTIFY_GLOBALHEADER))){
+        tvh_context_log(self, LOG_ERR, "NOTIFY_GLOBALHEADER returned error: %d", ret);
     }
     return ret;
 }
@@ -319,7 +583,30 @@ tvh_context_pack(TVHContext *self, AVPacket *avpkt)
     if (self->helper && self->helper->pack) {
         pkt = self->helper->pack(self, avpkt);
     } else {
-        pkt = pkt_alloc(self->stream->type, avpkt->data, avpkt->size, avpkt->pts, avpkt->dts, 0);
+        // th_pkt_t timestamps are expected to be in MPEG-TS 90kHz ticks.
+        // Encoder packets are in self->oavctx->time_base and can change if filter is changing the frame_rate
+        // (for example deinterlace_qsv can double the frame rate),
+        // so rescale here.
+        const AVRational tb90k = { 1, 90000 };
+        int64_t pts90 = avpkt->pts;
+        int64_t dts90 = avpkt->dts;
+        if (pts90 != AV_NOPTS_VALUE)
+            pts90 = av_rescale_q_rnd(pts90, self->oavctx->time_base, tb90k,
+                                    AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX);
+        if (dts90 != AV_NOPTS_VALUE)
+            dts90 = av_rescale_q_rnd(dts90, self->oavctx->time_base, tb90k,
+                                    AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX);
+        int64_t dur90 = 0;
+        if (avpkt->duration > 0) {
+            dur90 = av_rescale_q_rnd(avpkt->duration, self->oavctx->time_base, tb90k,
+                                    AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX);
+        } else if (self->oavctx->framerate.num > 0 && self->oavctx->framerate.den > 0) {
+            dur90 = av_rescale_q(1, av_inv_q(self->oavctx->framerate), tb90k); // 3000@30fps, 1500@60fps
+        }
+
+        pkt = pkt_alloc(self->stream->type, avpkt->data, avpkt->size, pts90, dts90, 0);
+        if (pkt && dur90 > 0)
+            pkt->pkt_duration = dur90;
     }
     if (!pkt) {
         tvh_context_log(self, LOG_ERR, "failed to create packet");
@@ -422,7 +709,7 @@ tvh_context_encode(TVHContext *self, AVFrame *avframe)
     int ret = 0;
 
     if (!avcodec_is_open(self->oavctx)) {
-        ret = tvh_context_open(self, OPEN_ENCODER);
+        ret = tvh_context_open_encoder(self);
     }
     if (!ret && !(ret = tvh_context_push_frame(self, avframe))) {
         while ((ret = tvh_context_pull_frame(self, self->oavframe)) != AVERROR(EAGAIN)) {
@@ -477,7 +764,7 @@ tvh_context_decode(TVHContext *self, AVPacket *avpkt)
     int ret = 0;
 
     if (!avcodec_is_open(self->iavctx)) {
-        ret = tvh_context_open(self, OPEN_DECODER);
+        ret = tvh_context_open_decoder(self);
     }
     if (!ret && !(ret = _context_decode(self, avpkt))) {
         ret = tvh_context_decode_packet(self, avpkt);
@@ -536,7 +823,391 @@ tvh_context_close(TVHContext *self, int flush)
     }
 }
 
+#if LIBAVCODEC_VERSION_MAJOR > 59
+int
+tvh_context_open_filters2(TVHContext *self,
+                         const char *source_name,
+                         const char *filters, 
+                         const char *sink_name)
+{
+    static const AVClass logclass = {
+        .class_name = "TVHGraph",
+        .version    = 1,
+    };
+    struct {
+        const AVClass *class;
+    } logctx = { &logclass };
+    const AVFilter *iavflt = NULL;
+    const AVFilter *oavflt = NULL;
+    AVBufferSrcParameters *par = NULL;
+    int ret = -1;
+    enum AVMediaType stream_type = AVMEDIA_TYPE_UNKNOWN;
 
+    tvh_context_log(self, LOG_DEBUG, "filters: '%s'", filters);
+
+    if (!(self->avfltgraph = avfilter_graph_alloc()) ||
+        !(par = av_buffersrc_parameters_alloc())) {
+        ret = AVERROR(ENOMEM);
+        goto finish;
+    }
+
+// source
+    if (!(iavflt = avfilter_get_by_name(source_name))) {
+        tvh_context_log(self, LOG_ERR, "filters: source filter'%s' not found", source_name);
+        ret = AVERROR_FILTER_NOT_FOUND;
+        goto finish;
+    }
+
+    // 1. ALLOCATE (No init yet, so it won't fail due to missing args)
+    self->iavfltctx = avfilter_graph_alloc_filter(self->avfltgraph, iavflt, "in");
+    if (!self->iavfltctx) {
+        tvh_context_log(self, LOG_ERR, "filters: failed to create 'in' filter");
+        goto finish;
+    }
+
+    // additional buffersrc params
+    memset(par, 0, sizeof(AVBufferSrcParameters));
+    
+    switch (self->iavctx->codec_type) {
+        case AVMEDIA_TYPE_VIDEO:
+            stream_type = AVMEDIA_TYPE_VIDEO;
+            break;
+        case AVMEDIA_TYPE_AUDIO:
+            stream_type = AVMEDIA_TYPE_AUDIO;
+            break;
+        default:
+            break;
+    }
+
+    if (stream_type == AVMEDIA_TYPE_UNKNOWN) {
+        ret = -1;
+        tvherror(LS_TRANSCODE, "filter can't process media type: %s", av_get_media_type_string(self->iavctx->codec_type));
+        goto finish;
+    }
+
+    // 2. CONFIGURE PARAMETERS
+    if (stream_type == AVMEDIA_TYPE_VIDEO) {
+        // for Video:
+        int int_pix_fmt = self->iavctx->pix_fmt;
+        AVRational sample_aspect_ratio = self->iavctx->sample_aspect_ratio;
+        if (self->iavframe && (sample_aspect_ratio.num <= 0 || sample_aspect_ratio.den <= 0)) {
+            // try to extract SAR from AVFrame
+            tvh_context_log(self, LOG_DEBUG, "codec %s is not advertising sample_aspect_ratio", self->iavctx->codec->name);
+            sample_aspect_ratio = self->iavframe->sample_aspect_ratio;
+            if (sample_aspect_ratio.num <= 0 || sample_aspect_ratio.den <= 0) {
+                tvh_context_log(self, LOG_DEBUG, "frame %s is not advertising sample_aspect_ratio", self->iavctx->codec->name);
+                if (self->sample_aspect_ratio.num && self->sample_aspect_ratio.den) {
+                    // We have SAR from TVH
+                    sample_aspect_ratio = (AVRational){self->sample_aspect_ratio.num, self->sample_aspect_ratio.den};
+                    tvherror(LS_TRANSCODE, 
+                    //tvh_context_log(self, LOG_DEBUG,
+                        "Manually set SAR to %d/%d based on TVH SAR %d:%d",
+                            sample_aspect_ratio.num, sample_aspect_ratio.den,
+                            self->sample_aspect_ratio.num, self->sample_aspect_ratio.den);
+                }
+                // we feed back the SAR to iavctx
+                self->iavframe->sample_aspect_ratio = sample_aspect_ratio;
+            }
+            if (sample_aspect_ratio.num <= 0 || sample_aspect_ratio.den <= 0) {
+                // set SAR to 1,1
+                tvh_context_log(self, LOG_DEBUG, "input stream is not advertising sample_aspect_ratio, default to {1,1}");
+                // Fallback: If TVH doesn't know, default to square pixels
+                sample_aspect_ratio = (AVRational){1, 1};
+            }
+            // we feed back the SAR to iavctx
+            self->iavctx->sample_aspect_ratio = sample_aspect_ratio;
+        }
+        // Basic video properties
+        par->width                = self->iavctx->width;
+        par->height               = self->iavctx->height;
+        par->sample_aspect_ratio  = sample_aspect_ratio;
+        par->frame_rate           = self->iavctx->framerate;
+        
+        // CRITICAL: Metadata synchronization (fixes the FFmpeg 7 warnings)
+        par->time_base            = av_make_q(self->iavctx->time_base.num, self->iavctx->time_base.den); // or stream->time_base
+#if LIBAVCODEC_VERSION_MAJOR > 60
+        par->color_range          = self->iavctx->color_range;  // Fixes "range: tv" warning
+        par->color_space          = self->iavctx->colorspace;   // Fixes "csp: unknown" warning
+        // to be added later on
+        //par->color_primaries = self->iavctx->color_primaries;
+        //par->color_trc       = self->iavctx->color_trc;
+#endif
+        // If using hardware acceleration (VAAPI/CUDA/etc), pass the frames context
+        if (self->iavctx->hw_frames_ctx){
+            // Increment the reference count so the filter "owns" a piece of the hardware context
+            par->hw_frames_ctx = av_buffer_ref(self->iavctx->hw_frames_ctx);
+            
+            if (!par->hw_frames_ctx) {
+                // Handle allocation error
+                ret = AVERROR(ENOMEM);
+                goto finish;
+            }
+            AVHWFramesContext *frames_ctx = (AVHWFramesContext*)self->iavctx->hw_frames_ctx->data;
+            int_pix_fmt = (int)frames_ctx->format;
+        }
+        par->format               = int_pix_fmt;
+
+        char logs[256];
+        str_snprintf(logs, sizeof(logs),
+            "filter video in configuration:"
+            " video_size=%dx%d"
+            ",pix_fmt=%s"
+            ",time_base=%d/%d"
+            ",frame_rate=%d/%d"
+            ",pixel_aspect:%d/%d"
+#if LIBAVCODEC_VERSION_MAJOR > 60
+            ",color_range:%s"
+            ",color_space:%s"
+#endif
+            ,self->iavctx->width, self->iavctx->height
+            ,av_get_pix_fmt_name(int_pix_fmt)
+            ,self->iavctx->time_base.num, self->iavctx->time_base.den
+            ,self->iavctx->framerate.num, self->iavctx->framerate.den
+            ,sample_aspect_ratio.num, sample_aspect_ratio.den
+#if LIBAVCODEC_VERSION_MAJOR > 60
+            ,av_color_range_name(self->iavctx->color_range)
+            ,av_color_space_name(self->iavctx->colorspace)
+#endif
+        );
+        // to be removed when we remove has_support_for_filter2
+        tvhinfo(LS_TRANSCODE, 
+        //tvh_context_log(self, LOG_DEBUG,
+                          "%s", logs);
+
+    } else if (stream_type == AVMEDIA_TYPE_AUDIO) {
+        // for Audio:
+        // Basic audio properties
+        par->format      = self->iavctx->sample_fmt;
+        par->sample_rate = self->iavctx->sample_rate;
+        par->time_base   = (AVRational){1, self->iavctx->sample_rate};
+
+        // Copy channel layout (Crucial for FFmpeg 7/8)
+        ret = av_channel_layout_copy(&par->ch_layout, &self->iavctx->ch_layout);
+        if (ret < 0) {
+            tvh_context_log(self, LOG_ERR, "filters: failed to set av_channel_layout with error %d", ret);
+            goto finish;
+        }
+
+        char logs[256];
+        memset(logs, 0, sizeof(logs));
+        char buf[64];
+        memset(buf, 0, sizeof(buf));
+        av_channel_layout_describe(&par->ch_layout, buf, sizeof(buf));
+        str_snprintf(logs, sizeof(logs),
+            "filter audio in configuration:"
+            " ch_layout=%s"
+            ",sample_fmt=%s"
+            ",sample_rate=%d"
+            ",time_base=%d/%d"
+            ,buf
+            ,av_get_sample_fmt_name(par->format)
+            ,par->sample_rate
+            ,par->time_base.num, par->time_base.den
+        );
+        // to be removed when we remove has_support_for_filter2
+        tvhinfo(LS_TRANSCODE, 
+        //tvh_context_log(self, LOG_DEBUG,
+                          "%s", logs);
+    } else tvherror(LS_TRANSCODE, "filter can process only 'buffer' and 'abuffer', most likely will fail.");
+
+    // Push the parameters into the uninitialized filter context
+    ret = av_buffersrc_parameters_set(self->iavfltctx, par);
+    if (ret < 0) {
+        tvh_context_log(self, LOG_ERR, "filters: failed to set AVFilterContext parameters with error %d", ret);
+        goto finish;
+    }
+
+    // 3. MANUALLY INITIALIZE
+    // Now that the params are inside, we call init with NULL
+    ret = avfilter_init_str(self->iavfltctx, NULL);
+    if (ret < 0) {
+        tvh_context_log(self, LOG_ERR, "filters: failed to initialize AVFilterContext with error %d", ret);
+        goto finish;
+    }
+
+// sink
+    if (!(oavflt = avfilter_get_by_name(sink_name))) {
+        tvh_context_log(self, LOG_ERR, "filters: sink filter '%s' not found", sink_name);
+        ret = AVERROR_FILTER_NOT_FOUND;
+        goto finish;
+    }
+
+    ret = avfilter_graph_create_filter(&self->oavfltctx, oavflt, "out", NULL, NULL, self->avfltgraph);
+    if (ret < 0) {
+        tvh_context_log(self, LOG_ERR, "filters: failed to create 'out' filter with error %d", ret);
+        goto finish;
+    }
+
+    // filters
+    // Build the linear chain and inject the hardware context 
+    if (filters && *filters) {
+        ret = build_linear_hw_filter_graph(self->avfltgraph, filters, 
+                                           self->iavfltctx, self->oavfltctx, 
+                                           self->hw_device_octx);
+        if (ret < 0) {
+            // Log error
+            tvh_context_log(self, LOG_ERR, "filters: fail during build_linear_hw_filter_graph() %d", ret);
+            goto finish;
+        }
+    } else {
+        // If there's no filter string, just link input directly to output
+        ret = avfilter_link(self->iavfltctx, 0, self->oavfltctx, 0);
+        if (ret < 0) {
+            // Log error
+            tvh_context_log(self, LOG_ERR, "filters: fail during build_linear_hw_filter_graph() %d", ret);
+            goto finish;
+        }
+    }
+
+    if (ret < 0) {
+        tvh_context_log(self, LOG_ERR, "filters: failed to add filters: '%s' with error %d", filters, ret);
+        goto finish;
+    }
+
+    // insert aditional filters required for conversions
+    avfilter_graph_set_auto_convert(self->avfltgraph, AVFILTER_AUTO_CONVERT_ALL);
+
+    //
+    if ((ret = avfilter_graph_config(self->avfltgraph, &logctx)) < 0) {
+        tvh_context_log(self, LOG_ERR, "filters: failed to config filter graph with error %d", ret);
+        goto finish;
+    }
+
+    stream_type = av_buffersink_get_type(self->oavfltctx);
+
+    // 1. CONFIGURE PARAMETERS
+    if (stream_type == AVMEDIA_TYPE_VIDEO) {
+        // for Video:
+        // Extract negotiated parameters from the sink context and pass them to the encoder context.
+        self->oavctx->pix_fmt   = av_buffersink_get_format(self->oavfltctx);
+        self->oavctx->width     = av_buffersink_get_w(self->oavfltctx);
+        self->oavctx->height    = av_buffersink_get_h(self->oavfltctx);
+        // Important: The filter graph may change the timebase
+        self->oavctx->time_base = av_buffersink_get_time_base(self->oavfltctx);
+        self->oavctx->framerate = av_buffersink_get_frame_rate(self->oavfltctx);
+#if LIBAVCODEC_VERSION_MAJOR > 60
+        // Get the output link to access color metadata
+        const AVFilterLink *outlink = self->oavfltctx->inputs[0];
+        // 1. Extract Color Range (MPEG/TV vs JPEG/PC)
+        self->oavctx->color_range = outlink->color_range;
+        // 2. Extract Color Space (e.g., BT.709, BT.2020)
+        self->oavctx->colorspace = outlink->colorspace;
+        // 3. Extract Color Primaries and Transfer Characteristics (Recommended)
+        // to be added later on
+        //self->oavctx->color_primaries = outlink->color_primaries;
+        //self->oavctx->color_trc       = outlink->color_trc;
+#endif
+        // Handle Sample Aspect Ratio (SAR)
+        AVRational sar = av_buffersink_get_sample_aspect_ratio(self->oavfltctx);
+        if (sar.num > 0 && sar.den > 0)
+            self->oavctx->sample_aspect_ratio = sar;
+
+        // 2. THE HARDWARE LINK
+        // Query the hardware frames context from the sink.
+        AVBufferRef *hw_frames_ctx = av_buffersink_get_hw_frames_ctx(self->oavfltctx);
+        
+        if (hw_frames_ctx) {
+            // We must create a new reference to the context. 
+            // The encoder context will take ownership of this reference. 
+            self->oavctx->hw_frames_ctx = av_buffer_ref(hw_frames_ctx);
+            if (!self->oavctx->hw_frames_ctx) {
+                ret = AVERROR(ENOMEM);
+                goto finish;
+            }
+            
+            // Optimization: Some encoders (like VAAPI) benefit from knowing 
+            // the underlying software format being "hidden" by the hardware surface.
+            const AVHWFramesContext *frames_fctx = (AVHWFramesContext *)hw_frames_ctx->data;
+            self->oavctx->sw_pix_fmt = frames_fctx->sw_format;
+            
+            // Log it so you can see it's working
+            tvh_context_log(self, LOG_DEBUG, "filters: filter sink provided HW frames (pix_fmt: %s, sw_pix_fmt: %s)", 
+                av_get_pix_fmt_name(self->oavctx->pix_fmt), av_get_pix_fmt_name(self->oavctx->sw_pix_fmt));
+        }
+        char logs[256];
+        str_snprintf(logs, sizeof(logs),
+            "filter video out configuration:"
+            " video_size=%dx%d"
+            ",pix_fmt=%s"
+            ",time_base=%d/%d"
+            ",frame_rate=%d/%d"
+            ",pixel_aspect:%d/%d"
+#if LIBAVCODEC_VERSION_MAJOR > 60
+            ",color_range:%s"
+            ",color_space:%s"
+#endif
+            ,self->oavctx->width, self->oavctx->height
+            ,av_get_pix_fmt_name(self->oavctx->pix_fmt)
+            ,self->oavctx->time_base.num, self->oavctx->time_base.den
+            ,self->oavctx->framerate.num, self->oavctx->framerate.den
+            ,self->oavctx->sample_aspect_ratio.num, self->oavctx->sample_aspect_ratio.den
+#if LIBAVCODEC_VERSION_MAJOR > 60
+            ,av_color_range_name(outlink->color_range)
+            ,av_color_space_name(outlink->colorspace)
+#endif
+        );
+        // to be removed when we remove has_support_for_filter2
+        tvhinfo(LS_TRANSCODE, 
+        //tvh_context_log(self, LOG_DEBUG,
+                          "%s", logs);
+
+    } else if (stream_type == AVMEDIA_TYPE_AUDIO) {
+        // for Audio:
+        // Extract negotiated parameters from the sink context and pass them to the encoder context.
+        self->oavctx->sample_rate = av_buffersink_get_sample_rate(self->oavfltctx);
+        self->oavctx->sample_fmt = av_buffersink_get_format(self->oavfltctx);
+        // Correct way to set up the audio encoder
+        self->oavctx->time_base = (AVRational){1, self->oavctx->sample_rate};   // CRITICAL
+
+        ret = av_buffersink_get_ch_layout(self->oavfltctx, &self->oavctx->ch_layout);
+        if (ret < 0) {
+            tvh_context_log(self, LOG_ERR, "filters: failed to config AVCodecContext ch_layout with error %d", ret);
+            goto finish;
+        }
+
+        char logs[256];
+        memset(logs, 0, sizeof(logs));
+        char buf[64];
+        memset(buf, 0, sizeof(buf));
+        av_channel_layout_describe(&self->oavctx->ch_layout, buf, sizeof(buf));
+        str_snprintf(logs, sizeof(logs),
+            "filter audio out configuration:"
+            " ch_layout=%s"
+            ",sample_fmt=%s"
+            ",sample_rate=%d"
+            ",time_base=%d/%d"
+            ,buf
+            ,av_get_sample_fmt_name(self->oavctx->sample_fmt)
+            ,self->oavctx->sample_rate
+            ,self->oavctx->time_base.num, self->oavctx->time_base.den
+        );
+        // to be removed when we remove has_support_for_filter2
+        tvhinfo(LS_TRANSCODE, 
+        //tvh_context_log(self, LOG_DEBUG,
+                          "%s", logs);
+
+    } else tvherror(LS_TRANSCODE, "filter can process only 'buffersink' and 'abuffersink', most likely will fail.");
+
+    if (ret >= 0 && tvhtrace_enabled()) {
+        char *graph = avfilter_graph_dump(self->avfltgraph, NULL);
+        char *str, *token, *saveptr = NULL;
+        for (str = graph; ; str = NULL) {
+          token = strtok_r(str, "\n", &saveptr);
+          if (token == NULL)
+            break;
+          tvh_context_log(self, LOG_TRACE, "filters dump: %s", token);
+        }
+        av_freep(&graph);
+    }
+
+finish:
+    if (par) {
+        av_buffer_unref(&par->hw_frames_ctx);
+        av_freep(&par);
+    }
+    return (ret > 0) ? 0 : ret;
+}
+#endif
 int
 tvh_context_open_filters(TVHContext *self,
                          const char *source_name, const char *source_args,
@@ -778,14 +1449,6 @@ tvh_context_destroy(TVHContext *self)
             pktbuf_ref_dec(self->input_gh);
             self->input_gh = NULL;
         }
-        if (self->oavframe) {
-            av_frame_free(&self->oavframe);
-            self->oavframe = NULL;
-        }
-        if (self->iavframe) {
-            av_frame_free(&self->iavframe);
-            self->iavframe = NULL;
-        }
         if (self->oavctx) {
             avcodec_free_context(&self->oavctx); // frees extradata
             self->oavctx = NULL;
@@ -794,6 +1457,17 @@ tvh_context_destroy(TVHContext *self)
             avcodec_free_context(&self->iavctx);
             self->iavctx = NULL;
         }
+        if (self->oavframe) {
+            av_frame_free(&self->oavframe);
+            self->oavframe = NULL;
+        }
+        if (self->iavframe) {
+            av_frame_free(&self->iavframe);
+            self->iavframe = NULL;
+        }
+#if ENABLE_HWACCELS
+        hwaccels_context_destroy(self);
+#endif
         self->type = NULL;
         self->profile = NULL;
         self->stream = NULL;

--- a/src/transcoding/transcode/hwaccels/hwaccels.c
+++ b/src/transcoding/transcode/hwaccels/hwaccels.c
@@ -20,6 +20,10 @@
 #include "hwaccels.h"
 #include "../internals.h"
 
+#if ENABLE_NVENC
+#include "nv.h"
+#endif
+
 #if ENABLE_VAAPI
 #include "vaapi.h"
 #endif
@@ -73,15 +77,20 @@ hwaccels_decode_setup_context(AVCodecContext *avctx,
                               const enum AVPixelFormat pix_fmt)
 {
     const AVPixFmtDescriptor *desc;
+    TVHContext *ctx = avctx->opaque;
 
     if (check_pix_fmt(avctx, pix_fmt)) {
         desc = av_pix_fmt_desc_get(pix_fmt);
         tvherror(LS_TRANSCODE, "no HWAccel for the pixel format '%s'", desc ? desc->name : "<unk>");
         return AVERROR(ENOENT);
     }
-    switch (pix_fmt) {
+    switch (ctx->iavhwdevtype) {
+#if ENABLE_NVENC
+        case AV_HWDEVICE_TYPE_CUDA:
+            return nv_decode_setup_context(avctx);
+#endif
 #if ENABLE_VAAPI
-        case AV_PIX_FMT_VAAPI:
+        case AV_HWDEVICE_TYPE_VAAPI:
             return vaapi_decode_setup_context(avctx);
 #endif
         default:
@@ -90,7 +99,47 @@ hwaccels_decode_setup_context(AVCodecContext *avctx,
     return -1;
 }
 
+static int is_pix_fmt_in_list(const enum AVPixelFormat check_pix_fmt, const enum AVPixelFormat *pix_fmts) {
+    enum AVPixelFormat pix_fmt = AV_PIX_FMT_NONE;
+    int i;
+    for (i = 0; pix_fmts[i] != AV_PIX_FMT_NONE; i++) {
+        pix_fmt = pix_fmts[i];
+        if (check_pix_fmt == pix_fmt)
+            return 1;
+    }
+    return 0;
+}
 
+/**
+ * @brief Negotiates and selects the optimal pixel format for decoding.
+ *
+ * This function is used as the 'get_format' callback for the FFmpeg decoder context. 
+ * Its primary goal is to select a hardware-accelerated pixel format if available 
+ * and supported by the current configuration.
+ *
+ * The selection process follows two distinct logic paths based on the profile:
+ * 1. **Modern API Path (New Implementation)**: If the profile supports 'filter2', 
+ * it iterates through the codec's hardware configurations. It looks for a 
+ * match between the required hardware device type and a configuration using 
+ * a hardware device context. If a match is found and the context is 
+ * successfully set up, the hardware pixel format is returned.
+ * 2. **Legacy Path (Old Implementation)**: If the modern path is unavailable or 
+ * not supported, it iterates through the provided list of candidate pixel 
+ * formats looking for any format marked with the `AV_PIX_FMT_FLAG_HWACCEL` 
+ * flag. It attempts to initialize the hardware context for the first valid 
+ * match found.
+ *
+ * If no hardware acceleration path is successful, the function falls back to the 
+ * first available software format provided in the `pix_fmts` list.
+ *
+ * @param avctx    The codec context being initialized for decoding.
+ * @param pix_fmts A null-terminated list of possible pixel formats acceptable 
+ * by the decoder.
+ *
+ * @return The selected AVPixelFormat. Returns a hardware pixel format if 
+ * acceleration setup is successful; otherwise, returns the software 
+ * fallback format.
+ */
 enum AVPixelFormat
 hwaccels_decode_get_format(AVCodecContext *avctx,
                            const enum AVPixelFormat *pix_fmts)
@@ -99,6 +148,46 @@ hwaccels_decode_get_format(AVCodecContext *avctx,
     const AVPixFmtDescriptor *desc;
     int i;
 
+    TVHContext *ctx = avctx->opaque;
+    if ((ctx->profile)->has_support_for_filter2) {
+        // new implementation
+        // Guard: delay HW frames context init until dimensions known.
+        // MPEG2 (and others) can call get_format() before sequence header -> width/height still 0.
+        if ((avctx->width <= 0 || avctx->height <= 0) &&
+            (avctx->coded_width <= 0 || avctx->coded_height <= 0)) {
+            // Pick first non-hwaccel format as a safe SW fallback for now.
+            for (i = 0; pix_fmts[i] != AV_PIX_FMT_NONE; i++) {
+                const AVPixFmtDescriptor *d = av_pix_fmt_desc_get(pix_fmts[i]);
+                if (!d) continue;
+                if (!(d->flags & AV_PIX_FMT_FLAG_HWACCEL))
+                    return pix_fmts[i];
+            }
+            return pix_fmts[0]; // last-resort
+        }
+        // 1. Iterate through all HW configs supported by this codec
+        for (i = 0; ; i++) {
+            const AVCodecHWConfig *config = avcodec_get_hw_config(avctx->codec, i);
+            if (!config) break;
+            // 2. If the current format in the list matches a format in a 
+            //    Hardware Device Context config, it's a hardware path
+            //    that is matching with input hw device type
+            if (config->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX &&
+                config->device_type == ctx->iavhwdevtype && 
+                is_pix_fmt_in_list(config->pix_fmt, pix_fmts) &&
+                !hwaccels_decode_setup_context(avctx, config->pix_fmt)) {
+                // Because it came from a HW_DEVICE_CTX config, we know 
+                // it's the hardware-accelerated path.
+                if (!avctx->hw_frames_ctx) {
+                    // hw_frames_ctx is not initialized most likely will fail
+                    tvhwarn(LS_LIBAV,  "Decoder hw_frames_ctx is not available for pix_fmt = %s", av_get_pix_fmt_name(config->pix_fmt));
+                }
+                tvhtrace(LS_TRANSCODE, "hwaccels: [%s] trying pix_fmt: %s", avctx->codec->name, av_get_pix_fmt_name(config->pix_fmt));
+                // return pix_fmt
+                return config->pix_fmt; 
+            }
+        }
+    }
+    // old implementation
     for (i = 0; pix_fmts[i] != AV_PIX_FMT_NONE; i++) {
         pix_fmt = pix_fmts[i];
         if ((desc = av_pix_fmt_desc_get(pix_fmt))) {
@@ -113,134 +202,90 @@ hwaccels_decode_get_format(AVCodecContext *avctx,
 }
 
 
-void
-hwaccels_decode_close_context(AVCodecContext *avctx)
-{
-    TVHContext *ctx = avctx->opaque;
-
-    if (ctx->hw_accel_ictx) {
-        switch (avctx->pix_fmt) {
-#if ENABLE_VAAPI
-            case AV_PIX_FMT_VAAPI:
-                vaapi_decode_close_context(avctx);
-                break;
-#endif
-            default:
-                break;
-        }
-        ctx->hw_accel_ictx = NULL;
-    }
-}
-
-
 int
-hwaccels_get_scale_filter(AVCodecContext *iavctx, AVCodecContext *oavctx,
-                          char *filter, size_t filter_len)
+hwaccels_decode_get_filters(TVHContext *self, char *filter, size_t filter_len)    
 {
-    TVHContext *ctx = iavctx->opaque;
 
-    if (ctx->hw_accel_ictx) {
-        switch (iavctx->pix_fmt) {
-#if ENABLE_VAAPI
-            case AV_PIX_FMT_VAAPI:
-                return vaapi_get_scale_filter(iavctx, oavctx, filter, filter_len);
+    switch (self->iavhwdevtype) {
+#if ENABLE_NVENC
+        case AV_HWDEVICE_TYPE_CUDA:
+            return nv_get_filters(self, filter, filter_len);
 #endif
-            default:
-                break;
-        }
+#if ENABLE_VAAPI
+        case AV_HWDEVICE_TYPE_VAAPI:
+            return vaapi_get_filters(self, filter, filter_len);
+#endif
+        default:
+            break;
     }
     
-    return -1;
+    return 0;
 }
 
 
 int
-hwaccels_get_deint_filter(AVCodecContext *avctx, char *filter, size_t filter_len)
+hwaccels_download(TVHContext *self, char *filter, size_t filter_len, int skip_format)    
 {
-    const TVHContext *ctx = avctx->opaque;
 
-    if (ctx->hw_accel_ictx) {
-        switch (avctx->pix_fmt) {
+    switch (self->iavhwdevtype) {
 #if ENABLE_VAAPI
-            case AV_PIX_FMT_VAAPI:
-                return vaapi_get_deint_filter(avctx, filter, filter_len);
+        case AV_HWDEVICE_TYPE_VAAPI:
+            // VAAPI will use default : 
+            // NOTE: this must be left last
 #endif
-            default:
-                break;
-        }
+        default:
+            if (skip_format) {
+                if (str_snprintf(filter, filter_len, "hwdownload")) {
+                    return -1;
+                }
+            }
+            else {
+                if (str_snprintf(filter, filter_len, "hwdownload,format=pix_fmts=%s",
+                                av_get_pix_fmt_name(self->iavctx->sw_pix_fmt))) {
+                    return -1;
+                }
+            }
+            break;
     }
-
-    return -1;
+    return 0;
 }
 
-int
-hwaccels_get_denoise_filter(AVCodecContext *avctx, int value, char *filter, size_t filter_len)
-{
-    TVHContext *ctx = avctx->opaque;
-
-    if (ctx->hw_accel_ictx) {
-        switch (avctx->pix_fmt) {
-#if ENABLE_VAAPI
-            case AV_PIX_FMT_VAAPI:
-                return vaapi_get_denoise_filter(avctx, value, filter, filter_len);
-#endif
-            default:
-                break;
-        }
-    }
-    
-    return -1;
-}
 
 int
-hwaccels_get_sharpness_filter(AVCodecContext *avctx, int value, char *filter, size_t filter_len)
+hwaccels_upload(TVHContext *self, char *filter, size_t filter_len)    
 {
-    TVHContext *ctx = avctx->opaque;
 
-    if (ctx->hw_accel_ictx) {
-        switch (avctx->pix_fmt) {
+    switch (self->oavhwdevtype) {
 #if ENABLE_VAAPI
-            case AV_PIX_FMT_VAAPI:
-                return vaapi_get_sharpness_filter(avctx, value, filter, filter_len);
+        case AV_HWDEVICE_TYPE_VAAPI:
+            // VAAPI will use default : 
+            // NOTE: this must be left last
 #endif
-            default:
-                break;
-        }
+        default:
+            if (str_snprintf(filter, filter_len, "format=pix_fmts=%s,hwupload",  // =extra_hw_frames=16
+                            av_get_pix_fmt_name(self->oavctx->sw_pix_fmt))) {
+                return -1;
+            }
+            break;
     }
     
-    return -1;
+    return 0;
 }
+
 
 /* encoding ================================================================= */
 
 int
-hwaccels_initialize_encoder_from_decoder(const AVCodecContext *iavctx, AVCodecContext *oavctx)
+hwaccels_encode_setup_context(TVHContext *self)
 {
-    switch (iavctx->pix_fmt) {
-        case AV_PIX_FMT_VAAPI:
-            /* we need to ref hw_frames_ctx of decoder to initialize encoder's codec.
-            Only after we get a decoded frame, can we obtain its hw_frames_ctx */
-            oavctx->hw_frames_ctx = av_buffer_ref(iavctx->hw_frames_ctx);
-            if (!oavctx->hw_frames_ctx) {
-                return AVERROR(ENOMEM);
-            }
-            return 0;
-        case AV_PIX_FMT_YUV420P:
-            break;
-        default:
-            break;
-    }
-    return 0;
-}
-
-
-int
-hwaccels_encode_setup_context(AVCodecContext *avctx)
-{
-    switch (avctx->pix_fmt) {
+    switch (self->oavhwdevtype) {
+#if ENABLE_NVENC
+        case AV_HWDEVICE_TYPE_CUDA:
+            return nv_encode_setup_context(self->oavctx);
+#endif
 #if ENABLE_VAAPI
-        case AV_PIX_FMT_VAAPI:
-            return vaapi_encode_setup_context(avctx);
+        case AV_HWDEVICE_TYPE_VAAPI:
+            return vaapi_encode_setup_context(self->oavctx);
 #endif
         default:
             break;
@@ -250,17 +295,26 @@ hwaccels_encode_setup_context(AVCodecContext *avctx)
 
 
 void
-hwaccels_encode_close_context(AVCodecContext *avctx)
+hwaccels_context_destroy(TVHContext *self)
 {
-    switch (avctx->pix_fmt) {
+    if (!self)
+        return;
+    switch (self->iavhwdevtype) {
+#if ENABLE_NVENC
+        case AV_HWDEVICE_TYPE_CUDA:
+            nv_decode_destroy(self);
+            break;
+#endif
 #if ENABLE_VAAPI
-        case AV_PIX_FMT_VAAPI:
-            vaapi_encode_close_context(avctx);
+        case AV_HWDEVICE_TYPE_VAAPI:
+            vaapi_decode_destroy(self);
             break;
 #endif
         default:
             break;
     }
+    if (self->hw_device_octx)
+        av_buffer_unref(&self->hw_device_octx);
 }
 
 
@@ -275,6 +329,9 @@ hwaccels_init(void)
 void
 hwaccels_done(void)
 {
+#if ENABLE_NVENC
+    nv_done();
+#endif
 #if ENABLE_VAAPI
     vaapi_done();
 #endif

--- a/src/transcoding/transcode/hwaccels/nv.c
+++ b/src/transcoding/transcode/hwaccels/nv.c
@@ -1,7 +1,7 @@
 /*
  *  tvheadend - Transcoding
  *
- *  Copyright (C) 2016 Tvheadend
+ *  Copyright (C) 2026 Tvheadend
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -19,23 +19,21 @@
 
 #include "transcoding/codec/internals.h"
 #include "../internals.h"
-#include "vaapi.h"
+#include "nv.h"
 
 #include <libavutil/hwcontext.h>
-#include <libavutil/hwcontext_vaapi.h>
 #include <libavutil/pixdesc.h>
-#include <va/va.h>
 
 
-typedef struct tvh_vaapi_context_t {
+typedef struct tvh_nv_context_t {
     AVBufferRef *hw_device_ref;
-} TVHVAContext;
+} TVNVContext;
 
 
-/* TVHVAContext ============================================================= */
+/* TVNVContext ============================================================= */
 
 static void
-tvh_va_context_destroy(TVHVAContext *self)
+tvh_nv_context_destroy(TVNVContext *self)
 {
     if (self) {
         if (self->hw_device_ref) {
@@ -57,17 +55,17 @@ static int set_hwframe_ctx(AVCodecContext *ctx, AVBufferRef *hw_device_ctx)
     int err = 0;
 
     if (!(hw_frames_ref = av_hwframe_ctx_alloc(hw_device_ctx))) {
-        tvherror_transcode(LST_VAAPI, "Decode: Failed to create VAAPI frame context.");
+        tvherror_transcode(LST_NVENC, "Decode: Failed to create CUDA frame context.");
         return AVERROR(ENOMEM);
     }
     frames_ctx = (AVHWFramesContext *)(hw_frames_ref->data);
-    frames_ctx->format    = AV_PIX_FMT_VAAPI;
+    frames_ctx->format    = AV_PIX_FMT_CUDA;
     frames_ctx->sw_format = AV_PIX_FMT_NV12;
     frames_ctx->width     = ctx->width;
     frames_ctx->height    = ctx->height;
     frames_ctx->initial_pool_size = 20;
     if ((err = av_hwframe_ctx_init(hw_frames_ref)) < 0) {
-        tvherror_transcode(LST_VAAPI, "Decode: Failed to initialize VAAPI frame context."
+        tvherror_transcode(LST_NVENC, "Decode: Failed to initialize CUDA frame context."
                 "Error code: %s",av_err2str(err));
         av_buffer_unref(&hw_frames_ref);
         return err;
@@ -75,85 +73,62 @@ static int set_hwframe_ctx(AVCodecContext *ctx, AVBufferRef *hw_device_ctx)
     ctx->hw_frames_ctx = av_buffer_ref(hw_frames_ref);
     if (!ctx->hw_frames_ctx) {
         err = AVERROR(ENOMEM);
-        tvherror_transcode(LST_VAAPI, "Decode: Failed to create a hardware frame context."
+        tvherror_transcode(LST_NVENC, "Decode: Failed to create a hardware frame context."
                 "Error code: %s",av_err2str(err));
     }
     av_buffer_unref(&hw_frames_ref);
     return err;
 }
 
-static int vaapi_get_scale_filter(AVCodecContext *iavctx, AVCodecContext *oavctx,
+static int nv_get_scale_filter(AVCodecContext *iavctx, AVCodecContext *oavctx,
                        char *filter, size_t filter_len)
 {
-    if (str_snprintf(filter, filter_len, "scale_vaapi=w=%d:h=%d", oavctx->width, oavctx->height)){
+    // https://ffmpeg.org/ffmpeg-filters.html#scale_005fcuda-1
+    if (str_snprintf(filter, filter_len, "scale_cuda=w=%d:h=%d", oavctx->width, oavctx->height)){
         return -1;
     }
     return 0;
 }
 
-static int vaapi_get_deint_filter(AVCodecContext *avctx, char *filter, size_t filter_len)
+static int nv_get_deint_filter(AVCodecContext *avctx, char *filter, size_t filter_len)
 {
     const TVHContext *ctx = avctx->opaque;
-
-    // Map user selected rate (0=frame,1=field) to VAAPI rate (1=frame,2=field)
-    int rate = (((TVHVideoCodecProfile *)ctx->profile)->deinterlace_field_rate == 1) ? 2 : 1;
-    int enable_auto = (((TVHVideoCodecProfile *)ctx->profile)->deinterlace_enable_auto == 1) ? 1 : 0;
-    int mode = ((TVHVideoCodecProfile *)ctx->profile)->deinterlace_vaapi_mode;
-    mode = (mode < 0 || mode > 4) ? 0 : mode;  // check we have valid deinterlace_vaapi mode
-
-    if (str_snprintf(filter, filter_len, "deinterlace_vaapi=mode=%d:rate=%d:auto=%d",
-                                         mode, rate, enable_auto)) {
+    // https://ffmpeg.org/ffmpeg-filters.html#yadif_005fcuda
+    if (str_snprintf(filter, filter_len, "yadif_cuda=mode=%d:deint=%d",
+                     ((TVHVideoCodecProfile *)ctx->profile)->deinterlace_field_rate,
+                     ((TVHVideoCodecProfile *)ctx->profile)->deinterlace_enable_auto )) {
         return -1;
     }
     return 0;
 }
-
-static int vaapi_get_denoise_filter(AVCodecContext *avctx, int value, char *filter, size_t filter_len)
-{
-    if (str_snprintf(filter, filter_len, "denoise_vaapi=%d", value)){
-        return -1;
-    }
-    return 0;
-}
-
-static int vaapi_get_sharpness_filter(AVCodecContext *avctx, int value, char *filter, size_t filter_len)
-{
-    if (str_snprintf(filter, filter_len, "sharpness_vaapi=%d", value)){
-        return -1;
-    }
-    return 0;
-}
-
 
 /* decoding ================================================================= */
 
 int
-vaapi_decode_setup_context(AVCodecContext *avctx)
+nv_decode_setup_context(AVCodecContext *avctx)
 {
     TVHContext *ctx = avctx->opaque;
 
-    TVHVAContext *self = NULL;
+    TVNVContext *self = NULL;
     int ret = -1;
 
-    if (!(self = calloc(1, sizeof(TVHVAContext)))) {
-        tvherror_transcode(LST_VAAPI, "Decode: Failed to allocate VAAPI context (TVHVAContext)");
+    if (!(self = calloc(1, sizeof(TVNVContext)))) {
+        tvherror_transcode(LST_NVENC, "Decode: Failed to allocate CUDA context (TVNVContext)");
         return AVERROR(ENOMEM);
     }
-    // lifted from ffmpeg-6.1.1/doc/examples/vaapi_transcode.c line 237
-    /* Open VAAPI device and create an AVHWDeviceContext for it*/
-    if ((ret = av_hwdevice_ctx_create(&self->hw_device_ref, AV_HWDEVICE_TYPE_VAAPI, ctx->hw_accel_device, NULL, 0)) < 0) {
-        tvherror_transcode(LST_VAAPI, "Decode: Failed to Open VAAPI device and create an AVHWDeviceContext for device: "
+    // Open NV device and create an AVHWDeviceContext for it
+    if ((ret = av_hwdevice_ctx_create(&self->hw_device_ref, AV_HWDEVICE_TYPE_CUDA, ctx->hw_accel_device, NULL, 0)) < 0) {
+        tvherror_transcode(LST_NVENC, "Decode: Failed to Open CUDA device and create an AVHWDeviceContext for device: "
                             "%s with error code: %s", 
                             ctx->hw_accel_device, av_err2str(ret));
         free(self);
         self = NULL;
         return ret;
     }
-    // lifted from ffmpeg-6.1.1/doc/examples/vaapi_transcode.c line 95
-    /* set hw_frames_ctx for decoder's AVCodecContext */
+    // set hw_frames_ctx for decoder's AVCodecContext
     avctx->hw_device_ctx = av_buffer_ref(self->hw_device_ref);
     if (!avctx->hw_device_ctx) {
-        tvherror_transcode(LST_VAAPI, "Decode: Failed to create a hardware device reference for device: %s.", 
+        tvherror_transcode(LST_NVENC, "Decode: Failed to create a hardware device reference for device: %s.", 
                         ctx->hw_accel_device);
         // unref hw_device_ref
         av_buffer_unref(&self->hw_device_ref);
@@ -162,10 +137,9 @@ vaapi_decode_setup_context(AVCodecContext *avctx)
         self = NULL;
         return AVERROR(ENOMEM);
     }
-    // lifted from ffmpeg-6.1.1/doc/examples/vaapi_encode.c line 152
-    /* set hw_frames_ctx for decoder's AVCodecContext */
+    // set hw_frames_ctx for decoder's AVCodecContext
     if ((ret = set_hwframe_ctx(avctx, avctx->hw_device_ctx)) < 0) {
-        tvherror_transcode(LST_VAAPI, "Decode: Failed to set hwframe context."
+        tvherror_transcode(LST_NVENC, "Decode: Failed to set hwframe context."
                                       "Error code: %s", av_err2str(ret));
         av_buffer_unref(&avctx->hw_device_ctx);
         // unref hw_device_ref
@@ -176,17 +150,17 @@ vaapi_decode_setup_context(AVCodecContext *avctx)
         return ret;
     }
     if (ctx->hw_accel_ictx) {
-        vaapi_decode_destroy(ctx);
+        nv_decode_destroy(ctx);
     }
     ctx->hw_accel_ictx = self;
-    avctx->pix_fmt = AV_PIX_FMT_VAAPI;
+    avctx->pix_fmt = AV_PIX_FMT_CUDA;
     avctx->sw_pix_fmt = AV_PIX_FMT_NV12;
     return 0;
 }
 
 
 /**
- * @brief Constructs a VAAPI hardware video filter chain string.
+ * @brief Constructs a NV hardware video filter chain string.
  *
  * This function evaluates the current transcoding profile and input/output
  * contexts to determine which hardware filters (deinterlacing, scaling, 
@@ -204,25 +178,21 @@ vaapi_decode_setup_context(AVCodecContext *avctx)
  * individual hardware filter strings.
  */
 int
-vaapi_get_filters(TVHContext *self, char *filter, size_t filter_len)    
+nv_get_filters(TVHContext *self, char *filter, size_t filter_len)    
 {
     // NOTE: filter_len > sum of all string --> previously used strcat()
     // Now using snprintf for guaranteed buffer safety
     char hw_deint[64];
     char hw_scale[64];
-    char hw_denoise[64];
-    char hw_sharpness[64];
     size_t len=0;
 
     int filter_scale = (self->iavctx->height != self->oavctx->height);
     int filter_deint = ((TVHVideoCodecProfile *)self->profile)->deinterlace;
-    int filter_denoise = ((TVHVideoCodecProfile *)self->profile)->filter_hw_denoise;
-    int filter_sharpness = ((TVHVideoCodecProfile *)self->profile)->filter_hw_sharpness;
 
     memset(hw_deint, 0, sizeof(hw_deint));
     if (filter_deint){
-        if (vaapi_get_deint_filter(self->iavctx, hw_deint, sizeof(hw_deint))){
-            tvherror_transcode(LST_VAAPI, "Filter: vaapi_get_deint_filter() returned with error.");
+        if (nv_get_deint_filter(self->iavctx, hw_deint, sizeof(hw_deint))){
+            tvherror_transcode(LST_NVENC, "Filter: nv_get_deint_filter() returned with error.");
             return -1;
         }
         else {
@@ -233,8 +203,8 @@ vaapi_get_filters(TVHContext *self, char *filter, size_t filter_len)
     
     memset(hw_scale, 0, sizeof(hw_scale));
     if (filter_scale){ 
-        if(vaapi_get_scale_filter(self->iavctx, self->oavctx, hw_scale, sizeof(hw_scale))){
-            tvherror_transcode(LST_VAAPI, "Filter: vaapi_get_scale_filter() returned with error.");
+        if(nv_get_scale_filter(self->iavctx, self->oavctx, hw_scale, sizeof(hw_scale))){
+            tvherror_transcode(LST_NVENC, "Filter: nv_get_scale_filter() returned with error.");
             return -1;
         }
         else {
@@ -242,37 +212,14 @@ vaapi_get_filters(TVHContext *self, char *filter, size_t filter_len)
             snprintf(filter + len, filter_len - len, "%s%s", (len > 0) ? "," : "", hw_scale);
         }
     }
-    
-    memset(hw_denoise, 0, sizeof(hw_denoise));
-    if (filter_denoise) { 
-        if (vaapi_get_denoise_filter(self->iavctx, filter_denoise, hw_denoise, sizeof(hw_denoise))){
-            tvherror_transcode(LST_VAAPI, "Filter: vaapi_get_denoise_filter() returned with error.");
-            return -1;
-        }
-        else {
-            len = strnlen(filter, filter_len);
-            snprintf(filter + len, filter_len - len, "%s%s", (len > 0) ? "," : "", hw_denoise);
-        }
-    }
-
-    memset(hw_sharpness, 0, sizeof(hw_sharpness));
-    if (filter_sharpness){
-        if (vaapi_get_sharpness_filter(self->iavctx, filter_sharpness, hw_sharpness, sizeof(hw_sharpness))){
-            tvherror_transcode(LST_VAAPI, "Filter: vaapi_get_sharpness_filter() returned with error.");
-            return -1;
-        }
-        else {
-            len = strnlen(filter, filter_len);
-            snprintf(filter + len, filter_len - len, "%s%s", (len > 0) ? "," : "", hw_sharpness);
-        }
-    }
     return 0;
 }
+
 
 /* encoding ================================================================= */
 
 int
-vaapi_encode_setup_context(AVCodecContext *avctx)
+nv_encode_setup_context(AVCodecContext *avctx)
 {
     TVHContext *ctx = avctx->opaque;
     int ret = 0;
@@ -280,9 +227,9 @@ vaapi_encode_setup_context(AVCodecContext *avctx)
     // this is required in case encode is called twice
     if (ctx->hw_device_octx)
         av_buffer_unref(&ctx->hw_device_octx);
-    /* Open VAAPI device and create an AVHWDeviceContext for it*/
-    if ((ret = av_hwdevice_ctx_create(&ctx->hw_device_octx, AV_HWDEVICE_TYPE_VAAPI, NULL, NULL, 0)) < 0) {
-        tvherror_transcode(LST_VAAPI, "Encode: Failed to open VAAPI device and create an AVHWDeviceContext for it."
+    // Open NV device and create an AVHWDeviceContext for it
+    if ((ret = av_hwdevice_ctx_create(&ctx->hw_device_octx, AV_HWDEVICE_TYPE_CUDA, NULL, NULL, 0)) < 0) {
+        tvherror_transcode(LST_NVENC, "Encode: Failed to open CUDA device and create an AVHWDeviceContext for it."
                 "Error code: %s",av_err2str(ret));
         return ret;
     }
@@ -291,14 +238,12 @@ vaapi_encode_setup_context(AVCodecContext *avctx)
         av_buffer_unref(&ctx->hw_device_octx);
         ctx->hw_device_octx = NULL;
         ret = AVERROR(ENOMEM);
-        tvherror_transcode(LST_VAAPI, "Encode: Failed to create a hardware device context."
+        tvherror_transcode(LST_NVENC, "Encode: Failed to create a hardware device context."
                 "Error code: %s",av_err2str(ret));
         return ret;
     }
-    
-    // 2. CRITICAL: Frames Context are created in tvh_context_open_filters2()
 
-    avctx->pix_fmt = AV_PIX_FMT_VAAPI;
+    avctx->pix_fmt = AV_PIX_FMT_CUDA;
     avctx->sw_pix_fmt = AV_PIX_FMT_NV12;
     return ret;
 }
@@ -307,16 +252,16 @@ vaapi_encode_setup_context(AVCodecContext *avctx)
 /* module =================================================================== */
 
 void
-vaapi_decode_destroy(TVHContext *ctx)
+nv_decode_destroy(TVHContext *ctx)
 {
     if (!ctx)
         return;
-    tvh_va_context_destroy(ctx->hw_accel_ictx);
+    tvh_nv_context_destroy(ctx->hw_accel_ictx);
     ctx->hw_accel_ictx = NULL;
 }
 
 void
-vaapi_done()
+nv_done()
 {
     /* nothing to do */
 }

--- a/src/transcoding/transcode/hwaccels/nv.h
+++ b/src/transcoding/transcode/hwaccels/nv.h
@@ -1,7 +1,7 @@
 /*
  *  tvheadend - Transcoding
  *
- *  Copyright (C) 2016 Tvheadend
+ *  Copyright (C) 2026 Tvheadend
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,49 +18,35 @@
  */
 
 
-#ifndef TVH_TRANSCODING_TRANSCODE_HWACCELS_H__
-#define TVH_TRANSCODING_TRANSCODE_HWACCELS_H__
+#ifndef TVH_TRANSCODING_TRANSCODE_HWACCELS_NV_H__
+#define TVH_TRANSCODING_TRANSCODE_HWACCELS_NV_H__
 
 
 #include "tvheadend.h"
-#include "../internals.h"
+
 #include <libavcodec/avcodec.h>
 
 
 /* decoding ================================================================= */
 
-enum AVPixelFormat
-hwaccels_decode_get_format(AVCodecContext *avctx,
-                           const enum AVPixelFormat *pix_fmts);
+int
+nv_decode_setup_context(AVCodecContext *avctx);
 
 int
-hwaccels_decode_get_filters(TVHContext *self, char *filter, size_t filter_len);
-
-int
-hwaccels_download(TVHContext *self, char *filter, size_t filter_len, int skip_format);
-
-int
-hwaccels_upload(TVHContext *self, char *filter, size_t filter_len);
-
+nv_get_filters(TVHContext *self, char *filter, size_t filter_len);
 
 /* encoding ================================================================= */
 
 int
-hwaccels_encode_setup_context(TVHContext *self);
+nv_encode_setup_context(AVCodecContext *avctx);
 
 /* module =================================================================== */
 
 void
-hwaccels_init(void);
+nv_decode_destroy(TVHContext *ctx);
 
 void
-hwaccels_done(void);
+nv_done(void);
 
-/**
- * Release TVH-owned hardware resources after @c avcodec_free_context has been
- * called on both decoder and encoder contexts (see @c tvh_context_destroy).
- */
-void
-hwaccels_context_destroy(TVHContext *self);
 
-#endif // TVH_TRANSCODING_TRANSCODE_HWACCELS_H__
+#endif // TVH_TRANSCODING_TRANSCODE_HWACCELS_NV_H__

--- a/src/transcoding/transcode/hwaccels/vaapi.h
+++ b/src/transcoding/transcode/hwaccels/vaapi.h
@@ -32,32 +32,18 @@
 int
 vaapi_decode_setup_context(AVCodecContext *avctx);
 
-void
-vaapi_decode_close_context(AVCodecContext *avctx);
-
 int
-vaapi_get_scale_filter(AVCodecContext *iavctx, AVCodecContext *oavctx, char *filter, size_t filter_len);
-
-int
-vaapi_get_deint_filter(AVCodecContext *avctx, char *filter, size_t filter_len);
-
-int
-vaapi_get_denoise_filter(AVCodecContext *avctx, int value, char *filter, size_t filter_len);
-
-int
-vaapi_get_sharpness_filter(AVCodecContext *avctx, int value, char *filter, size_t filter_len);
-
+vaapi_get_filters(TVHContext *self, char *filter, size_t filter_len);
 
 /* encoding ================================================================= */
 
 int
 vaapi_encode_setup_context(AVCodecContext *avctx);
 
-void
-vaapi_encode_close_context(AVCodecContext *avctx);
-
-
 /* module =================================================================== */
+
+void
+vaapi_decode_destroy(TVHContext *ctx);
 
 void
 vaapi_done(void);

--- a/src/transcoding/transcode/internals.h
+++ b/src/transcoding/transcode/internals.h
@@ -48,12 +48,14 @@ typedef struct tvh_context_type TVHContextType;
 typedef struct tvh_context TVHContext;
 typedef struct tvh_context_helper TVHContextHelper;
 
-// post phase _MUST_ be == phase + 1
+
 typedef enum {
+    PREPARE_DECODER,
     OPEN_DECODER,
-    OPEN_DECODER_POST,
-    OPEN_ENCODER,
-    OPEN_ENCODER_POST
+    NOTIFY_GLOBALHEADER,
+    PREPARE_ENCODER,
+    OPEN_FILTERS,
+    OPEN_ENCODER
 } TVHOpenPhase;
 
 #if LIBAVCODEC_VERSION_MAJOR > 59
@@ -169,10 +171,18 @@ struct tvh_context {
     int64_t delta;
     uint8_t sri;
     // hardware acceleration
+    // store the AVHWDeviceType to be used in decide the filters and hwaccels functions calls
+    enum AVHWDeviceType iavhwdevtype;
+    enum AVHWDeviceType oavhwdevtype;
+    // used to transport the sample aspect ratio from packets to filter
+    AVRational sample_aspect_ratio;
     char *hw_accel_device;
     AVBufferRef *hw_device_ref;
     void *hw_accel_ictx;
     AVBufferRef *hw_device_octx;
+    // used as 'temporary storage' to pass dict from one state machine to other
+    // (PREPARE_DECODER --> OPEN_DECODER or PREPARE_ENCODER --> OPEN_ENCODER)
+    AVDictionary *temp_opts;
 };
 
 int
@@ -184,6 +194,43 @@ tvh_context_get_str_opt(AVDictionary **opts, const char *key, char **value);
 void
 tvh_context_close(TVHContext *self, int flush);
 
+#if LIBAVCODEC_VERSION_MAJOR > 59
+/**
+ * @brief Initializes and configures an FFmpeg AVFilterGraph for audio or video processing.
+ *
+ * This function acts as the bridge between the decoder and the encoder. It constructs
+ * a filter graph, configures the input source using parameters from the input codec 
+ * context (`iavctx`), applies a user-specified filter chain, and extracts the negotiated 
+ * output parameters from the sink to configure the output codec context (`oavctx`).
+ *
+ * It handles format extraction, Sample Aspect Ratio (SAR) fallbacks, hardware frame 
+ * contexts (e.g., VAAPI/CUDA), and color space metadata synchronization for modern 
+ * FFmpeg APIs (FFmpeg 6.0/7.0+).
+ *
+ * @param self        Pointer to the main TVH transcoding context.
+ * @param source_name The name of the FFmpeg source filter to use (e.g., "buffer" for video, 
+ * "abuffer" for audio).
+ * @param filters     A string describing the linear filter chain to insert between source 
+ * and sink (e.g., "yadif=1,scale=1920:1080"). If NULL or empty, the 
+ * source is linked directly to the sink.
+ * @param sink_name   The name of the FFmpeg sink filter to use (e.g., "buffersink" for video, 
+ * "abuffersink" for audio).
+ *
+ * @return 0 on successful graph configuration, or a negative FFmpeg AVERROR code on failure.
+ *
+ * @note 
+ * - If the filter graph alters the stream's properties (e.g., changing resolution, pixel 
+ * format, or sample rate), this function automatically updates `self->oavctx` to match 
+ * the new negotiated parameters.
+ * - Hardware frame contexts are properly referenced and mapped if hardware decoding/filtering 
+ * is active.
+ */
+int
+tvh_context_open_filters2(TVHContext *self,
+                         const char *source_name,
+                         const char *filters, 
+                         const char *sink_name);
+#endif
 /* __VA_ARGS__ = NULL terminated list of sink options
    sink option = (const char *name, av_opt_set_type opt_set_type, int size, const uint8_t *value) */
 int

--- a/src/transcoding/transcode/stream.c
+++ b/src/transcoding/transcode/stream.c
@@ -66,6 +66,7 @@ tvh_stream_setup(TVHStream *self, TVHCodecProfile *profile, tvh_ssc_t *ssc)
 #if ENABLE_MMAL | ENABLE_NVENC | ENABLE_VAAPI
     int hwaccel = -1;
     int hwaccel_details = -1;
+    enum AVHWDeviceType avhwdevtype = AV_HWDEVICE_TYPE_NONE;
     if (SCT_ISVIDEO(ssc->es_type)) {
         if (((hwaccel         = tvh_codec_profile_video_get_hwaccel(profile)) < 0) ||
             ((hwaccel_details = tvh_codec_profile_video_get_hwaccel_details(profile)) < 0)) {
@@ -99,23 +100,26 @@ tvh_stream_setup(TVHStream *self, TVHCodecProfile *profile, tvh_ssc_t *ssc)
             } else if (icodec_id == AV_CODEC_ID_VP8) {
                 icodec = avcodec_find_decoder_by_name("vp8_cuvid");
             }
+            if (icodec) avhwdevtype = AV_HWDEVICE_TYPE_CUDA;
         }
 #endif
 #if ENABLE_VAAPI
         if (!icodec && 
             idnode_is_instance(&profile->idnode, (idclass_t *)&codec_profile_video_class) &&
             hwaccel &&
-            (hwaccel_details == HWACCEL_PRIORITIZE_VAAPI)) {
-            if (icodec_id == AV_CODEC_ID_MPEG2VIDEO) {
-                icodec = avcodec_find_decoder_by_name("mpeg2_vaapi");
-            } else if (icodec_id == AV_CODEC_ID_H264) {
-                icodec = avcodec_find_decoder_by_name("h264_vaapi");
-            } else if (icodec_id == AV_CODEC_ID_HEVC) {
-                icodec = avcodec_find_decoder_by_name("hevc_vaapi");
-            } else if (icodec_id == AV_CODEC_ID_VP9) {
-                icodec = avcodec_find_decoder_by_name("vp9_vaapi");
-            } else if (icodec_id == AV_CODEC_ID_VP8) {
-                icodec = avcodec_find_decoder_by_name("vp8_vaapi");
+            // VAAPI is used also for software encoders
+            (hwaccel_details == HWACCEL_AUTO || hwaccel_details == HWACCEL_PRIORITIZE_VAAPI)) {
+                // VAAPI does not have a standalone decoder named mpeg2_vaapi h264_vaapi hevc_vaapi vp9_vaapi
+                // Instead, VAAPI uses the standard software decoder (e.g., mpeg2video) and "accelerates" it by attaching a hardware device context to it.
+            icodec = avcodec_find_decoder(icodec_id);
+
+            for (int i = 0;; i++) {
+                const AVCodecHWConfig *config = avcodec_get_hw_config(icodec, i);
+                if (!config) break;
+                if (config->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX &&
+                    config->device_type == AV_HWDEVICE_TYPE_VAAPI) {
+                    avhwdevtype =  AV_HWDEVICE_TYPE_VAAPI;
+                }
             }
         }
 #endif
@@ -141,6 +145,10 @@ tvh_stream_setup(TVHStream *self, TVHCodecProfile *profile, tvh_ssc_t *ssc)
                                              icodec, ocodec, ssc->ssc_gh))) {
         return -1;
     }
+#if ENABLE_MMAL | ENABLE_NVENC | ENABLE_VAAPI
+    // record decoder hw accel (to be used later on, during decode for pix fmt selection)
+    self->context->iavhwdevtype = avhwdevtype;
+#endif // from ENABLE_MMAL | ENABLE_NVENC | ENABLE_VAAPI
     self->type = ssc->es_type = codec_id2streaming_component_type(ocodec->id);
     if (ssc->es_type == SCT_UNKNOWN) {
         tvh_stream_log(self, LOG_ERR, "unable to translate AV type %s [%d] to SCT!", ocodec->name, ocodec->id);

--- a/src/transcoding/transcode/transcoder.c
+++ b/src/transcoding/transcode/transcoder.c
@@ -93,6 +93,12 @@ tvh_transcoder_handle(TVHTranscoder *self, th_pkt_t *pkt)
 
     SLIST_FOREACH(stream, &self->streams, link) {
         if (pkt->pkt_componentindex == stream->index) {
+#if ENABLE_LIBAV
+            // add DAR when stream->context is available
+            if (SCT_ISVIDEO(pkt->pkt_type) && (stream->context)) {
+                stream->context->sample_aspect_ratio = (AVRational){pkt->v.pkt_sample_aspect_ratio.num, pkt->v.pkt_sample_aspect_ratio.den};
+            }
+#endif
             err = tvh_stream_handle(stream, pkt);
             if (err) {
                 tvh_stream_stop(stream, 0);

--- a/src/transcoding/transcode/video.c
+++ b/src/transcoding/transcode/video.c
@@ -25,18 +25,80 @@
 #endif
 
 
-static int
-_video_filters_hw_pix_fmt(enum AVPixelFormat pix_fmt)
+#if ENABLE_HWACCELS
+/**
+ * @brief Identifies the hardware acceleration type for an encoder.
+ *
+ * This function determines the appropriate hardware device type by inspecting 
+ * the encoder's codec name and, as a fallback, the pixel format flags. 
+ * It is specifically tailored for encoder contexts where hardware-specific 
+ * codec names (e.g., those ending in '_nvenc' or '_vaapi') are explicitly used.
+ *
+ * Logic flow:
+ * 1. **NVIDIA NVENC**: If `ENABLE_NVENC` is defined, it checks for NVIDIA-specific 
+ * encoder names, returning `AV_HWDEVICE_TYPE_CUDA`.
+ * 2. **VAAPI**: If `ENABLE_VAAPI` is defined, it checks for VAAPI-specific 
+ * encoder names, returning `AV_HWDEVICE_TYPE_VAAPI`.
+ * 3. **Fallback**: If no name matches, it inspects the current pixel format's 
+ * descriptors. If the format is flagged for hardware acceleration 
+ * (`AV_PIX_FMT_FLAG_HWACCEL`), it returns a generic success value (1).
+ *
+ * @param avctx Pointer to the AVCodecContext of the encoder.
+ *
+ * @return The detected AVHWDeviceType (CUDA or VAAPI), 1 for generic hardware 
+ * pixel formats, or AV_HWDEVICE_TYPE_NONE if no hardware acceleration 
+ * is identified.
+ */
+static enum AVHWDeviceType
+get_encoder_hw_device_type(AVCodecContext *avctx)
 {
     const AVPixFmtDescriptor *desc;
 
+    // first we try to detect the hadrware pix_fmt using codec name
+#if ENABLE_NVENC
+    // check NVDEC/NVENC encoder
+    if (avctx->codec && 
+        (strstr(avctx->codec->name, "h264_nvenc") || strstr(avctx->codec->name, "hevc_nvenc"))) {
+            return AV_HWDEVICE_TYPE_CUDA;
+    }
+#endif
+#if ENABLE_VAAPI
+    // check VAAPI encoder
+    if (avctx->codec &&
+        (strstr(avctx->codec->name, "mpeg2_vaapi") || strstr(avctx->codec->name, "h264_vaapi") || strstr(avctx->codec->name, "hevc_vaapi") ||
+        strstr(avctx->codec->name, "vp9_vaapi") || strstr(avctx->codec->name, "vp8_vaapi"))) {
+            return AV_HWDEVICE_TYPE_VAAPI;
+    }
+#endif
+// START to be removed when we remove has_support_for_filter2
+    // backup we return to old method
+    enum AVPixelFormat pix_fmt = avctx->pix_fmt;
     if ((desc = av_pix_fmt_desc_get(pix_fmt)) &&
         (desc->flags & AV_PIX_FMT_FLAG_HWACCEL)) {
         return 1;
     }
-    return 0;
+// END to be removed when we remove has_support_for_filter2
+    return AV_HWDEVICE_TYPE_NONE;
 }
+#endif
 
+
+/**
+ * @brief Constructs a software-based deinterlacing filter string.
+ *
+ * This function generates a filter string based on the 'yadif' (Yet Another 
+ * Deinterlacing Filter) algorithm. It retrieves deinterlacing parameters 
+ * from the user's video codec profile, specifically the field rate mode 
+ * and the auto-enable logic.
+ *
+ * @param self      Pointer to the TVHContext containing the transcoding profile.
+ * @param deint     Pointer to the destination buffer where the yadif filter 
+ * string will be written (e.g., "yadif=mode=0:deint=0").
+ * @param deint_len The maximum size of the destination buffer.
+ *
+ * @return 0 on success, or -1 if the filter string could not be formatted 
+ * within the provided buffer length.
+ */
 static int
 _video_get_sw_deint_filter(TVHContext *self, char *deint, size_t deint_len)
 {
@@ -48,118 +110,110 @@ _video_get_sw_deint_filter(TVHContext *self, char *deint, size_t deint_len)
     return 0;
 }
 
+
+/**
+ * @brief Generates the complete video filter chain string for a transcoding session.
+ *
+ * This function constructs the final FFmpeg/libavcodec video filter string by evaluating 
+ * the required software filters (scaling, deinterlacing) and the hardware acceleration 
+ * capabilities of the input (decoder) and output (encoder) contexts.
+ *
+ * When hardware acceleration is enabled, it uses the following logic matrix to 
+ * determine if frames must be downloaded from the GPU to main memory, or uploaded 
+ * from main memory to the GPU:
+ *
+ * Input -> Output | Download | Upload | Notes
+ * ----------------|----------|--------|---------------------------------------
+ * HW    -> HW     |    0     |   0    | Stays in VRAM (unless HW types differ)
+ * SW    -> HW     |    0     |   1    | Requires CPU to GPU upload
+ * HW    -> SW     |    1     |   0    | Requires GPU to CPU download
+ * SW    -> SW     |    0     |   0    | Entirely in main memory
+ *
+ * If hardware acceleration is disabled, it falls back to standard software-based 
+ * format formatting for `hwdownload` and `hwupload`. The resulting filter pieces 
+ * are concatenated into a single, dynamically allocated, comma-separated string.
+ *
+ * @param self    Pointer to the TVHContext containing the current transcoding state,
+ * including input/output AV contexts and codec profiles.
+ * @param filters Pointer to a char pointer. On success, this will be updated to point 
+ * to a newly allocated string containing the comma-separated filter graph. 
+ * The caller is responsible for freeing this string.
+ *
+ * @return 0 on success, or -1 if an error occurs during filter string generation or memory allocation.
+ */
 static int
 _video_filters_get_filters(TVHContext *self, char **filters)
 {
     char download[48];
     char deint[64];
-    char hw_deint[64];
     char scale[24];
-    char hw_scale[64];
     char upload[48];
-    char hw_denoise[64];
-    char hw_sharpness[64];
-    int ihw = _video_filters_hw_pix_fmt(self->iavctx->pix_fmt);
-    int ohw = _video_filters_hw_pix_fmt(self->oavctx->pix_fmt);
+#if ENABLE_HWACCELS
+    char hw_filters[512];
+    int skip_download_format = 0;
+#endif
     int filter_scale = (self->iavctx->height != self->oavctx->height);
     int filter_deint = ((TVHVideoCodecProfile *)self->profile)->deinterlace;
     int filter_download = 0;
     int filter_upload = 0;
+
 #if ENABLE_HWACCELS
-    int filter_denoise = ((TVHVideoCodecProfile *)self->profile)->filter_hw_denoise;
-    int filter_sharpness = ((TVHVideoCodecProfile *)self->profile)->filter_hw_sharpness;
-#endif
+    // get encoder hardware acceleration type 
+    self->oavhwdevtype = get_encoder_hw_device_type(self->oavctx);
+
     //  in --> out  |  download   |   upload 
     // -------------|-------------|------------
     //  hw --> hw   |     0       |     0
     //  sw --> hw   |     0       |     1
     //  hw --> sw   |     1       |     0
     //  sw --> sw   |     0       |     0
-    filter_download = (ihw && (!ohw)) ? 1 : 0;
-    filter_upload = ((!ihw) && ohw) ? 1 : 0;
+    filter_download = (self->iavhwdevtype && (!self->oavhwdevtype)) ? 1 : 0;
+    filter_upload = ((!self->iavhwdevtype) && self->oavhwdevtype) ? 1 : 0;
+    // special case is when we use hw --> hw but the hw device types are different
+    if (self->iavhwdevtype && self->oavhwdevtype && 
+        (self->iavhwdevtype != self->oavhwdevtype)){
+        filter_download = 1;
+        filter_upload = 1;
+        skip_download_format = 1;   // to avoid two identical format strings
+    }
+#endif
 
     memset(deint, 0, sizeof(deint));
-    memset(hw_deint, 0, sizeof(hw_deint));
-#if ENABLE_HWACCELS
-    if (filter_deint) {
-        // when hwaccel is enabled we have two options:
-        if (ihw) {
-            // hw deint
-            if (hwaccels_get_deint_filter(self->iavctx, hw_deint, sizeof(hw_deint))) {
-                return -1;
-            }
-        }
-        else {
-            // sw deint
-            if (_video_get_sw_deint_filter(self, deint, sizeof(deint))) {
-                return -1;
-            }
-        }
-    }
-#else
-    if (filter_deint) {
-        if (_video_get_sw_deint_filter(self, deint, sizeof(deint))) {
+    if (filter_deint &&
+        _video_get_sw_deint_filter(self, deint, sizeof(deint))){
             return -1;
-        }
     }
-#endif
 
     memset(scale, 0, sizeof(scale));
-    memset(hw_scale, 0, sizeof(hw_scale));
-#if ENABLE_HWACCELS
-    if (filter_scale) {
-        // when hwaccel is enabled we have two options:
-        if (ihw) {
-            // hw scale
-            hwaccels_get_scale_filter(self->iavctx, self->oavctx, hw_scale, sizeof(hw_scale));
-        }
-        else {
-            // sw scale
-            if (str_snprintf(scale, sizeof(scale), "scale=w=-2:h=%d",
-                         self->oavctx->height)) {
-                return -1;
-            }
-        }
-    }
-#else
-    if (filter_scale) {
-        if (str_snprintf(scale, sizeof(scale), "scale=w=-2:h=%d",
+    if (filter_scale &&
+        str_snprintf(scale, sizeof(scale), "scale=w=-2:h=%d",
                          self->oavctx->height)) {
             return -1;
-        }
     }
-#endif
-
-    memset(hw_denoise, 0, sizeof(hw_denoise));
-#if ENABLE_HWACCELS
-    if (filter_denoise) {
-        // used only when hwaccel is enabled
-        if (ihw) {
-            // hw scale
-            hwaccels_get_denoise_filter(self->iavctx, filter_denoise, hw_denoise, sizeof(hw_denoise));
-        }
-    }
-#endif
-
-    memset(hw_sharpness, 0, sizeof(hw_sharpness));
-#if ENABLE_HWACCELS
-    if (filter_sharpness) {
-        // used only when hwaccel is enabled
-        if (ihw) {
-            // hw scale
-            hwaccels_get_sharpness_filter(self->iavctx, filter_sharpness, hw_sharpness, sizeof(hw_sharpness));
-        }
-    }
-#endif
 
 #if ENABLE_HWACCELS
-    // no filter required.
+    memset(hw_filters, 0, sizeof(hw_filters));
+    if (self->iavhwdevtype &&
+        // setup the hardware filter on each hwaccel
+        hwaccels_decode_get_filters(self, hw_filters, sizeof(hw_filters))){
+            tvherror(LS_TRANSCODE, "filters: video: function hwaccels_get_filter() returned with error.");
+    }
+    memset(download, 0, sizeof(download));
+    if (filter_download &&
+        // setup the download filter
+        hwaccels_download(self, download, sizeof(download), skip_download_format)){
+            tvherror(LS_TRANSCODE, "filters: video: function hwaccels_download() returned with error.");
+    }
+    memset(upload, 0, sizeof(upload));
+    if (filter_upload &&
+        // setup the upload filter
+        hwaccels_upload(self, upload, sizeof(upload))){
+            tvherror(LS_TRANSCODE, "filters: video: function hwaccels_upload() returned with error.");
+    }
 #else
     if (deint[0] == '\0' && scale[0] == '\0') {
         filter_download = filter_upload = 0;
     }
-#endif
-
     memset(download, 0, sizeof(download));
     if (filter_download &&
         str_snprintf(download, sizeof(download), "hwdownload,format=pix_fmts=%s",
@@ -174,10 +228,24 @@ _video_filters_get_filters(TVHContext *self, char **filters)
                      av_get_pix_fmt_name(self->oavctx->pix_fmt))) {
         return -1;
     }
+#endif
 
-    if (!(*filters = str_join(",", hw_deint, hw_scale, hw_denoise, hw_sharpness, download, deint, scale, upload, NULL))) {
+#if ENABLE_HWACCELS
+    if (self->iavhwdevtype) {
+        if (!(*filters = str_join(",", hw_filters, download, upload, NULL))) {
+            return -1;
+        }
+    }
+    else {
+        if (!(*filters = str_join(",", deint, scale, upload, NULL))) {
+            return -1;
+        }
+    }
+#else
+    if (!(*filters = str_join(",", download, deint, scale, upload, NULL))) {
         return -1;
     }
+#endif
 
     return 0;
 }
@@ -192,11 +260,14 @@ tvh_video_context_open_decoder(TVHContext *self, AVDictionary **opts)
         return -1;
     }
     if (hwaccel) {
+        // temprorary until we transition all codecs to filter2
+        self->profile->has_support_for_filter2 = 1;
         self->iavctx->get_format = hwaccels_decode_get_format;
     }
     mystrset(&self->hw_accel_device, self->profile->device);
 #endif
     self->iavctx->time_base = av_make_q(1, 90000); // MPEG-TS uses a fixed timebase of 90kHz
+    self->iavctx->pkt_timebase = self->iavctx->time_base; // to fix the warning: libav: AVCodecContext: Invalid pkt_timebase, passing timestamps as-is.
     return 0;
 }
 
@@ -223,8 +294,10 @@ static int
 tvh_video_context_open_encoder(TVHContext *self, AVDictionary **opts)
 {
     AVRational ticks_per_frame;
-    int deinterlace  = ((TVHVideoCodecProfile *)self->profile)->deinterlace;
-    int field_rate = (deinterlace && ((TVHVideoCodecProfile *)self->profile)->deinterlace_field_rate) ? 2 : 1;
+    // To be fixed properly later on:
+    //int deinterlace  = ((TVHVideoCodecProfile *)self->profile)->deinterlace;
+    //int field_rate = (deinterlace && ((TVHVideoCodecProfile *)self->profile)->deinterlace_field_rate) ? 2 : 1;
+    int field_rate = 1;
     int gop_size = ((TVHVideoCodecProfile *)self->profile)->gop_size;
 
     if (tvh_context_get_int_opt(opts, "pix_fmt", &self->oavctx->pix_fmt) ||
@@ -234,35 +307,23 @@ tvh_video_context_open_encoder(TVHContext *self, AVDictionary **opts)
     }
 
 #if ENABLE_HWACCELS
-    // hwaccel is the user input for Hardware acceleration from Codec parameteres
-    int hwaccel = -1;
-    if ((hwaccel = tvh_codec_profile_video_get_hwaccel(self->profile)) < 0) {
+    // get encoder hardware acceleration type 
+    self->oavhwdevtype = get_encoder_hw_device_type(self->oavctx);
+    // initialize encoder
+    if (hwaccels_encode_setup_context(self)) {
         return -1;
-    }
-    if (_video_filters_hw_pix_fmt(self->oavctx->pix_fmt)){
-        // encoder is hw accelerated
-        if (hwaccel) {
-            // decoder is hw accelerated 
-            // --> we initialize encoder from decoder as recomanded in: 
-            // ffmpeg-6.1.1/doc/examples/vaapi_transcode.c line 169
-            if (hwaccels_initialize_encoder_from_decoder(self->iavctx, self->oavctx)) {
-                return -1;
-            }
-        }
-        else {
-            // decoder is sw
-            // --> we initialize as recommended in:
-            // ffmpeg-6.1.1/doc/examples/vaapi_encode.c line 145
-            if (hwaccels_encode_setup_context(self->oavctx)) {
-                return -1;
-            }
-        }
     }
 #endif // from ENABLE_HWACCELS
 
-    // XXX: is this a safe assumption?
+    // check frame rate
     if (!self->iavctx->framerate.num) {
-        self->iavctx->framerate = av_make_q(30, 1);
+        // compute frame rate from es_frame_duration or pkt_duration
+        int fdur = (self->src_pkt) ? ((self->src_pkt->pkt_duration > INT_MAX) ? INT_MAX : (int)self->src_pkt->pkt_duration) : 0;
+        if (fdur > 0) {
+            AVRational fr = av_make_q(90000, fdur);
+            av_reduce(&fr.num, &fr.den, fr.num, fr.den, INT_MAX);
+            self->iavctx->framerate = fr;
+        }
     }
     self->oavctx->framerate = av_mul_q(self->iavctx->framerate, (AVRational) { field_rate, 1 }); //take into account double rate i.e. field-based deinterlacers
     int ticks_per_frame_tmp = (90000 * self->oavctx->framerate.den) / self->oavctx->framerate.num; // We assume 90kHz as timebase which is mandatory for MPEG-TS
@@ -318,17 +379,29 @@ tvh_video_context_open_filters(TVHContext *self)
 
     // filters
     if (_video_filters_get_filters(self, &filters)) {
+        tvherror(LS_TRANSCODE, "filters: video: function _video_filters_get_filters() returned with error.");
+        str_clear(filters);
         return -1;
     }
+    
+    tvhinfo(LS_TRANSCODE, "filters: video: '%s'", filters);
 
 #if LIBAVCODEC_VERSION_MAJOR > 59
-    int ret = tvh_context_open_filters(self,
-        "buffer", source_args,                                  // source
-        strlen(filters) ? filters : "null",                     // filters
-        "buffersink",                                           // sink
-        "pix_fmts", AV_OPT_SET_BIN,                             // sink option: pix_fmt
-        sizeof(self->oavctx->pix_fmt), &self->oavctx->pix_fmt,
-        NULL);                                                  // _IMPORTANT!_
+    int ret = -1;
+    if (self->profile->has_support_for_filter2)
+        ret = tvh_context_open_filters2(self,
+            "buffer",                                               // source
+            (filters && filters[0] != '\0') ? filters : "null",     // filters
+            "buffersink"                                            // sink
+        );
+    else
+        ret = tvh_context_open_filters(self,
+            "buffer", source_args,                                  // source
+            strlen(filters) ? filters : "null",                     // filters
+            "buffersink",                                           // sink
+            "pix_fmts", AV_OPT_SET_BIN,                             // sink option: pix_fmt
+            sizeof(self->oavctx->pix_fmt), &self->oavctx->pix_fmt,
+            NULL);                                                  // _IMPORTANT!_
 #else
     int ret = tvh_context_open_filters(self,
         "buffer", source_args,              // source
@@ -342,18 +415,35 @@ tvh_video_context_open_filters(TVHContext *self)
     return ret;
 }
 
-
+/**
+ * Video half of the transcoder open state machine: dispatches @p phase to the
+ * appropriate setup routine.
+ *
+ * Handled phases:
+ * - PREPARE_DECODER — allocate/configure decoder-side @c AVCodecContext (and HW paths).
+ * - NOTIFY_GLOBALHEADER — propagate global headers / extradata as needed.
+ * - PREPARE_ENCODER — choose output size, pixel format, time base, GOP, HW encode hooks, etc.
+ * - OPEN_FILTERS — build the libavfilter graph (@c buffer → filters → @c buffersink).
+ *
+ * Phases such as OPEN_DECODER and OPEN_ENCODER are opened in @c context.c
+ * (@c tvh_context_open); this callback returns 0 for any unhandled @p phase.
+ *
+ * @param self  Transcode context (decoder + encoder + filter graph owner).
+ * @param phase Which open step @ref tvh_context_open is executing.
+ * @param opts  Codec/profile options dictionary (used by decoder/encoder prep paths).
+ * @return      0 on success or no-op; a negative @c AVERROR code on failure from the callee.
+ */
 static int
 tvh_video_context_open(TVHContext *self, TVHOpenPhase phase, AVDictionary **opts)
 {
     switch (phase) {
-        case OPEN_DECODER:
+        case PREPARE_DECODER:
             return tvh_video_context_open_decoder(self, opts);
-        case OPEN_DECODER_POST:
+        case NOTIFY_GLOBALHEADER:
             return tvh_video_context_notify_gh(self);
-        case OPEN_ENCODER:
+        case PREPARE_ENCODER:
             return tvh_video_context_open_encoder(self, opts);
-        case OPEN_ENCODER_POST:
+        case OPEN_FILTERS:
             return tvh_video_context_open_filters(self);
         default:
             break;
@@ -515,9 +605,15 @@ tvh_video_context_wrap(TVHContext *self, AVPacket *avpkt, th_pkt_t *pkt)
                             pict_type);
             break;
     }
-    pkt->pkt_duration   = avpkt->duration;
+    // only if packet duration is valid we passed on
+    if (avpkt->duration > 0)
+        pkt->pkt_duration = avpkt->duration;
     pkt->pkt_commercial = self->src_pkt->pkt_commercial;
     pkt->v.pkt_field      = (self->oavctx->field_order > AV_FIELD_PROGRESSIVE);
+#if ENABLE_LIBAV
+    pkt->v.pkt_sample_aspect_ratio.num = self->src_pkt->v.pkt_sample_aspect_ratio.num;
+    pkt->v.pkt_sample_aspect_ratio.den = self->src_pkt->v.pkt_sample_aspect_ratio.den;
+#endif
     pkt->v.pkt_aspect_num = self->src_pkt->v.pkt_aspect_num;
     pkt->v.pkt_aspect_den = self->src_pkt->v.pkt_aspect_den;
     return 0;
@@ -527,10 +623,7 @@ tvh_video_context_wrap(TVHContext *self, AVPacket *avpkt, th_pkt_t *pkt)
 static void
 tvh_video_context_close(TVHContext *self)
 {
-#if ENABLE_HWACCELS
-    hwaccels_encode_close_context(self->oavctx);
-    hwaccels_decode_close_context(self->iavctx);
-#endif
+
 }
 
 


### PR DESCRIPTION
- update the filter initialization from avfilter_graph_create_filter() to avfilter_graph_alloc_filter() +  avfilter_init_str(()
- transition audio filter to aformat for audio conversions.
- used avfilter_graph_alloc_filter() and avfilter_init_str to allow attach of hw_device_ctx to upload filter
- use codec_type to separate audio from video processing
- updated with a more robust implementation how get_format() is selecting pixel format
- cleaned up vaapi
- added parsing for height and width from Sequence Header and Extension Header
- transfer of sample_aspect_ratio from h264 and hevc and compute  that form DAR for mpeg2
- add sample_aspect_ratio to to elementary_info (esstream) and th_pkt
- fixed bug for not searching if beginning or end was found during search in src/plumbing/globalheaders.c
- fixing PTS_MASK + 1 for wrapping around in src/plumbing/globalheaders.c
- workaround for time stamp discontinuity V4L2 decoder
- fixed a bug in src/muxer/muxer_libav.c where DAR was pushed into SAR
- separated states ENCODE and DECODE in 6 in order to get granularity to build filter before encoder is opened.
- added asetpts filter in audio path
- removed initialize encoder from decoder because filter has to override the encoder buffers.
- moved the string concatenation from video.c to vaapi.c. This will allow different separation strings and will allow separations of settings between hardware accels
- move also download and upload to hwaccel.c (to be forwarded to hwaccels if needed)
- changed the dispatch from hwaccell to other accels, to AVHWDeviceType because is more robust with many decoders/encoders implemented
- VAAPI does not have a standalone decoder named mpeg2_vaapi h264_vaapi hevc_vaapi vp9_vaapi
- if filter will change the frame rate we have to rescale PTS/DTS/duration
- if frame rate is not set we compute it from pkt_duration (instead of default to 30)
- we onlt use avpkt->duration if is set
- update tvh_pkt_t->pkt_duration and parser_es_r->es_frame_duration to int64_t to match AVPacket->duration

- starting ffmpeg8 all filter must be fully configured before initialization, and that requires some extensive changes in context.c
- new format should cover all cases when filters are altering PTS or frame rate, because self->iavfltctx in is configured from self->iavctx and self->oavctx is configured from self->oavfltctx . 