### PR TITLE
timeshift: fix subscriptionLive flooding clients with stale packets

### DIFF
--- a/src/timeshift/timeshift_reader.c
+++ b/src/timeshift/timeshift_reader.c
@@ -668,13 +668,60 @@ void *timeshift_reader ( void *p )
                   ts->full = 0;
                 }
 
-                /* Release */
-                if (sm)
+                /* Release current read packet */
+                if (sm) {
                   streaming_msg_free(sm);
+                  sm = NULL;
+                }
 
-                /* Find end */
-                skip_time = 0x7fffffffffffffffLL;
-                // TODO: change this sometime!
+                /* Close read file and reset seek position */
+                _read_close(seek);
+
+                /* Re-send the latest stream start so client has codec info */
+                {
+                  timeshift_file_t *newest = timeshift_filemgr_newest(ts);
+                  timeshift_file_t *f = newest;
+                  streaming_message_t *sstart_sm = NULL;
+                  int tmpend = 0;
+                  while (f && !sstart_sm) {
+                    timeshift_index_data_t *ti = TAILQ_LAST(&f->sstart, timeshift_index_data_list);
+                    if (ti)
+                      sstart_sm = ti->data;
+                    else
+                      f = timeshift_filemgr_prev(f, &tmpend, 0);
+                  }
+                  if (sstart_sm)
+                    streaming_target_deliver2(ts->output, streaming_msg_clone(sstart_sm));
+                  if (f != newest)
+                    timeshift_file_put(f);
+                  timeshift_file_put(newest);
+                }
+
+                /* Transition to live */
+                tvhdebug(LS_TIMESHIFT, "ts %d skip to live", ts->id);
+                cur_speed = 100;
+                ts->state = TS_LIVE;
+                tvhtrace(LS_TIMESHIFT, "reader - set TS_LIVE (skip live)");
+
+                /* Send speed change to output */
+                {
+                  streaming_message_t *spd = streaming_msg_create_code(SMT_SPEED, cur_speed);
+                  streaming_target_deliver2(ts->output, spd);
+                }
+
+                /* Build skip response for the client */
+                skip->type = SMT_SKIP_ABS_TIME;
+                skip->time = 0;
+                timeshift_fill_status(ts, &skip->timeshift, ts->buf_time);
+                mono_last_status = mono_now;
+
+                /* Deliver the skip response and clear ctrl */
+                streaming_target_deliver2(ts->output, ctrl);
+                ctrl = NULL;
+                skip = NULL;
+
+                /* Send updated timeshift status (shift=0) */
+                timeshift_status(ts, ts->buf_time);
               }
               break;
 
@@ -751,7 +798,7 @@ void *timeshift_reader ( void *p )
           }
 
           /* Error */
-          if (!skip) {
+          if (!skip && ctrl) {
             ((streaming_skip_t*)ctrl->sm_data)->type = SMT_SKIP_ERROR;
             streaming_target_deliver2(ts->output, ctrl);
             ctrl = NULL;

--- a/src/timeshift/timeshift_reader.c
+++ b/src/timeshift/timeshift_reader.c
@@ -679,22 +679,21 @@ void *timeshift_reader ( void *p )
 
                 /* Re-send the latest stream start so client has codec info */
                 {
-                  timeshift_file_t *newest = timeshift_filemgr_newest(ts);
-                  timeshift_file_t *f = newest;
+                  timeshift_file_t *f = timeshift_filemgr_newest(ts);
                   streaming_message_t *sstart_sm = NULL;
                   int tmpend = 0;
-                  while (f && !sstart_sm) {
+                  while (f) {
                     timeshift_index_data_t *ti = TAILQ_LAST(&f->sstart, timeshift_index_data_list);
-                    if (ti)
+                    if (ti) {
                       sstart_sm = ti->data;
-                    else
-                      f = timeshift_filemgr_prev(f, &tmpend, 0);
+                      break;
+                    }
+                    f = timeshift_filemgr_prev(f, &tmpend, 0);
                   }
                   if (sstart_sm)
                     streaming_target_deliver2(ts->output, streaming_msg_clone(sstart_sm));
-                  if (f != newest)
+                  if (f)
                     timeshift_file_put(f);
-                  timeshift_file_put(newest);
                 }
 
                 /* Transition to live */
@@ -722,6 +721,11 @@ void *timeshift_reader ( void *p )
 
                 /* Send updated timeshift status (shift=0) */
                 timeshift_status(ts, ts->buf_time);
+              } else {
+                /* Already live — discard the skip control message */
+                streaming_msg_free(ctrl);
+                ctrl = NULL;
+                skip = NULL;
               }
               break;
 


### PR DESCRIPTION
## Summary

- Replace the `SMT_SKIP_LIVE` fast-forward hack (marked `// TODO: change this sometime!`) that delivered all buffered packets unpaced
- Instead, close the read position, re-send the latest stream start, and transition directly to `TS_LIVE`
- The timeshift buffer is preserved so users can still seek backwards after going live
- Added NULL guard for `ctrl` in the error path to prevent a crash

## Problem

When a client sends `subscriptionLive`, the reader thread set `skip_time = INT64_MAX` and fast-forwarded through the entire timeshift buffer, delivering every remaining packet in a tight loop. This flooded clients with potentially minutes of stale data, causing stuttering, high latency, and long transition times back to live. Clients had to work around this by using `subscriptionSkip` to a near-live position instead.

## Testing

Tested with a custom HTSP client (satTV) against a live DVB-S2 setup:
- Paused for 30+ seconds to build timeshift buffer
- Called `subscriptionLive` — transition to live was near-instant
- Verified backward seeking still works after going live (buffer preserved)
- Verified `subscriptionSkip` still works as before (backwards compatible)

Fixes #2087