### PR TITLE
channels: fix reentrancy guard in channel_class_changed()

### DIFF
--- a/src/channels.c
+++ b/src/channels.c
@@ -92,7 +92,7 @@ channel_class_changed ( idnode_t *self )
   htsp_channel_update(ch);
 
 end:
-  atomic_dec(&ch->ch_changed_ref, 0);
+  atomic_dec(&ch->ch_changed_ref, 1);
 }
 
 static htsmsg_t *


### PR DESCRIPTION
## Summary

`channel_class_changed()` uses `ch_changed_ref` as a reentrancy guard to coalesce multiple property changes into a single notification. However, `atomic_dec(&ch->ch_changed_ref, 0)` at the end of the function subtracts 0 instead of 1, so the counter never resets to 0.

After the first call to `channel_class_changed()` for a given channel, all subsequent calls see `atomic_add(&ch->ch_changed_ref, 1) > 0` and return early — permanently suppressing HTSP `channelUpdate` / `channelDelete` notifications and bouquet/tag propagation for that channel.

## Root cause

In `src/channels.c` line 95:

```c
// Bug: subtracts 0, counter stays at 1 after first call
atomic_dec(&ch->ch_changed_ref, 0);

// Fix: properly decrements counter back to 0
atomic_dec(&ch->ch_changed_ref, 1);
```

## Impact

- HTSP clients with `enableAsyncMetadata` never receive `channelUpdate` after the first property change per channel (number, name, icon, etc.)
- Channel reordering via the web UI or API is invisible to connected HTSP clients
- The initial sync is unaffected (it sends channels in a direct loop, bypassing `channel_class_changed()`)

## How to reproduce

1. Connect an HTSP client with `enableAsyncMetadata`
2. Change a channel's number or name via the web UI
3. Observe that the HTSP client receives no `channelUpdate` message
4. Verified with tcpdump: zero bytes sent from TVHeadend to the HTSP client after the change