### PR TITLE
htsp: fix signalStatus for DVBv5 hardware, add scale and raw value fields

### DIFF
--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -51,7 +51,7 @@
 
 static void *htsp_server, *htsp_server_2;
 
-#define HTSP_PROTO_VERSION 43
+#define HTSP_PROTO_VERSION 44
 
 #define HTSP_ASYNC_OFF  0x00
 #define HTSP_ASYNC_ON   0x01
@@ -4497,9 +4497,13 @@ htsp_subscription_signal_status(htsp_subscription_t *hs, signal_status_t *sig)
   if (!htsp_anonymize(hs->hs_htsp)) {
     htsmsg_add_str(m, "feStatus",   sig->status_text);
     if((sig->snr != -2) && (sig->snr_scale == SIGNAL_STATUS_SCALE_RELATIVE))
-      htsmsg_add_u32(m, "feSNR",    sig->snr);
+      htsmsg_add_u32(m, "feSNR", sig->snr);
+    else if((sig->snr != -2) && (sig->snr_scale == SIGNAL_STATUS_SCALE_DECIBEL))
+      htsmsg_add_s64(m, "feAbsoluteSNR", sig->snr);
     if((sig->signal != -2) && (sig->signal_scale == SIGNAL_STATUS_SCALE_RELATIVE))
       htsmsg_add_u32(m, "feSignal", sig->signal);
+    else if((sig->signal != -2) && (sig->signal_scale == SIGNAL_STATUS_SCALE_DECIBEL))
+      htsmsg_add_s64(m, "feAbsoluteSignal", sig->signal);
     if(sig->ber != -2)
       htsmsg_add_u32(m, "feBER",    sig->ber);
     if(sig->unc != -2)


### PR DESCRIPTION
## Problem

The HTSP `signalStatus` message has been silently dropping `feSNR` and `feSignal` for **all modern DVBv5 hardware** since the DVBv5 migration in 2014. This affects every tuner that reports signal values in decibel scale (which is the preferred/accurate reporting mode in DVBv5).

**Root cause** (`src/htsp_server.c`, line ~4499):

```c
if((sig->snr != -2) && (sig->snr_scale == SIGNAL_STATUS_SCALE_RELATIVE))
    htsmsg_add_u32(m, "feSNR", sig->snr);
```

The condition requires `SIGNAL_STATUS_SCALE_RELATIVE` (enum 1), but modern drivers report `SIGNAL_STATUS_SCALE_DECIBEL` (enum 2). The values are available internally (the web UI and HTTP API display them correctly via `tvh_strdupa` formatting) — they are just never serialized into the HTSP message.

**Affected hardware**: Any tuner using DVBv5 `DTV_STAT_CNR` / `DTV_STAT_SIGNAL_STRENGTH` with decibel scale — including Digital Devices, TBS, recent Silicon Labs, and most modern demodulators.

### User reports and prior discussion

This has been a known issue for years. The Kodi forum thread [**"Kodi signal strength/snr indicator in db/dBm"**](https://forum.kodi.tv/showthread.php?tid=359189) (opened Dec 2020, 51+ replies across 4 pages) documents the problem in detail:

- Multiple users report that TVHeadend's web UI shows correct signal values, but Kodi always displays **0% / 0%** for both SNR and signal strength.
- User `bluzee` ([post #19](https://forum.kodi.tv/showthread.php?tid=359189&pid=3096699#pid3096699), May 2022) traced the issue to the exact same `SIGNAL_STATUS_SCALE_RELATIVE` check in `htsp_server.c` that this PR fixes.
- @ksooo, the Kodi pvr.hts maintainer, confirmed the root cause and stated ([post #18](https://forum.kodi.tv/showthread.php?tid=359189&pid=3096507#pid3096507), May 2022):

  > *"I know pretty well how to fix this. Again, in order to fix this in Kodi, tvheadend must be changed to offer a programming interface for the dbm values. Currently it is lacking such an API. Somebody must open a feature request for tvheadend and once this got implemented we can fix this on Kodi side."*

## Fix

For `SCALE_DECIBEL` drivers, two new fields are added carrying the raw values directly from the kernel — no conversion, no loss of precision:

| Field              | Type  | Value                                    | When sent                  |
|:-------------------|:-----:|:-----------------------------------------|:---------------------------|
| `feSNR`            | u32   | 0–65535 relative (unchanged)             | `SCALE_RELATIVE` drivers   |
| `feSignal`         | u32   | 0–65535 relative (unchanged)             | `SCALE_RELATIVE` drivers   |
| `feAbsoluteSNR`    | s64   | dB × 1000 (e.g. 15800 = 15.8 dB)        | `SCALE_DECIBEL` drivers    |
| `feAbsoluteSignal` | s64   | dBm × 1000 (e.g. -36500 = −36.5 dBm)    | `SCALE_DECIBEL` drivers    |

Clients determine the type of data by checking which field is present:
- `feSNR` / `feSignal` present → relative percentage values (legacy behavior, completely unchanged)
- `feAbsoluteSNR` / `feAbsoluteSignal` present → absolute dB/dBm values from DVBv5 hardware

The two sets of fields are mutually exclusive per signal type — a given `signalStatus` message will contain either the relative or the absolute field for each metric, never both.

HTSP protocol version bumped from 43 to 44.

### GitBook HTSP specification

The following entries should be added to the `signalStatus` message in the [HTSP specification](https://docs.tvheadend.org/documentation/development/htsp/server-to-client-methods):

```
feAbsoluteSNR    s64   optional   Signal to noise ratio in dB × 1000.
                                  Present when the tuner reports in
                                  SIGNAL_STATUS_SCALE_DECIBEL.
                                  Mutually exclusive with feSNR.
                                  Added in version 44.

feAbsoluteSignal s64   optional   Signal strength in dBm × 1000.
                                  Present when the tuner reports in
                                  SIGNAL_STATUS_SCALE_DECIBEL.
                                  Mutually exclusive with feSignal.
                                  Added in version 44.
```

Happy to submit the GitBook update directly if given contributor access.

## Impact on existing clients

**Zero regression.** The existing `feSNR` / `feSignal` fields are completely unchanged for `SCALE_RELATIVE` hardware. For `SCALE_DECIBEL` hardware, these fields were never sent before (that's the bug), so no existing client depends on them. The new `feAbsoluteSNR` / `feAbsoluteSignal` fields are additive — clients that don't read them simply ignore them.

## Testing

Tested with Digital Devices MaxSX8 (DVB-S2, MxL5xx demodulator) — a pure DVBv5 driver that only reports `SIGNAL_STATUS_SCALE_DECIBEL`:

- Before: `signalStatus` contained only `feStatus`, `feBER`, `feUNC` — no signal/SNR data
- After: `feAbsoluteSNR` and `feAbsoluteSignal` populated with correct dB×1000 / dBm×1000 values matching the TVHeadend web UI
- `feSNR` / `feSignal` correctly not sent (driver does not report `SCALE_RELATIVE`)
- Build: clean compile, no warnings