### PR TITLE
htsbuf: escape all JSON control bytes per RFC 8259

### DIFF
--- a/src/htsbuf.c
+++ b/src/htsbuf.c
@@ -545,23 +545,33 @@ void
 htsbuf_append_and_escape_jsonstr(htsbuf_queue_t *hq, const char *str)
 {
   const char *s = str;
+  /* `\uXXXX` is 6 chars; +1 for the null terminator snprintf
+   * writes. Sized exactly so a future format-string change
+   * trips a compiler warning rather than silently fitting. */
+  char esc[7];
 
   htsbuf_append(hq, "\"", 1);
 
-  while(*s != 0) {
-    if(*s == '"' || *s == '\\' || *s == '\n' || *s == '\r' || *s == '\t') {
+  while (*s != 0) {
+    unsigned char c = (unsigned char)*s;
+    if (c == '"' || c == '\\' || c < 0x20) {
       htsbuf_append(hq, str, s - str);
 
-      if(*s == '"')
-	htsbuf_append(hq, "\\\"", 2);
-      else if(*s == '\n') 
-	htsbuf_append(hq, "\\n", 2);
-      else if(*s == '\r') 
-	htsbuf_append(hq, "\\r", 2);
-      else if(*s == '\t') 
-	htsbuf_append(hq, "\\t", 2);
-      else
-	htsbuf_append(hq, "\\\\", 2);
+      switch (c) {
+      case '"':  htsbuf_append(hq, "\\\"", 2); break;
+      case '\\': htsbuf_append(hq, "\\\\", 2); break;
+      case '\b': htsbuf_append(hq, "\\b",  2); break;
+      case '\f': htsbuf_append(hq, "\\f",  2); break;
+      case '\n': htsbuf_append(hq, "\\n",  2); break;
+      case '\r': htsbuf_append(hq, "\\r",  2); break;
+      case '\t': htsbuf_append(hq, "\\t",  2); break;
+      default:
+        /* Any remaining 0x00-0x1F control byte. RFC 8259 §7
+         * mandates \uXXXX for these. */
+        snprintf(esc, sizeof(esc), "\\u%04x", c);
+        htsbuf_append(hq, esc, 6);
+        break;
+      }
       s++;
       str = s;
     } else {


### PR DESCRIPTION
## Problem

`htsbuf_append_and_escape_jsonstr` in `src/htsbuf.c` is the function every JSON-emitting code path in tvheadend funnels through (see `src/htsmsg_json.c:53,67,72,76` — every `htsmsg_t` serialised to JSON, which covers every `api/...` REST response and the Comet bus). Today it escapes only five characters: `"`, `\`, `\n`, `\r`, `\t`. The other 27 ASCII control bytes (0x00–0x1F minus `\n`, `\r`, `\t`) are appended verbatim.

This produces JSON output that strict parsers reject. The bug surfaces whenever a stored string ever contained one of those bytes — broadcaster EPG data is a frequent culprit (DVB-EIT and XMLTV feeds occasionally carry stray BEL / SOH / etc.), and user-editable string fields can pick them up too (paste from a terminal, scripted API client, etc.).

Affected downstream parsers include browser `JSON.parse`, Python `json.loads`, Go `encoding/json`, `jq`, Rust `serde_json`, and `jansson`. A response containing one stray byte fails at the offending column with `Invalid control character at: line N column M`.

## What the spec says

**RFC 8259 §7 (Strings):**

> All Unicode characters may be placed within the quotation marks, except for the characters that MUST be escaped: quotation mark, reverse solidus, and the control characters (U+0000 through U+001F).

ECMA-404 makes the identical requirement.

The recognised escape forms are the two-character shortcuts `\b` (0x08), `\t` (0x09), `\n` (0x0A), `\f` (0x0C), `\r` (0x0D); for any other 0x00–0x1F byte, the `\uXXXX` form is required.

## Reproduction (before the fix)

Verified against `master` HEAD on a `--noacl` dev binary:

```bash
# Pick any DVR entry's UUID:
UUID=$(curl -s 'http://localhost:9981/api/dvr/entry/grid?limit=1' \
  | python3 -c 'import sys,json; print(json.load(sys.stdin)["entries"][0]["uuid"])')

# Set its comment to a string containing 0x07 (BEL). The input
# parser correctly accepts  and stores a literal 0x07 byte —
# the bug only bites on output.
curl -s -X POST 'http://localhost:9981/api/idnode/save' \
  --data-urlencode "node={\"uuid\":\"$UUID\",\"comment\":\"test  here\"}"

# Fetch the grid back and try a strict JSON parser:
curl -s 'http://localhost:9981/api/dvr/entry/grid?limit=200' > /tmp/grid.json
python3 -c 'import json; json.load(open("/tmp/grid.json"))'
```

Output:

```
json.decoder.JSONDecodeError:
  Invalid control character at: line 1 column 1734 (char 1733)
```

Hex-dump at that offset confirms a literal 0x07 byte sitting unescaped inside the JSON string:

```
"comment":"control-byte test \x07 here","category":[]
                              ^^^^ literal 0x07, not 
```

## The fix

One function in `src/htsbuf.c`. Trigger condition extends to `c < 0x20`; adds `\b` and `\f` shortform escapes (RFC 8259 §7 recognises them); falls back to `\uXXXX` for the remaining control bytes. Casts to `unsigned char` so the comparison is well-defined on platforms where plain `char` is signed.

```c
void
htsbuf_append_and_escape_jsonstr(htsbuf_queue_t *hq, const char *str)
{
  const char *s = str;
  char esc[8];

  htsbuf_append(hq, "\"", 1);

  while (*s != 0) {
    unsigned char c = (unsigned char)*s;
    if (c == '"' || c == '\\' || c < 0x20) {
      htsbuf_append(hq, str, s - str);

      switch (c) {
      case '"':  htsbuf_append(hq, "\\\"", 2); break;
      case '\\': htsbuf_append(hq, "\\\\", 2); break;
      case '\b': htsbuf_append(hq, "\\b",  2); break;
      case '\f': htsbuf_append(hq, "\\f",  2); break;
      case '\n': htsbuf_append(hq, "\\n",  2); break;
      case '\r': htsbuf_append(hq, "\\r",  2); break;
      case '\t': htsbuf_append(hq, "\\t",  2); break;
      default:
        /* Any remaining 0x00-0x1F control byte. RFC 8259 §7
         * mandates \uXXXX for these. */
        snprintf(esc, sizeof(esc), "\\u%04x", c);
        htsbuf_append(hq, esc, 6);
        break;
      }
      s++;
      str = s;
    } else {
      s++;
    }
  }
  htsbuf_append(hq, str, s - str);
  htsbuf_append(hq, "\"", 1);
}
```

**Behaviour delta:** zero for any string that didn't already contain a control byte (the trigger still hits the same five characters with the same outputs). Only previously-malformed JSON output becomes well-formed. UTF-8 multi-byte sequences pass through unchanged (continuation 0x80–0xBF and lead 0xC0–0xFF don't trigger `c < 0x20`).

**Performance delta:** negligible — same single-pass loop.

## Verification (after the fix)

A small standalone test program links the patched `htsbuf.o`, exercises the function over every byte 0x01–0x1F (skipping 0x00 because it terminates a C string), and round-trips the output through Python's strict parser:

```c
/* /tmp/jsonescape_test.c — link against patched build.linux/src/htsbuf.o */
#include <stdio.h>
#include "htsbuf.h"

void hexdump(const char *t, const void *b, size_t l) { (void)t; (void)b; (void)l; }

int main(void) {
    htsbuf_queue_t hq;
    htsbuf_queue_init(&hq, 0);
    htsbuf_append(&hq, "{", 1);
    int first = 1;
    for (int b = 0x01; b < 0x20; b++) {
        if (!first) htsbuf_append(&hq, ",", 1);
        first = 0;
        char field[16];
        snprintf(field, sizeof(field), "byte_%02x", b);
        htsbuf_append_and_escape_jsonstr(&hq, field);
        htsbuf_append(&hq, ":", 1);
        char val[16];
        snprintf(val, sizeof(val), "x%cy", b);
        htsbuf_append_and_escape_jsonstr(&hq, val);
    }
    htsbuf_append(&hq, "}", 1);
    char *out = htsbuf_to_string(&hq);
    printf("%s\n", out);
    return 0;
}
```

```
$ gcc -I src /tmp/jsonescape_test.c build.linux/src/htsbuf.o -o /tmp/jsonescape_test
$ /tmp/jsonescape_test
{"byte_01":"xy","byte_02":"xy","byte_03":"xy","byte_04":"xy","byte_05":"xy","byte_06":"xy","byte_07":"xy","byte_08":"x\by","byte_09":"x\ty","byte_0a":"x\ny","byte_0b":"xy","byte_0c":"x\fy","byte_0d":"x\ry","byte_0e":"xy","byte_0f":"xy","byte_10":"xy","byte_11":"xy","byte_12":"xy","byte_13":"xy","byte_14":"xy","byte_15":"xy","byte_16":"xy","byte_17":"xy","byte_18":"xy","byte_19":"xy","byte_1a":"xy","byte_1b":"xy","byte_1c":"xy","byte_1d":"xy","byte_1e":"xy","byte_1f":"xy"}

$ /tmp/jsonescape_test | python3 -c 'import json,sys; d=json.load(sys.stdin); print(f"PARSE OK — {len(d)} fields, all round-trip OK")'
PARSE OK — 31 fields, all round-trip OK
```

Every byte gets the right form: `\b` `\t` `\n` `\f` `\r` for the named shortcuts, `\uXXXX` for everything else in the range. Every output round-trips back to the original byte through Python's strict parser.

## Notes

PR #2034 proposes replacing the custom JSON code with `cJSON` but explicitly retains `htsbuf_append_and_escape_jsonstr` ("retained in htsbuf.c for webui.c usage"), so the bug fixed here is independent of whether that PR lands.

— Oliver
