### PR TITLE
mpegts: align DVB delivery-system defaults with the enum

### DIFF
--- a/src/input/mpegts/mpegts_mux_dvb.c
+++ b/src/input/mpegts/mpegts_mux_dvb.c
@@ -208,7 +208,7 @@ const idclass_t dvb_mux_dvbt_class =
   .ic_caption    = N_("DVB-T multiplex"),
   .ic_properties = (const property_t[]){
     {
-      MUX_PROP_STR("delsys", N_("Delivery system"), dvbt, delsys, "DVBT"),
+      MUX_PROP_STR("delsys", N_("Delivery system"), dvbt, delsys, "DVB-T"),
       .desc     = N_("The delivery system the mux uses. "
                      "Make sure that your tuner supports the delivery "
                      "system selected here."),
@@ -229,7 +229,7 @@ const idclass_t dvb_mux_dvbt_class =
                      "do not like the AUTO setting."),
     },
     {
-      MUX_PROP_STR("constellation", N_("Constellation"), dvbt, qam, N_("AUTO")),
+      MUX_PROP_STR("constellation", N_("Constellation"), dvbt, qam, N_("QAM/AUTO")),
       .desc     = N_("The COFDM modulation used by the mux. "
                      "If you're not sure of the value leave as AUTO."),
     },
@@ -324,7 +324,7 @@ const idclass_t dvb_mux_dvbc_class =
       .off      = offsetof(dvb_mux_t, lm_tuning.u.dmc_fe_qam.symbol_rate),
     },
     {
-      MUX_PROP_STR("constellation", N_("Constellation"), dvbc, qam, N_("AUTO")),
+      MUX_PROP_STR("constellation", N_("Constellation"), dvbc, qam, N_("QAM/AUTO")),
       .desc     = N_("The quadrature amplitude modulation (QAM) used by the mux. "
                      "If you're not sure of the value leave as AUTO."),
     },
@@ -462,7 +462,7 @@ const idclass_t dvb_mux_dvbs_class =
   .ic_caption    = N_("DVB-S multiplex"),
   .ic_properties = (const property_t[]){
     {
-      MUX_PROP_STR("delsys", N_("Delivery system"), dvbs, delsys, "DVBS"),
+      MUX_PROP_STR("delsys", N_("Delivery system"), dvbs, delsys, "DVB-S"),
       .desc     = N_("The delivery system used by your provider."),
     },
     {
@@ -596,7 +596,7 @@ const idclass_t dvb_mux_atsc_t_class =
       .set      = dvb_mux_dvbt_class_frequency_set,
     },
     {
-      MUX_PROP_STR("modulation", N_("Modulation"), atsc_t, qam, N_("AUTO")),
+      MUX_PROP_STR("modulation", N_("Modulation"), atsc_t, qam, N_("QAM/AUTO")),
       .desc     = N_("The modulation used on the mux."),
     },
     {}
@@ -644,7 +644,7 @@ const idclass_t dvb_mux_atsc_c_class =
       .off      = offsetof(dvb_mux_t, lm_tuning.u.dmc_fe_qam.symbol_rate),
     },
     {
-      MUX_PROP_STR("constellation", N_("Constellation"), dvbc, qam, N_("AUTO")),
+      MUX_PROP_STR("constellation", N_("Constellation"), dvbc, qam, N_("QAM/AUTO")),
       .desc     = N_("The quadrature amplitude modulation (QAM) used by the mux. "
                      "If you're not sure of the value leave as AUTO."),
     },
@@ -775,7 +775,7 @@ const idclass_t dvb_mux_isdb_t_class =
       .desc     = N_("The layer A forward error correction."),
     },
     {
-      MUX_PROP_STR("layera_mod", N_("Layer A: Constellation"), isdb_t, isdbt_mod_a, N_("AUTO")),
+      MUX_PROP_STR("layera_mod", N_("Layer A: Constellation"), isdb_t, isdbt_mod_a, N_("QAM/AUTO")),
       .desc     = N_("The layer A constellation."),
     },
     {
@@ -798,7 +798,7 @@ const idclass_t dvb_mux_isdb_t_class =
       .desc     = N_("The layer B forward error correction."),
     },
     {
-      MUX_PROP_STR("layerb_mod", N_("Layer B: Constellation"), isdb_t, isdbt_mod_b, N_("AUTO")),
+      MUX_PROP_STR("layerb_mod", N_("Layer B: Constellation"), isdb_t, isdbt_mod_b, N_("QAM/AUTO")),
       .desc     = N_("The layer B constellation."),
     },
     {
@@ -821,7 +821,7 @@ const idclass_t dvb_mux_isdb_t_class =
       .desc     = N_("The layer C forward error correction."),
     },
     {
-      MUX_PROP_STR("layerc_mod", N_("Layer C: Constellation"), isdb_t, isdbt_mod_c, N_("AUTO")),
+      MUX_PROP_STR("layerc_mod", N_("Layer C: Constellation"), isdb_t, isdbt_mod_c, N_("QAM/AUTO")),
       .desc     = N_("The layer C constellation."),
     },
     {
@@ -872,7 +872,7 @@ const idclass_t dvb_mux_isdb_c_class =
       .off      = offsetof(dvb_mux_t, lm_tuning.u.dmc_fe_qam.symbol_rate),
     },
     {
-      MUX_PROP_STR("constellation", N_("Constellation"), dvbc, qam, N_("AUTO")),
+      MUX_PROP_STR("constellation", N_("Constellation"), dvbc, qam, N_("QAM/AUTO")),
       .desc     = N_("The quadrature amplitude modulation (QAM) used by the mux. "
                      "If you're not sure of the value leave as AUTO."),
     },
@@ -924,7 +924,7 @@ const idclass_t dvb_mux_isdb_s_class =
   .ic_caption    = N_("ISDB-S multiplex"),
   .ic_properties = (const property_t[]){
     {
-      MUX_PROP_STR("delsys", N_("Delivery system"), isdb_s, delsys, "ISDBS"),
+      MUX_PROP_STR("delsys", N_("Delivery system"), isdb_s, delsys, "ISDB-S"),
       .desc     = N_("The delivery system used by your provider."),
     },
     {
@@ -1015,7 +1015,7 @@ const idclass_t dvb_mux_dtmb_class =
   .ic_caption    = N_("DTMB multiplex"),
   .ic_properties = (const property_t[]){
     {
-      MUX_PROP_STR("delsys", N_("Delivery system"), dtmb, delsys, "DVBT"),
+      MUX_PROP_STR("delsys", N_("Delivery system"), dtmb, delsys, "DTMB"),
       .desc     = N_("The delivery system the mux uses. "
                      "Make sure that your tuner supports the delivery "
                      "system selected here."),
@@ -1036,7 +1036,7 @@ const idclass_t dvb_mux_dtmb_class =
                      "do not like the AUTO setting."),
     },
     {
-      MUX_PROP_STR("constellation", N_("Constellation"), dtmb, qam, N_("AUTO")),
+      MUX_PROP_STR("constellation", N_("Constellation"), dtmb, qam, N_("QAM/AUTO")),
       .desc     = N_("The COFDM modulation used by the mux. "
                      "If you're not sure of the value leave as AUTO."),
     },


### PR DESCRIPTION
## Summary

Several mux classes in `src/input/mpegts/mpegts_mux_dvb.c` declare a
default value that the corresponding `*_enum` callback never emits.
Each enum function iterates a small list of `DVB_*` constants and emits
the canonical string returned by the matching `dvb_*2str` helper, which
scans the relevant strtab in `dvb_support.c` and returns the first
matching row.

Two distinct mismatches:

### 1. Delivery-system defaults

Three classes used the unhyphenated spelling and one carried the wrong
constant entirely (copy-pasted from the dvbt class above — DTMB is not
DVBT):

| Class | Default before | After |
|---|---|---|
| `dvb_mux_dvbt_class` | `"DVBT"` | `"DVB-T"` |
| `dvb_mux_dvbs_class` | `"DVBS"` | `"DVB-S"` |
| `dvb_mux_isdb_s_class` | `"ISDBS"` | `"ISDB-S"` |
| `dvb_mux_dtmb_class` | `"DVBT"` | `"DTMB"` |

The other delsys defaults (DVB-C, ATSC-T, ATSC-C, ISDB-T, DAB) already
match what the enum exposes; this PR touches only the four misaligned
ones.

### 2. QAM constellation / modulation defaults

`qamtab` carries two entries for "auto":

```
{ "AUTO",     DVB_MOD_AUTO },
{ "QAM/AUTO", DVB_MOD_QAM_AUTO },
```

The enum arrays for the QAM-based modulation classes pass
`DVB_MOD_QAM_AUTO`, so the dropdown publishes `"QAM/AUTO"` — but each
class declared the default as `"AUTO"`, which parses to a different
constant (`DVB_MOD_AUTO`) and isn't a member of the published enum.

| Class | Property | Default before | After |
|---|---|---|---|
| `dvb_mux_dvbt_class` | `constellation` | `"AUTO"` | `"QAM/AUTO"` |
| `dvb_mux_dvbc_class` | `constellation` | `"AUTO"` | `"QAM/AUTO"` |
| `dvb_mux_atsc_t_class` | `modulation` | `"AUTO"` | `"QAM/AUTO"` |
| `dvb_mux_atsc_c_class` | `constellation` | `"AUTO"` | `"QAM/AUTO"` |
| `dvb_mux_isdb_t_class` | `layera_mod` | `"AUTO"` | `"QAM/AUTO"` |
| `dvb_mux_isdb_t_class` | `layerb_mod` | `"AUTO"` | `"QAM/AUTO"` |
| `dvb_mux_isdb_t_class` | `layerc_mod` | `"AUTO"` | `"QAM/AUTO"` |
| `dvb_mux_isdb_c_class` | `constellation` | `"AUTO"` | `"QAM/AUTO"` |
| `dvb_mux_dtmb_class` | `constellation` | `"AUTO"` | `"QAM/AUTO"` |

The other DVB tables (`modetab`, `guardtab`, `hiertab`) only carry a
single AUTO entry, and bandwidth / FEC fall through to
`dvb_common2str` which canonicalises value 1 to `"AUTO"`. So the
remaining 22 `MUX_PROP_STR(..., N_("AUTO"))` declarations are already
in alignment; this PR touches only the nine misaligned ones.

## Effect

Any client that validates enum membership on submit (rejects values
not present in the published enum) refuses to send the default — the
user has to manually re-pick the canonical value before the form will
save. The ExtJS combobox doesn't enforce enum membership on submit,
so the bug went unnoticed there.

## Migration

The delsys side has no on-disk impact: `dvb_str2delsys` still accepts
the unhyphenated spellings AND maps them to the same `DVB_SYS_*`
constant, so existing config files continue to load unchanged.

For the QAM cases the canonical and legacy strings parse to *different*
constants (`DVB_MOD_QAM_AUTO` vs `DVB_MOD_AUTO`). Existing configs
persisted with `"AUTO"` continue to load and tune correctly — both
signal "let the driver decide" — but the loaded value isn't a member
of the published enum. UIs that synthesise a current-value option
(any sane combobox) keep the form editable until the user re-saves
with the canonical choice; UIs that don't may need a one-off re-pick
on the affected fields.

## Test plan

- [ ] `./configure && make -j$(nproc)` builds cleanly with `-Werror`.
- [ ] Delivery system: create a DVB-T network → Add mux → Delivery System dropdown shows `"DVB-T"` selected (was `"DVBT"`, not in the dropdown). Same check on DVB-S, ISDB-S, DTMB.
- [ ] Modulation: create a DVB-T / DVB-C / ATSC-T / ATSC-C / ISDB-T / ISDB-C / DTMB network → Add mux → constellation / modulation / layer A/B/C dropdown shows `"QAM/AUTO"` selected (was `"AUTO"`, not in the dropdown).
- [ ] Existing config-file load: a config persisted before this patch still loads as the same `DVB_SYS_*` / `DVB_MOD_*` constant and tunes successfully.