### PR TITLE
intl: include docs translations in the runtime catalog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -665,7 +665,7 @@ MD-WIZARD   = $(patsubst docs/wizard/%.md,%,$(sort $(wildcard docs/wizard/*.md))
 # Internationalization
 #
 PO-FILES  = $(wildcard $(foreach f,$(LANGUAGES),intl/tvheadend.$(f).po))
-PO-FILES += $(wildcard $(foreach f,$(LANGUAGES-DOC),intl/docs/tvheadend.doc.$(f).po))
+PO-FILES += $(wildcard $(foreach f,$(LANGUAGES),intl/docs/tvheadend.doc.$(f).po))
 SRCS += src/tvh_locale.c
 
 POC_PY=PYTHONIOENCODING=utf-8 $(PYTHON) support/poc.py

--- a/support/poc.py
+++ b/support/poc.py
@@ -114,9 +114,38 @@ def load(po_files, fn):
     po_files[lang] = po.strings
 
 def cstr(s):
-  return s.replace('\t', '\\t').\
-           replace('\n', '\\n').\
-           replace('"', '\\"');
+  # Emit a C string literal body from a Python string. Output is
+  # ASCII-only: control characters and non-ASCII bytes are emitted
+  # as octal \NNN escapes so the generated source carries no
+  # bidirectional control characters (avoids -Wbidi-chars) and is
+  # portable across editors and tools. The compiled binary holds
+  # the same UTF-8 byte sequence as the .po source (octal escapes
+  # resolve to single bytes at translation phase 5). Octal escapes
+  # are bounded to exactly 3 digits by the C standard, so the next
+  # character is always safely literal — unlike \xHH, which is
+  # greedy.
+  #
+  # Trigraph sequences (??=, ??/, ...) are deliberately not
+  # escaped: the project doesn't pass -trigraphs to the compiler,
+  # GCC and Clang both default to off, and C23 removed trigraphs
+  # entirely.
+  #
+  # bytearray() makes the byte iteration yield int in both Python 2
+  # and Python 3. In Python 3 `s` is unicode and we encode to UTF-8;
+  # in Python 2 `s` is already a UTF-8 byte string (utf8open returns
+  # a standard file object whose read() yields str/bytes), so we
+  # feed `s` through directly — calling .encode() on it would
+  # trigger an implicit ASCII decode and fail on non-ASCII content.
+  out = []
+  for b in bytearray(s.encode('utf-8') if sys.version_info[0] >= 3 else s):
+    if b == 0x09: out.append('\\t')
+    elif b == 0x0a: out.append('\\n')
+    elif b == 0x0d: out.append('\\r')
+    elif b == 0x22: out.append('\\"')
+    elif b == 0x5c: out.append('\\\\')
+    elif 0x20 <= b <= 0x7e: out.append(chr(b))
+    else: out.append('\\%03o' % b)
+  return ''.join(out)
 
 def to_c(po_files):
 


### PR DESCRIPTION
Makefile line 668 references $(LANGUAGES-DOC) — a variable that
is never defined anywhere in the repository. GNU Make expands
undefined variables to empty, so the docs catalog
(intl/docs/tvheadend.doc.<lang>.po) never reaches PO-FILES, the
poc.py generator, or src/tvh_locale_inc.c. Every msgid sourced
from docs/class/*.md, docs/property/*.md, and docs/wizard/*.md
falls back to English on every language at runtime via
tvh_gettext_lang(), even when the matching translation exists.

User-visible surfaces affected: the setup wizard's per-step
description paragraphs, every per-class help page served via
/markdown/<class>, and every per-property help text.

Repro: build with LANGUAGES=pl, then
  grep -c "Welcome to Tvheadend" src/tvh_locale_inc.c
returns 0, even though intl/docs/tvheadend.doc.pl.po carries
the Polish translation
  "__Witamy w Tvheadend – Twoim serwerze do transmisji
   strumieniowej TV i rejestratorze wideo__"
for the wizard's hello-step headline. After this fix the count
is non-zero and the Polish wizard renders its description in
Polish instead of English.

Coverage today (filled msgstr entries): Polish 100%, French
95.5%, English en_GB / en_US ~100%, Estonian 41.8%, Korean
33.5%, Spanish 20.7%, plus partial work in Norwegian, German,
Danish, Dutch, Swedish, and Bulgarian.

Origin: introduced in commit 7ec64dd70d ("intl: fix the broken
build", 2016-04-13), which added $(wildcard ...) to both
PO-FILES lines but also renamed the docs-line variable from
$(LANGUAGES) to $(LANGUAGES-DOC) without adding a definition.
No prior pull request or GitHub issue has tracked the bug — the
docs catalog has been silently absent from the runtime since.

Two coordinated changes:

  1. Makefile — use $(LANGUAGES) on the docs line, matching the
     main-catalog line directly above. The existing
     `make LANGUAGES="..."` override now affects both catalogs
     consistently.

  2. support/poc.py — rewrite cstr() to emit every non-ASCII
     byte as an octal \NNN escape, producing an ASCII-only
     src/tvh_locale_inc.c. The compiled binary contains the
     same UTF-8 byte sequence as before (octal escapes resolve
     to single bytes at compile time). This avoids tripping
     GCC's -Wbidi-chars Trojan-Source check on any
     translator-introduced bidi control character — concrete
     case: intl/docs/tvheadend.doc.pl.po:6935 translates "The"
     as a lone U+202E, almost certainly a stray keystroke.
     Octal escapes are bounded to exactly 3 digits by the C
     standard, so they don't suffer the greedy-consumption
     pitfall of \xHH hex escapes. The rewrite also correctly
     escapes literal backslashes, which the previous cstr()
     silently passed through.

Catalog ordering: PO-FILES lists the main catalog first and the
docs catalog second; poc.py's load() merges via dict.update(),
so on overlapping msgids the docs translation wins. For Polish
244 msgids overlap (227 identical, 17 different); for French
244 overlap (229 identical, 14 different); for en_GB 244 overlap
(243 identical, 0 different). The differing entries are minor
translator variants — accent / spelling / article-elision tweaks
— not semantic regressions. Examples:

  - French "Status":           main "Etat" → docs "État"
                                (accent fix — docs likely more correct)
  - French "Channel name":     main "Nom de la chaine" → docs
                                "Nom de chaine" (article dropped, stylistic)
  - Polish "Timeshift":        main "Funkcja Timeshift" → docs
                                "Timeshift" (shorter, stylistic)
  - Polish "Map unnamed channels":
                                main "Mapuj nienazwane kanały" → docs
                                "Mapuj nie nazwane kanały" (spelling variant)
