### PR TITLE
idnode: strict gt/lt + new ge/le/ne filter comparators, API v20

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -25,7 +25,8 @@
 #include "redblack.h"
 #include "access.h"
 
-#define TVH_API_VERSION 19
+/* 20: idnode numeric filter gained the ge / le / ne comparators */
+#define TVH_API_VERSION 20
 
 /*
  * Command hook

--- a/src/api/api_idnode.c
+++ b/src/api/api_idnode.c
@@ -55,7 +55,10 @@ api_idnode_flist_conf( htsmsg_t *args, const char *name )
 static struct strtab filtcmptab[] = {
   { "gt", IC_GT },
   { "lt", IC_LT },
-  { "eq", IC_EQ }
+  { "eq", IC_EQ },
+  { "ge", IC_GE },
+  { "le", IC_LE },
+  { "ne", IC_NE }
 };
 
 static void

--- a/src/idnode.c
+++ b/src/idnode.c
@@ -867,30 +867,48 @@ idnode_filter_init
   }
 }
 
+/* Shared ordered-comparison outcome: `cmp` is the three-way result
+ * (<0 / 0 / >0) of comparing the row value against the filter value;
+ * returns 1 when the row FAILS the filter. */
+static int
+idnode_filter_cmp_fails ( int cmp, idnode_filter_comp_t comp )
+{
+  switch (comp) {
+    case IC_EQ: return cmp != 0;
+    case IC_LT: return cmp >= 0;
+    case IC_GT: return cmp <= 0;
+    case IC_GE: return cmp < 0;
+    case IC_LE: return cmp > 0;
+    case IC_NE: return cmp == 0;
+    case IC_IN:
+    case IC_RE: return 0; // Note: invalid for ordered comparisons
+  }
+  return 0;
+}
+
 int
 idnode_filter
   ( idnode_t *in, idnode_filter_t *filter, const char *lang )
 {
   idnode_filter_ele_t *f;
-  
+
   LIST_FOREACH(f, filter, link) {
     if (!f->checked)
       idnode_filter_init(in, filter);
     if (f->type == IF_STR) {
       const char *str;
       char *strdisp;
-      int r = 1;
+      int r;
       str = strdisp = idnode_get_display(in, idnode_find_prop(in, f->key), lang);
       if (!str)
         if (!(str = idnode_get_str(in, f->key)))
           return 1;
-      switch(f->comp) {
-        case IC_IN: r = strstr(str, f->u.s) == NULL; break;
-        case IC_EQ: r = strcmp(str, f->u.s) != 0; break;
-        case IC_LT: r = strcmp(str, f->u.s) > 0; break;
-        case IC_GT: r = strcmp(str, f->u.s) < 0; break;
-        case IC_RE: r = !!regexec(&f->u.re, str, 0, NULL, 0); break;
-      }
+      if (f->comp == IC_IN)
+        r = strstr(str, f->u.s) == NULL;
+      else if (f->comp == IC_RE)
+        r = !!regexec(&f->u.re, str, 0, NULL, 0);
+      else
+        r = idnode_filter_cmp_fails(strcmp(str, f->u.s), f->comp);
       if (strdisp)
         free(strdisp);
       if (r)
@@ -900,45 +918,15 @@ idnode_filter
       if (idnode_get_s64(in, f->key, &a))
         return 1;
       b = (f->type == IF_NUM) ? f->u.n.n : f->u.b;
-      switch (f->comp) {
-        case IC_IN:
-        case IC_RE:
-          break; // Note: invalid
-        case IC_EQ:
-          if (a != b)
-            return 1;
-          break;
-        case IC_LT:
-          if (a > b)
-            return 1;
-          break;
-        case IC_GT:
-          if (a < b)
-            return 1;
-          break;
-      }
+      if (idnode_filter_cmp_fails((a > b) - (a < b), f->comp))
+        return 1;
     } else if (f->type == IF_DBL) {
       double a, b;
       if (idnode_get_dbl(in, f->key, &a))
         return 1;
       b = f->u.dbl;
-      switch (f->comp) {
-        case IC_IN:
-        case IC_RE:
-          break; // Note: invalid
-        case IC_EQ:
-          if (a != b)
-            return 1;
-          break;
-        case IC_LT:
-          if (a > b)
-            return 1;
-          break;
-        case IC_GT:
-          if (a < b)
-            return 1;
-          break;
-      }
+      if (idnode_filter_cmp_fails((a > b) - (a < b), f->comp))
+        return 1;
     }
   }
 

--- a/src/idnode.h
+++ b/src/idnode.h
@@ -161,6 +161,20 @@ typedef struct idnode_sort {
 } idnode_sort_t;
 
 /*
+ * Filter comparison operators. IC_IN / IC_RE apply to strings only.
+ */
+typedef enum idnode_filter_comp {
+  IC_EQ, ///< Equals
+  IC_LT, ///< Less than (strict)
+  IC_GT, ///< Greater than (strict)
+  IC_GE, ///< Greater than or equal
+  IC_LE, ///< Less than or equal
+  IC_NE, ///< Not equal
+  IC_IN, ///< contains (STR only)
+  IC_RE, ///< regexp (STR only)
+} idnode_filter_comp_t;
+
+/*
  * Filter definition
  */
 typedef struct idnode_filter_ele
@@ -185,13 +199,7 @@ typedef struct idnode_filter_ele
     double   dbl;
     regex_t  re;
   } u;                                ///< Filter data
-  enum {
-    IC_EQ, ///< Equals
-    IC_LT, ///< LT
-    IC_GT, ///< GT
-    IC_IN, ///< contains (STR only)
-    IC_RE, ///< regexp (STR only)
-  } comp;                             ///< Filter comparison
+  idnode_filter_comp_t comp;          ///< Filter comparison
 } idnode_filter_ele_t;
 
 typedef LIST_HEAD(,idnode_filter_ele) idnode_filter_t;

--- a/src/webui/static-vue/src/components/DataGrid.vue
+++ b/src/webui/static-vue/src/components/DataGrid.vue
@@ -42,6 +42,8 @@ import VirtualScroller from 'primevue/virtualscroller'
 import ColumnHeaderMenu from '@/components/ColumnHeaderMenu.vue'
 import type { ColumnDef } from '@/types/column'
 import type { BaseRow, GroupableFieldDef } from '@/types/grid'
+import type { NumericFilterModel } from '@/components/NumericFilterControls.vue'
+import { NUMERIC_OP_GLYPHS } from '@/components/columnFilterSummary'
 import {
   ArrowDown as ArrowDownIcon,
   ArrowUp as ArrowUpIcon,
@@ -1213,7 +1215,7 @@ function filterActiveFor(col: ColumnDef): boolean {
  * actually typed into the filter popover, so the preview is
  * recognisably theirs:
  *   string  → `Filter: contains "abc"`
- *   number  → `Filter: = 12345`
+ *   number  → `Filter: > 12345` / `Filter: 5 – 10`
  *   boolean → `Filter: Yes` / `Filter: No`
  * Returns '' when no filter is active; the caller passes that
  * through to the menu which then suppresses the `title`. Enum
@@ -1238,8 +1240,23 @@ function filterTitleFor(col: ColumnDef): string {
     const opt = opts?.find((o) => o.key === v || String(o.key) === String(v))
     return t('Filter: = {0}', opt?.val ?? String(v))
   }
-  /* numeric and any future filterType — value renders verbatim. */
+  if (col.filterType === 'numeric' && v !== null && typeof v === 'object') {
+    return numericFilterTitle(v as NumericFilterModel)
+  }
+  /* any future filterType — value renders verbatim. */
   return t('Filter: = {0}', String(v))
+}
+
+/* The numeric filter value is a NumericFilterModel, not a scalar —
+ * render its operator glyph + value(s) rather than String(v)'s
+ * "[object Object]". */
+function numericFilterTitle(m: NumericFilterModel): string {
+  if (m.value === null) return ''
+  if (m.op === 'between') {
+    if (m.value2 === null || m.value2 === undefined) return ''
+    return t('Filter: {0} – {1}', String(m.value), String(m.value2))
+  }
+  return t('Filter: {0} {1}', NUMERIC_OP_GLYPHS[m.op] ?? '=', String(m.value))
 }
 
 /* Ref onto PrimeVue's DataTable instance. We use it to call

--- a/src/webui/static-vue/src/components/IdnodeGrid.vue
+++ b/src/webui/static-vue/src/components/IdnodeGrid.vue
@@ -584,12 +584,36 @@ if (!props.persistColumns) {
 /* Per-column filter persistence — separate localStorage key
  * since the composable's scope is sort + cols + order only.
  * Same restore-on-mount + drop-on-empty semantics the old
- * GridPrefs.filter slot had. */
+ * GridPrefs.filter slot had.
+ *
+ * Format v2: `{ v: 2, filters: FilterDef[] }`. Version 1 was the
+ * bare array, written while the server treated gt/lt inclusively
+ * (as >=/<=) and the picker labelled them ≥/≤ — so a v1 numeric
+ * gt/lt carries inclusive INTENT and migrates to ge/le on load,
+ * preserving what the user saved. */
+interface PersistedFilterV2 {
+  v: 2
+  filters: FilterDef[]
+}
+
+function migrateV1Filter(filters: FilterDef[]): FilterDef[] {
+  return filters.map((f) => {
+    if (f.type !== 'numeric') return f
+    if (f.comparison === 'gt') return { ...f, comparison: 'ge' }
+    if (f.comparison === 'lt') return { ...f, comparison: 'le' }
+    return f
+  })
+}
+
 function loadFilter(): FilterDef[] | undefined {
   if (!props.persistColumns) return undefined
   try {
     const raw = localStorage.getItem(FILTER_KEY)
-    return raw ? (JSON.parse(raw) as FilterDef[]) : undefined
+    if (!raw) return undefined
+    const parsed = JSON.parse(raw) as PersistedFilterV2 | FilterDef[]
+    if (Array.isArray(parsed)) return migrateV1Filter(parsed)
+    if (parsed && parsed.v === 2 && Array.isArray(parsed.filters)) return parsed.filters
+    return undefined
   } catch {
     return undefined
   }
@@ -601,7 +625,8 @@ function saveFilter(filters: FilterDef[] | null): void {
     if (filters === null || filters.length === 0) {
       localStorage.removeItem(FILTER_KEY)
     } else {
-      localStorage.setItem(FILTER_KEY, JSON.stringify(filters))
+      const blob: PersistedFilterV2 = { v: 2, filters }
+      localStorage.setItem(FILTER_KEY, JSON.stringify(blob))
     }
   } catch {
     /* localStorage full or unavailable — silent fail. */
@@ -1531,26 +1556,28 @@ type DTFilterMeta = Record<string, DTFilterEntry>
 
 /* Reverse mapping for numeric columns: the wire format is 1 or 2
  * `FilterDef` entries on the same field, the model is a single
- * `NumericFilterModel`. Between is detected by the gt+lt pair —
- * since gt/lt are server-side inclusive today, the bounds round-
- * trip verbatim. */
+ * `NumericFilterModel`. Between is detected by the ge+le pair the
+ * forward mapping emits (a legacy gt+lt pair — pre-v2 in-memory
+ * state — is accepted too and reads as the same inclusive range). */
+const SINGLE_NUMERIC_OPS: ReadonlySet<string> = new Set(['eq', 'ne', 'lt', 'le', 'gt', 'ge'])
+
 function entriesToNumericModel(entries: FilterDef[]): NumericFilterModel | null {
   if (entries.length === 0) return null
   if (entries.length === 1) {
     const e = entries[0]
-    const op = (e.comparison ?? 'eq') as NumericFilterModel['op']
-    if (op === 'eq' || op === 'lt' || op === 'gt') {
-      return { op, value: Number(e.value), value2: null }
+    const op = e.comparison ?? 'eq'
+    if (SINGLE_NUMERIC_OPS.has(op)) {
+      return { op: op as NumericFilterModel['op'], value: Number(e.value), value2: null }
     }
     return { op: 'eq', value: Number(e.value), value2: null }
   }
-  const gt = entries.find((e) => e.comparison === 'gt')
-  const lt = entries.find((e) => e.comparison === 'lt')
-  if (gt && lt) {
+  const lower = entries.find((e) => e.comparison === 'ge' || e.comparison === 'gt')
+  const upper = entries.find((e) => e.comparison === 'le' || e.comparison === 'lt')
+  if (lower && upper) {
     return {
       op: 'between',
-      value: Number(gt.value),
-      value2: Number(lt.value),
+      value: Number(lower.value),
+      value2: Number(upper.value),
     }
   }
   /* Unexpected multi-entry combination; render the first entry. */
@@ -1604,26 +1631,18 @@ function persistFilter(filters: FilterDef[]) {
   saveFilter(filters)
 }
 
-/* Forward mapping for numeric columns: 1 entry for eq/lt/gt, 2
- * entries for Between (synthesised as `gt:min` AND `lt:max`).
- *
- * Server vocabulary today is `eq`, `gt`, `lt`. The `gt` matcher
- * at `src/idnode.c:911-918` keeps rows where a >= b (it rejects
- * only a < b), and `lt` keeps a <= b — long-standing inclusive-
- * when-strict-was-intended bug. NumericFilterControls labels the
- * operators by what they actually do (`≥` / `≤`), so Between
- * sends the bounds as-is and the server's inclusive interpretation
- * lands an inclusive range. A separate upstream C PR will tighten
- * IC_GT/IC_LT to strict `>` / `<` and add IC_GE/IC_LE; once that
- * lands the Vue UI gains both strict and inclusive operators and
- * Between switches to use IC_GE/IC_LE explicitly. */
+/* Forward mapping for numeric columns: 1 entry for the single
+ * operators (eq/ne/lt/le/gt/ge, passed to the server verbatim —
+ * API v20 comparators, `idnode_filter`), 2 entries for Between,
+ * synthesised as `ge:min` AND `le:max` so the displayed range is
+ * inclusive at both bounds. */
 function numericModelToEntries(field: string, m: NumericFilterModel | null): FilterDef[] {
   if (m === null || m.value === null) return []
   if (m.op === 'between') {
     if (m.value2 === null || m.value2 === undefined) return []
     return [
-      { field, type: 'numeric', value: m.value, comparison: 'gt' },
-      { field, type: 'numeric', value: m.value2, comparison: 'lt' },
+      { field, type: 'numeric', value: m.value, comparison: 'ge' },
+      { field, type: 'numeric', value: m.value2, comparison: 'le' },
     ]
   }
   return [{ field, type: 'numeric', value: m.value, comparison: m.op }]

--- a/src/webui/static-vue/src/components/NumericFilterControls.vue
+++ b/src/webui/static-vue/src/components/NumericFilterControls.vue
@@ -16,17 +16,11 @@
  * Apply commits the model to filterCallback → IdnodeGrid's
  * onFilter translates it to 1-or-2 wire entries.
  *
- * Operators: =, ≤, ≥, Between. The ≤ / ≥ labels match how the
- * server actually behaves today: `idnode_filter`'s IC_GT keeps
- * rows where a >= b (and IC_LT keeps a <= b) — a long-standing
- * inclusive-when-strict-was-intended bug at `src/idnode.c:911-918`
- * (and the parallel cases for IF_DBL / strings). Both Classic
- * and v2 inherit the behaviour, so we label the operators by
- * what they actually do. A separate upstream C PR will tighten
- * IC_GT/IC_LT to strict `>` / `<` and add IC_GE/IC_LE/IC_NE for
- * the missing operators. Once that lands, the labels here
- * switch to `<` / `>` and we add `≥` / `≤` / `!=` as additional
- * entries.
+ * Operators: =, ≠, <, ≤, >, ≥, Between — mapping 1:1 onto the
+ * server comparators eq/ne/lt/le/gt/ge (API v20; `idnode_filter`
+ * treats gt/lt strictly and ge/le/ne complete the set). Between
+ * translates to a ge+le pair so the displayed range is inclusive
+ * at both bounds.
  *
  * Between renders a Min + Max input pair; the other three
  * render a single Value input. Switching to Between seeds
@@ -38,7 +32,7 @@ import { useI18n } from '@/composables/useI18n'
 
 const { t } = useI18n()
 
-export type NumericFilterOp = 'eq' | 'lt' | 'gt' | 'between'
+export type NumericFilterOp = 'eq' | 'ne' | 'lt' | 'le' | 'gt' | 'ge' | 'between'
 
 export interface NumericFilterModel {
   op: NumericFilterOp
@@ -100,8 +94,11 @@ function onValue2Change(raw: string) {
         @change="onOpChange(($event.target as HTMLSelectElement).value as NumericFilterOp)"
       >
         <option value="eq">=</option>
-        <option value="lt">≤</option>
-        <option value="gt">≥</option>
+        <option value="ne">≠</option>
+        <option value="lt">&lt;</option>
+        <option value="le">≤</option>
+        <option value="gt">&gt;</option>
+        <option value="ge">≥</option>
         <option value="between">{{ t('Between') }}</option>
       </select>
     </label>

--- a/src/webui/static-vue/src/components/__tests__/DataGrid.test.ts
+++ b/src/webui/static-vue/src/components/__tests__/DataGrid.test.ts
@@ -36,6 +36,7 @@ vi.mock('@/composables/useIsPhone', async () => {
 })
 
 import DataGrid from '../DataGrid.vue'
+import ColumnHeaderMenu from '../ColumnHeaderMenu.vue'
 import type { ColumnDef } from '@/types/column'
 import { channelNumberCompare } from '@/utils/channelNumberSort'
 
@@ -104,6 +105,34 @@ describe('DataGrid', () => {
 
   afterEach(() => {
     /* clear any localStorage residue from selection tests */
+  })
+
+  describe('numeric funnel tooltip (filterTitle)', () => {
+    /* The numeric filter meta value is a NumericFilterModel object;
+     * the funnel hover must render its glyph + value(s), never the
+     * stringified object. */
+    const numCols: ColumnDef[] = [
+      { field: 'bytes', label: 'Bytes', sortable: true, minVisible: 'phone', filterType: 'numeric' },
+    ]
+
+    function titleFor(model: unknown): string | undefined {
+      const wrapper = mountGrid({
+        columns: numCols,
+        entries: [{ uuid: 'a', title: 'A', bytes: 1 }],
+        filters: { bytes: { value: model, matchMode: 'equals' } },
+      })
+      return wrapper.findComponent(ColumnHeaderMenu).props('filterTitle') as string | undefined
+    }
+
+    it('renders operator glyph + value, not "[object Object]"', () => {
+      expect(titleFor({ op: 'gt', value: 5, value2: null })).toBe('Filter: > 5')
+      expect(titleFor({ op: 'ge', value: 5, value2: null })).toBe('Filter: ≥ 5')
+      expect(titleFor({ op: 'ne', value: 5, value2: null })).toBe('Filter: ≠ 5')
+    })
+
+    it('renders a between model as "min – max"', () => {
+      expect(titleFor({ op: 'between', value: 5, value2: 10 })).toBe('Filter: 5 – 10')
+    })
   })
 
   it('renders error banner when error prop is set', () => {

--- a/src/webui/static-vue/src/components/__tests__/IdnodeGrid.test.ts
+++ b/src/webui/static-vue/src/components/__tests__/IdnodeGrid.test.ts
@@ -400,6 +400,16 @@ function mountForGuard() {
   })
 }
 
+/* Seed a persisted-filter blob, mount, and return what the grid
+ * pushed into the store — shared by the load/migration cases so
+ * the setItem/mount/expect skeleton isn't cloned per test. */
+function mountWithPersistedFilter(blob: unknown): unknown {
+  localStorage.setItem('tvh-grid:test-key:filter', JSON.stringify(blob))
+  mountGrid()
+  const calls = mockStore.update.mock.calls
+  return calls[calls.length - 1]?.[0]
+}
+
 describe('IdnodeGrid', () => {
   beforeEach(() => {
     mockStore = makeStore()
@@ -580,19 +590,44 @@ describe('IdnodeGrid', () => {
     const stored = localStorage.getItem('tvh-grid:test-key:filter')
     expect(stored).not.toBeNull()
     const parsed = JSON.parse(stored!) as unknown
-    expect(parsed).toEqual([
-      { field: 'title', type: 'string', value: 'abc' },
-    ])
+    expect(parsed).toEqual({
+      v: 2,
+      filters: [{ field: 'title', type: 'string', value: 'abc' }],
+    })
   })
 
-  it('seeds the store filter from persisted prefs at mount (lazy mode)', () => {
-    localStorage.setItem(
-      'tvh-grid:test-key:filter',
-      JSON.stringify([{ field: 'title', type: 'string', value: 'persisted' }]),
-    )
-    mountGrid()
-    expect(mockStore.update).toHaveBeenCalledWith({
+  it('seeds the store filter from a legacy v1 blob (bare array) at mount', () => {
+    const pushed = mountWithPersistedFilter([
+      { field: 'title', type: 'string', value: 'persisted' },
+    ])
+    expect(pushed).toEqual({
       filter: [{ field: 'title', type: 'string', value: 'persisted' }],
+    })
+  })
+
+  it('migrates legacy v1 numeric gt/lt (inclusive intent) to ge/le on load', () => {
+    /* v1 blobs were written while the picker labelled gt/lt as ≥/≤
+     * (matching the then-inclusive server); the saved intent is
+     * inclusive, so the load path rewrites them to ge/le. */
+    const pushed = mountWithPersistedFilter([
+      { field: 'size', type: 'numeric', value: 5, comparison: 'gt' },
+      { field: 'size', type: 'numeric', value: 10, comparison: 'lt' },
+    ])
+    expect(pushed).toEqual({
+      filter: [
+        { field: 'size', type: 'numeric', value: 5, comparison: 'ge' },
+        { field: 'size', type: 'numeric', value: 10, comparison: 'le' },
+      ],
+    })
+  })
+
+  it('loads a v2 blob verbatim (strict gt survives)', () => {
+    const pushed = mountWithPersistedFilter({
+      v: 2,
+      filters: [{ field: 'size', type: 'numeric', value: 5, comparison: 'gt' }],
+    })
+    expect(pushed).toEqual({
+      filter: [{ field: 'size', type: 'numeric', value: 5, comparison: 'gt' }],
     })
   })
 
@@ -624,13 +659,10 @@ describe('IdnodeGrid', () => {
   /*
    * Numeric column filter — model → wire-entries translation.
    * The per-column filter model is a NumericFilterModel object
-   * (op + value [+ value2]); the wire is 1 entry for eq/lt/gt,
-   * 2 entries for Between. Server's gt/lt are inclusive today
-   * (idnode.c:911-918), so the UI labels them as ≥/≤ and
-   * Between sends bounds verbatim — no off-by-one shift. Once
-   * the server gains strict gt/lt + new ge/le operators, the
-   * UI flips labels back to </> and adds ≥/≤/!= as separate
-   * entries.
+   * (op + value [+ value2]); the wire is 1 entry for the single
+   * operators (eq/ne/lt/le/gt/ge — the API-v20 idnode comparators,
+   * passed through verbatim), 2 entries for Between, synthesised
+   * as ge:min + le:max so the displayed range is inclusive.
    */
   describe('numeric filter operators', () => {
     it('eq model emits a single wire entry with comparison:eq', async () => {
@@ -672,7 +704,24 @@ describe('IdnodeGrid', () => {
       })
     })
 
-    it('between model emits TWO wire entries with the raw bounds (no shift)', async () => {
+    it('ne/le/ge models pass through 1:1', async () => {
+      for (const op of ['ne', 'le', 'ge'] as const) {
+        mockStore = makeStore({})
+        const wrapper = mountGrid()
+        const dataGrid = wrapper.findComponent({ name: 'DataGrid' })
+        dataGrid.vm.$emit('filter', {
+          filters: { size: { value: { op, value: 7, value2: null } } },
+        })
+        await wrapper.vm.$nextTick()
+        expect(mockStore.update).toHaveBeenCalledWith({
+          filter: [{ field: 'size', type: 'numeric', value: 7, comparison: op }],
+          start: 0,
+        })
+        wrapper.unmount()
+      }
+    })
+
+    it('between model emits TWO wire entries as inclusive ge+le', async () => {
       const wrapper = mountGrid()
       const dataGrid = wrapper.findComponent({ name: 'DataGrid' })
       dataGrid.vm.$emit('filter', {
@@ -681,8 +730,8 @@ describe('IdnodeGrid', () => {
       await wrapper.vm.$nextTick()
       expect(mockStore.update).toHaveBeenCalledWith({
         filter: [
-          { field: 'size', type: 'numeric', value: 5, comparison: 'gt' },
-          { field: 'size', type: 'numeric', value: 10, comparison: 'lt' },
+          { field: 'size', type: 'numeric', value: 5, comparison: 'ge' },
+          { field: 'size', type: 'numeric', value: 10, comparison: 'le' },
         ],
         start: 0,
       })
@@ -727,17 +776,37 @@ describe('IdnodeGrid', () => {
       expect(filters.size?.value).toEqual({ op: 'eq', value: 5, value2: null })
     })
 
-    it('seeds a between model from a gt+lt pair (bounds round-trip verbatim)', () => {
-      mockStore = makeStore({
-        filter: [
-          { field: 'size', type: 'numeric', value: 5, comparison: 'gt' },
-          { field: 'size', type: 'numeric', value: 10, comparison: 'lt' },
-        ],
-      })
-      const wrapper = mountGrid()
-      const dataGrid = wrapper.findComponent({ name: 'DataGrid' })
-      const filters = dataGrid.props('filters') as Record<string, { value: unknown }>
-      expect(filters.size?.value).toEqual({ op: 'between', value: 5, value2: 10 })
+    it('seeds a between model from a lower+upper pair (ge+le, and legacy gt+lt)', () => {
+      const pairs = [
+        ['ge', 'le'],
+        ['gt', 'lt'],
+      ] as const
+      for (const [lo, hi] of pairs) {
+        mockStore = makeStore({
+          filter: [
+            { field: 'size', type: 'numeric', value: 5, comparison: lo },
+            { field: 'size', type: 'numeric', value: 10, comparison: hi },
+          ],
+        })
+        const wrapper = mountGrid()
+        const dataGrid = wrapper.findComponent({ name: 'DataGrid' })
+        const filters = dataGrid.props('filters') as Record<string, { value: unknown }>
+        expect(filters.size?.value).toEqual({ op: 'between', value: 5, value2: 10 })
+        wrapper.unmount()
+      }
+    })
+
+    it('seeds single ne/le/ge models from their wire entries', () => {
+      for (const op of ['ne', 'le', 'ge'] as const) {
+        mockStore = makeStore({
+          filter: [{ field: 'size', type: 'numeric', value: 7, comparison: op }],
+        })
+        const wrapper = mountGrid()
+        const dataGrid = wrapper.findComponent({ name: 'DataGrid' })
+        const filters = dataGrid.props('filters') as Record<string, { value: unknown }>
+        expect(filters.size?.value).toEqual({ op, value: 7, value2: null })
+        wrapper.unmount()
+      }
     })
 
   })

--- a/src/webui/static-vue/src/components/__tests__/NumericFilterControls.test.ts
+++ b/src/webui/static-vue/src/components/__tests__/NumericFilterControls.test.ts
@@ -60,6 +60,32 @@ describe('NumericFilterControls', () => {
       const sel = wrapper.find('.num-filter__select').element as HTMLSelectElement
       expect(sel.value).toBe('gt')
     })
+
+    it('offers the full API-v20 operator set with truthful symbols', () => {
+      const wrapper = mountControls(null)
+      const options = wrapper
+        .findAll('.num-filter__select option')
+        .map((o) => [(o.element as HTMLOptionElement).value, o.text()])
+      expect(options).toEqual([
+        ['eq', '='],
+        ['ne', '≠'],
+        ['lt', '<'],
+        ['le', '≤'],
+        ['gt', '>'],
+        ['ge', '≥'],
+        ['between', 'Between'],
+      ])
+    })
+
+    it('single-value ops ne/le/ge render one Value input and emit 1:1', async () => {
+      for (const op of ['ne', 'le', 'ge'] as const) {
+        const wrapper = mountControls({ op: 'eq', value: 9, value2: null })
+        await wrapper.find('.num-filter__select').setValue(op)
+        const emits = wrapper.emitted('update:modelValue')
+        expect(emits![0][0]).toEqual({ op, value: 9, value2: null })
+        wrapper.unmount()
+      }
+    })
   })
 
   describe('emits on change', () => {

--- a/src/webui/static-vue/src/components/__tests__/columnFilterSummary.test.ts
+++ b/src/webui/static-vue/src/components/__tests__/columnFilterSummary.test.ts
@@ -94,25 +94,37 @@ describe('summarizeFilterEntries', () => {
     ).toBe('= 5')
   })
 
-  it('numeric gt → "≥ value" (server\'s `gt` is inclusive — bug tracked upstream)', () => {
-    expect(
-      summarizeFilterEntries(
-        [{ field: 'size', type: 'numeric', value: 100, comparison: 'gt' }],
-        LABELS,
-      ),
-    ).toBe('≥ 100')
+  it('numeric comparators render their strict/inclusive glyphs (API v20)', () => {
+    const cases: Array<[string, string]> = [
+      ['ne', '≠ 100'],
+      ['lt', '< 100'],
+      ['le', '≤ 100'],
+      ['gt', '> 100'],
+      ['ge', '≥ 100'],
+    ]
+    for (const [cmp, expected] of cases) {
+      expect(
+        summarizeFilterEntries(
+          [{ field: 'size', type: 'numeric', value: 100, comparison: cmp }],
+          LABELS,
+        ),
+      ).toBe(expected)
+    }
   })
 
-  it('numeric lt → "≤ value"', () => {
+  it('numeric ge+le pair (Between) → "min – max" with en-dash', () => {
     expect(
       summarizeFilterEntries(
-        [{ field: 'size', type: 'numeric', value: 50, comparison: 'lt' }],
+        [
+          { field: 'size', type: 'numeric', value: 5, comparison: 'ge' },
+          { field: 'size', type: 'numeric', value: 10, comparison: 'le' },
+        ],
         LABELS,
       ),
-    ).toBe('≤ 50')
+    ).toBe('5 – 10')
   })
 
-  it('numeric gt+lt pair (Between) → "min – max" with en-dash', () => {
+  it('legacy gt+lt pair still reads as a Between range', () => {
     expect(
       summarizeFilterEntries(
         [
@@ -128,8 +140,8 @@ describe('summarizeFilterEntries', () => {
     expect(
       summarizeFilterEntries(
         [
-          { field: 'size', type: 'numeric', value: 10, comparison: 'lt' },
-          { field: 'size', type: 'numeric', value: 5, comparison: 'gt' },
+          { field: 'size', type: 'numeric', value: 10, comparison: 'le' },
+          { field: 'size', type: 'numeric', value: 5, comparison: 'ge' },
         ],
         LABELS,
       ),
@@ -331,9 +343,9 @@ describe('summarizeFilterEntries — enum-label resolver', () => {
   })
 
   it('resolver does NOT apply to non-eq comparisons', () => {
-    /* `≥ 100` / `≤ 50` / between are unambiguously numeric.
+    /* `> 100` / `≤ 50` / between are unambiguously numeric.
      * Even if a resolver IS supplied, the operator-glyph
-     * format stays — resolving "≥ Important" reads as
+     * format stays — resolving "> Important" reads as
      * nonsense. */
     const labels = {
       ...LABELS,
@@ -344,7 +356,7 @@ describe('summarizeFilterEntries — enum-label resolver', () => {
         [{ field: 'pri', type: 'numeric', value: 2, comparison: 'gt' }],
         labels,
       ),
-    ).toBe('≥ 2')
+    ).toBe('> 2')
   })
 
   it('handles string-keyed enums (resolver value param is string|number)', () => {

--- a/src/webui/static-vue/src/components/columnFilterSummary.ts
+++ b/src/webui/static-vue/src/components/columnFilterSummary.ts
@@ -17,12 +17,23 @@
  * + the field key (used by the ✕ clear emit).
  *
  * String values get quoted; numeric operators get a glyph
- * (`= 5`, `≥ 100`, `≤ 50`, `5 – 10` for a min+max pair); boolean
+ * (`= 5`, `> 100`, `≤ 50`, `5 – 10` for a min+max pair); boolean
  * resolves to a localised Yes/No via a caller-supplied formatter
  * so this file stays locale-agnostic.
  */
 
 import type { FilterDef } from '@/types/grid'
+
+/* Comparator → display glyph for the API-v20 idnode operators.
+ * Shared with DataGrid's funnel-icon hover tooltip. */
+export const NUMERIC_OP_GLYPHS: Readonly<Record<string, string>> = {
+  eq: '=',
+  ne: '≠',
+  lt: '<',
+  le: '≤',
+  gt: '>',
+  ge: '≥',
+}
 
 export interface ColumnFilterRow {
   /** Field key — passed back in the clear-filter / edit-filter emit. */
@@ -107,18 +118,18 @@ export function summarizeFilterEntries(
 }
 
 /*
- * Numeric Between: two entries on the same field, one `gt`
- * (lower bound) + one `lt` (upper bound). Returns null when the
- * pair doesn't fit that shape (e.g. two `gt` entries) so the
- * caller can fall through to "empty" rather than rendering
- * something misleading.
+ * Numeric Between: two entries on the same field — a lower bound
+ * (`ge`, or `gt` from legacy state) + an upper bound (`le`/`lt`).
+ * Returns null when the pair doesn't fit that shape (e.g. two
+ * lower bounds) so the caller can fall through to "empty" rather
+ * than rendering something misleading.
  */
 function formatBetween(entries: readonly FilterDef[]): string | null {
   if (!entries.every((e) => e.type === 'numeric')) return null
-  const gt = entries.find((e) => e.comparison === 'gt')
-  const lt = entries.find((e) => e.comparison === 'lt')
-  if (!gt || !lt) return null
-  return `${formatNumeric(gt.value)} – ${formatNumeric(lt.value)}`
+  const lower = entries.find((e) => e.comparison === 'ge' || e.comparison === 'gt')
+  const upper = entries.find((e) => e.comparison === 'le' || e.comparison === 'lt')
+  if (!lower || !upper) return null
+  return `${formatNumeric(lower.value)} – ${formatNumeric(upper.value)}`
 }
 
 /*
@@ -147,8 +158,8 @@ function formatNumericEntry(e: FilterDef, labels: ColumnFilterLabels): string {
     }
     return `= ${formatNumeric(e.value)}`
   }
-  if (cmp === 'gt') return `≥ ${formatNumeric(e.value)}`
-  if (cmp === 'lt') return `≤ ${formatNumeric(e.value)}`
+  const glyph = NUMERIC_OP_GLYPHS[cmp]
+  if (glyph) return `${glyph} ${formatNumeric(e.value)}`
   return ''
 }
 

--- a/src/webui/static-vue/src/composables/useEpgViewState.ts
+++ b/src/webui/static-vue/src/composables/useEpgViewState.ts
@@ -944,6 +944,9 @@ export function useEpgViewState(opts: UseEpgViewStateOpts = {}): UseEpgViewState
       limit: 999_999_999,
       sort: 'start',
       dir: 'ASC',
+      /* gt/lt are the EPG endpoint's own (inclusive) comparators —
+       * see the vocabulary note in epgTableFilters.ts; the idnode
+       * grids' API-v20 ge/le are not understood here. */
       filter: JSON.stringify([
         { field: 'start', type: 'numeric', value: dEnd, comparison: 'lt' } satisfies FilterDef,
         { field: 'stop', type: 'numeric', value: epoch, comparison: 'gt' } satisfies FilterDef,

--- a/src/webui/static-vue/src/types/grid.ts
+++ b/src/webui/static-vue/src/types/grid.ts
@@ -27,8 +27,13 @@ export interface FilterDef {
   field: string
   type: 'string' | 'numeric' | 'boolean'
   value: string | number | boolean
-  /* numeric only — comparison from str2val(filtcmptab) — `eq`/`gt`/`lt`/etc.
-   * Defaults to `eq` if omitted. */
+  /* numeric only — comparison operator; defaults to `eq` if omitted.
+   * Two vocabularies exist server-side:
+   *   - idnode grids (src/idnode.c, API v20): `eq`/`ne` and STRICT
+   *     `lt`/`gt` plus inclusive `le`/`ge`.
+   *   - epg/events/grid (src/api/api_epg.c filtcmptab): only
+   *     `eq`/`gt`/`lt`, matched INCLUSIVELY — ge/le are not accepted
+   *     there. */
   comparison?: string
   /* numeric only — for split-int fields (rare). */
   intsplit?: number

--- a/src/webui/static-vue/src/views/epg/epgTableFilters.ts
+++ b/src/webui/static-vue/src/views/epg/epgTableFilters.ts
@@ -101,6 +101,13 @@ export interface BuildFiltersOutput {
  * composes the two halves of `now` / `today` into a range
  * automatically when it sees a gt+lt pair on the same field.
  *
+ * Comparator vocabulary: `epg/events/grid` has its OWN filter
+ * engine with only `eq`/`gt`/`lt` (`api_epg.c filtcmptab`), where
+ * gt/lt match INCLUSIVELY (`epg.c` EC_GT/EC_LT). The idnode grids'
+ * API-v20 set (`ne`/`ge`/`le`, strict gt/lt) does NOT apply here —
+ * sending `ge`/`le` to this endpoint would be silently dropped, so
+ * these entries must stay on gt/lt.
+ *
  * 'today' includes the currently-airing show (`start <
  * end-of-today AND stop > now`) — matches the user's mental
  * model of "today's remaining schedule, including what I'm


### PR DESCRIPTION
## Summary

The idnode numeric filter (the `comparison` field on
`type:"numeric"` filter entries, used by every `/api/.../grid`
endpoint) offered only `gt` / `lt` / `eq`, and `gt` / `lt` matched
*inclusively* — `gt` behaved as `>=`, `lt` as `<=` — contradicting
their names. The anomaly is documented:
https://docs.tvheadend.org/documentation/development/json-api/api-description/common-parameters

This PR tightens `gt` / `lt` to strict inequality and adds the three
missing operators:

| `comparison` | meaning |
|---|---|
| `eq` | `==` |
| `gt` | `>`  (now strict) |
| `lt` | `<`  (now strict) |
| `ge` | `>=` (new) |
| `le` | `<=` (new) |
| `ne` | `!=` (new) |

The operators apply to numeric (integer and double) filters.

## API version

`TVH_API_VERSION` is bumped 19 → 20 so clients can detect the
corrected/expanded operator set via `api/serverinfo`.

## Behaviour change

Making `gt` / `lt` strict is a breaking change for any client that
relied on the old inclusive behaviour; such callers should move to
`ge` / `le`, which preserve the previous semantics. There is no
per-request API-version negotiation, so the change applies to every
client of an upgraded server — the version bump is the detection
signal.

## Changes

- `src/idnode.h` — `IC_GE` / `IC_LE` / `IC_NE` added to the filter
  comparator enum, which is now the named `idnode_filter_comp_t`.
- `src/idnode.c` — `gt` / `lt` made strict; the comparison decision is
  a single shared helper (`idnode_filter_cmp_fails()` on a three-way
  compare) used by the string, integer, and double branches, replacing
  three copies of the operator switch.
- `src/api/api_idnode.c` — `ge` / `le` / `ne` wire strings.
- `src/api.h` — `TVH_API_VERSION` 19 → 20.
- `src/webui/static-vue/` — the Vue UI adopts the new operator set
  (see "Web UIs" below): numeric filter picker, wire mapping,
  summary chips + funnel tooltip, persisted-filter migration,
  comparator-vocabulary documentation.

## Web UIs

**The new Vue UI ships the new features in the same commit**, so
server and UI can never be inconsistent:

- The numeric column filter (any grid column with a numeric funnel,
  e.g. Channels → Number) now offers the full truthful operator set —
  `=`, `≠`, `<`, `≤`, `>`, `≥`, and `Between` — mapping 1:1 onto the
  server comparators. `Between` translates to `ge:min` + `le:max`, so
  the displayed range is inclusive at both bounds.
- Filter summary chips (View Options → Filters) and the funnel-icon
  hover render the matching glyphs (`> 5`, `≤ 10`, `5 – 10`). The
  hover previously stringified the filter model — fixed here.
- **Saved filters keep their meaning:** persisted per-grid filters are
  now versioned; filters saved before this change stored `gt`/`lt`
  under ≥/≤ labels (matching the then-inclusive server) and migrate
  to `ge`/`le` on load.
- The EPG grid endpoint (`epg/events/grid`) has its own `eq`/`gt`/`lt`
  filter vocabulary (`api_epg.c`, matched inclusively) and is
  deliberately untouched — the client senders that talk to it stay on
  `gt`/`lt`, and both vocabularies are documented at the type and call
  sites so they don't get conflated later.

**The legacy ExtJS UI needs no change** — a nice side effect: its
numeric filter menu has always displayed strict `>` / `<` / `=` icons
while the server matched inclusively. With this PR the displayed
operators become truthful for the first time.

## Test plan

- [x] Builds clean under `-Werror` (`-Wswitch` enforces that every
      `idnode_filter()` switch handles the new enum members).
- [x] `api/serverinfo` reports `api_version: 20`.
- [x] Exercised a numeric grid filter (`channel/grid` on `number`)
      with all six operators — `gt`/`lt` strict, `ge`/`le`
      inclusive, `ne` excludes only the equal row.
- [x] Vue UI: 2653 vitest cases green (new coverage for the operator
      picker, wire mapping, Between as ge+le, chip/tooltip glyphs, and
      the legacy-filter migration); browser-verified on Channels
      (strict vs inclusive differ by exactly the boundary row) and the
      EPG time-window presets (unchanged).
