### PR TITLE
epg: fix channel-name DESC sort (was calling description sort)

### DIFF
--- a/src/epg.c
+++ b/src/epg.c
@@ -2606,7 +2606,7 @@ static int _epg_sort_channel_ascending ( const void *a, const void *b, void *eq 
 
 static int _epg_sort_channel_descending ( const void *a, const void *b, void *eq )
 {
-  return _epg_sort_description_ascending(a, b, eq) * -1;
+  return _epg_sort_channel_ascending(a, b, eq) * -1;
 }
 
 static int _epg_sort_channel_num_ascending ( const void *a, const void *b, void *eq )


### PR DESCRIPTION
## Summary

`src/epg.c:2607-2610` — `_epg_sort_channel_descending` delegates to
`_epg_sort_description_ascending` and negates, so requesting sort
by channel-name DESC returns events ordered by reverse description
text instead of reverse channel name. Rows cluster by adjacent
description prose rather than by channel.

The sibling `_epg_sort_channel_ascending` (lines 2598-2605) uses
`channel_get_name` correctly, and every other `_descending` variant
in `epg.c` delegates to its own matching `_ascending` (title,
subtitle, summary, description, extratext, genre). Channel is the
only outlier — a copy-paste typo.

One-line fix: delegate to `_epg_sort_channel_ascending`.

## Test plan

- [x] Build clean (`./configure && make`)
- [ ] On a server with multiple channels carrying EPG, hit:
      `curl 'http://<host>/api/epg/events/grid?sort=channelName&dir=DESC&limit=20'`
      Pre-fix: rows show no apparent channel ordering. Post-fix:
      rows cluster by channel in reverse alphabetical order.
- [ ] Visible in the Classic web UI's EPG view when sorting the
      Channel column descending.