### PR TITLE
transcoding update to filter2 update to ffmpeg 8

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -272,7 +272,7 @@ jobs:
             mkdir -p .staticlib
             export STATICLIB_CACHE=/workspace/.staticlib
             export VUE_FILE_CACHE=/workspace/.vuecache
-            AUTOBUILD_CONFIGURE_EXTRA="--enable-ccache --enable-ffmpeg_static --enable-hdhomerun_static --python=python3 --enable-vue_cache --disable-vue_build" ./Autobuild.sh ${{ (startsWith(matrix.container[0], 'i386') && '-a i386') || '' }}
+            AUTOBUILD_CONFIGURE_EXTRA="${{ contains(matrix.container[1], 'trusty') && '--ffmpeg=6 ' || '' }} --enable-ccache --enable-ffmpeg_static --enable-hdhomerun_static --python=python3 --enable-vue_cache --disable-vue_build" ./Autobuild.sh ${{ (startsWith(matrix.container[0], 'i386') && '-a i386') || '' }}
         run: docker exec build-container bash -c "$SCRIPT"
       - name: copy-result
         env:
@@ -334,7 +334,7 @@ jobs:
           export STATICLIB_CACHE="$PWD/.staticlib"
           export VUE_FILE_CACHE="$PWD/.vuecache"
           export TVH_EXTRA_CONFIGURE="--enable-vue_cache --disable-vue_build"
-          ./configure --disable-dvbscan --disable-libfdkaac_static --disable-ffmpeg_static --disable-hdhomerun_static --disable-libfdkaac_static --disable-libopus_static --disable-libtheora_static --disable-libvorbis_static --disable-libvpx_static --disable-libx264_static --disable-libx265_static --enable-libfdkaac --enable-hdhomerun_client --enable-libsystemd_daemon --python=/usr/bin/python3 $TVH_EXTRA_CONFIGURE && make -C rpm build -j$(nproc) || (echo "PARALLEL BUILD FAILED, DOING SINGLE THREADED BUILD" && make -C rpm build)
+          ./configure ${{ contains(fromJson('["37", "38", "39", "40", "41", "42", "43"]'), matrix.releasever) && '--ffmpeg=7 ' || '' }} --disable-dvbscan --disable-libfdkaac_static --disable-ffmpeg_static --disable-hdhomerun_static --disable-libfdkaac_static --disable-libopus_static --disable-libtheora_static --disable-libvorbis_static --disable-libvpx_static --disable-libx264_static --disable-libx265_static --enable-libfdkaac --enable-hdhomerun_client --enable-libsystemd_daemon --python=/usr/bin/python3 $TVH_EXTRA_CONFIGURE && make -C rpm build -j$(nproc) || (echo "PARALLEL BUILD FAILED, DOING SINGLE THREADED BUILD" && make -C rpm build)
       - name: copy-result
         run: cp rpm/RPMS/*/tvheadend*.rpm .
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build-cloudsmith.yml
+++ b/.github/workflows/build-cloudsmith.yml
@@ -283,7 +283,7 @@ jobs:
             mkdir -p .staticlib
             export STATICLIB_CACHE=/workspace/.staticlib
             export VUE_FILE_CACHE=/workspace/.vuecache
-            AUTOBUILD_CONFIGURE_EXTRA="--enable-ccache --enable-ffmpeg_static --enable-hdhomerun_static --python=python3 --enable-vue_cache --disable-vue_build" ./Autobuild.sh ${{ (startsWith(matrix.container[0], 'i386') && '-a i386') || '' }}
+            AUTOBUILD_CONFIGURE_EXTRA="${{ contains(matrix.container[1], 'trusty') && '--ffmpeg=6 ' || '' }} --enable-ccache --enable-ffmpeg_static --enable-hdhomerun_static --python=python3 --enable-vue_cache --disable-vue_build" ./Autobuild.sh ${{ (startsWith(matrix.container[0], 'i386') && '-a i386') || '' }}
         run: docker exec -e PCLOUD_TOKEN build-container bash -c "$SCRIPT"
       - name: copy-result
         env:
@@ -350,7 +350,7 @@ jobs:
           export STATICLIB_CACHE="$PWD/.staticlib"
           export VUE_FILE_CACHE="$PWD/.vuecache"
           export TVH_EXTRA_CONFIGURE="--enable-vue_cache --disable-vue_build"
-          ./configure --disable-dvbscan --disable-libfdkaac_static --disable-ffmpeg_static --disable-hdhomerun_static --disable-libfdkaac_static --disable-libopus_static --disable-libtheora_static --disable-libvorbis_static --disable-libvpx_static --disable-libx264_static --disable-libx265_static --enable-libfdkaac --enable-hdhomerun_client --enable-libsystemd_daemon --python=/usr/bin/python3 $TVH_EXTRA_CONFIGURE && make -C rpm build -j$(nproc) || (echo "PARALLEL BUILD FAILED, DOING SINGLE THREADED BUILD" && make -C rpm build)
+          ./configure ${{ contains(fromJson('["37", "38", "39", "40", "41", "42", "43"]'), matrix.releasever) && '--ffmpeg=7 ' || '' }} --disable-dvbscan --disable-libfdkaac_static --disable-ffmpeg_static --disable-hdhomerun_static --disable-libfdkaac_static --disable-libopus_static --disable-libtheora_static --disable-libvorbis_static --disable-libvpx_static --disable-libx264_static --disable-libx265_static --enable-libfdkaac --enable-hdhomerun_client --enable-libsystemd_daemon --python=/usr/bin/python3 $TVH_EXTRA_CONFIGURE && make -C rpm build -j$(nproc) || (echo "PARALLEL BUILD FAILED, DOING SINGLE THREADED BUILD" && make -C rpm build)
       - name: copy-result
         run: cp rpm/RPMS/*/tvheadend*.rpm .
       - uses: actions/upload-artifact@v4

--- a/Containerfile.debian
+++ b/Containerfile.debian
@@ -62,9 +62,7 @@ RUN apt-get update --yes && apt-get install --yes \
                 --enable-hdhomerun_client \
                 --enable-kqueue \
                 --enable-libav \
-                --enable-nvenc \
                 --enable-pngquant \
-                --enable-qsv \
                 --python=python3 \
         && \
         make DESTDIR='/tvheadend' -j$(($(nproc) - 1)) install

--- a/Makefile
+++ b/Makefile
@@ -535,19 +535,34 @@ endif
 ifeq ($(CONFIG_VAAPI),yes)
 LIBS-CODECS += vaapi
 endif
+ifeq ($(CONFIG_QSV),yes)
+LIBS-CODECS += qsv
+endif
 ifeq ($(CONFIG_NVENC),yes)
 LIBS-CODECS += nvenc
 endif
 ifeq ($(CONFIG_OMX),yes)
 LIBS-CODECS += omx
 endif
+ifeq ($(CONFIG_V4L2M2M),yes)
+LIBS-CODECS += v4l2-m2m
+endif
 SRCS-CODECS += $(foreach lib,$(LIBS-CODECS),src/transcoding/codec/codecs/libs/$(lib).c)
 
 #hwaccels
 ifeq ($(CONFIG_HWACCELS),yes)
 SRCS-HWACCELS += src/transcoding/transcode/hwaccels/hwaccels.c
+ifeq ($(CONFIG_NVENC),yes)
+SRCS-HWACCELS += src/transcoding/transcode/hwaccels/nv.c
+endif
 ifeq ($(CONFIG_VAAPI),yes)
 SRCS-HWACCELS += src/transcoding/transcode/hwaccels/vaapi.c
+endif
+ifeq ($(CONFIG_QSV),yes)
+SRCS-HWACCELS += src/transcoding/transcode/hwaccels/qsv.c
+endif
+ifeq ($(CONFIG_V4L2M2M),yes)
+SRCS-HWACCELS += src/transcoding/transcode/hwaccels/v4l2-m2m.c
 endif
 endif
 

--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -37,11 +37,12 @@ COMPONENTS     = avutil avcodec avformat swscale swresample avfilter
 PROTOCOLS      = file http https hls mmsh mmst rtmp rtmpe rtmps rtmpt rtmpte rtmpts \
                  ffrtmpcrypt ffrtmphttp rtp srtp tcp udp udplite unix crypto
 DECODERS       = mpeg2video mp2 aac vorbis ac3 eac3 aac_latm opus h264 hevc theora flac
+PARSERS        = mpegvideo aac vorbis ac3 aac_latm opus h264 hevc flac
 ENCODERS       = mpeg2video mp2 aac vorbis flac
-MUXERS         = mpegts matroska mp4
+MUXERS         = mpeg2dvd mpegts matroska mp4 webm
 DEMUXERS       = mpegts matroska hls flv live_flv
 BSFS           = h264_mp4toannexb hevc_mp4toannexb
-FILTERS        = yadif format hwupload hwdownload scale null aresample anull
+FILTERS        = yadif format hwupload hwdownload scale null aresample aformat asetpts anull pad
 HWACCELS       =
 
 NASM_VER       = 2.16.03
@@ -107,10 +108,23 @@ FFNVCODEC_TB   = $(FFNVCODEC).tar.gz
 FFNVCODEC_URL  = https://github.com/FFmpeg/nv-codec-headers/releases/download/n$(FFNVCODEC_VER)/nv-codec-headers-$(FFNVCODEC_VER).tar.gz
 FFNVCODEC_SHA1 = 74231bb5572ebde98652a26ce98ede7895b4c730
 
+# NOTE: VAAPI patches must be updated based on ffmpeg selection (section "# VAAPI")
+ifeq ($(CONFIG_FFMPEG_VER),5)
+FFMPEG         = ffmpeg-5.1.4
+FFMPEG_SHA1    = e64a16f32289a8bb5629f3b3234b95f11f32a66f
+else ifeq ($(CONFIG_FFMPEG_VER),6)
 FFMPEG         = ffmpeg-6.1.1
+FFMPEG_SHA1    = 157e7b0f6521142e1ebd786175e363e9f1b59312
+else ifeq ($(CONFIG_FFMPEG_VER),7)
+FFMPEG         = ffmpeg-7.1.3
+FFMPEG_SHA1    = 1aba57070ed172fac4f5a648a260e44dabbca0a4
+else
+FFMPEG         = ffmpeg-8.1.2
+FFMPEG_SHA1    = 6fcb1b5bbe54d4fb80d4e7722fe23d2716f5eba5
+endif
+
 FFMPEG_TB      = $(FFMPEG).tar.bz2
 FFMPEG_URL     = https://ffmpeg.org/releases/$(FFMPEG_TB)
-FFMPEG_SHA1    = 157e7b0f6521142e1ebd786175e363e9f1b59312
 
 
 # ##############################################################################
@@ -567,12 +581,25 @@ endif
 
 ifeq (yes,$(CONFIG_NVENC))
 
+ifeq ($(CONFIG_FFMPEG_VER),5)
+	die "Invalid ffmpeg version: '$val'. Supported versions are 6, 7, or 8." 
+endif
+## if you experience failures when you enable yadif_cuda or scale_cuda with NVDEC you need to ensure 
+## that ffmpeg was compiled with 
+## check if file ffbuild/config.log search for "check_nvcc" and bellow that 
+## if you see "clang: not found" it means you are missing clang
+## install clang with:
+# sudo apt install clang
+## clean the project
+#  make distclean
+## and recompile again
 ## YOU MUST INSTALL CUDA from NVIDIA for "libnpp" 
 ## https://developer.nvidia.com/blog/nvidia-ffmpeg-transcoding-guide/
 EXTLIBS   += cuda cuvid nvdec nvenc libnpp
 ENCODERS  += h264_nvenc hevc_nvenc
 DECODERS  += h264_cuvid hevc_cuvid vp8_cuvid vp9_cuvid mpeg2_cuvid
 HWACCELS  += h264_nvdec hevc_nvdec vp8_nvdec vp9_nvdec mjpeg_nvdec mpeg1_nvdec mpeg2_nvdec mpeg4_nvdec
+FILTERS   += yadif_cuda scale_cuda
 ECFLAGS   += -I/usr/local/cuda/include
 
 ## NVIDIA LIB for "libnpp" 
@@ -616,6 +643,31 @@ EXTLIBS  += vaapi
 ENCODERS += h264_vaapi hevc_vaapi vp8_vaapi vp9_vaapi
 HWACCELS += mpeg2_vaapi h264_vaapi hevc_vaapi vp9_vaapi
 FILTERS  += deinterlace_vaapi scale_vaapi denoise_vaapi sharpness_vaapi
+# Apply the patches independently for each ffmpeg flavor
+ifeq ($(CONFIG_FFMPEG_VER),7)
+FFMPEG_DIFFS += ffmpeg.vaapi.diff ffmpeg.vaapi2.diff
+else ifeq ($(CONFIG_FFMPEG_VER),8)
+FFMPEG_DIFFS += ffmpeg.vaapi.diff
+endif
+
+endif
+
+
+# ##############################################################################
+# QSV
+#
+
+ifeq (yes,$(CONFIG_QSV))
+
+# libvpl was introduced in ffmpeg6
+ifeq ($(CONFIG_FFMPEG_VER),5)
+EXTLIBS  += libmfx
+else
+EXTLIBS  += libvpl
+endif
+ENCODERS += h264_qsv hevc_qsv vp9_qsv
+DECODERS += mpeg2_qsv h264_qsv hevc_qsv vp9_qsv vp8_qsv av1_qsv mjpeg_qsv
+FILTERS  += deinterlace_qsv scale_qsv vpp_qsv
 
 endif
 
@@ -647,6 +699,21 @@ endif
 ifeq (yes,$(CONFIG_OMX_RPI))
 
 EXTLIBS  += omx_rpi
+
+endif
+
+
+# ##############################################################################
+# V4L2M2M
+#
+
+ifeq (yes,$(CONFIG_V4L2M2M))
+
+EXTLIBS  += libdrm libv4l2 v4l2-m2m
+ENCODERS += h264_v4l2m2m
+HWACCELS += drm
+FILTERS  += deinterlace_v4l2m2m scale_v4l2m2m
+DECODERS += h264_v4l2m2m
 
 endif
 
@@ -698,10 +765,10 @@ $(LIB_ROOT)/$(FFMPEG)/.tvh_build: \
 		--extra-cflags="$(ECFLAGS)" \
 		--extra-libs="$(ELIBS)" \
 		--pkg-config="$(ROOTDIR)/support/pkg-config.ffmpeg" \
-		--enable-openssl \
 		$(foreach component,$(COMPONENTS),--enable-$(component)) \
 		$(foreach extlib,$(EXTLIBS),--enable-$(extlib)) \
 		$(foreach protocol,$(PROTOCOLS),--enable-protocol=$(protocol)) \
+		$(foreach decoder,$(PARSERS),--enable-parser=$(decoder)) \
 		$(foreach decoder,$(DECODERS),--enable-decoder=$(decoder)) \
 		$(foreach encoder,$(ENCODERS),--enable-encoder=$(encoder)) \
 		$(foreach demuxer,$(DEMUXERS),--enable-demuxer=$(demuxer)) \

--- a/configure
+++ b/configure
@@ -57,8 +57,10 @@ OPTIONS=(
   "libopus_static:yes"
   "nvenc:no"
   "vaapi:auto"
+  "qsv:no"
   "mmal:no"
   "omx:no"
+  "v4l2m2m:no"
   "inotify:auto"
   "epoll:auto"
   "pcre:auto"
@@ -96,6 +98,8 @@ esac
 # ###########################################################################
 opt=
 val=
+CONFIG_FFMPEG_VER=8  # Default to 8 if the flag is never sent
+
 for opt do
   val=${opt#*=}
   opt=${opt%%=*}
@@ -106,6 +110,17 @@ for opt do
       ;;
     *dir|prefix)
       eval "$opt=$val"
+      ;;
+    ffmpeg)
+      # Validate the input
+      case "$val" in
+        5|6|7|8)
+          eval "CONFIG_FFMPEG_VER=\"$val\""
+          ;;
+        *)
+          die "Invalid ffmpeg version: '$val'. Supported versions are 5, 6, 7, or 8."
+          ;;
+      esac
       ;;
     gzip)
       eval "$(toupper ${opt}CMD)=\"$val\""
@@ -779,6 +794,29 @@ if enabled_or_auto vaapi; then
 fi
 
 #
+# qsv
+#
+if enabled_or_auto qsv; then
+  if check_pkg libmfx ">=1.28"; then
+    enable qsv
+    enable hwaccels
+  elif check_pkg vpl ">=2.0"; then
+    enable qsv
+    enable hwaccels
+  elif enable qsv; then
+    die "Intel MediaSDK (AKA Quick Sync Video) - libmfx or oneVPL - not found"
+  fi
+fi
+
+#
+# v4l2
+#
+if enabled v4l2m2m; then
+  check_pkg libv4l2 ">=1.22" || die "libv4l2 1.22 package not found"
+  enable hwaccels
+fi
+
+#
 # Inotify
 #
 if enabled_or_auto inotify; then
@@ -900,6 +938,7 @@ fi
 
 # Write config
 write_config
+echo "CONFIG_FFMPEG_VER=${CONFIG_FFMPEG_VER:-8}" >> "${ROOTDIR}/.config.mk"
 cat >> "${CONFIG_H}" <<EOF
 #define TVHEADEND_DATADIR "$(eval echo ${datadir})/tvheadend"
 EOF

--- a/data/conf/transcoder/codecs
+++ b/data/conf/transcoder/codecs
@@ -1,27 +1,125 @@
 [
     {
-	"description": "WEBTV codec VP8",
-	"name": "webtv-vp8",
-	"codec_name": "libvpx",
-	"height": 384,
+        "description": "WEBTV codec VP8",
+        "name": "webtv-vp8",
+        "codec_name": "libvpx",
+        "height": 384,
         "deadline": 1,
         "crf": 28,
         "cpu-used": 8
     },
     {
-	"description": "WEBTV codec H264",
-	"name": "webtv-h264",
-	"codec_name": "libx264",
-	"height": 384
+        "description": "WEBTV codec VP8 VAAPI",
+        "name": "webtv-vp8-vaapi",
+        "codec_name": "vp8_vaapi",
+        "height": 384,
+        "bit_rate": 1500,
+        "max_bit_rate": 2000,
+        "hwaccel": true,
+        "decoder_hwaccel_type": 3
     },
     {
-	"description": "WEBTV codec Vorbis",
-	"name": "webtv-vorbis",
-	"codec_name": "vorbis"
+        "description": "WEBTV codec VP9",
+        "name": "webtv-vp9",
+        "codec_name": "libvpx-vp9",
+        "height": 384,
+        "deadline": 1,
+        "crf": 28,
+        "cpu-used": 8
     },
     {
-	"description": "WEBTV codec AAC",
-	"name": "webtv-aac",
-	"codec_name": "aac"
+        "description": "WEBTV codec VP9 VAAPI",
+        "name": "webtv-vp9-vaapi",
+        "codec_name": "vp9_vaapi",
+        "height": 384,
+        "bit_rate": 1500,
+        "max_bit_rate": 2000,
+        "hwaccel": true,
+        "decoder_hwaccel_type": 3
+    },
+    {
+        "description": "WEBTV codec H264",
+        "name": "webtv-h264",
+        "codec_name": "libx264",
+        "height": 384,
+        "preset": "faster",
+        "tune": "zerolatency"
+    },
+    {
+        "description": "WEBTV codec H264 QSV",
+        "name": "webtv-h264-qsv",
+        "codec_name": "h264_qsv",
+        "height": 384,
+        "bit_rate": 1500,
+        "max_bit_rate": 2000,
+        "hwaccel": true,
+        "decoder_hwaccel_type": 5
+    },
+    {
+        "description": "WEBTV codec H264 VAAPI",
+        "name": "webtv-h264-vaapi",
+        "codec_name": "h264_vaapi",
+        "height": 384,
+        "bit_rate": 1500,
+        "max_bit_rate": 2000,
+        "hwaccel": true,
+        "decoder_hwaccel_type": 3
+    },
+    {
+        "description": "WEBTV codec HEVC",
+        "name": "webtv-hevc",
+        "codec_name": "libx265",
+        "height": 384,
+        "preset": "ultrafast",
+        "tune": "fastdecode"
+    },
+    {
+        "description": "WEBTV codec HEVC QSV",
+        "name": "webtv-hevc-qsv",
+        "codec_name": "hevc_qsv",
+        "height": 384,
+        "bit_rate": 1500,
+        "max_bit_rate": 2000,
+        "hwaccel": true,
+        "decoder_hwaccel_type": 5
+    },
+    {
+        "description": "WEBTV codec HEVC VAAPI",
+        "name": "webtv-hevc-vaapi",
+        "codec_name": "hevc_vaapi",
+        "height": 384,
+        "bit_rate": 1500,
+        "max_bit_rate": 2000,
+        "hwaccel": true,
+        "decoder_hwaccel_type": 3
+    },
+    {
+        "description": "WEBTV codec Vorbis",
+        "name": "webtv-vorbis",
+        "codec_name": "vorbis",
+        "channel_layout": 3
+    },
+    {
+        "description": "WEBTV codec libVorbis",
+        "name": "webtv-libvorbis",
+        "codec_name": "libvorbis",
+        "channel_layout": 3
+    },
+    {
+        "description": "WEBTV codec AAC",
+        "name": "webtv-aac",
+        "codec_name": "aac",
+        "coder": "twoloop",
+        "sample_rate": 48000,
+        "channel_layout": 3
+    },
+    {
+        "description": "WEBTV codec libOpus",
+        "name": "webtv-libopus",
+        "codec_name": "libopus",
+        "bit_rate": 128,
+        "vbr": 2,
+        "complexity": 10,
+        "channel_layout": 3
     }
 ]

--- a/data/conf/transcoder/profiles
+++ b/data/conf/transcoder/profiles
@@ -1,30 +1,131 @@
 [
     {
-	"comment": "WEBTV profile VP8/Vorbis/WEBM",
-	"name": "webtv-vp8-vorbis-webm",
-	"pro_vcodec": "webtv-vp8",
-	"pro_acodec": "webtv-vorbis",
-	"container": 6
+        "comment": "WEBTV profile VP8 VAAPI/Vorbis/WEBM",
+        "container": 6,
+        "pro_vcodec": "webtv-vp8-vaapi",
+        "pro_acodec": "webtv-vorbis",
+        "name": "webtv-vp8-vaapi-vorbis-webm",
+        "enabled": false
     },
     {
-	"comment": "WEBTV profile H264/AAC/MPEG-TS",
-	"name": "webtv-h264-aac-mpegts",
-	"pro_vcodec": "webtv-h264",
-	"pro_acodec": "webtv-aac",
-	"container": 2
+        "comment": "WEBTV profile VP8 Software/Vorbis/WEBM",
+        "container": 6,
+        "pro_vcodec": "webtv-vp8",
+        "pro_acodec": "webtv-vorbis",
+        "name": "webtv-vp8-software-vorbis-webm"
     },
     {
-	"comment": "WEBTV profile H264/AAC/Matroska",
-	"name": "webtv-h264-aac-matroska",
-	"pro_vcodec": "webtv-h264",
-	"pro_acodec": "webtv-aac",
-	"container": 1
+        "comment": "WEBTV profile VP9 VAAPI/Vorbis/WEBM",
+        "container": 6,
+        "pro_vcodec": "webtv-vp9-vaapi",
+        "pro_acodec": "webtv-vorbis",
+        "name": "webtv-vp9-vaapi-vorbis-webm",
+        "enabled": false
     },
     {
-	"comment": "WEBTV profile H264/Vorbis/MP4",
-	"name": "webtv-h264-vorbis-mp4",
-	"pro_vcodec": "webtv-h264",
-	"pro_acodec": "webtv-vorbis",
-	"container": 9
+        "comment": "WEBTV profile VP9 Software/Vorbis/WEBM",
+        "container": 6,
+        "pro_vcodec": "webtv-vp9",
+        "pro_acodec": "webtv-vorbis",
+        "name": "webtv-vp9-software-vorbis-webm"
+    },
+    {
+        "comment": "WEBTV profile H264 QSV/AAC/Matroska",
+        "container": 1,
+        "pro_vcodec": "webtv-h264-qsv",
+        "pro_acodec": "webtv-aac",
+        "name": "webtv-h264-qsv-aac-mkv",
+        "enabled": false
+    },
+    {
+        "comment": "WEBTV profile H264 VAAPI/AAC/Matroska",
+        "container": 1,
+        "pro_vcodec": "webtv-h264-vaapi",
+        "pro_acodec": "webtv-aac",
+        "name": "webtv-h264-vaapi-aac-mkv",
+        "enabled": false
+    },
+    {
+        "comment": "WEBTV profile H264 Software/AAC/Matroska",
+        "container": 1,
+        "pro_vcodec": "webtv-h264",
+        "pro_acodec": "webtv-aac",
+        "name": "webtv-h264-software-aac-mkv"
+    },
+    {
+        "comment": "WEBTV profile H264 QSV/AAC/MP4",
+        "container": 9,
+        "pro_vcodec": "webtv-h264-qsv",
+        "pro_acodec": "webtv-aac",
+        "name": "webtv-h264-qsv-aac-mp4",
+        "enabled": false
+    },
+    {
+        "comment": "WEBTV profile H264 VAAPI/AAC/MP4",
+        "container": 9,
+        "pro_vcodec": "webtv-h264-vaapi",
+        "pro_acodec": "webtv-aac",
+        "name": "webtv-h264-vaapi-aac-mp4",
+        "enabled": false
+    },
+    {
+        "comment": "WEBTV profile H264 Software/AAC/MP4",
+        "container": 9,
+        "pro_vcodec": "webtv-h264",
+        "pro_acodec": "webtv-aac",
+        "name": "webtv-h264-software-aac-mp4"
+    },
+    {
+        "comment": "WEBTV profile H264 Software/AAC/MPEG-TS",
+        "container": 2,
+        "pro_vcodec": "webtv-h264",
+        "pro_acodec": "webtv-aac",
+        "name": "webtv-h264-software-aac-mpegts"
+    },
+    {
+        "comment": "WEBTV profile HEVC QSV/AAC/Matroska",
+        "container": 1,
+        "pro_vcodec": "webtv-hevc-qsv",
+        "pro_acodec": "webtv-aac",
+        "name": "webtv-hevc-qsv-aac-mkv",
+        "enabled": false
+    },
+    {
+        "comment": "WEBTV profile HEVC VAAPI/AAC/Matroska",
+        "container": 1,
+        "pro_vcodec": "webtv-hevc-vaapi",
+        "pro_acodec": "webtv-aac",
+        "name": "webtv-hevc-vaapi-aac-mkv",
+        "enabled": false
+    },
+    {
+        "comment": "WEBTV profile HEVC Software/AAC/Matroska",
+        "container": 1,
+        "pro_vcodec": "webtv-hevc",
+        "pro_acodec": "webtv-aac",
+        "name": "webtv-hevc-software-aac-mkv"
+    },
+    {
+        "comment": "WEBTV profile HEVC QSV/AAC/MP4",
+        "container": 9,
+        "pro_vcodec": "webtv-hevc-qsv",
+        "pro_acodec": "webtv-aac",
+        "name": "webtv-hevc-qsv-aac-mp4",
+        "enabled": false
+    },
+    {
+        "comment": "WEBTV profile HEVC VAAPI/AAC/MP4",
+        "container": 9,
+        "pro_vcodec": "webtv-hevc-vaapi",
+        "pro_acodec": "webtv-aac",
+        "name": "webtv-hevc-vaapi-aac-mp4",
+        "enabled": false
+    },
+    {
+        "comment": "WEBTV profile HEVC Software/AAC/MP4",
+        "container": 9,
+        "pro_vcodec": "webtv-hevc",
+        "pro_acodec": "webtv-aac",
+        "name": "webtv-hevc-software-aac-mp4"
     }
 ]

--- a/src/api/api_service.c
+++ b/src/api/api_service.c
@@ -87,7 +87,7 @@ api_service_streams_get_one ( elementary_stream_t *es, int use_filter )
   } else if (SCT_ISVIDEO(es->es_type)) {
     htsmsg_add_u32(e, "width",          es->es_width);
     htsmsg_add_u32(e, "height",         es->es_height);
-    htsmsg_add_u32(e, "duration",       es->es_frame_duration);
+    htsmsg_add_u32(e, "duration",       ((es->es_frame_duration > INT_MAX) ? INT_MAX : (int)es->es_frame_duration));
     htsmsg_add_u32(e, "aspect_num",     es->es_aspect_num);
     htsmsg_add_u32(e, "aspect_den",     es->es_aspect_den);
   } else if (es->es_type == SCT_CA) {

--- a/src/config.c
+++ b/src/config.c
@@ -2247,6 +2247,10 @@ const idclass_t config_class = {
          .name   = N_("Miscellaneous Settings"),
          .number = 8,
       },
+      {
+         .name   = N_("Transcoding"),
+         .number = 9,
+      },
       {}
   },
   .ic_properties = (const property_t[]){
@@ -2873,7 +2877,7 @@ const idclass_t config_class = {
                    "NOTE: After save, Tvheadend restart is required!"),
       .off    = offsetof(config_t, enable_vainfo),
       .opts   = PO_EXPERT,
-      .group  = 7,
+      .group  = 9,
     },
 #endif
     {

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -1499,7 +1499,7 @@ dvr_rec_start(dvr_entry_t *de, const streaming_start_t *ss)
 
       htsmsg_add_u32(e, "width",      ssc->es_width);
       htsmsg_add_u32(e, "height",     ssc->es_height);
-      htsmsg_add_u32(e, "duration",   ssc->es_frame_duration);
+      htsmsg_add_u32(e, "duration",   ((ssc->es_frame_duration > INT_MAX) ? INT_MAX : (int)ssc->es_frame_duration));
       htsmsg_add_u32(e, "aspect_num", ssc->es_aspect_num);
       htsmsg_add_u32(e, "aspect_den", ssc->es_aspect_den);
     } else {

--- a/src/esstream.h
+++ b/src/esstream.h
@@ -22,6 +22,9 @@
 
 #include "descrambler/descrambler.h"
 #include "input/mpegts/dvb.h"
+#if ENABLE_LIBAV
+#include <libavutil/rational.h>
+#endif
 
 /**
  *
@@ -93,13 +96,23 @@ struct elementary_info {
   int16_t es_pid;
   int es_type;
 
-  int es_frame_duration;
+  int64_t es_frame_duration;
 
+  // temporary used for each field
+  int es_width_2b;
+  int es_height_2b;
+  int es_width_12b;
+  int es_height_12b;
+
+  // store the final width,height (after 2bits+12bits concatenation)
   int es_width;
   int es_height;
 
   uint16_t es_aspect_num;
   uint16_t es_aspect_den;
+#if ENABLE_LIBAV
+  AVRational es_sample_aspect_ratio;
+#endif
 
   char es_lang[4];           /* ISO 639 2B 3-letter language code */
   uint8_t es_audio_type;     /* Audio type */

--- a/src/htsp_server.c
+++ b/src/htsp_server.c
@@ -4199,7 +4199,7 @@ htsp_stream_deliver(htsp_subscription_t *hs, th_pkt_t *pkt)
     htsmsg_add_s64(m, "dts", dts);
   }
 
-  uint32_t dur = hs->hs_90khz ? pkt->pkt_duration : ts_rescale(pkt->pkt_duration, 1000000);
+  uint32_t dur = (uint32_t) (hs->hs_90khz ? ((pkt->pkt_duration > INT_MAX) ? INT_MAX : (int)pkt->pkt_duration) : ts_rescale(pkt->pkt_duration, 1000000));
   htsmsg_add_u32(m, "duration", dur);
 
   /**
@@ -4323,7 +4323,7 @@ htsp_subscription_start(htsp_subscription_t *hs, const streaming_start_t *ss)
       if(ssc->es_height)
         htsmsg_add_u32(c, "height", ssc->es_height);
       if(ssc->es_frame_duration)
-        htsmsg_add_u32(c, "duration", hs->hs_90khz ? ssc->es_frame_duration :
+        htsmsg_add_u32(c, "duration", hs->hs_90khz ? ((ssc->es_frame_duration > INT_MAX) ? INT_MAX : (int)ssc->es_frame_duration) :
                        ts_rescale(ssc->es_frame_duration, 1000000));
       if (ssc->es_aspect_num)
         htsmsg_add_u32(c, "aspect_num", ssc->es_aspect_num);

--- a/src/libav.c
+++ b/src/libav.c
@@ -133,6 +133,9 @@ streaming_component_type2codec_id(streaming_component_type_t type)
   case SCT_OPUS:
     codec_id = AV_CODEC_ID_OPUS;
     break;
+  case SCT_FLAC:
+    codec_id = AV_CODEC_ID_FLAC;
+    break;
   case SCT_DVBSUB:
     codec_id = AV_CODEC_ID_DVB_SUBTITLE;
     break;

--- a/src/muxer.c
+++ b/src/muxer.c
@@ -58,6 +58,9 @@ static struct strtab container_audio_mime[] = {
   { "audio/mp4",                MC_AVMP4 },
   { "application/octet-stream", MC_PASS },
   { "application/octet-stream", MC_RAW },
+  { "audio/ogg",                MC_OGA },
+  { "audio/ogg",                MC_OGG },
+  { "audio/ogg",                MC_OPUS },
 };
 
 
@@ -98,6 +101,10 @@ static struct strtab container_name[] = {
   { "mp4a",       MC_MP4A },
   { "oga",        MC_VORBIS },
   { "ac4",        MC_AC4 },
+  { "oga",        MC_OGA },
+  { "ogv",        MC_OGV },
+  { "ogg",        MC_OGG },
+  { "opus",       MC_OPUS },
 };
 
 
@@ -121,6 +128,10 @@ static struct strtab container_audio_file_suffix[] = {
   { "mp4a", MC_MP4A },
   { "oga",  MC_VORBIS },
   { "ac4",  MC_AC4 },
+  { "oga",  MC_OGA },
+  { "ogv",  MC_OGV },
+  { "ogg",  MC_OGG },
+  { "opus", MC_OPUS },
 };
 
 
@@ -138,6 +149,7 @@ static struct strtab container_video_file_suffix[] = {
   { "mkv",  MC_AVMATROSKA },
   { "webm", MC_AVWEBM },
   { "mp4",  MC_AVMP4 },
+  { "ogv",  MC_OGV },
 };
 
 

--- a/src/muxer.h
+++ b/src/muxer.h
@@ -42,7 +42,11 @@ typedef enum {
   MC_AAC         = 12,
   MC_MP4A        = 13,
   MC_VORBIS      = 14,
-  MC_AC4         = 15
+  MC_AC4         = 15,
+  MC_OGA         = 16,
+  MC_OGV         = 17,
+  MC_OGG         = 18,
+  MC_OPUS        = 19
 } muxer_container_type_t;
 
 typedef enum {

--- a/src/muxer/muxer_libav.c
+++ b/src/muxer/muxer_libav.c
@@ -47,7 +47,22 @@ typedef struct lav_muxer {
   int lm_init;
 } lav_muxer_t;
 
-#define MUX_BUF_SIZE 4096
+/* Output buffer for the non-seekable AVIO context. libavformat writes each box
+   with a placeholder size and then seeks back to patch it (update_size()),
+   which on a non-seekable output only succeeds while the target byte is still
+   in the unflushed buffer. At 4096 an HEVC moov straddled that boundary: the
+   seek failed silently and the moov kept its placeholder size of 0, giving an
+   unparseable file with neither video nor audio -- intermittently for a fresh
+   client, always for one joining a running transcode.
+
+   Measured on a 1280x720 MPEG-2 source scaled to 384p:
+     libx265    global header 2449 -> hvcC 2477, moov 4022..5078
+     hevc_qsv   global header  104 -> hvcC  120, moov 1657..2421
+     libx264    global header   40 -> avcC   43, moov 1568..2328
+   Only libx265 came near the limit, because x265 embeds a verbose SEI (its
+   full option string) in the global header. 32k leaves roughly six times the
+   worst case observed, for 32k per active libav-muxed client. */
+#define MUX_BUF_SIZE 32768
 
 static const AVRational mpeg_tc = {1, 90000};
 
@@ -72,13 +87,35 @@ lav_muxer_write(void *opaque, uint8_t *buf, int buf_size)
   }
 
   r = write(lm->lm_fd, buf, buf_size);
-  if (r != buf_size)
+  if (r != buf_size) {
+    /* A failed write to the client socket on a normal disconnect (EPIPE/
+     * ECONNRESET) is an end-of-streaming notification, not a muxer fault.
+     * Flag it as EOS like the pass/mkv muxers do, so the webui stops quietly
+     * instead of logging a misleading "muxer reported errors". Real write
+     * failures (e.g. ENOSPC while recording) still count without m_eos. */
+    if (r < 0 && MC_IS_EOS_ERROR(errno))
+      lm->m_eos = 1;
     lm->m_errors++;
-  
+  }
+
   /* No room to notify about errors here. */
   /* We need to complete av_write_trailer() to free */
   /* all associated structures. */
   return buf_size;
+}
+
+// Separate the containers between AVCC/HVCC and Annex B
+// NOTE: MPEG-PS is only mpeg2 (so is not using either)
+// only MP4, MOV, WEBM, FLV, RTPM, M4V, 3GP and F4V is using isom_write_avcc() and isom_write_hvcc()
+static int
+has_avcc_hvcc(int type) {
+  return ((type == MC_AVMP4) || (type == MC_AVWEBM) || (type == MC_WEBM));
+}
+
+// only MPEG-TS and MKV
+static int
+is_annex_B(int type) {
+  return ((type == MC_MPEGTS) || (type == MC_AVMATROSKA) || (type == MC_MATROSKA));
 }
 
 
@@ -111,6 +148,9 @@ lav_muxer_add_stream(lav_muxer_t *lm,
     break;
 
   case MC_MPEGPS:
+    // Set the maximum bitrate permitted by the VBV (9.8 Mbps for DVD)
+    c->rc_max_rate = 9800000;
+    // Set the VBV buffer size (1.835 Mbps for DVD)
     c->rc_buffer_size = 224*1024*8;
     //Fall-through
   case MC_MPEGTS:
@@ -122,18 +162,37 @@ lav_muxer_add_stream(lav_muxer_t *lm,
     st->time_base = AV_TIME_BASE_Q;
     break;
   }
+  /* A track that needs a codec configuration but has no global header ends up
+   * with empty extradata. For MP4 that is fatal for the whole file, not just
+   * this track: the single moov cannot be written, so even the audio never
+   * ships -- and nothing said so. Report both ways it can happen. */
+  if(!ssc->ssc_gh && (ssc->es_type == SCT_H264 || ssc->es_type == SCT_HEVC))
+    tvherror(LS_LIBAV, "%s: no global header available; the track will have "
+                       "no codec configuration",
+             streaming_component_type2txt(ssc->es_type));
 
   if(ssc->ssc_gh) {
-    if (ssc->es_type == SCT_H264 || ssc->es_type == SCT_HEVC) {
+    if ((has_avcc_hvcc(lm->m_config.m_type)) &&
+      (ssc->es_type == SCT_H264 || ssc->es_type == SCT_HEVC)) {
       sbuf_t hdr;
+      int r;
       sbuf_init(&hdr);
       if (ssc->es_type == SCT_H264) {
-          isom_write_avcc(&hdr, pktbuf_ptr(ssc->ssc_gh),
-                          pktbuf_len(ssc->ssc_gh));
+          r = isom_write_avcc(&hdr, pktbuf_ptr(ssc->ssc_gh), pktbuf_len(ssc->ssc_gh));
       } else {
-          isom_write_hvcc(&hdr, pktbuf_ptr(ssc->ssc_gh),
-                          pktbuf_len(ssc->ssc_gh));
+          r = isom_write_hvcc(&hdr, pktbuf_ptr(ssc->ssc_gh), pktbuf_len(ssc->ssc_gh));
       }
+      if (r < 0 || hdr.sb_ptr <= 0)
+        tvherror(LS_LIBAV, "%s: cannot build %s from the %zu byte global "
+                           "header; the track will have no codec configuration",
+                 streaming_component_type2txt(ssc->es_type),
+                 ssc->es_type == SCT_H264 ? "avcC" : "hvcC",
+                 pktbuf_len(ssc->ssc_gh));
+      else
+        tvhtrace(LS_LIBAV, "%s: %s built: %zu byte global header -> %d bytes",
+                 streaming_component_type2txt(ssc->es_type),
+                 ssc->es_type == SCT_H264 ? "avcC" : "hvcC",
+                 pktbuf_len(ssc->ssc_gh), hdr.sb_ptr);
       c->extradata_size = hdr.sb_ptr;
       c->extradata = av_malloc(hdr.sb_ptr);
       memcpy(c->extradata, hdr.sb_data, hdr.sb_ptr);
@@ -172,54 +231,56 @@ lav_muxer_add_stream(lav_muxer_t *lm,
     c->width      = ssc->es_width;
     c->height     = ssc->es_height;
 
-    c->time_base.num = 1;
-    c->time_base.den = 25;
-
-    c->sample_aspect_ratio.num = ssc->es_aspect_num;
-    c->sample_aspect_ratio.den = ssc->es_aspect_den;
-
-    if (lm->m_config.m_type == MC_AVMP4) {
-      /* this is a whole hell */
-      AVRational ratio = { c->height, c->width };
-      c->sample_aspect_ratio = av_mul_q(c->sample_aspect_ratio, ratio);
+    if (st->time_base.num == 0 || st->time_base.den == 0) {
+      // Fallback to default timebase
+      st->time_base = mpeg_tc;
     }
+    // Encoder time_base = 1/FPS = frame duration in seconds =
+    // (st->time_base.num * es_frame_duration) / st->time_base.den, reduced.
+    av_reduce(&c->time_base.num, &c->time_base.den, (int64_t)st->time_base.num * ssc->es_frame_duration, st->time_base.den, INT_MAX);
+
+    // log SAR
+    tvhtrace(LS_LIBAV, "Muxer: sample aspect ratio = %d/%d", ssc->es_sample_aspect_ratio.num, ssc->es_sample_aspect_ratio.den);
+    
+    c->sample_aspect_ratio.num = ssc->es_sample_aspect_ratio.num;
+    c->sample_aspect_ratio.den = ssc->es_sample_aspect_ratio.den;
 
     avcodec_parameters_from_context(st->codecpar, c);
     st->sample_aspect_ratio.num = c->sample_aspect_ratio.num;
     st->sample_aspect_ratio.den = c->sample_aspect_ratio.den;
 
-    if (ssc->es_type == SCT_H264) {
-      if (av_bsf_alloc(lm->bsf_h264_filter, &lm->ctx)) {
-        tvherror(LS_LIBAV,  "Failed to alloc AVBitStreamFilter for h264_mp4toannexb");
-        goto fail;
+    // skip BSF for MPEG-2 video, regardless of container.
+    if (ssc->es_type != SCT_MPEG2VIDEO && is_annex_B(lm->m_config.m_type)) {
+      if (ssc->es_type == SCT_H264) {
+        if (av_bsf_alloc(lm->bsf_h264_filter, &lm->ctx)) {
+          tvherror(LS_LIBAV,  "Failed to alloc AVBitStreamFilter for h264_mp4toannexb");
+          goto fail;
+        }
       }
-    }
-    else if (ssc->es_type == SCT_HEVC) {
-      if (av_bsf_alloc(lm->bsf_hevc_filter, &lm->ctx)) {
-        tvherror(LS_LIBAV,  "Failed to alloc AVBitStreamFilter for hevc_mp4toannexb");
-        goto fail;
+      else if (ssc->es_type == SCT_HEVC) {
+        if (av_bsf_alloc(lm->bsf_hevc_filter, &lm->ctx)) {
+          tvherror(LS_LIBAV,  "Failed to alloc AVBitStreamFilter for hevc_mp4toannexb");
+          goto fail;
+        }
       }
-    }
-    else if (ssc->es_type == SCT_VP9) {
-      if (av_bsf_alloc(lm->bsf_vp9_filter, &lm->ctx)) {
-        tvherror(LS_LIBAV,  "Failed to alloc AVBitStreamFilter for vp9_superframe ");
-        goto fail;
+      else if (ssc->es_type == SCT_VP9) {
+        if (av_bsf_alloc(lm->bsf_vp9_filter, &lm->ctx)) {
+          tvherror(LS_LIBAV,  "Failed to alloc AVBitStreamFilter for vp9_superframe ");
+          goto fail;
+        }
       }
-    }
-    else {
-      if (av_bsf_alloc(lm->bsf_h264_filter, &lm->ctx)) {
-        tvherror(LS_LIBAV,  "Failed to alloc AVBitStreamFilter for h264_mp4toannexb");
-        goto fail;
+      // only use lm->ctx if BSF was allocated
+      if (lm->ctx) {
+        if(avcodec_parameters_copy(lm->ctx->par_in, st->codecpar)) {
+          tvherror(LS_LIBAV,  "Failed to copy paramters to AVBSFContext");
+          goto fail;
+        }
+        lm->ctx->time_base_in = st->time_base;
+        if (av_bsf_init(lm->ctx)) {
+          tvherror(LS_LIBAV,  "Failed to init AVBSFContext");
+          goto fail;
+        }
       }
-    }
-    if(avcodec_parameters_copy(lm->ctx->par_in, st->codecpar)) {
-      tvherror(LS_LIBAV,  "Failed to copy paramters to AVBSFContext");
-      goto fail;
-    }
-    lm->ctx->time_base_in = st->time_base;
-    if (av_bsf_init(lm->ctx)) {
-      tvherror(LS_LIBAV,  "Failed to init AVBSFContext");
-      goto fail;
     }
   } else if(SCT_ISSUBTITLE(ssc->es_type)) {
     c->codec_type = AVMEDIA_TYPE_SUBTITLE;
@@ -300,6 +361,24 @@ lav_muxer_support_stream(muxer_container_type_t mc,
     ret |= (type == SCT_AC4);
     break;
 
+  case MC_OGA:
+    ret |= (type == SCT_FLAC);
+    break;
+
+  case MC_OGV:
+    ret |= (type == SCT_THEORA);
+    ret |= (type == SCT_VORBIS);
+    ret |= (type == SCT_OPUS);
+    break;
+  
+  case MC_OGG:
+    ret |= (type == SCT_VORBIS);
+    break;
+  
+  case MC_OPUS:
+    ret |= (type == SCT_OPUS);
+    break;
+
   default:
     break;
   }
@@ -343,6 +422,45 @@ lav_muxer_mime(muxer_t* m, const struct streaming_start *ss)
     return muxer_container_type2mime(MC_UNKNOWN, 0);
 }
 
+static const char *get_muxer_name(int type){
+  const char *muxer_name;
+  switch(type) {
+    case MC_MPEGPS:
+      muxer_name = "dvd";
+      break;
+    case MC_MPEGTS:
+      muxer_name = "mpegts";
+      break;
+    case MC_MATROSKA:
+    case MC_AVMATROSKA:
+      muxer_name = "matroska";
+      break;
+    case MC_WEBM:
+    case MC_AVWEBM:
+      muxer_name = "webm";
+      break;
+    case MC_AVMP4:
+      muxer_name = "mp4";
+      break;
+    case MC_OGA:
+      muxer_name = "oga";
+      break;
+    case MC_OGV:
+      muxer_name = "ogv";
+      break;
+    case MC_OGG:
+      muxer_name = "ogg";
+      break;
+    case MC_OPUS:
+      muxer_name = "opus";
+      break;
+    default:
+      muxer_name = muxer_container_type2txt(type);
+      break;
+  }
+  return muxer_name;
+}
+
 
 /**
  * Init the muxer with streams
@@ -362,38 +480,15 @@ lav_muxer_init(muxer_t* m, struct streaming_start *ss, const char *name)
 #else
   AVOutputFormat *fmt;
 #endif
-  const char *muxer_name;
   int rc = -1;
 
   snprintf(app, sizeof(app), "Tvheadend %s", tvheadend_version);
 
   oc = lm->lm_oc;
 
-  switch(lm->m_config.m_type) {
-  case MC_MPEGPS:
-    muxer_name = "dvd";
-    break;
-  case MC_MPEGTS:
-    muxer_name = "mpegts";
-    break;
-  case MC_MATROSKA:
-  case MC_AVMATROSKA:
-    muxer_name = "matroska";
-    break;
-  case MC_WEBM:
-  case MC_AVWEBM:
-    muxer_name = "webm";
-    break;
-  case MC_AVMP4:
-    muxer_name = "mp4";
-    break;
-  default:
-    muxer_name = muxer_container_type2txt(lm->m_config.m_type);
-    break;
-  }
   fmt = lm->lm_oc->oformat;
-  if(avformat_alloc_output_context2(&oc, fmt, muxer_name, NULL) < 0) {
-    tvherror(LS_LIBAV,  "Can't find the '%s' muxer", muxer_name);
+  if(avformat_alloc_output_context2(&oc, fmt, NULL, NULL) < 0) {
+    tvherror(LS_LIBAV,  "Can't find the muxer");
     return -1;
   }
   av_dict_set(&oc->metadata, "title", name, 0);
@@ -447,7 +542,12 @@ lav_muxer_init(muxer_t* m, struct streaming_start *ss, const char *name)
   }
 
   if(lm->m_config.m_type == MC_AVMP4) {
-    av_dict_set(&opts, "frag_duration", "1", 0);
+    /* frag_duration is in microseconds: "1" fragments after every frame
+       (a moof+mdat per picture), whose per-frame overhead back-pressures
+       the streaming chain and makes playback stutter over time. Fragment
+       once per second instead -- far less overhead, latency still well
+       under the player buffer. */
+    av_dict_set(&opts, "frag_duration", "1000000", 0);
     av_dict_set(&opts, "ism_lookahead", "0", 0);
   }
 
@@ -465,9 +565,11 @@ lav_muxer_init(muxer_t* m, struct streaming_start *ss, const char *name)
         tvhdebug(LS_LIBAV,  "MPEGTS: mpegts_pmt_start_pid = %s", mpegts_info);
         av_dict_set(&opts, "mpegts_pmt_start_pid", mpegts_info, 0);
       }
+#if LIBAVUTIL_VERSION_MAJOR >= 57
       if (!lm->m_config.u.transcode.m_rewrite_nit) {
         av_dict_set(&opts, "mpegts_flags", "nit", 0);
       }
+#endif
     }
     else {
       // we transfer as many parameters as possible
@@ -501,7 +603,9 @@ lav_muxer_init(muxer_t* m, struct streaming_start *ss, const char *name)
         tvhdebug(LS_LIBAV,  "MPEGTS: mpegts_original_network_id = %s", mpegts_info);
         av_dict_set(&opts, "mpegts_original_network_id", mpegts_info, 0);
       }
+#if LIBAVUTIL_VERSION_MAJOR >= 57
       av_dict_set(&opts, "mpegts_flags", "nit", 0);
+#endif
       av_dict_set(&opts, "mpegts_copyts", "1", 0);
     }
   }
@@ -535,7 +639,17 @@ static int
 lav_muxer_reconfigure(muxer_t* m, const struct streaming_start *ss)
 {
   lav_muxer_t *lm = (lav_muxer_t*)m;
+  /* The libav muxer cannot be reconfigured in place: avformat_write_header()
+     has already emitted ftyp/moov describing the streams it was initialised
+     with, and there is no way to revise that once written. Report the failure
+     so the caller falls back to its own handling, as it always has.
 
+     Returning 0 here (as an earlier revision did) claims a reconfiguration
+     that never happened: the muxer keeps its stale state, the caller's
+     "Unable to reconfigure stream" warning never fires, and a client that
+     joins an already-running shared transcode is served a malformed header --
+     an MP4 whose moov box declares a size of 0, which no player can parse, so
+     neither video nor audio ever start. */
   lm->m_errors++;
 
   return -1;
@@ -764,6 +878,72 @@ lav_muxer_destroy(muxer_t *m)
 }
 
 
+static const AVOutputFormat *
+lav_muxer_find_oformat(muxer_container_type_t type)
+{
+  static const struct {
+    muxer_container_type_t mc;
+    const char *names[4];
+  } tab[] = {
+    { MC_WEBM,       { "webm", NULL } },
+    { MC_AVWEBM,     { "webm", NULL } },
+    { MC_MATROSKA,   { "matroska", NULL } },
+    { MC_AVMATROSKA, { "matroska", NULL } },
+    { MC_AVMP4,      { "mp4", "mov", NULL } },
+    { MC_MPEGTS,     { "mpegts", NULL } },
+    { MC_OGA,        { "oga", "ogg", NULL } },
+    { MC_OGV,        { "ogv", "ogg", NULL } },
+    { MC_OGG,        { "ogg", NULL } },
+    { MC_OPUS,       { "opus", "ogg", NULL } },
+  };
+  const char *fallback_names[2];
+  const char *name;
+  int i, j;
+
+  for (i = 0; i < sizeof(tab) / sizeof(tab[0]); i++) {
+    if (tab[i].mc != type)
+      continue;
+    for (j = 0; tab[i].names[j]; j++) {
+      const AVOutputFormat *fmt =
+        av_guess_format(tab[i].names[j], NULL, NULL);
+      if (fmt)
+        return fmt;
+    }
+    break;
+  }
+
+  /* Extension-based guess (e.g. "x.oga" -> ogg muxer) */
+  switch (type) {
+  case MC_WEBM:
+  case MC_AVWEBM:     name = "x.webm"; break;
+  case MC_MATROSKA:
+  case MC_AVMATROSKA: name = "x.mkv";  break;
+  case MC_AVMP4:      name = "x.mp4";  break;
+  case MC_OGA:        name = "x.oga";  break;
+  case MC_OGV:        name = "x.ogv";  break;
+  case MC_OGG:        name = "x.ogg";  break;
+  case MC_OPUS:       name = "x.opus"; break;
+  default:
+    name = NULL;
+    break;
+  }
+  if (name) {
+    const AVOutputFormat *fmt = av_guess_format(NULL, name, NULL);
+    if (fmt)
+      return fmt;
+  }
+
+  fallback_names[0] = get_muxer_name(type);
+  fallback_names[1] = NULL;
+  for (j = 0; fallback_names[j]; j++) {
+    const AVOutputFormat *fmt =
+      av_guess_format(fallback_names[j], NULL, NULL);
+    if (fmt)
+      return fmt;
+  }
+  return NULL;
+}
+
 /**
  * Create a new libavformat based muxer
  */
@@ -771,7 +951,6 @@ muxer_t*
 lav_muxer_create(const muxer_config_t *m_cfg,
                  const muxer_hints_t *hints)
 {
-  const char *mux_name;
   lav_muxer_t *lm;
 #if LIBAVCODEC_VERSION_MAJOR > 58
   const AVOutputFormat *fmt;
@@ -779,31 +958,14 @@ lav_muxer_create(const muxer_config_t *m_cfg,
   AVOutputFormat *fmt;
 #endif
 
-  switch(m_cfg->m_type) {
-  case MC_MPEGPS:
-    mux_name = "dvd";
-    break;
-  case MC_MATROSKA:
-  case MC_AVMATROSKA:
-    mux_name = "matroska";
-    break;
-  case MC_WEBM:
-  case MC_AVWEBM:
-    mux_name = "webm";
-    break;
-  case MC_AVMP4:
-    mux_name = "mp4";
-    break;
-  default:
-    mux_name = muxer_container_type2txt(m_cfg->m_type);
-    break;
-  }
-
-  fmt = av_guess_format(mux_name, NULL, NULL);
-  if(!fmt) {
-    tvherror(LS_LIBAV,  "Can't find the '%s' muxer", mux_name);
+  fmt = lav_muxer_find_oformat(m_cfg->m_type);
+  if (!fmt) {
+    tvherror(LS_LIBAV, "Can't find a muxer for '%s'",
+             muxer_container_type2txt(m_cfg->m_type));
     return NULL;
   }
+  tvhdebug(LS_LIBAV, "Using libavformat muxer '%s' for container %s",
+           fmt->name, muxer_container_type2txt(m_cfg->m_type));
 
   lm = calloc(1, sizeof(lav_muxer_t));
   lm->m_open_stream  = lav_muxer_open_stream;

--- a/src/muxer/muxer_mkv.c
+++ b/src/muxer/muxer_mkv.c
@@ -283,8 +283,10 @@ mk_build_tracks(mk_muxer_t *mk, streaming_start_t *ss)
     tr->sri = ssc->es_sri;
     tr->nextpts = PTS_UNSET;
 
-    if (mk->webm && ssc->es_type != SCT_VP8 && ssc->es_type != SCT_VORBIS)
-      tvhwarn(LS_MKV, "WEBM format supports only VP8+VORBIS streams (detected %s)",
+    if (mk->webm &&
+        ssc->es_type != SCT_VP8 && ssc->es_type != SCT_VP9 &&
+        ssc->es_type != SCT_VORBIS && ssc->es_type != SCT_OPUS)
+      tvhwarn(LS_MKV, "WEBM format supports only VP8/VP9 video and Vorbis/Opus audio (detected %s)",
               streaming_component_type2txt(ssc->es_type));
 
     switch(ssc->es_type) {

--- a/src/packet.c
+++ b/src/packet.c
@@ -182,7 +182,7 @@ pkt_trace_(const char *file, int line, int subsys, th_pkt_t *pkt,
   snprintf(buf, sizeof(buf),
            "%s%spkt stream %d %s%s%s"
            " pcr %s dts %s pts %s"
-           " dur %d len %zu err %i%s%s",
+           " dur %"PRId64" len %zu err %i%s%s",
            fmt ? fmt : "",
            fmt ? " (" : "",
            pkt->pkt_componentindex,

--- a/src/packet.h
+++ b/src/packet.h
@@ -53,7 +53,7 @@ typedef struct th_pkt {
   int64_t pkt_dts;
   int64_t pkt_pts;
   int64_t pkt_pcr;
-  int pkt_duration;
+  int64_t pkt_duration;
   int pkt_refcount;
 
   uint8_t pkt_type;
@@ -68,6 +68,9 @@ typedef struct th_pkt {
 
       uint16_t pkt_aspect_num;
       uint16_t pkt_aspect_den;
+#if ENABLE_LIBAV
+      AVRational pkt_sample_aspect_ratio;
+#endif
     } v;
     struct {
       uint8_t pkt_keyframe;

--- a/src/parsers/parser_h264.c
+++ b/src/parsers/parser_h264.c
@@ -444,6 +444,11 @@ h264_decode_slice_header(parser_es_t *st, bitstream_t *bs, int *pkttype,
     parser_set_stream_vparam(st, width, height, d);
 
   if (sps->aspect_num && sps->aspect_den) {
+#if ENABLE_LIBAV
+    // save SAR
+    st->es_sample_aspect_ratio.num = sps->aspect_num;
+    st->es_sample_aspect_ratio.den = sps->aspect_den;
+#endif
     width  *= sps->aspect_num;
     height *= sps->aspect_den;
     if (width && height) {
@@ -452,6 +457,11 @@ h264_decode_slice_header(parser_es_t *st, bitstream_t *bs, int *pkttype,
       st->es_aspect_den = height / v;
     }
   } else {
+#if ENABLE_LIBAV
+    // save SAR
+    st->es_sample_aspect_ratio.num = 0;
+    st->es_sample_aspect_ratio.den = 1;
+#endif
     st->es_aspect_num = 0;
     st->es_aspect_den = 1;
   }

--- a/src/parsers/parser_hevc.c
+++ b/src/parsers/parser_hevc.c
@@ -1164,11 +1164,19 @@ int isom_write_hvcc(sbuf_t *pb, const uint8_t *data, int size)
         case HEVC_NAL_VPS:
         case HEVC_NAL_SPS:
         case HEVC_NAL_PPS:
-        case HEVC_NAL_SEI_PREFIX:
-        case HEVC_NAL_SEI_SUFFIX:
+            /* VPS/SPS/PPS are mandatory: a parse failure means we cannot build a
+             * valid hvcC, so bail out. */
             ret = hvcc_add_nal_unit(buf, len, &hvcc);
             if (ret < 0)
                 goto end;
+            break;
+        case HEVC_NAL_SEI_PREFIX:
+        case HEVC_NAL_SEI_SUFFIX:
+            /* SEI is optional in the hvcC. Some encoders (notably hevc_qsv) emit a
+             * tiny SEI NAL that hvcc_add_nal_unit() rejects; that must NOT discard
+             * the whole configuration record (which left an empty hvcC/CodecPrivate
+             * and an undecodable HEVC track). Add it best-effort and ignore errors. */
+            hvcc_add_nal_unit(buf, len, &hvcc);
             break;
         default:
             break;
@@ -1713,6 +1721,11 @@ hevc_decode_slice_header(parser_es_t *st, bitstream_t *bs, int *pkttype)
     parser_set_stream_vparam(st, width, height, d);
 
   if (sps->vui.sar.num && sps->vui.sar.den) {
+#if ENABLE_LIBAV
+    // save SAR
+    st->es_sample_aspect_ratio.num = sps->vui.sar.num;
+    st->es_sample_aspect_ratio.den = sps->vui.sar.den;
+#endif
     width  *= sps->vui.sar.num;
     height *= sps->vui.sar.den;
     if (width && height) {
@@ -1721,6 +1734,11 @@ hevc_decode_slice_header(parser_es_t *st, bitstream_t *bs, int *pkttype)
       st->es_aspect_den = height / v;
     }
   } else {
+#if ENABLE_LIBAV
+    // save SAR
+    st->es_sample_aspect_ratio.num = 0;
+    st->es_sample_aspect_ratio.den = 1;
+#endif
     st->es_aspect_num = 0;
     st->es_aspect_den = 1;
   }

--- a/src/parsers/parsers.c
+++ b/src/parsers/parsers.c
@@ -144,6 +144,10 @@ deliver:
   if (SCT_ISVIDEO(pkt->pkt_type)) {
     pkt->v.pkt_aspect_num = st->es_aspect_num;
     pkt->v.pkt_aspect_den = st->es_aspect_den;
+#if ENABLE_LIBAV
+    pkt->v.pkt_sample_aspect_ratio.num = st->es_sample_aspect_ratio.num;
+    pkt->v.pkt_sample_aspect_ratio.den = st->es_sample_aspect_ratio.den;
+#endif
   }
 
   /* Forward packet */
@@ -1100,12 +1104,11 @@ parse_mpeg2video_pic_start(parser_t *t, parser_es_t *st, int *frametype,
  *
  */
 void
-parser_set_stream_vparam(parser_es_t *st, int width, int height,
-                         int duration)
+parser_set_stream_vparam(parser_es_t *st, int width, int height, int64_t duration)
 {
   int need_save = 0;
 
-  tvhtrace(LS_PARSER, "vparam %02d: w=%d h=%d d=%d (old w=%d h=%d d=%d meta=%d)",
+  tvhtrace(LS_PARSER, "vparam %02d: w=%d h=%d d=%"PRId64" (old w=%d h=%d d=%"PRId64" meta=%d)",
            st->es_index, width, height, duration, st->es_width, st->es_height,
            st->es_frame_duration, st->es_meta_change);
   if(st->es_width == 0 && st->es_height == 0 && st->es_frame_duration < 2) {
@@ -1131,13 +1134,35 @@ parser_set_stream_vparam(parser_es_t *st, int width, int height,
   }
 }
 
+static void
+parser_combine_stream_vparam(parser_es_t *st, int64_t duration) {
 
+  int width  = (st->es_width_2b  << 12) | (st->es_width_12b  & 0xFFFu);
+  int height = (st->es_height_2b << 12) | (st->es_height_12b & 0xFFFu);
+#if ENABLE_LIBAV
+  /* CALCULATE SAR 
+     Now that we have the coded frame size, we can refine the SAR 
+     calculation if we already have the DAR from the 0xB3 header. */
+  if (st->es_aspect_num && st->es_aspect_den && width > 0 && height > 0) {
+    // SAR = (DAR_num * display_height) / (DAR_den * display_width)
+    uint32_t sample_aspect_ratio_num = st->es_aspect_num * height;
+    uint32_t sample_aspect_ratio_den = st->es_aspect_den * width;
+    // Note: You should simplify this fraction via GCD.
+    uint32_t v = gcdU32(sample_aspect_ratio_num, sample_aspect_ratio_den);
+    st->es_sample_aspect_ratio.num = sample_aspect_ratio_num / v;
+    st->es_sample_aspect_ratio.den = sample_aspect_ratio_den / v;
+  }
+#endif
+  parser_set_stream_vparam(st, width, height, duration);
+}
+
+/* Standard MPEG-2 DAR table: {numerator, denominator} */
 static const uint8_t mpeg2_aspect[16][2]={
-    {0,1},
-    {1,1},
-    {4,3},
-    {16,9},
-    {221,100},
+    {0,1},      /* Reserved */
+    {1,1},      /* Square Pixels (SAR is 1:1, DAR depends on W/H) */
+    {4,3},      /* 4:3 DAR */
+    {16,9},     /* 16:9 DAR */
+    {221,100},  /* 2.21:1 DAR */
     {0,1},
     {0,1},
     {0,1},
@@ -1153,35 +1178,194 @@ static const uint8_t mpeg2_aspect[16][2]={
 
 
 /**
- * Parse mpeg2video sequence start
+ * @brief Parses the MPEG-2 Video Sequence Header to extract stream metadata.
+ *
+ * This function reads the mandatory fixed-length fields of an MPEG-2 sequence 
+ * start code. It populates the elementary stream (ES) structure with 
+ * resolution, aspect ratio, and frame timing data.
+ *
+ * @param t   Pointer to the global parser state.
+ * @param st  Pointer to the stream-specific context where results are stored.
+ * @param bs  Pointer to the bitstream buffer currently being read.
+ * * @return int PARSER_APPEND on success, or PARSER_RESET if there is insufficient data.
  */
 static int
 parse_mpeg2video_seq_start(parser_t *t, parser_es_t *st,
                            bitstream_t *bs)
 {
-  int width, height, aspect, duration;
-
+  int aspect, duration;
+  /* 1. Check for minimum required bits. 
+     The Sequence Header core (up to VBV size) is 61 bits long.
+     If we have less, we return RESET to wait for more data. */
   if(bs->len < 61)
     return PARSER_RESET;
-  
-  width = read_bits(bs, 12);
-  height = read_bits(bs, 12);
+  /* 2. Read Resolution: 
+     Horizontal and Vertical sizes are 12 bits each in the MPEG-2 spec. */
+  st->es_width_2b = 0;
+  st->es_height_2b = 0;
+  st->es_width_12b = read_bits(bs, 12);
+  st->es_height_12b = read_bits(bs, 12);
+  /* 3. Read Aspect Ratio:
+     A 4-bit index used to determine the Sample or Display aspect ratio. */
   aspect = read_bits(bs, 4);
-
+  /* Look up the actual numerator/denominator from a predefined MPEG-2 table. */
   st->es_aspect_num = mpeg2_aspect[aspect][0];
   st->es_aspect_den = mpeg2_aspect[aspect][1];
-
+  /* 4. Read Frame Rate:
+     A 4-bit 'frame_rate_code'. This is mapped to a duration (likely in 90kHz ticks)
+     using the mpeg2video_framedurations lookup table. */
   duration = mpeg2video_framedurations[read_bits(bs, 4)];
-
+  /* 5. Skip Bit Rate and Marker:
+     - 18 bits for the bit_rate_value.
+     - 1 bit for the marker_bit (always '1' to prevent start-code emulation). */
   skip_bits(bs, 18);
   skip_bits(bs, 1);
   
 #if 0
+  /* Optional: Read VBV Buffer Size (10 bits).
+     VBV (Video Buffering Verifier) ensures the stream doesn't overflow the decoder buffer. */
   int v = read_bits(bs, 10) * 16 * 1024 / 8;
   st->es_vbv_size = v;
 #endif
+  /* 6. Commit Parameters:
+     Update the stream context with the newly parsed width, height, and duration. */
+  parser_combine_stream_vparam(st, duration);
+  /* Return APPEND to signal that parsing of this header is complete. */
+  return PARSER_APPEND;
+}
 
-  parser_set_stream_vparam(st, width, height, duration);
+/*
+ * parse_mpeg2video_seq_ext - Parse MPEG-2 sequence_extension (ISO/IEC 13818-2).
+ *
+ * extension_start_code_identifier: 0001 (0x1). Fixed-length syntax: 48 bits
+ * starting at the first bit of that 4-bit identifier (not counting the prior
+ * extension_start_code 0x000001B5 if the caller already consumed it).
+ *
+ * Bitstream layout (MSB-first, order must match the standard):
+ *   - extension_start_code_identifier (4)  -- consumed here via skip_bits(4)
+ *   - profile_and_level_indication (8)
+ *   - progressive_sequence (1)
+ *   - chroma_format (2)  -- value 00 is forbidden in conforming streams
+ *   - horizontal_size_extension (2)
+ *   - vertical_size_extension (2)
+ *   - bit_rate_extension (12)
+ *   - marker_bit (1)  -- shall be 1
+ *   - vbv_buffer_size_extension (8)
+ *   - low_delay (1)
+ *   - frame_rate_extension_n (2)
+ *   - frame_rate_extension_d (5)
+ *
+ * Preconditions:
+ *   - `bs` is positioned at the first bit of extension_start_code_identifier.
+ *   - At least 48 bits are available (returns PARSER_DROP if not).
+ *
+ * Coded picture size:
+ *   Combine with 12-bit horizontal_size_value / vertical_size_value from
+ *   sequence_header (0xB3): full width/height = (ext << 12) | value.
+ *   Extensions may be zero; the formula still applies.
+ *
+ * This implementation only refreshes width/height when either extension
+ * nibble is non-zero and is always applying the OR to achieve a one code
+ * path for all streams.
+ *
+ * Returns PARSER_APPEND on success, PARSER_DROP if the fixed extension
+ * cannot be read in full.
+ */
+static int
+parse_mpeg2video_seq_ext(parser_t *t, parser_es_t *st, bitstream_t *bs)
+{
+  /* 1. Check for minimum required bits. 
+     The Sequence Extension (0x1) is 48 bits long.
+     If we have less, we return PARSER_DROP to wait for more data. */
+  if(bs->len < 48)
+    return PARSER_DROP;
+  /* Skip the 4-bit ID we already read (0x1) */
+  skip_bits(bs, 4); 
+
+  skip_bits(bs, 8); // skip profile_and_level_indication
+  skip_bits(bs, 1); // skip progressive_sequence
+  skip_bits(bs, 2); // skip chroma_format
+  
+  /* Horizontal/Vertical size extensions (2 bits each) 
+     These would be appended to the 12-bit values from 0xB3 */
+  st->es_width_2b  = read_bits(bs, 2);
+  st->es_height_2b = read_bits(bs, 2);
+  skip_bits(bs, 12); // skip bit_rate_extension
+  // marker always 1
+  skip_bits(bs, 1); // skip marker_bit; TODO: maybe we sould check if is '1'
+
+  skip_bits(bs, 8); // skip vbv_buffer_size_extension
+  skip_bits(bs, 1); // skip low_delay
+  skip_bits(bs, 2); // skip frame_rate_extension_n
+  skip_bits(bs, 5); // skip frame_rate_extension_d
+
+  // Update st-> values
+  if (st->es_width_2b || st->es_height_2b) {
+    /* Commit Parameters:
+      Update the stream context with the newly parsed width, height, and duration. */
+    parser_combine_stream_vparam(st, st->es_frame_duration);
+  }
+  
+  /* Return APPEND to signal that parsing of this header is complete. */
+  return PARSER_APPEND; 
+}
+
+
+/*
+ * Parse MPEG-2 sequence_display_extension (ISO/IEC 13818-2, sequence_display_extension).
+ *
+ * Preconditions:
+ *   - bs is positioned at the first bit of extension_start_code_identifier.
+ *   - That identifier is 0x2 (binary 0010) for sequence_display_extension; the caller
+ *     should verify extension_start_code (0x000001B5) and optionally the ID before calling.
+ *
+ * Syntax (fixed part only; no frame_center offsets — those are in picture_display_extension):
+ *   - video_format (3), colour_description (1)
+ *   - if colour_description: colour_primaries (8), transfer_characteristics (8),
+ *     matrix_coefficients (8)
+ *   - display_horizontal_size (14), marker_bit (1), display_vertical_size (14)
+ *
+ * Length: 37 bits without optional colour fields, 61 bits with them (not counting the
+ * 32-bit extension_start_code, which is outside this routine if already consumed).
+ *
+ * Returns PARSER_APPEND on success, PARSER_DROP if insufficient bits remain.
+ */
+static int
+parse_mpeg2video_display_ext(parser_t *t, parser_es_t *st, bitstream_t *bs)
+{
+  /* 1. Check for minimum required bits. 
+     The Display Extension (0x2) is between 37 bits and 61 bits long.
+     If we have less, we return RESET to wait for more data. */
+  if(bs->len < 37)
+    return PARSER_DROP;
+  /* Skip the 4-bit ID (0x2) */
+  skip_bits(bs, 4);
+
+  skip_bits(bs, 3); // skip video_format
+  int colour_description = read_bits(bs, 1);
+
+  if (colour_description) {
+    if (bs->len < 61)
+      return PARSER_DROP;
+    skip_bits(bs, 8); // skip primaries
+    skip_bits(bs, 8); // skip transfer
+    skip_bits(bs, 8); // skip matrix
+  } else {
+    if (bs->len < 37)
+      return PARSER_DROP;
+  }
+
+  /* skip Display Sizes - 2 x 14 bits each */
+  /* display_horizontal/vertical_size describe the intended display
+     rectangle (pan&scan), NOT the coded frame size: they must not be
+     written into the es_width/es_height raw fields, which the sequence
+     header resets every GOP (the values would oscillate and corrupt the
+     SAR derived from them in parser_combine_stream_vparam()). */
+  skip_bits(bs, 14);
+  skip_bits(bs, 1); // Marker bit; TODO: maybe we sould check if is '1'
+  skip_bits(bs, 14);
+
+  /* Return APPEND to signal that parsing of this header is complete. */
   return PARSER_APPEND;
 }
 
@@ -1229,6 +1413,21 @@ parser_global_data_move(parser_es_t *st, const uint8_t *data, size_t len, int re
  * 'steal' the st->es_buffer and use it as 'pkt' buffer
  *
  */
+/**
+ * @brief Main reassembly and parsing logic for MPEG-2 Video elementary streams.
+ *
+ * This function processes MPEG-2 start codes to reconstruct frames from slices.
+ * It handles metadata extraction (Sequence, GOP, Extensions) and manages the
+ * lifecycle of media packets (th_pkt_t), including timestamp extrapolation
+ * and payload "stealing" for efficiency.
+ *
+ * @param t               Pointer to the global parser state.
+ * @param st              Pointer to the stream-specific context.
+ * @param len             Length of the current start code's data.
+ * @param next_startcode  The lookahead start code (used to detect frame boundaries).
+ * @param sc_offset       Offset in the stream buffer where the current code starts.
+ * @return int            Parser directive (APPEND, DROP, HEADER, or RESET).
+ */
 static int
 parse_mpeg2video(parser_t *t, parser_es_t *st, size_t len,
                  uint32_t next_startcode, int sc_offset)
@@ -1237,15 +1436,16 @@ parse_mpeg2video(parser_t *t, parser_es_t *st, size_t len,
   bitstream_t bs;
   int frametype;
   th_pkt_t *pkt;
-
+  /* 0x1E0 is the PES start code for Video. If found, signal it's a header. */
   if(next_startcode == 0x1e0)
     return PARSER_HEADER;
-
+  /* Initialize bitstream reader, skipping the 4-byte start code prefix (00 00 01 XX) */
   init_rbits(&bs, buf + 4, (len - 4) * 8);
-
+  /* Switch on the last byte of the start code */
   switch(st->es_startcode & 0xff) {
   case 0xe0 ... 0xef:
-    /* System start codes for video */
+    /* 1. PES/System Start Codes:
+       If we find a PES header, parse it to extract PTS/DTS and reset. */
     if(len < 9)
       return PARSER_RESET;
 
@@ -1253,16 +1453,17 @@ parse_mpeg2video(parser_t *t, parser_es_t *st, size_t len,
     return PARSER_RESET;
 
   case 0x00:
-    /* Picture start code */
+    /* 2. Picture Start Code:
+       Start of a new frame. We need a valid duration before we can proceed. */
     if(st->es_frame_duration == 0)
       return PARSER_RESET;
-
+    /* Extract frame type (I, P, or B) from the picture header. */
     if(parse_mpeg2video_pic_start(t, st, &frametype, &bs) != PARSER_APPEND)
       return PARSER_RESET;
-
+    /* If there was a previous unfinished packet, release it. */
     if(st->es_curpkt != NULL)
       pkt_ref_dec(st->es_curpkt);
-
+    /* Allocate a new packet and populate it with current timing/metadata. */
     pkt = pkt_alloc(st->es_type, NULL, 0, st->es_curpts, st->es_curdts, t->prs_current_pcr);
     pkt->v.pkt_frametype = frametype;
     pkt->pkt_duration = st->es_frame_duration;
@@ -1274,13 +1475,15 @@ parse_mpeg2video(parser_t *t, parser_es_t *st, size_t len,
     if(st->es_curdts != PTS_UNSET)
       st->es_curdts += st->es_frame_duration;
 
-    /* PTS cannot be extrapolated (it's not linear) */
+    /* PTS is non-linear in MPEG-2 (due to B-frame reordering), so we can't extrapolate it. */
     st->es_curpts = PTS_UNSET; 
 
     break;
 
   case 0xb3:
-    /* Sequence start code */
+    /* 3. Sequence Header:
+       Contains critical stream info (Resolution, Aspect Ratio).
+       'parser_global_data_move' saves this as extradata/global header. */
     if(!st->es_buf.sb_err) {
       if(parse_mpeg2video_seq_start(t, st, &bs) != PARSER_APPEND)
         return PARSER_RESET;
@@ -1291,45 +1494,102 @@ parse_mpeg2video(parser_t *t, parser_es_t *st, size_t len,
     return PARSER_DROP;
 
   case 0xb5:
+    /* 4. Extension Header:
+       Check if it's a Sequence Extension (0x1) or Display Extension (0x2). */
     if(len < 5)
       return PARSER_RESET;
     switch(buf[4] >> 4) {
     case 0x1:
       // Sequence Extension
-      if(!st->es_buf.sb_err)
+      /* Fixed (~48 bits from first bit of ID, including marker_bit)*/
+      if(!st->es_buf.sb_err) {
+        if(parse_mpeg2video_seq_ext(t, st, &bs) != PARSER_APPEND)
+          return PARSER_RESET;
         parser_global_data_move(st, buf, len, 0);
+      }
       return PARSER_DROP;
     case 0x2:
       // Sequence Display Extension
-      if(!st->es_buf.sb_err)
+      /* Variable (depends on flags + number_of_frame_center_offsets and optional colour description)*/
+      if(!st->es_buf.sb_err) {
+        if(parse_mpeg2video_display_ext(t, st, &bs) != PARSER_APPEND)
+          return PARSER_RESET;
         parser_global_data_move(st, buf, len, 0);
+      }
       return PARSER_DROP;
+/* other information that can be added later on: 
+  TODO: add data in the future.
+    case 0x03:
+      // Quant Matrix Extension
+      // Variable (depends on which load_*_intra/non_intra flags are set → optional 8×64 matrices)
+      if(!st->es_buf.sb_err) {
+        parser_global_data_move(st, buf, len, 0);
+      }
+    case 0x04:
+      // Copyright extension
+      // Fixed (fixed-width fields)
+    case 0x05:
+      // Sequence scalable extension
+      // Fixed
+      if(!st->es_buf.sb_err) {
+        parser_global_data_move(st, buf, len, 0);
+      }
+    case 0x06:
+      // reserved
+    case 0x07:
+      // Picture display extension
+      // Variable (number_of_frame_center_offsets + repeated offset pairs)
+    case 0x08:
+      // Picture coding extension
+      // Fixed (long but fixed)
+    case 0x09:
+      // Picture spatial scalable extension
+      // Fixed
+    case 0x0A:
+      // Picture temporal scalable extension
+      // Fixed
+    case 0x0B:
+      // Camera parameter extension
+      // Fixed
+    case 0x0C:
+      // ITU-T T.35 extension
+      // Variable (length follows T.35 payload rules)
+    case 0x0D:
+    case 0x0E:
+      // reserved
+    case 0x0F:
+      // forbidden
+*/
     }
     break;
 
   case 0x01 ... 0xaf:
-    /* Slices */
-
+    /* 5. Slices:
+       These contain the actual macroblock data. We stay in this case until 
+       the 'next_startcode' indicates the end of the picture (a new pic or sequence). */
     if(next_startcode == 0x100 || next_startcode > 0x1af) {
-      /* Last picture slice (because next not a slice) */
+      /* This is the final slice of the current frame. */
       th_pkt_t *pkt = st->es_curpkt;
       size_t metalen = 0;
       if(pkt == NULL) {
         /* no packet, may've been discarded by sanity checks here */
         return PARSER_RESET;
       }
-
+      /* Attach accumulated global headers (SPS/PPS/GOP) to this packet's metadata. */
       if(st->es_global_data) {
         pkt->pkt_meta = pktbuf_make(st->es_global_data,
                                     metalen = st->es_global_data_len);
         st->es_global_data = NULL;
         st->es_global_data_len = 0;
       }
-
+      /* Check for stream errors before finalizing payload. */
       if (st->es_buf.sb_err) {
         pkt->pkt_err = st->es_buf.sb_err;
         st->es_buf.sb_err = 0;
       }
+      /* Payload handling:
+         If we have metadata, we must copy everything into a new buffer.
+         Otherwise, we "steal" the internal buffer to avoid a memory copy. */
       if (metalen) {
         pkt->pkt_payload = pktbuf_alloc(NULL, metalen + st->es_buf.sb_ptr - 4);
         memcpy(pktbuf_ptr(pkt->pkt_payload), pktbuf_ptr(pkt->pkt_meta), metalen);
@@ -1340,7 +1600,7 @@ parse_mpeg2video(parser_t *t, parser_es_t *st, size_t len,
         sbuf_steal_data(&st->es_buf);
       }
       pkt->pkt_duration = st->es_frame_duration;
-
+      /* Deliver the packet to the next stage of the pipeline. */
       if (st->es_priv) {
         if (!TAILQ_EMPTY(&st->es_backlog))
           parser_do_backlog(t, st, NULL, pkt->pkt_meta);
@@ -1357,19 +1617,22 @@ parse_mpeg2video(parser_t *t, parser_es_t *st, size_t len,
     break;
 
   case 0xb8:
-    // GOP header
+    /* 6. Group of Pictures (GOP) Header:
+       Store this as global data so it's prepended to the next I-frame. */
     if(!st->es_buf.sb_err)
       parser_global_data_move(st, buf, len, 0);
     return PARSER_DROP;
 
   case 0xb2:
-    // User data
+    /* 7. User Data:
+       Usually contains closed captions or hardware-specific info. 
+       Currently ignored by this switch. */
     break;
 
   default:
     break;
   }
-
+  /* Continue accumulating data until a frame boundary is hit. */
   return PARSER_APPEND;
 }
 

--- a/src/parsers/parsers.h
+++ b/src/parsers/parsers.h
@@ -134,7 +134,7 @@ void parse_mpeg_ts(parser_t *t, parser_es_t *st, const uint8_t *data,
 
 void parser_enqueue_packet(struct service *t, parser_es_t *st, th_pkt_t *pkt);
 
-void parser_set_stream_vparam(parser_es_t *st, int width, int height, int duration);
+void parser_set_stream_vparam(parser_es_t *st, int width, int height, int64_t duration);
 
 extern const unsigned int mpeg2video_framedurations[16];
 

--- a/src/plumbing/globalheaders.c
+++ b/src/plumbing/globalheaders.c
@@ -23,20 +23,18 @@
 
 typedef struct globalheaders {
   streaming_target_t gh_input;
-
   streaming_target_t *gh_output;
-
   struct th_pktref_queue gh_holdq;
-
   streaming_start_t *gh_ss;
-
   int gh_passthru;
-
+  // pts of the first picture sent downstream
+  int64_t gh_first_video_pts;
 } globalheaders_t;
 
-/* note: there up to 2.5 sec diffs in some sources! */
-#define MAX_SCAN_TIME   5000  // in ms
-#define MAX_NOPKT_TIME  2500  // in ms
+// note: there up to 2.5 sec diffs in some sources!
+// NOTE: lookahead is introducing a delay that should be accounted here. 100 frames can be as long as 4 sec.
+#define MAX_SCAN_TIME   10000 // in ms
+#define MAX_NOPKT_TIME  7500  // in ms
 
 /**
  *
@@ -74,48 +72,96 @@ gh_flush(globalheaders_t *gh)
   }
 
   pktref_clear_queue(&gh->gh_holdq);
+  gh->gh_first_video_pts = PTS_UNSET;
 }
 
 
 /**
+ * @brief Initializes stream metadata and ensures a global header exists for the component.
  *
+ * This function extracts essential stream parameters (frame duration, audio channels, 
+ * sample rate, and video aspect ratio) from an incoming packet if they are not already 
+ * defined in the streaming start component (ssc).
+ * * It is primarily responsible for ensuring the 'ssc_gh' (Global Header/Extradata) is 
+ * populated. If the packet contains metadata (pkt_meta), it increments the reference 
+ * count and assigns it. 
+ * * Special Case: AAC/MP4A
+ * If an AAC stream lacks a global header, this function manually constructs a 2-byte 
+ * (or 5-byte for SBR) AudioSpecificConfig (AAC-LC) using the packet's sample rate 
+ * index and channel configuration. This is required for many decoders to initialize 
+ * correctly.
+ *
+ * @param ssc  The streaming start component context to be updated.
+ * @param pkt  The input packet containing raw media data and technical attributes.
+ *
+ * @note This function returns immediately if ssc->ssc_gh is already set.
  */
 static void
 apply_header(streaming_start_component_t *ssc, th_pkt_t *pkt)
 {
+  /* 1. Set the elementary stream (ES) frame duration if it hasn't been initialized 
+        yet (is 0) and the incoming packet has a valid duration. */
   if(ssc->es_frame_duration == 0 && pkt->pkt_duration != 0)
     ssc->es_frame_duration = pkt->pkt_duration;
-
+  /* 2. Audio-specific initialization: 
+        If the stream is an audio type and the channel count hasn't been set yet, 
+        copy the channel count and Sample Rate Indices (SRI) from the packet. */
   if(SCT_ISAUDIO(ssc->es_type) && !ssc->es_channels) {
     ssc->es_channels = pkt->a.pkt_channels;
     ssc->es_sri      = pkt->a.pkt_sri;
     ssc->es_ext_sri  = pkt->a.pkt_ext_sri;
   }
-
+  /* 3. Video-specific initialization:
+        If the stream is a video type and the packet contains aspect ratio information,
+        copy the Sample Aspect Ratio (SAR) and Elementary Stream Aspect Ratio to the component. */
   if(SCT_ISVIDEO(ssc->es_type)) {
     if(pkt->v.pkt_aspect_num && pkt->v.pkt_aspect_den) {
+#if ENABLE_LIBAV
+      ssc->es_sample_aspect_ratio.num = pkt->v.pkt_sample_aspect_ratio.num;
+      ssc->es_sample_aspect_ratio.den = pkt->v.pkt_sample_aspect_ratio.den;
+#endif
       ssc->es_aspect_num = pkt->v.pkt_aspect_num;
       ssc->es_aspect_den = pkt->v.pkt_aspect_den;
     }
   }
-
+  /* 4. Global Header (Extradata) Check:
+        If the streaming component already has a global header initialized, 
+        there is no further work to do. */
   if(ssc->ssc_gh != NULL)
     return;
-
+  /* 5. Apply existing packet metadata as the global header:
+        If the packet contains metadata, assign it to the component's global header 
+        and increment the reference counter for the packet buffer to prevent it from 
+        being freed prematurely. */
   if(pkt->pkt_meta != NULL) {
     ssc->ssc_gh = pkt->pkt_meta;
     pktbuf_ref_inc(ssc->ssc_gh);
     return;
   }
-
+  /* 6. Synthesize AAC AudioSpecificConfig:
+        If there was no packet metadata, but the stream is AAC/MP4A, we must manually 
+        generate the MPEG-4 AudioSpecificConfig header required by decoders. */
   if (ssc->es_type == SCT_MP4A || ssc->es_type == SCT_AAC) {
+    /* Allocate 5 bytes if an extended Sample Rate Index (SBR/HE-AAC) exists, otherwise 2 bytes. */
     ssc->ssc_gh = pktbuf_alloc(NULL, pkt->a.pkt_ext_sri ? 5 : 2);
     uint8_t *d = pktbuf_ptr(ssc->ssc_gh);
-
+    /* Hardcode the Audio Object Type to 2 (AAC-LC - Low Complexity) */
     const int profile = 2; /* AAC LC */
+    /* Byte 0: 
+       - Top 5 bits: Audio Object Type (profile << 3)
+       - Bottom 3 bits: Top 3 bits of the 4-bit Sample Rate Index (SRI) */
     d[0] = (profile << 3) | ((pkt->a.pkt_sri & 0xe) >> 1);
+    /* Byte 1:
+       - Top 1 bit: Bottom 1 bit of the 4-bit SRI
+       - Next 4 bits: Channel Configuration (channels << 3)
+       - Bottom 3 bits: 0 (Frame length, DependsOnCoreCoder, ExtensionFlag) */
     d[1] = ((pkt->a.pkt_sri & 0x1) << 7) | (pkt->a.pkt_channels << 3);
+    /* Bytes 2-4: SBR (Spectral Band Replication) Extension signaling for HE-AAC */
     if (pkt->a.pkt_ext_sri) { /* SBR extension */
+      /* Byte 4:
+         - Top 1 bit: 1 (signals SBR is present)
+         - Next 4 bits: The extended Sample Rate Index
+         - Bottom 3 bits: 0 */
       d[2] = 0x56;
       d[3] = 0xe5;
       d[4] = 0x80 | ((pkt->a.pkt_ext_sri - 1) << 3);
@@ -125,7 +171,26 @@ apply_header(streaming_start_component_t *ssc, th_pkt_t *pkt)
 
 
 /**
+ * @brief Validates if sufficient metadata has been collected to initialize the stream.
  *
+ * This function checks the streaming start component (ssc) to ensure that all 
+ * critical parameters required by decoders or muxers have been populated. 
+ * It prevents the stream from starting prematurely with incomplete headers.
+ *
+ * @param ssc           The streaming start component context to validate.
+ * @param not_so_picky  Flag to relax validation. If non-zero, the function will 
+ * ignore missing video dimensions (width/height) and aspect ratios, 
+ * which is useful for certain "raw" or passthrough scenarios.
+ *
+ * @return int          Returns 1 if the metadata is complete and the stream can 
+ * proceed; returns 0 if more information is required.
+ *
+ * @note Validation criteria include:
+ * - Existence of frame duration for both audio and video.
+ * - Presence of audio channel configuration for audio streams.
+ * - (If picky) Presence of width, height, and aspect ratio for video streams.
+ * - Presence of a Global Header (extradata) if the codec type requires it 
+ * (checked via gh_require_meta).
  */
 static int
 header_complete(streaming_start_component_t *ssc, int not_so_picky)
@@ -153,50 +218,109 @@ header_complete(streaming_start_component_t *ssc, int not_so_picky)
 
 
 /**
+ * @brief Calculates the time duration (delay) represented by packets in the hold queue.
+ * * This function determines the time spread between the earliest and latest queued 
+ * packets for a specific stream component (identified by `index`). It does this by 
+ * scanning the queue from both ends to find the first and last packets belonging to 
+ * the target stream that have valid Decoding Time Stamps (DTS), and computing the 
+ * difference while accounting for timestamp wraparound.
  *
+ * @param gh Pointer to the global headers context containing the packet hold queue.
+ * @param index The elementary stream (ES) index to calculate the delay for.
+ * @return int64_t The calculated time difference (delay) in DTS units. Returns 0 if 
+ * valid timestamps aren't found OR if a massive timestamp discontinuity is detected. 
+ * Returns 1 for special payloadless transcode packets.
  */
 static int64_t
 gh_queue_delay(globalheaders_t *gh, int index)
 {
+  /* Initialize pointers to the first (head) and last (tail) elements of the hold queue */
   th_pktref_t *f = TAILQ_FIRST(&gh->gh_holdq);
   th_pktref_t *l = TAILQ_LAST(&gh->gh_holdq, th_pktref_queue);
   streaming_start_component_t *ssc;
   int64_t diff;
+  int8_t found_f = 0, found_l = 0;
 
   /*
    * Find only packets which require the meta data. Ignore others.
    */
+  /*
+   * 1. Forward Search: Find the EARLIEST packet in the queue for this stream.
+   * Iterate from the front of the queue towards the back. We are looking for the 
+   * first packet that has a valid DTS and belongs to the requested stream index.
+   */
   while (f != l) {
     if (f->pr_pkt->pkt_dts != PTS_UNSET) {
+      /* Retrieve the stream component context using the packet's internal component index */
       ssc = streaming_start_component_find_by_index
               (gh->gh_ss, f->pr_pkt->pkt_componentindex);
-      if (ssc && ssc->es_index == index)
+      /* If the packet belongs to the requested elementary stream index, stop searching */
+      if (ssc && ssc->es_index == index){
+        found_f = 1;
         break;
+      }
     }
+    /* Move to the next packet in the queue */
     f = TAILQ_NEXT(f, pr_link);
   }
+  /*
+   * 2. Backward Search: Find the LATEST packet in the queue for this stream.
+   * Iterate from the back of the queue towards the front. Stop when we find the 
+   * last packet matching our stream index with a valid DTS.
+   */
   while (l != f) {
     if (l->pr_pkt->pkt_dts != PTS_UNSET) {
       ssc = streaming_start_component_find_by_index
               (gh->gh_ss, l->pr_pkt->pkt_componentindex);
-      if (ssc && ssc->es_index == index)
+      if (ssc && ssc->es_index == index){
+        found_l = 1;
         break;
+      }
     }
+    /* Move to the previous packet in the queue */
     l = TAILQ_PREV(l, th_pktref_queue, pr_link);
   }
-
-  if (l->pr_pkt->pkt_dts != PTS_UNSET && f->pr_pkt->pkt_dts != PTS_UNSET) {
-    diff = (l->pr_pkt->pkt_dts & PTS_MASK) - (f->pr_pkt->pkt_dts & PTS_MASK);
-    if (diff < 0)
-      diff += PTS_MASK;
-  } else {
-    diff = 0;
-  }
-
-  /* special noop packet from transcoder, increase decision limit */
+  /*
+   * 3. Edge Case - Empty Transcoder Packet:
+   * special noop packet from transcoder, increase decision limit.
+   * If the queue resolved to a single packet (first == last) and it has no actual
+   * media payload, artificially return a delay of 1. This prevents the system from
+   * treating it as a standard zero-delay scenario. Checked before the found_f/found_l
+   * gate below, which would otherwise return 0 when only one packet is queued.
+   */
   if (l == f && l->pr_pkt->pkt_payload == NULL)
     return 1;
 
+  /* * 4. Calculate Delay Difference:
+   * If both a first and last packet with valid timestamps were found, compute the delay.
+   */
+  if (l->pr_pkt->pkt_dts != PTS_UNSET && f->pr_pkt->pkt_dts != PTS_UNSET) {
+    /* Mask the DTS values (usually 33-bit for MPEG-TS) to drop overflow bits, 
+       then subtract the early timestamp from the late timestamp. */
+    if (found_f && found_l) {
+      /* Calculate raw difference */
+      diff = (l->pr_pkt->pkt_dts & PTS_MASK) - (f->pr_pkt->pkt_dts & PTS_MASK);
+    } else {
+        return 0;
+    }
+    /* Handle Timestamp Rollover/Wraparound: 
+       If the difference is negative, the timestamp counter rolled over its maximum 
+       value (PTS_MASK+1) between the first and last packet. Add the mask to correct it. */
+    if (diff < 0)
+      /* When a 33-bit counter overflows (wraps around), it goes from the maximum value back to 0. 
+        The total number of unique values in that clock cycle is 233, which is PTS_MASK + 1.*/
+      diff += (int64_t)PTS_MASK + 1;
+    /*  The V4L2/Discontinuity Fix:
+        If the diff is greater than half the mask (roughly 13 hours),
+        it means f was actually significantly ahead of l. 
+        This is usually a startup discontinuity. */
+    if (diff > (PTS_MASK >> 1)) {
+      diff = 0; 
+    }
+  } else {
+    /* If no valid matching packets were found, there is no determinable delay. */
+    diff = 0;
+  }
   return diff;
 }
 
@@ -238,13 +362,13 @@ headers_complete(globalheaders_t *gh)
        * - maximal timeout is reached without metadata
        */
       if(threshold || (qd[i] <= 0 && qd_max > (MAX_NOPKT_TIME * 90))) {
-	ssc->ssc_disabled = 1;
+	      ssc->ssc_disabled = 1;
         tvhdebug(LS_GLOBALHEADERS, "gh disable stream %d %s%s%s (PID %i) threshold %d qd %"PRId64" qd_max %"PRId64,
              ssc->es_index, streaming_component_type2txt(ssc->es_type),
              ssc->es_lang[0] ? " " : "", ssc->es_lang, ssc->es_pid,
              threshold, qd[i], qd_max);
       } else {
-	return 0;
+	      return 0;
       }
     } else {
       ssc->ssc_disabled = 0;
@@ -319,13 +443,54 @@ gh_hold(globalheaders_t *gh, streaming_message_t *sm)
 				   streaming_start_copy(gh->gh_ss));
     streaming_target_deliver2(gh->gh_output, sm);
 
-    // Send all pending packets
-    while((pkt = pktref_get_first(&gh->gh_holdq)) != NULL) {
-      if (pkt->pkt_payload) {
-        sm = streaming_msg_create_pkt(pkt);
-        streaming_target_deliver2(gh->gh_output, sm);
+    /* The hold queue usually starts with audio: on a transcoded stream the
+       audio encoder produces its first packet while the video side is still
+       waiting for the source to deliver a sequence header, so video only joins
+       0.5 to 1.5 s later. Releasing the queue as-is hands the client a stream
+       whose audio begins well before its first picture -- measured on one
+       source: audio at 0 ms against video at 534 ms (software), 1391 ms
+       (VAAPI), 1368 ms (QSV).
+
+       Drop the audio that precedes the first picture so both tracks start
+       together. Nothing is delayed and no video is touched; only leading audio
+       with nothing to show alongside it is discarded. If the queue holds no
+       video at all -- an audio-only subscription -- everything is released
+       unchanged. */
+    {
+      th_pktref_t *pr;
+      int64_t first_video_pts = PTS_UNSET;
+
+      TAILQ_FOREACH(pr, &gh->gh_holdq, pr_link) {
+        ssc = streaming_start_component_find_by_index(gh->gh_ss,
+                                        pr->pr_pkt->pkt_componentindex);
+        if (ssc && SCT_ISVIDEO(ssc->es_type)) {
+          first_video_pts = pr->pr_pkt->pkt_pts;
+          break;
+        }
       }
-      pkt_ref_dec(pkt);
+      // carried into passthru so the same test keeps applying
+      gh->gh_first_video_pts = first_video_pts;
+
+      // Send all pending packets
+      while((pkt = pktref_get_first(&gh->gh_holdq)) != NULL) {
+        if (pkt->pkt_payload) {
+          int skip = 0;
+          if (first_video_pts != PTS_UNSET) {
+            ssc = streaming_start_component_find_by_index(gh->gh_ss,
+                                            pkt->pkt_componentindex);
+            skip = ssc && !SCT_ISVIDEO(ssc->es_type) &&
+                   pkt->pkt_pts != PTS_UNSET &&
+                   pkt->pkt_pts < first_video_pts;
+          }
+          if (skip) {
+            pkt_trace(LS_GLOBALHEADERS, pkt, "drop, precedes first picture");
+          } else {
+            sm = streaming_msg_create_pkt(pkt);
+            streaming_target_deliver2(gh->gh_output, sm);
+          }
+        }
+        pkt_ref_dec(pkt);
+      }
     }
     gh->gh_passthru = 1;
     break;
@@ -393,6 +558,29 @@ gh_pass(globalheaders_t *gh, streaming_message_t *sm)
     break;
   case SMT_PACKET:
     pkt = sm->sm_data;
+    /* Extends the hold-queue filter past the release, on the same test: a
+       packet is dropped when its pts precedes the first picture, whatever the
+       moment it arrives.
+
+       Arrival order is not presentation order here. The audio encoder lags the
+       video one on the delivery clock while still stamping its output with the
+       original stream times, so audio reaches this point *after* the first
+       picture yet carries a pts *before* it -- and would be presented ahead of
+       any image. Measured on one software run: the first picture was written
+       first at pts 572 ms, immediately followed by audio stamped 277 to 384 ms.
+       A "have we seen a picture yet" flag lets exactly that case through, which
+       is why the comparison has to stay on the timestamps. */
+    if (gh->gh_first_video_pts != PTS_UNSET && pkt->pkt_payload &&
+        pkt->pkt_pts != PTS_UNSET && pkt->pkt_pts < gh->gh_first_video_pts) {
+      streaming_start_component_t *vssc =
+        streaming_start_component_find_by_index(gh->gh_ss,
+                                                pkt->pkt_componentindex);
+      if (vssc && !SCT_ISVIDEO(vssc->es_type)) {
+        pkt_trace(LS_GLOBALHEADERS, pkt, "drop, precedes first picture");
+        streaming_msg_free(sm);
+        break;
+      }
+    }
     if (pkt->pkt_payload || pkt->pkt_err)
       streaming_target_deliver2(gh->gh_output, sm);
     else
@@ -441,6 +629,8 @@ globalheaders_create(streaming_target_t *output)
 
   TAILQ_INIT(&gh->gh_holdq);
 
+  // calloc leaves this at 0, which is a valid timestamp
+  gh->gh_first_video_pts = PTS_UNSET;
   gh->gh_output = output;
   streaming_target_init(&gh->gh_input, &globalheaders_input_ops, gh, 0);
   return &gh->gh_input;

--- a/src/plumbing/tsfix.c
+++ b/src/plumbing/tsfix.c
@@ -27,68 +27,112 @@
 LIST_HEAD(tfstream_list, tfstream);
 
 /**
- *
+ * @brief Represents a single Elementary Stream (Video, Audio, or Subtitle).
+ * 
+ * Tracks the timestamp state for a specific component within the multiplex.
+ * Because different streams (e.g., audio vs video) can have slight time drifts,
+ * this structure maintains the stream's local history to ensure its timestamps
+ * remain monotonic.
  */
 typedef struct tfstream {
 
   LIST_ENTRY(tfstream) tfs_link;
 
+  // Unique index for this component in the mux
   int tfs_index;
 
+  // Is this MPEG2, H264, AC3, AAC, etc.?
   streaming_component_type_t tfs_type;
+  // Boolean flag: 1 if video
   uint8_t tfs_video;
+  // Boolean flag: 1 if audio
   uint8_t tfs_audio;
+  // Boolean flag: 1 if subtitle
   uint8_t tfs_subtitle;
 
+  // Counter for consecutive DTS jump errors
   int tfs_bad_dts;
+  // Stream-specific reference timestamp (used if drifting)
   int64_t tfs_local_ref;
+  // The last output (normalized) DTS
   int64_t tfs_last_dts_norm;
+  // Tracks 33-bit wraparounds (multiples of PTS_MASK + 1)
   int64_t tfs_dts_epoch;
 
+  // The raw DTS as it arrived from the source
   int64_t tfs_last_dts_in;
 
+  // Flag indicating if we've processed at least one valid packet
   int tfs_seen;
 
+  // If this stream relies on another's timing (e.g., subs tied to audio)
   struct tfstream *tfs_parent;
 
 } tfstream_t;
 
 
 /**
- *
+ * @brief Main context for the Timestamp Fixer (tsfix).
+ * 
+ * Handles the normalization of the entire transport stream. It establishes a 
+ * "master clock reference" (tf_tsref) when the stream starts so that all output
+ * timestamps can be neatly offset to start near zero, making life easier for
+ * downstream decoders and muxers.
  */
 typedef struct tsfix {
+  // Input pad for receiving stream messages
   streaming_target_t tf_input;
 
+  // Output pad to send fixed packets downstream
   streaming_target_t *tf_output;
 
+  // Linked list of all tfstream_t components
   struct tfstream_list tf_streams;
+  // Flag: Does this stream contain video?
   int tf_hasvideo;
+  // Flag: Should we buffer until the first video frame?
   int tf_wait_for_video;
+  // Master reference clock (starting timestamp of the stream)
   int64_t tf_tsref;
+  // System clock time when processing started
   int64_t tf_start_time;
+  // Offset used during timeshifting/seeking
   int64_t dts_offset;
+  // Flag to apply the timeshift offset
   int dts_offset_apply;
 
+  // Queue for packets waiting for PTS calculation (e.g. MPEG2 B-frames)
   struct th_pktref_queue tf_ptsq;
+  // Queue for early packets that arrived before tf_tsref was established
   struct th_pktref_queue tf_backlog;
 
 } tsfix_t;
 
 
 /**
- * Compute the timestamp deltas
+ * @brief Computes the absolute difference between two 33-bit timestamps.
+ * 
+ * Handles the edge case where the 33-bit clock rolls over from its maximum 
+ * value (0x1FFFFFFFF) back to 0.
+ * 
+ * @param ts1 First timestamp
+ * @param ts2 Second timestamp
+ * @return int64_t The absolute difference in 90kHz ticks.
  */
 static int64_t
 tsfix_ts_diff(int64_t ts1, int64_t ts2)
 {
   int64_t r;
+  // Restrict to 33 bits
   ts1 &= PTS_MASK;
   ts2 &= PTS_MASK;
 
   r = llabs(ts1 - ts2);
+
+  // If the difference is greater than half the max 33-bit value, 
+  // it means a wraparound occurred between ts1 and ts2.
   if (r > (PTS_MASK / 2)) {
-    /* try to wrap the lowest value */
+    // try to wrap the lowest value
     if (ts1 < ts2)
       ts1 += PTS_MASK + 1;
     else
@@ -98,8 +142,9 @@ tsfix_ts_diff(int64_t ts1, int64_t ts2)
   return r;
 }
 
+
 /**
- *
+ * @brief Destroys all stream contexts and clears queues.
  */
 static void
 tsfix_destroy_streams(tsfix_t *tf)
@@ -114,6 +159,9 @@ tsfix_destroy_streams(tsfix_t *tf)
 }
 
 
+/**
+ * @brief Looks up a stream context by its component index.
+ */
 static tfstream_t *
 tfs_find(tsfix_t *tf, th_pkt_t *pkt)
 {
@@ -124,8 +172,9 @@ tfs_find(tsfix_t *tf, th_pkt_t *pkt)
   return tfs;
 }
 
+
 /**
- *
+ * @brief Allocates and initializes a new stream context (video, audio, etc.).
  */
 static tfstream_t *
 tsfix_add_stream(tsfix_t *tf, int index, streaming_component_type_t type)
@@ -141,6 +190,7 @@ tsfix_add_stream(tsfix_t *tf, int index, streaming_component_type_t type)
     tfs->tfs_subtitle = 1;
 
   tfs->tfs_index = index;
+  // Initialize states to "unset"
   tfs->tfs_local_ref = PTS_UNSET;
   tfs->tfs_last_dts_norm = PTS_UNSET;
   tfs->tfs_last_dts_in = PTS_UNSET;
@@ -153,7 +203,10 @@ tsfix_add_stream(tsfix_t *tf, int index, streaming_component_type_t type)
 
 
 /**
- *
+ * @brief Initializes the tsfix module when a new stream starts.
+ * 
+ * Sets up expected streams and determines if the pipeline should block
+ * until the first valid video packet arrives.
  */
 static void
 tsfix_start(tsfix_t *tf, streaming_start_t *ss)
@@ -165,6 +218,7 @@ tsfix_start(tsfix_t *tf, streaming_start_t *ss)
     const streaming_start_component_t *ssc = &ss->ss_components[i];
     tfs = tsfix_add_stream(tf, ssc->es_index, ssc->es_type);
     if (tfs->tfs_video) {
+      // If we don't know the resolution yet, wait for video headers
       if (ssc->es_width == 0 || ssc->es_height == 0)
         /* only first video stream may be valid */
         vwait = !hasvideo ? 1 : 0;
@@ -182,7 +236,7 @@ tsfix_start(tsfix_t *tf, streaming_start_t *ss)
 
 
 /**
- *
+ * @brief Cleans up when the stream stops.
  */
 static void
 tsfix_stop(tsfix_t *tf)
@@ -192,7 +246,7 @@ tsfix_stop(tsfix_t *tf)
 
 
 /**
- *
+ * @brief Safely drops a packet and logs the reason.
  */
 static void
 tsfix_packet_drop(tfstream_t *tfs, th_pkt_t *pkt, const char *reason)
@@ -205,14 +259,26 @@ tsfix_packet_drop(tfstream_t *tfs, th_pkt_t *pkt, const char *reason)
   pkt_ref_dec(pkt);
 }
 
+
 /**
- *
+ * @brief The core timestamp normalization engine.
+ * 
+ * 1. Subtracts the initial starting offset (`tf_tsref`) so timestamps start near 0.
+ * 2. Monitors for 33-bit rollovers and increments `tfs_dts_epoch` to maintain a 
+ *    continuously growing 64-bit timestamp.
+ * 3. Enforces monotonic output (drops timestamps that jump backward into the past).
+ * 
+ * @param tf Context
+ * @param tfs Stream state
+ * @param pkt Packet to normalize
+ * @param backlog Flag indicating if we are processing the startup backlog
  */
 static void
 normalize_ts(tsfix_t *tf, tfstream_t *tfs, th_pkt_t *pkt, int backlog)
 {
   int64_t ref, dts, odts, opts, d;
 
+  // If we haven't found a valid starting clock yet, park the packet in backlog
   if(tf->tf_tsref == PTS_UNSET) {
     if (backlog) {
       if (pkt->pkt_dts != PTS_UNSET)
@@ -223,10 +289,12 @@ normalize_ts(tsfix_t *tf, tfstream_t *tfs, th_pkt_t *pkt, int backlog)
     return;
   }
 
+  // Use the stream's local reference if it drifted, otherwise use master ref
   ref = tfs->tfs_local_ref != PTS_UNSET ? tfs->tfs_local_ref : tf->tf_tsref;
   odts = pkt->pkt_dts;
   opts = pkt->pkt_pts;
 
+  // Fallback: Use PTS if DTS is missing
   if (pkt->pkt_dts == PTS_UNSET) {
     if (pkt->pkt_pts != PTS_UNSET)
       pkt->pkt_dts = pkt->pkt_pts;
@@ -236,22 +304,25 @@ normalize_ts(tsfix_t *tf, tfstream_t *tfs, th_pkt_t *pkt, int backlog)
 
   pkt->pkt_dts &= PTS_MASK;
 
-  /* Subtract the transport wide start offset */
+  // Subtract the transport wide start offset (this is where timestamps are zeroed out)
   if (tf->dts_offset_apply)
     dts = pts_diff(ref, pkt->pkt_dts + tf->dts_offset);
   else
     dts = pts_diff(ref, pkt->pkt_dts);
 
+  // Validate monotonic behavior
   if (tfs->tfs_last_dts_norm == PTS_UNSET) {
     if (dts < 0 || pkt->pkt_err) {
-      /* Early packet with negative time stamp, drop those */
+      // Early packet with negative time stamp, drop those
       tsfix_packet_drop(tfs, pkt, "negative/error");
       return;
     }
   } else {
-    const int64_t nlimit =      -1; /* allow negative values - rounding errors? */
-    int64_t low          =   90000; /* one second */
-    int64_t upper        = 2*90000; /* two seconds */
+    const int64_t nlimit =      -1; // allow negative values - rounding errors?
+    int64_t low          = 2*90000; // two second
+    int64_t upper        = 3*90000; // three seconds
+
+    // d = distance between current calculated DTS and the last output DTS
     d = dts + tfs->tfs_dts_epoch - tfs->tfs_last_dts_norm;
 
     if (tfs->tfs_subtitle) {
@@ -264,23 +335,25 @@ normalize_ts(tsfix_t *tf, tfstream_t *tfs, th_pkt_t *pkt, int backlog)
     }
 
     if (d < nlimit || d > low) {
+      // If the jump is massive, check if it's a 33-bit wraparound
       if (d < -PTS_MASK || d > -PTS_MASK + upper) {
         if (pkt->pkt_err) {
           tsfix_packet_drop(tfs, pkt, "possible wrong discontinuity");
           return;
         }
-	tfs->tfs_bad_dts++;
+	      tfs->tfs_bad_dts++;
         if (tfs->tfs_bad_dts < 5) {
-	  tvhwarn(LS_TSFIX,
-		   "transport stream %s, DTS discontinuity. "
-		   "DTS = %" PRId64 ", last = %" PRId64,
-		   streaming_component_type2txt(tfs->tfs_type),
-		   dts, tfs->tfs_last_dts_norm);
-	}
+          char _dts[22], _dts_old[22];
+          tvhwarn(LS_TSFIX,
+            "transport stream %s, DTS discontinuity. DTS = %s, last = %s",
+            streaming_component_type2txt(tfs->tfs_type),
+            pts_to_string(dts, _dts),
+            pts_to_string(tfs->tfs_last_dts_norm, _dts_old));
+        }
       } else {
-	/* DTS wrapped, increase upper bits */
-	tfs->tfs_dts_epoch += PTS_MASK + 1;
-	tfs->tfs_bad_dts = 0;
+        // DTS wrapped (passed 26.5 hours). Increase the epoch so the 64-bit int keeps growing
+        tfs->tfs_dts_epoch += PTS_MASK + 1;
+        tfs->tfs_bad_dts = 0;
       }
     } else {
       tfs->tfs_bad_dts = 0;
@@ -290,13 +363,17 @@ normalize_ts(tsfix_t *tf, tfstream_t *tfs, th_pkt_t *pkt, int backlog)
   dts += tfs->tfs_dts_epoch;
   tfs->tfs_last_dts_norm = dts;
 
+  // Fix up PTS relative to our newly calculated 64-bit DTS
   if(pkt->pkt_pts != PTS_UNSET) {
-    /* Compute delta between PTS and DTS (and watch out for 33 bit wrap) */
+    // Compute delta between PTS and DTS (and watch out for 33 bit wrap)
     d = ((pkt->pkt_pts & PTS_MASK) - pkt->pkt_dts) & PTS_MASK;
+    // Add that delta back to the clean DTS
     pkt->pkt_pts = dts + d;
   }
+
+  // Fix up PCR (Program Clock Reference) relative to DTS
   if(pkt->pkt_pcr != PTS_UNSET) {
-    /* Compute delta between PCR and DTS (and watch out for 33 bit wrap) */
+    // Compute delta between PCR and DTS (and watch out for 33 bit wrap)
     d = ((pkt->pkt_pcr & PTS_MASK) - pkt->pkt_dts) & PTS_MASK;
     if (d > PTS_MASK / 2)
       d = -(PTS_MASK - d);
@@ -312,20 +389,24 @@ normalize_ts(tsfix_t *tf, tfstream_t *tfs, th_pkt_t *pkt, int backlog)
 
 deliver:
   if (tvhtrace_enabled()) {
-    char _odts[22], _opts[22];
+    char _odts[22], _opts[22], _ref[22];
     pkt_trace(LS_TSFIX, pkt,
-              "deliver odts %s opts %s ref %"PRId64" epoch %"PRId64,
-              pts_to_string(odts, _odts), pts_to_string(opts, _opts),
-              ref, tfs->tfs_dts_epoch);
+              "deliver odts %s opts %s ref %s epoch %"PRId64,
+              pts_to_string(odts, _odts),
+              pts_to_string(opts, _opts),
+              pts_to_string(ref, _ref),
+              tfs->tfs_dts_epoch);
   }
 
+  // Send corrected packet out of the module
   streaming_message_t *sm = streaming_msg_create_pkt(pkt);
   streaming_target_deliver2(tf->tf_output, sm);
   pkt_ref_dec(pkt);
 }
 
+
 /**
- *
+ * @brief Checks if a specific stream has drifted far enough to need a new local reference.
  */
 static inline int
 txfix_need_to_update_ref(tsfix_t *tf, tfstream_t *tfs, th_pkt_t *pkt)
@@ -335,8 +416,10 @@ txfix_need_to_update_ref(tsfix_t *tf, tfstream_t *tfs, th_pkt_t *pkt)
          pkt->pkt_dts != PTS_UNSET;
 }
 
+
 /**
- *
+ * @brief Calculates a local reference for streams that get wildly out of sync 
+ * (like audio drifting from video or subs syncing to audio).
  */
 static int
 tsfix_update_ref(tsfix_t *tf, tfstream_t *tfs, th_pkt_t *pkt)
@@ -348,22 +431,25 @@ tsfix_update_ref(tsfix_t *tf, tfstream_t *tfs, th_pkt_t *pkt)
     return REF_ERROR;
 
   if (tfs->tfs_audio) {
+    // If audio is more than 3 seconds off the master clock, reset its local clock
     diff = tsfix_ts_diff(tf->tf_tsref, pkt->pkt_dts);
     if (diff > 3 * 90000) {
-      tvhwarn(LS_TSFIX, "The timediff for %s is big (%"PRId64"), using current dts",
-              streaming_component_type2txt(tfs->tfs_type), diff);
+      char _dts[22];
+      tvhwarn(LS_TSFIX, "The timediff for %s is big (%"PRId64"), using current dts: %s",
+              streaming_component_type2txt(tfs->tfs_type), diff, pts_to_string(pkt->pkt_dts, _dts));
       tfs->tfs_local_ref = pkt->pkt_dts;
     } else {
       tfs->tfs_local_ref = tf->tf_tsref;
     }
   } else if (tfs->tfs_type == SCT_DVBSUB || tfs->tfs_type == SCT_TEXTSUB) {
-    /* find first valid audio stream and check the dts timediffs */
+    // Subs are often timed to audio. Find the first valid audio stream and compare.
     LIST_FOREACH(tfs2, &tf->tf_streams, tfs_link)
       if (tfs2->tfs_audio && tfs2->tfs_last_dts_in != PTS_UNSET) {
         diff = tsfix_ts_diff(tfs2->tfs_last_dts_in, pkt->pkt_dts);
         if (diff > 6 * 90000) {
-          tvhwarn(LS_TSFIX, "The timediff for %s is big (%"PRId64"), using audio dts",
-                  streaming_component_type2txt(tfs->tfs_type), diff);
+          char _dts[22];
+          tvhwarn(LS_TSFIX, "The timediff for %s is big (%"PRId64"), using audio dts: %s",
+                  streaming_component_type2txt(tfs->tfs_type), diff, pts_to_string(pkt->pkt_dts, _dts));
           tfs->tfs_parent = tfs2;
           tfs->tfs_local_ref = tfs2->tfs_local_ref;
         } else {
@@ -376,7 +462,9 @@ tsfix_update_ref(tsfix_t *tf, tfstream_t *tfs, th_pkt_t *pkt)
   } else if (tfs->tfs_type == SCT_TELETEXT) {
     diff = tsfix_ts_diff(tf->tf_tsref, pkt->pkt_dts);
     if (diff > 2 * 90000) {
-      tvhwarn(LS_TSFIX, "The timediff for TELETEXT is big (%"PRId64"), using current dts", diff);
+      char _dts[22];
+      tvhwarn(LS_TSFIX, "The timediff for TELETEXT is big (%"PRId64"), using current dts: %s", 
+              diff, pts_to_string(pkt->pkt_dts, _dts));
       tfs->tfs_local_ref = pkt->pkt_dts;
     } else {
       tfs->tfs_local_ref = tf->tf_tsref;
@@ -385,8 +473,9 @@ tsfix_update_ref(tsfix_t *tf, tfstream_t *tfs, th_pkt_t *pkt)
   return REF_OK;
 }
 
+
 /**
- *
+ * @brief Flushes the backlog of early packets once a master reference clock is found.
  */
 static void
 tsfix_backlog(tsfix_t *tf)
@@ -410,7 +499,7 @@ tsfix_backlog(tsfix_t *tf)
 
 
 /**
- *
+ * @brief Determines the maximum timespan covered by the packets currently in the backlog.
  */
 static int64_t
 tsfix_backlog_diff(tsfix_t *tf)
@@ -453,6 +542,13 @@ tsfix_backlog_diff(tsfix_t *tf)
  * 12: B dts 4922741536 pts <unset>    rpts 4922741536
  * 13: I dts 4922745136 pts 4922755936 rpts 4922755936
  */
+/**
+ * @brief Recovers missing Presentation Time Stamps (PTS) based on MPEG2 frame ordering.
+ *
+ * In MPEG2, decoding order (DTS) and presentation order (PTS) differ because of B-frames.
+ * I and P frames decode early so subsequent B-frames can use them for reference.
+ * If the source stream omits PTS, this infers it by looking ahead at the next I/P frame.
+ */
 static void
 recover_pts(tsfix_t *tf, tfstream_t *tfs, th_pkt_t *pkt)
 {
@@ -468,41 +564,57 @@ recover_pts(tsfix_t *tf, tfstream_t *tfs, th_pkt_t *pkt)
     case SCT_MPEG2VIDEO:
 
       switch(pkt->v.pkt_frametype) {
+        char _pts[22], _pts_old[22], _dts[22];
       case PKT_B_FRAME:
         if (pkt->pkt_pts == PTS_UNSET) {
-	  /* B-frames have same PTS as DTS, pass them on */
-	  tvhtrace(LS_TSFIX, "%-12s PTS b-frame set to %"PRId64" (old %"PRId64")",
-		   streaming_component_type2txt(tfs->tfs_type),
-		   pkt->pkt_dts, pkt->pkt_pts);
-	  pkt->pkt_pts = pkt->pkt_dts;
+        // B-frames are presented as soon as they are decoded
+        tvhtrace(LS_TSFIX, "%-12s PTS %c-frame set to %s (old %s), DTS %s",
+          streaming_component_type2txt(tfs->tfs_type),
+          pkt_frametype_to_char(pkt->v.pkt_frametype),
+          pts_to_string(pkt->pkt_dts, _pts),
+          pts_to_string(pkt->pkt_pts, _pts_old),
+          pts_to_string(pkt->pkt_dts, _dts));
+        pkt->pkt_pts = pkt->pkt_dts;
         }
-	break;
+        break;
       
       case PKT_I_FRAME:
       case PKT_P_FRAME:
         if (pkt->pkt_pts == PTS_UNSET) {
-	  /* Presentation occurs at DTS of next I or P frame,
-	     try to find it */
+          /* Presentation occurs at DTS of next I or P frame.
+            Look ahead in the queue for the first subsequent I/P frame. */
           total = 0;
           PKTREF_FOREACH(srch, &tf->tf_ptsq) {
-            if (pkt->pkt_componentindex != tfs->tfs_index)
+            // Does this queued packet we are currently looking at belong to the stream we are trying to fix?
+            if (srch->pr_pkt->pkt_componentindex != tfs->tfs_index)
               continue;
             total++;
+            // Skip the frame itself
+            if (srch->pr_pkt == pkt)
+              continue;
+
+            // Match the NEXT I or P frame ahead in the stream (frametype <= PKT_P_FRAME)
             if (srch->pr_pkt->v.pkt_frametype <= PKT_P_FRAME &&
                 pts_is_greater_or_equal(pkt->pkt_dts, srch->pr_pkt->pkt_dts) > 0 &&
                 pts_diff(pkt->pkt_dts, srch->pr_pkt->pkt_dts) < 10 * 90000) {
-              tvhtrace(LS_TSFIX, "%-12s PTS *-frame set to %"PRId64" (old %"PRId64"), DTS %"PRId64,
+              tvhtrace(LS_TSFIX, "%-12s PTS %c-frame set to %s (old %s), DTS %s",
                           streaming_component_type2txt(tfs->tfs_type),
-                          srch->pr_pkt->pkt_dts, pkt->pkt_pts, pkt->pkt_dts);
+                          pkt_frametype_to_char(pkt->v.pkt_frametype),
+                          pts_to_string(srch->pr_pkt->pkt_dts, _pts),
+                          pts_to_string(pkt->pkt_pts, _pts_old),
+                          pts_to_string(pkt->pkt_dts, _dts));
+              // We found the next I/P frame. Use its Decode time as our Presentation time.
               pkt->pkt_pts = srch->pr_pkt->pkt_dts;
               break;
             }	  
           }
           if (srch == NULL) {
             if (total < 50) {
-              /* return packet back to tf_ptsq */
+              // return packet back to tf_ptsq
+              // We haven't received the next I/P frame yet. Put this back in the queue and wait.
               pktref_insert_head(&tf->tf_ptsq, pkt);
             } else {
+              // Safety valve to prevent unbounded memory growth if the stream is corrupted
               tsfix_packet_drop(tfs, pkt, "mpeg2video overflow");
             }
             return; /* not arrived yet or invalid, wait */
@@ -521,29 +633,56 @@ recover_pts(tsfix_t *tf, tfstream_t *tfs, th_pkt_t *pkt)
 
 
 /**
- * Compute PTS (if not known)
+ * @brief Evaluates if PTS needs complex recovery (MPEG2) or simple matching (Audio).
  */
 static void
 compute_pts(tsfix_t *tf, tfstream_t *tfs, th_pkt_t *pkt)
 {
   // If PTS is missing, set it to DTS if not video
+  // Audio frames decode and present immediately. PTS = DTS.
   if(pkt->pkt_pts == PTS_UNSET && !tfs->tfs_video) {
     pkt->pkt_pts = pkt->pkt_dts;
-    tvhtrace(LS_TSFIX, "%-12s PTS set to %"PRId64,
+    char _pts[22];
+    tvhtrace(LS_TSFIX, "%-12s PTS set to %s",
 		streaming_component_type2txt(tfs->tfs_type),
-		pkt->pkt_pts);
+		pts_to_string(pkt->pkt_pts, _pts));
   }
 
-  /* PTS known and no other packets in queue, deliver at once */
-  if(pkt->pkt_pts != PTS_UNSET && TAILQ_FIRST(&tf->tf_ptsq) == NULL)
+  // PTS known and no other packets in queue, deliver at once
+  // If we have PTS and no other video packets waiting in line, deliver directly.
+  if(pkt->pkt_pts != PTS_UNSET && TAILQ_FIRST(&tf->tf_ptsq) == NULL){
+    // pring good frames
+    char _pts[22], _pts_old[22], _dts[22];
+    tvhtrace(LS_TSFIX, "%-12s PTS %c-frame set to %s (old %s), DTS %s",
+      streaming_component_type2txt(tfs->tfs_type),
+      pkt_frametype_to_char(pkt->v.pkt_frametype),
+      pts_to_string(pkt->pkt_pts, _pts),
+      pts_to_string(pkt->pkt_pts, _pts_old),
+      pts_to_string(pkt->pkt_dts, _dts));
     normalize_ts(tf, tfs, pkt, 1);
+  }
   else
     recover_pts(tf, tfs, pkt);
 }
 
 
 /**
+ * @brief Processes an incoming streaming packet for timestamp correction.
  *
+ * This function ingests a raw media packet into the timestamp fixer (tsfix) pipeline.
+ * It is responsible for establishing the initial reference clock for the stream by
+ * waiting for a valid video keyframe (I-Frame) or audio frame. Once the reference
+ * is set, subsequent packets are evaluated against it to maintain A/V sync and 
+ * filter out packets with corrupted or severely misaligned timestamps.
+ *
+ * @param tf Pointer to the timestamp fixer context/state.
+ * @param sm Pointer to the incoming streaming message containing the packet payload.
+ *           The streaming message wrapper is freed by this function, but the 
+ *           underlying packet is shallow-copied and processed.
+ *
+ * @note The function operates on a 90kHz clock scale (standard for MPEG-TS). 
+ *       Thresholds like 90000 (1 sec) and 22500 (250 ms) are used to cap 
+ *       backlog processing and prevent excessive clock skewing on startup.
  */
 static void
 tsfix_input_packet(tsfix_t *tf, streaming_message_t *sm)
@@ -553,15 +692,19 @@ tsfix_input_packet(tsfix_t *tf, streaming_message_t *sm)
   int64_t diff, diff2, threshold;
   int r;
 
+  // Shallow copy so we can manipulate fields without affecting upstream caches
   pkt = pkt_copy_shallow(sm->sm_data);
   tfs = tfs_find(tf, pkt);
   streaming_msg_free(sm);
 
+  // Drop if it arrived before the module fully started
   if (tfs == NULL || mclk() < tf->tf_start_time) {
     tsfix_packet_drop(tfs, pkt, "start time");
     return;
   }
 
+  // --- REFERENCE CLOCK ACQUISITION ---
+  // If we don't have a master clock yet, try to use this packet to set it.
   if (tf->tf_tsref == PTS_UNSET && pkt->pkt_dts != PTS_UNSET &&
       ((!tf->tf_hasvideo && tfs->tfs_audio) ||
        (tfs->tfs_video && pkt->v.pkt_frametype == PKT_I_FRAME))) {
@@ -569,26 +712,44 @@ tsfix_input_packet(tsfix_t *tf, streaming_message_t *sm)
       tsfix_packet_drop(tfs, pkt, "ref1");
       return;
     }
+
+    // Set backlog threshold (250ms default, 1s if we are waiting on other streams)
     threshold = 22500;
     LIST_FOREACH(tfs2, &tf->tf_streams, tfs_link)
       if (tfs != tfs2 && (tfs2->tfs_audio || tfs2->tfs_video) && !tfs2->tfs_seen) {
         threshold = 90000;
         break;
       }
+    
+    // Set master reference to this packet's DTS (or PCR if available)
     tf->tf_tsref = pkt->pkt_dts & PTS_MASK;
     if (pts_is_greater_or_equal(pkt->pkt_pcr, pkt->pkt_dts) > 0)
       tf->tf_tsref = pkt->pkt_pcr & PTS_MASK;
+    
+    // Rewind the clock slightly based on what accumulated in the backlog
     diff = diff2 = tsfix_backlog_diff(tf);
     if (diff > threshold) {
       if (diff > 160000)
         diff = 160000;
       tf->tf_tsref = (tf->tf_tsref - diff) % PTS_MASK;
-      tvhtrace(LS_TSFIX, "reference clock set to %"PRId64" (dts %"PRId64" pcr %"PRId64" backlog %"PRId64")", tf->tf_tsref, pkt->pkt_dts, pkt->pkt_pcr, diff2);
+      char _tsref[22], _dts[22], _pcr[22];
+      tvhtrace(LS_TSFIX, "reference clock set to %s (dts %s pcr %s backlog %"PRId64")",
+              pts_to_string(tf->tf_tsref, _tsref),
+              pts_to_string(pkt->pkt_dts, _dts),
+              pts_to_string(pkt->pkt_pcr, _pcr),
+              diff2);
+      // Flush backlog now that reference is set
       tsfix_backlog(tf);
     } else {
-      tvhtrace(LS_TSFIX, "reference clock set to %"PRId64" (dts %"PRId64" pcr %"PRId64" backlog %"PRId64")", tf->tf_tsref, pkt->pkt_dts, pkt->pkt_pcr, diff2);
+      char _tsref[22], _dts[22], _pcr[22];
+      tvhtrace(LS_TSFIX, "reference clock set to %s (dts %s pcr %s backlog %"PRId64")",
+              pts_to_string(tf->tf_tsref, _tsref),
+              pts_to_string(pkt->pkt_dts, _dts),
+              pts_to_string(pkt->pkt_pcr, _pcr),
+              diff2);
     }
   } else if (txfix_need_to_update_ref(tf, tfs, pkt)) {
+    // Handling for streams that drift out of sync mid-stream
     r = tsfix_update_ref(tf, tfs, pkt);
     if (r != REF_OK) {
       tsfix_packet_drop(tfs, pkt, r == REF_ERROR ? "refe" : "refd");
@@ -596,10 +757,12 @@ tsfix_input_packet(tsfix_t *tf, streaming_message_t *sm)
     }
   }
 
-  int pdur = pkt->pkt_duration >> pkt->v.pkt_field;
+  int64_t pdur = pkt->pkt_duration >> pkt->v.pkt_field;
 
+  // --- MISSING DTS FALLBACK ---
   if (pkt->pkt_dts == PTS_UNSET) {
     if (tfs->tfs_last_dts_in == PTS_UNSET) {
+      // If we don't have a previous DTS to extrapolate from, we can't save it
       if (tfs->tfs_type == SCT_TELETEXT) {
         sm = streaming_msg_create_pkt(pkt);
         streaming_target_deliver2(tf->tf_output, sm);
@@ -608,14 +771,20 @@ tsfix_input_packet(tsfix_t *tf, streaming_message_t *sm)
       return;
     }
 
+    // Extrapolate DTS by adding frame duration to the last known DTS
     if (pkt->pkt_payload != NULL || pkt->pkt_pts != PTS_UNSET) {
       pkt->pkt_dts = (tfs->tfs_last_dts_in + pdur) & PTS_MASK;
-      tvhtrace(LS_TSFIX, "%-12s DTS set to last %"PRId64" +%d == %"PRId64", PTS = %"PRId64,
-		streaming_component_type2txt(tfs->tfs_type),
-		tfs->tfs_last_dts_in, pdur, pkt->pkt_dts, pkt->pkt_pts);
+      char _dts_old[22], _dts[22], _pts[22];
+      tvhtrace(LS_TSFIX, "%-12s DTS set from last %s + %"PRId64" = %s, PTS = %s",
+        streaming_component_type2txt(tfs->tfs_type),
+        pts_to_string(tfs->tfs_last_dts_in, _dts_old),
+        pdur,
+        pts_to_string(pkt->pkt_dts, _dts),
+        pts_to_string(pkt->pkt_pts, _pts));
     }
   }
 
+  // Force subtitle timing to match its parent audio track if synced
   if (tfs->tfs_parent)
     pkt->pkt_dts = pkt->pkt_pts = tfs->tfs_parent->tfs_last_dts_in;
 
@@ -626,7 +795,7 @@ tsfix_input_packet(tsfix_t *tf, streaming_message_t *sm)
 
 
 /**
- *
+ * @brief Input event loop. Handles packets, start/stop events, and timeshifts.
  */
 static void
 tsfix_input(void *opaque, streaming_message_t *sm)
@@ -653,6 +822,7 @@ tsfix_input(void *opaque, streaming_message_t *sm)
     tsfix_stop(tf);
     break;
   case SMT_TIMESHIFT_STATUS:
+    // User scrubbed the DVR. Pick up the jump offset so we can apply it.
     if(tf->dts_offset == PTS_UNSET) {
       timeshift_status_t *status;
       status = sm->sm_data;
@@ -665,6 +835,7 @@ tsfix_input(void *opaque, streaming_message_t *sm)
       tf->dts_offset_apply = 1;
     }
     break;
+  // Ignore status updates
   case SMT_GRACE:
   case SMT_EXIT:
   case SMT_SERVICE_STATUS:
@@ -696,7 +867,7 @@ static streaming_ops_t tsfix_input_ops = {
 
 
 /**
- *
+ * @brief Constructor. Allocates and hooks the timestamp fixer into the chain.
  */
 streaming_target_t *
 tsfix_create(streaming_target_t *output)
@@ -712,8 +883,9 @@ tsfix_create(streaming_target_t *output)
   return &tf->tf_input;
 }
 
+
 /**
- *
+ * @brief Destructor. Frees all memory related to this tsfix instance.
  */
 void
 tsfix_destroy(streaming_target_t *pad)

--- a/src/profile.c
+++ b/src/profile.c
@@ -779,13 +779,18 @@ profile_sharer_deliver(profile_chain_t *prch, streaming_message_t *sm)
      * time correction here
      */
     if (pkt->pkt_pts >= prch->prch_ts_delta &&
-        pkt->pkt_dts >= prch->prch_ts_delta &&
-        pkt->pkt_pcr >= prch->prch_ts_delta) {
+        pkt->pkt_dts >= prch->prch_ts_delta) {
       th_pkt_t *n = pkt_copy_shallow(pkt);
       pkt_ref_dec(pkt);
       n->pkt_pts -= prch->prch_ts_delta;
       n->pkt_dts -= prch->prch_ts_delta;
-      n->pkt_pcr -= prch->prch_ts_delta;
+      // pkt_pcr can legitimately lag pts/dts (notably for transcoded audio, whose
+      // pcr trails its dts by several seconds). Gating the drop on pcr discarded
+      // the whole audio track on a late sharer join (rapid same-channel profile
+      // switch), so globalheaders timed out and disabled audio -> MP4 video-only.
+      // Gate only on pts/dts; clamp the rebased pcr so it never underflows.
+      n->pkt_pcr = (pkt->pkt_pcr >= prch->prch_ts_delta) ?
+                     pkt->pkt_pcr - prch->prch_ts_delta : 0;
       sm->sm_data = n;
     } else {
       pkt_trace(LS_PROFILE, pkt, "packet drop (delta %"PRId64")", prch->prch_ts_delta);
@@ -993,6 +998,12 @@ profile_sharer_destroy(profile_chain_t *prch)
 #endif
     if (prsh->prsh_start_msg)
       streaming_start_unref(prsh->prsh_start_msg);
+    /* prsh is about to be freed, so no chain may keep a pointer to it.  Only
+       the prsh_queue_run path above cleared these, which leaves prch_sharer
+       dangling for a chain torn down before the queue thread ever started --
+       and profile_chain_close() is called twice on exactly that path. */
+    prch->prch_sharer = NULL;
+    prch->prch_post_share = NULL;
     free(prsh);
   } else {
     if (prsh->prsh_queue_run) {
@@ -2312,6 +2323,10 @@ profile_class_mc_list ( void *o, const char *lang )
     { N_("Matroska (mkv)/av-lib"),        MC_AVMATROSKA },
     { N_("WEBM/av-lib"),                  MC_AVWEBM },
     { N_("MP4/av-lib"),                   MC_AVMP4 },
+    { N_("OGA/av-lib"),                   MC_OGA },
+    { N_("OGV/av-lib"),                   MC_OGV },
+    { N_("OGG/av-lib"),                   MC_OGG },
+    { N_("OPUS/av-lib"),                  MC_OPUS }
   };
   return strtab2htsmsg(tab, 1, lang);
 }
@@ -2739,6 +2754,11 @@ profile_transcode_mc_valid(int mc)
   case MC_VORBIS:
   case MC_AVMATROSKA:
   case MC_AVMP4:
+  case MC_AVWEBM:
+  case MC_OGA:
+  case MC_OGV:
+  case MC_OGG:
+  case MC_OPUS:
     return 1;
   default:
     return 0;

--- a/src/service.c
+++ b/src/service.c
@@ -1664,7 +1664,7 @@ void service_save ( service_t *t, htsmsg_t *m )
       if(st->es_height)
 	      htsmsg_add_u32(sub, "height", st->es_height);
       if(st->es_frame_duration)
-        htsmsg_add_u32(sub, "duration", st->es_frame_duration);
+        htsmsg_add_u32(sub, "duration", ((st->es_frame_duration > INT_MAX) ? INT_MAX : (int)st->es_frame_duration));
     }
 
     htsmsg_add_msg(list, NULL, sub);

--- a/src/timeshift.c
+++ b/src/timeshift.c
@@ -51,7 +51,7 @@ timeshift_packet_log0
   th_pkt_t *pkt = sm->sm_data;
   tvhtrace(LS_TIMESHIFT,
            "ts %d pkt %s - stream %d type %c pts %10"PRId64
-           " dts %10"PRId64" dur %10d len %6zu time %14"PRId64,
+           " dts %10"PRId64" dur %10"PRId64" len %6zu time %14"PRId64,
            ts->id, source,
            pkt->pkt_componentindex,
            SCT_ISVIDEO(pkt->pkt_type) ? pkt_frametype_to_char(pkt->v.pkt_frametype) : '-',

--- a/src/transcoding/codec.h
+++ b/src/transcoding/codec.h
@@ -131,10 +131,7 @@ void
 tvh_codec_profile_video_destroy(TVHCodecProfile *_self);
 
 int
-tvh_codec_profile_video_get_hwaccel(TVHCodecProfile *self);
-
-int
-tvh_codec_profile_video_get_hwaccel_details(TVHCodecProfile *self);
+tvh_codec_profile_video_get_decoder_hwaccel_type(TVHCodecProfile *self);
 
 const enum AVPixelFormat *
 tvh_codec_profile_video_get_pix_fmts(TVHCodecProfile *self);

--- a/src/transcoding/codec/codec.c
+++ b/src/transcoding/codec/codec.c
@@ -69,6 +69,11 @@ extern TVHCodec tvh_codec_vaapi_vp8;
 extern TVHCodec tvh_codec_vaapi_vp9;
 #endif
 
+#if ENABLE_QSV
+extern TVHCodec tvh_codec_qsv_h264;
+extern TVHCodec tvh_codec_qsv_hevc;
+#endif
+
 #if ENABLE_NVENC
 extern TVHCodec tvh_codec_nvenc_h264;
 extern TVHCodec tvh_codec_nvenc_hevc;
@@ -76,6 +81,10 @@ extern TVHCodec tvh_codec_nvenc_hevc;
 
 #if ENABLE_OMX
 extern TVHCodec tvh_codec_omx_h264;
+#endif
+
+#if ENABLE_V4L2M2M
+extern TVHCodec tvh_codec_v4l2m2m_h264;
 #endif
 
 
@@ -115,11 +124,31 @@ codec_get_title(const AVCodec *self)
 
 /* TVHCodec ================================================================= */
 
+/* The AVCodec config fields (pix_fmts, sample_fmts, supported_samplerates,
+   ch_layouts) are deprecated since lavc 61.13 (ffmpeg 7.1) in favor of
+   avcodec_get_supported_config(), which keeps the same semantics: the list
+   uses the same config-specific terminator and NULL means "all supported". */
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100)
+static const void *
+tvh_codec_get_supported_config(const AVCodec *codec, enum AVCodecConfig config)
+{
+    const void *configs = NULL;
+
+    if (avcodec_get_supported_config(NULL, codec, config, 0, &configs, NULL) < 0)
+        return NULL;
+    return configs;
+}
+#endif
+
 static void
 tvh_codec_video_init(TVHVideoCodec *self, const AVCodec *codec)
 {
     if (!self->pix_fmts) {
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100)
+        self->pix_fmts = tvh_codec_get_supported_config(codec, AV_CODEC_CONFIG_PIX_FORMAT);
+#else
         self->pix_fmts = codec->pix_fmts;
+#endif
     }
 }
 
@@ -131,15 +160,25 @@ tvh_codec_audio_init(TVHAudioCodec *self, const AVCodec *codec)
     };
 
     if (!self->sample_fmts) {
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100)
+        self->sample_fmts = tvh_codec_get_supported_config(codec, AV_CODEC_CONFIG_SAMPLE_FORMAT);
+#else
         self->sample_fmts = codec->sample_fmts;
+#endif
     }
     if (!self->sample_rates) {
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100)
+        self->sample_rates = tvh_codec_get_supported_config(codec, AV_CODEC_CONFIG_SAMPLE_RATE);
+#else
         self->sample_rates = codec->supported_samplerates;
+#endif
         if (!self->sample_rates)
             self->sample_rates = default_sample_rates;
     }
     if (!self->channel_layouts) {
-#if LIBAVCODEC_VERSION_MAJOR > 59
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100)
+        self->channel_layouts = tvh_codec_get_supported_config(codec, AV_CODEC_CONFIG_CHANNEL_LAYOUT);
+#elif LIBAVCODEC_VERSION_MAJOR > 59
         self->channel_layouts = codec->ch_layouts;
 #else
         self->channel_layouts = codec->channel_layouts;
@@ -320,6 +359,11 @@ tvh_codecs_register()
     }
 #endif
 
+#if ENABLE_QSV
+    tvh_codec_register(&tvh_codec_qsv_h264);
+    tvh_codec_register(&tvh_codec_qsv_hevc);
+#endif
+
 #if ENABLE_NVENC
     tvh_codec_register(&tvh_codec_nvenc_h264);
     tvh_codec_register(&tvh_codec_nvenc_hevc);
@@ -327,6 +371,10 @@ tvh_codecs_register()
 
 #if ENABLE_OMX
     tvh_codec_register(&tvh_codec_omx_h264);
+#endif
+
+#if ENABLE_V4L2M2M
+    tvh_codec_register(&tvh_codec_v4l2m2m_h264);
 #endif
 }
 

--- a/src/transcoding/codec/codecs/aac.c
+++ b/src/transcoding/codec/codecs/aac.c
@@ -40,7 +40,8 @@ static const AVChannelLayout aac_channel_layouts[] = {
     AV_CHANNEL_LAYOUT_4POINT0,
     AV_CHANNEL_LAYOUT_5POINT0_BACK,
     AV_CHANNEL_LAYOUT_5POINT1_BACK,
-    AV_CHANNEL_LAYOUT_7POINT1,
+    AV_CHANNEL_LAYOUT_6POINT1_BACK,
+    AV_CHANNEL_LAYOUT_5POINT1POINT2_BACK,
     { 0 },
 };
 #else
@@ -67,12 +68,14 @@ typedef struct {
 static int
 tvh_codec_profile_aac_open(tvh_codec_profile_aac_t *self, AVDictionary **opts)
 {
+    TVHCodecProfile *p = (TVHCodecProfile *)self;
+
     // bit_rate or global_quality
-    if (self->bit_rate) {
-        AV_DICT_SET_BIT_RATE(LST_AAC, opts, self->bit_rate);
+    if (p->bit_rate) {
+        AV_DICT_SET_BIT_RATE(LST_AAC, opts, p->bit_rate);
     }
     else {
-        AV_DICT_SET_GLOBAL_QUALITY(LST_AAC, opts, self->qscale, 1);
+        AV_DICT_SET_GLOBAL_QUALITY(LST_AAC, opts, p->qscale, 1);
     }
     AV_DICT_SET(LST_AAC, opts, "aac_coder", self->coder, 0);
     return 0;

--- a/src/transcoding/codec/codecs/libs/libfdk_aac.c
+++ b/src/transcoding/codec/codecs/libs/libfdk_aac.c
@@ -22,6 +22,35 @@
 
 
 /* libfdk_aac =============================================================== */
+#if LIBAVCODEC_VERSION_MAJOR > 59
+// see libvorbis_setup() in ffmpeg-6.1.1/libavcodec/libvorbisenc.c
+static const AVChannelLayout libfdk_aac_channel_layouts[] = {
+    AV_CHANNEL_LAYOUT_MONO,
+    AV_CHANNEL_LAYOUT_STEREO,
+    AV_CHANNEL_LAYOUT_SURROUND,
+    AV_CHANNEL_LAYOUT_4POINT0,
+    AV_CHANNEL_LAYOUT_5POINT0_BACK,
+    AV_CHANNEL_LAYOUT_5POINT1_BACK,
+    AV_CHANNEL_LAYOUT_6POINT1_BACK,
+    AV_CHANNEL_LAYOUT_7POINT1,
+    AV_CHANNEL_LAYOUT_7POINT1_WIDE,
+    { 0 }
+};
+#else
+// see libvorbis_setup() in ffmpeg-3.0.2/libavcodec/libvorbisenc.c
+static const uint64_t libfdk_aac_channel_layouts[] = {
+    AV_CH_LAYOUT_MONO,
+    AV_CH_LAYOUT_STEREO,
+    AV_CH_LAYOUT_SURROUND,
+    AV_CH_LAYOUT_4POINT0,
+    AV_CH_LAYOUT_5POINT0_BACK,
+    AV_CH_LAYOUT_5POINT1_BACK,
+    AV_CH_LAYOUT_6POINT1_BACK,
+    AV_CH_LAYOUT_7POINT1,
+    AV_CH_LAYOUT_7POINT1_WIDE,
+    0
+};
+#endif
 
 typedef struct {
     TVHAudioCodecProfile;
@@ -138,4 +167,5 @@ TVHAudioCodec tvh_codec_libfdk_aac = {
     .idclass = &codec_profile_libfdk_aac_class,
     .profile_init = tvh_codec_profile_audio_init,
     .profile_destroy = tvh_codec_profile_audio_destroy,
+    .channel_layouts = libfdk_aac_channel_layouts,
 };

--- a/src/transcoding/codec/codecs/libs/libopus.c
+++ b/src/transcoding/codec/codecs/libs/libopus.c
@@ -25,6 +25,28 @@
 
 /* libopus ================================================================== */
 
+#if LIBAVCODEC_VERSION_MAJOR > 59
+// see libopus_validate_layout_and_get_channel_map() in /ffmpeg-6.1.1/libavcodec/libopusenc.c
+static const AVChannelLayout libopus_channel_layouts[] = {
+    AV_CHANNEL_LAYOUT_MONO,
+    AV_CHANNEL_LAYOUT_STEREO,
+    AV_CHANNEL_LAYOUT_SURROUND,
+    AV_CHANNEL_LAYOUT_QUAD,
+    AV_CHANNEL_LAYOUT_5POINT0_BACK,
+    { 0 }
+};
+#else
+// see ....
+static const uint64_t libopus_channel_layouts[] = {
+    AV_CH_LAYOUT_MONO,
+    AV_CH_LAYOUT_STEREO,
+    AV_CH_LAYOUT_SURROUND,
+    AV_CH_LAYOUT_QUAD,
+    AV_CH_LAYOUT_5POINT0_BACK,
+    0
+};
+#endif
+
 typedef struct {
     TVHAudioCodecProfile;
     int vbr;
@@ -130,9 +152,11 @@ static const codec_profile_class_t codec_profile_libopus_class = {
 
 
 TVHAudioCodec tvh_codec_libopus = {
-    .name    = "libopus",
-    .size    = sizeof(tvh_codec_profile_libopus_t),
-    .idclass = &codec_profile_libopus_class,
-    .profile_init = tvh_codec_profile_audio_init,
+    .name            = "libopus",
+    .size            = sizeof(tvh_codec_profile_libopus_t),
+    .idclass         = &codec_profile_libopus_class,
+    .profiles        = NULL,
+    .profile_init    = tvh_codec_profile_audio_init,
     .profile_destroy = tvh_codec_profile_audio_destroy,
+    .channel_layouts = libopus_channel_layouts,
 };

--- a/src/transcoding/codec/codecs/libs/libtheora.c
+++ b/src/transcoding/codec/codecs/libs/libtheora.c
@@ -64,6 +64,16 @@ static const codec_profile_class_t codec_profile_libtheora_class = {
                 .intextra = INTEXTRA_RANGE(0, 10, 1),
                 .def.d    = 0,
             },
+            {
+                .type     = PT_INT,
+                .id       = "encoder_hwaccel_type",
+                .name     = N_("Encoder hardware acceleration type"),
+                .desc     = N_("Encoder hardware acceleration type"),
+                .group    = 2,
+                .opts     = PO_PHIDDEN,
+                .off      = offsetof(TVHVideoCodecProfile, encoder_hwaccel_type),
+                .def.i    = AV_HWDEVICE_TYPE_NONE,
+            },
             {}
         }
     },

--- a/src/transcoding/codec/codecs/libs/libvorbis.c
+++ b/src/transcoding/codec/codecs/libs/libvorbis.c
@@ -24,7 +24,7 @@
 /* libvorbis ================================================================ */
 
 #if LIBAVCODEC_VERSION_MAJOR > 59
-// see libvorbis_setup() in ffmpeg-6.0/libavcodec/libvorbisenc.c
+// see libvorbis_setup() in ffmpeg-6.1.1/libavcodec/libvorbisenc.c
 static const AVChannelLayout libvorbis_channel_layouts[] = {
     AV_CHANNEL_LAYOUT_MONO,
     AV_CHANNEL_LAYOUT_STEREO,
@@ -36,7 +36,8 @@ static const AVChannelLayout libvorbis_channel_layouts[] = {
     AV_CHANNEL_LAYOUT_5POINT1,
     AV_CHANNEL_LAYOUT_5POINT1_BACK,
     AV_CHANNEL_LAYOUT_6POINT1,
-    AV_CHANNEL_LAYOUT_7POINT1
+    AV_CHANNEL_LAYOUT_7POINT1,
+    { 0 }
 };
 #else
 // see libvorbis_setup() in ffmpeg-3.0.2/libavcodec/libvorbisenc.c
@@ -111,7 +112,8 @@ TVHAudioCodec tvh_codec_libvorbis = {
     .name            = "libvorbis",
     .size            = sizeof(TVHAudioCodecProfile),
     .idclass         = &codec_profile_libvorbis_class,
-    .channel_layouts = libvorbis_channel_layouts,
+    .profiles        = NULL,
     .profile_init    = tvh_codec_profile_audio_init,
     .profile_destroy = tvh_codec_profile_audio_destroy,
+    .channel_layouts = libvorbis_channel_layouts,
 };

--- a/src/transcoding/codec/codecs/libs/libvpx.c
+++ b/src/transcoding/codec/codecs/libs/libvpx.c
@@ -37,10 +37,13 @@ static int
 tvh_codec_profile_libvpx_open(tvh_codec_profile_libvpx_t *self,
                               AVDictionary **opts)
 {
+    TVHCodecProfile *p = (TVHCodecProfile *)self;
+    TVHVideoCodecProfile *vp = (TVHVideoCodecProfile *)self;
+
     AV_DICT_SET_TVH_REQUIRE_META(LST_LIBVPX, opts, 0);
-    AV_DICT_SET_BIT_RATE(LST_LIBVPX, opts, self->bit_rate ? self->bit_rate : 2560);
-    if (self->crf) {
-        AV_DICT_SET_CRF(LST_LIBVPX, opts, self->crf, 10);
+    AV_DICT_SET_BIT_RATE(LST_LIBVPX, opts, p->bit_rate ? p->bit_rate : 2560);
+    if (vp->crf) {
+        AV_DICT_SET_CRF(LST_LIBVPX, opts, vp->crf, 10);
     }
     AV_DICT_SET_INT(LST_LIBVPX, opts, "deadline", self->deadline, 0);
     AV_DICT_SET_INT(LST_LIBVPX, opts, "cpu-used", self->cpu_used, 0);
@@ -146,6 +149,16 @@ static const codec_profile_class_t codec_profile_libvpx_class = {
                 .off      = offsetof(TVHVideoCodecProfile, gop_size),
                 .intextra = INTEXTRA_RANGE(0, 1000, 1),
                 .def.i    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "encoder_hwaccel_type",
+                .name     = N_("Encoder hardware acceleration type"),
+                .desc     = N_("Encoder hardware acceleration type"),
+                .group    = 2,
+                .opts     = PO_PHIDDEN,
+                .off      = offsetof(TVHVideoCodecProfile, encoder_hwaccel_type),
+                .def.i    = AV_HWDEVICE_TYPE_NONE,
             },
             {}
         }

--- a/src/transcoding/codec/codecs/libs/libx26x.c
+++ b/src/transcoding/codec/codecs/libs/libx26x.c
@@ -102,6 +102,16 @@ static const codec_profile_class_t codec_profile_libx26x_class = {
                 .intextra = INTEXTRA_RANGE(0, 1000, 1),
                 .def.i    = 0,
             },
+            {
+                .type     = PT_INT,
+                .id       = "encoder_hwaccel_type",
+                .name     = N_("Encoder hardware acceleration type"),
+                .desc     = N_("Encoder hardware acceleration type"),
+                .group    = 2,
+                .opts     = PO_PHIDDEN,
+                .off      = offsetof(TVHVideoCodecProfile, encoder_hwaccel_type),
+                .def.i    = AV_HWDEVICE_TYPE_NONE,
+            },
             {}
         }
     },
@@ -141,12 +151,15 @@ static int
 tvh_codec_profile_libx264_open(tvh_codec_profile_libx26x_t *self,
                                AVDictionary **opts)
 {
+    TVHCodecProfile *p = (TVHCodecProfile *)self;
+    const TVHVideoCodecProfile *vp = (TVHVideoCodecProfile *)self;
+
     // bit_rate or crf
-    if (self->bit_rate) {
-        AV_DICT_SET_BIT_RATE(LST_LIBX26X, opts, self->bit_rate);
+    if (p->bit_rate) {
+        AV_DICT_SET_BIT_RATE(LST_LIBX26X, opts, p->bit_rate);
     }
     else {
-        AV_DICT_SET_CRF(LST_LIBX26X, opts, self->crf, 15);
+        AV_DICT_SET_CRF(LST_LIBX26X, opts, vp->crf, 15);
     }
     // params
     if (self->params && strlen(self->params)) {
@@ -240,12 +253,15 @@ static int
 tvh_codec_profile_libx265_open(tvh_codec_profile_libx26x_t *self,
                                AVDictionary **opts)
 {
+    TVHCodecProfile *p = (TVHCodecProfile *)self;
+    TVHVideoCodecProfile *vp = (TVHVideoCodecProfile *)self;
+
     // bit_rate or crf
-    if (self->bit_rate) {
-        AV_DICT_SET_BIT_RATE(LST_LIBX26X, opts, self->bit_rate);
+    if (p->bit_rate) {
+        AV_DICT_SET_BIT_RATE(LST_LIBX26X, opts, p->bit_rate);
     }
     else {
-        AV_DICT_SET_CRF(LST_LIBX26X, opts, self->crf, 18);
+        AV_DICT_SET_CRF(LST_LIBX26X, opts, vp->crf, 18);
     }
     // params
     if (self->params && strlen(self->params)) {

--- a/src/transcoding/codec/codecs/libs/nvenc.c
+++ b/src/transcoding/codec/codecs/libs/nvenc.c
@@ -21,11 +21,15 @@
 #include "transcoding/codec/internals.h"
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <ffnvcodec/nvEncodeAPI.h>
 
+#define PRESET_SKIP                  -1
+// matched with ffmpeg/libavcodec/nvenc.h line 120
 #define PRESET_DEFAULT               0
 #define PRESET_SLOW                  1
 #define PRESET_MEDIUM                2
 #define PRESET_FAST                  3
+#if NVENCAPI_MAJOR_VERSION < 10
 #define PRESET_HP                    4
 #define PRESET_HQ                    5
 #define PRESET_BD                    6
@@ -34,20 +38,33 @@
 #define PRESET_LOW_LATENCY_HP        9
 #define PRESET_LOSSLESS_DEFAULT      10
 #define PRESET_LOSSLESS_HP           11
+#else
+#define PRESET_P1                    12
+#define PRESET_P2                    13
+#define PRESET_P3                    14
+#define PRESET_P4                    15
+#define PRESET_P5                    16
+#define PRESET_P6                    17
+#define PRESET_P7                    18
+#endif
 
+// matched with src/webui/static/app/codec.js --> function filter_based_on_rc_nvenc(form)
 #define NV_ENC_PARAMS_RC_AUTO                  0
 #define NV_ENC_PARAMS_RC_CONSTQP               1
 #define NV_ENC_PARAMS_RC_VBR                   2
 #define NV_ENC_PARAMS_RC_CBR                   3
+#define NV_ENC_PARAMS_RC_VBR_MINQP             4 
 #define NV_ENC_PARAMS_RC_CBR_LD_HQ             8
 #define NV_ENC_PARAMS_RC_CBR_HQ                16
 #define NV_ENC_PARAMS_RC_VBR_HQ                32
 
+// matched with ffmpeg/libavcodec/nvenc.h
 #define NV_ENC_H264_PROFILE_BASELINE			    0
 #define NV_ENC_H264_PROFILE_MAIN			        1
 #define NV_ENC_H264_PROFILE_HIGH			        2
 #define NV_ENC_H264_PROFILE_HIGH_444P           	3
 
+// matched with ffmpeg/libavcodec/nvenc.h
 #define NV_ENC_HEVC_PROFILE_MAIN			        0
 #define NV_ENC_HEVC_PROFILE_MAIN_10 			    1
 #define NV_ENC_HEVC_PROFILE_REXT			        2
@@ -88,8 +105,11 @@
 #define NV_ENC_LEVEL_HEVC_61                        183
 #define NV_ENC_LEVEL_HEVC_62                        186
 
-#define AV_DICT_SET_CQ(d, v, a) \
-    AV_DICT_SET_INT(LST_NVENC, (d), "cq", (v) ? (v) : (a), AV_DICT_DONT_OVERWRITE)
+#define NV_ENC_TUNING_INFO_UNDEFINED                0   //< Undefined tuningInfo. Invalid value for encoding.
+#define NV_ENC_TUNING_INFO_HIGH_QUALITY             1   //< Tune presets for latency tolerant encoding.
+#define NV_ENC_TUNING_INFO_LOW_LATENCY              2   //< Tune presets for low latency streaming.
+#define NV_ENC_TUNING_INFO_ULTRA_LOW_LATENCY        3   //< Tune presets for ultra low latency streaming.
+#define NV_ENC_TUNING_INFO_LOSSLESS                 4   //< Tune presets for lossless encoding.
 
 
 /* nvenc ==================================================================== */
@@ -97,11 +117,91 @@
 typedef struct {
     TVHVideoCodecProfile;
     int nvenc_profile;
+/**
+ * NVENC Constant QP [qp]
+ * @note
+ * int:
+ * VALUE - Constant QP value (1-51, 0=skip)
+ */
+    int qp;
+/**
+ * NVENC Selects which NVENC capable GPU to use. First GPU is 0, second is 1, and so on. [gpu]
+ * @note
+ * int:
+ * VALUE - GPU to use. First GPU is 0, second is 1, and so on. (from -2 to 15) (default any) (from 0 to 15, -1=any, -2=skip)
+ */
     int devicenum;
+/**
+ * NVENC Set the encoding preset [preset]
+ * @note
+ * int:
+ * VALUE - encoding preset (from 0 to 18) (default p4) (from ffmpeg/libavcodec/nvenc.h line 120, -1=skip)
+ */
     int preset;
+/**
+ * NVENC Set the encoding tuning info [tune]
+ * @note
+ * int:
+ * VALUE - encoding tuning info (from 1 to 4) (default skip) (from nvEncodeAPI.h, 0=skip)
+ */
+    int tune;
+/**
+ * NVENC Maximum bitrate [maxrate]
+ * @note
+ * double:
+ * VALUE - max bitrate in bps
+ */
+    double max_bit_rate;
+/**
+ * NVENC Maximum bitrate scale factor
+ * @note
+ * double:
+ * VALUE - max bitrate scale factor
+ */
+    double bit_rate_scale_factor;
+/**
+ * NVENC Override the preset rate-control method [rc]
+ * @note
+ * int:
+ * VALUE - rc mode accepted values (from 0 to 32) (default auto)
+ * Note: some rc modes are deprecated
+ */
     int rc;
+/**
+ * NVENC Set target quality level for constant quality mode in VBR rate control [cq]
+ * @note
+ * int:
+ * VALUE - quality level (0 to 51, 0 means automatic)
+ */
+    int cq;
+/**
+ * NVENC Set the encoding level restriction [level]
+ * @note
+ * int:
+ * VALUE - level restriction (from 0 to 62)
+ */
     int level;
-    int quality;
+/**
+ * NVENC Sets the lowest possible quantization level [qmin]
+ * @note
+ * int:
+ * VALUE - quantization restriction (from 0 to 51)
+ */
+    int qmin;
+/**
+ * NVENC Sets the highest possible quantization level [qmax]
+ * @note
+ * int:
+ * VALUE - quantization restriction (from 0 to 51)
+ */
+    int qmax;
+/**
+ * NVENC Sets the maximum allowed difference between the Quantization Parameter (QP) of consecutive frames [qdiff]
+ * @note
+ * int:
+ * VALUE - quantization restriction (from -1 to 69)
+ */
+    int qdiff;
 } tvh_codec_profile_nvenc_t;
 
 static int
@@ -113,83 +213,195 @@ tvh_codec_profile_nvenc_open(tvh_codec_profile_nvenc_t *self,
         {"slow",        PRESET_SLOW},
         {"medium",      PRESET_MEDIUM},
         {"fast",        PRESET_FAST},
-        {"hp",		PRESET_HP},
-        {"hq",		PRESET_HQ},
-        {"bd",		PRESET_BD},
-        {"ll",		PRESET_LOW_LATENCY_DEFAULT},
-        {"llhq",	PRESET_LOW_LATENCY_HQ},
-        {"llhp",	PRESET_LOW_LATENCY_HP},
+#if NVENCAPI_MAJOR_VERSION < 10
+        {"hp",		    PRESET_HP},
+        {"hq",		    PRESET_HQ},
+        {"bd",		    PRESET_BD},
+        {"ll",		    PRESET_LOW_LATENCY_DEFAULT},
+        {"llhq",	    PRESET_LOW_LATENCY_HQ},
+        {"llhp",	    PRESET_LOW_LATENCY_HP},
         {"lossless",	PRESET_LOSSLESS_DEFAULT},
         {"losslesshp",	PRESET_LOSSLESS_HP},
+#else
+        {"p1",          PRESET_P1},
+        {"p2",          PRESET_P2},
+        {"p3",          PRESET_P3},
+        {"p4",          PRESET_P4},
+        {"p5",          PRESET_P5},
+        {"p6",          PRESET_P6},
+        {"p7",          PRESET_P7},
+#endif
     };
     static const struct strtab rctab[] = {
         {"constqp",	      NV_ENC_PARAMS_RC_CONSTQP},
         {"vbr",           NV_ENC_PARAMS_RC_VBR},
         {"cbr",           NV_ENC_PARAMS_RC_CBR},
+#if NVENCAPI_MAJOR_VERSION < 10
+        {"vbr_minqp",     NV_ENC_PARAMS_RC_VBR_MINQP},
         {"cbr_ld_hq",     NV_ENC_PARAMS_RC_CBR_LD_HQ},
         {"cbr_hq",        NV_ENC_PARAMS_RC_CBR_HQ},
         {"vbr_hq",        NV_ENC_PARAMS_RC_VBR_HQ},
+#endif
     };
+#if NVENCAPI_MAJOR_VERSION >= 10
+    static const struct strtab tunetab[] = {
+        {"hq",            NV_ENC_TUNING_INFO_HIGH_QUALITY},
+        {"ll",            NV_ENC_TUNING_INFO_LOW_LATENCY},
+        {"ull",           NV_ENC_TUNING_INFO_ULTRA_LOW_LATENCY},
+        {"lossless",      NV_ENC_TUNING_INFO_LOSSLESS},
+    };
+#endif
     const char *s;
 
-    AV_DICT_SET_INT(LST_NVENC, opts, "gpu", MINMAX(self->devicenum, 0, 15), 0);
-    if (self->preset != PRESET_DEFAULT &&
-        (s = val2str(self->profile, presettab)) != NULL) {
-        AV_DICT_SET(LST_NVENC, opts, "preset", s, 0);
+    if (self->devicenum != -2) {
+        AV_DICT_SET_INT(LST_NVENC, opts, "gpu", self->devicenum, 0);
     }
+    if (self->preset != PRESET_SKIP &&
+        (s = val2str(self->preset, presettab)) != NULL) {
+            AV_DICT_SET(LST_NVENC, opts, "preset", s, 0);
+        }
+#if NVENCAPI_MAJOR_VERSION >= 10
+    if (self->tune != NV_ENC_TUNING_INFO_UNDEFINED &&
+        (s = val2str(self->tune, tunetab)) != NULL) {
+            AV_DICT_SET(LST_NVENC, opts, "tune", s, 0);
+        }
+#endif
     if (self->rc != NV_ENC_PARAMS_RC_AUTO &&
         (s = val2str(self->rc, rctab)) != NULL) {
-        AV_DICT_SET(LST_NVENC, opts, "rc", s, 0);
+            AV_DICT_SET(LST_NVENC, opts, "rc", s, 0);
+        }
+    
+    int int_bitrate = (int)((self->bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
+    int int_max_bitrate = (int)((self->max_bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
+    int int_qp = self->qp;
+    int int_cq = self->cq;
+    // disable fields based on rc mode to match the UI behavior
+    // skip and auto are not filtering
+    if (self->rc == NV_ENC_PARAMS_RC_VBR || self->rc == NV_ENC_PARAMS_RC_AUTO
+#if NVENCAPI_MAJOR_VERSION < 10
+        || self->rc == NV_ENC_PARAMS_RC_VBR_MINQP || self->rc == NV_ENC_PARAMS_RC_VBR_HQ
+#endif
+        ) {
+        // force max_bitrate to be >= with bitrate (to avoid crash)
+        if (int_bitrate > int_max_bitrate) {
+            tvherror_transcode(LST_NVENC, "Bitrate %d kbps is greater than Max bitrate %d kbps, increase Max bitrate to %d kbps", int_bitrate / 1024, int_max_bitrate / 1024, int_bitrate / 1024);
+            int_max_bitrate = int_bitrate;
+        }
+        if (int_bitrate) {
+            tvhinfo_transcode(LST_NVENC, "Bitrate = %d kbps; Max bitrate = %d kbps", int_bitrate / 1024, int_max_bitrate / 1024);
+        }
+        int_qp = 0; // disable qp setting
     }
-    if (self->bit_rate) {
-        AV_DICT_SET_BIT_RATE(LST_NVENC, opts, self->bit_rate);
+    else if(self->rc == NV_ENC_PARAMS_RC_CBR
+#if NVENCAPI_MAJOR_VERSION < 10
+            || self->rc == NV_ENC_PARAMS_RC_CBR_LD_HQ || self->rc == NV_ENC_PARAMS_RC_CBR_HQ
+#endif
+            ) {
+            // in CBR mode max_bitrate is ignored by nvenc, so we only use bitrate
+            if (int_bitrate) {
+                tvhinfo_transcode(LST_NVENC, "Bitrate = %d kbps", int_bitrate / 1024);
+            }
+            int_max_bitrate = 0; // disable max_bitrate setting
+            int_qp = 0;         // disable qp setting
+            int_cq = 0;         // disable cq setting
+        }
+        else if(self->rc == NV_ENC_PARAMS_RC_CONSTQP) {
+            // in CQP mode both bitrate and max_bitrate are ignored by nvenc, so we only use qp
+            int_bitrate = 0;    // disable bitrate setting
+            int_max_bitrate = 0; // disable max_bitrate setting
+            int_cq = 0;         // disable cq setting
+        }
+    if (int_bitrate) {
+        AV_DICT_SET_INT(LST_NVENC, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
     }
-    AV_DICT_SET_INT(LST_NVENC, opts, "quality", self->quality, 0);
+    if (int_max_bitrate) {
+        AV_DICT_SET_INT(LST_NVENC, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
+    }
+    if (int_qp) {
+        AV_DICT_SET_INT(LST_NVENC, opts, "qp", int_qp, 0);
+    }
+    if (int_cq) {
+        AV_DICT_SET_INT(LST_NVENC, opts, "cq", int_cq, 0);
+    }
+    
+    if (self->qmin) {
+        AV_DICT_SET_INT(LST_NVENC, opts, "qmin", self->qmin, 0);
+    }
+    if (self->qmax) {
+        AV_DICT_SET_INT(LST_NVENC, opts, "qmax", self->qmax, 0);
+    }
+    if (self->qdiff != -2) {
+        AV_DICT_SET_INT(LST_NVENC, opts, "qdiff", self->qdiff, 0);
+    }
     return 0;
-}
-
-static htsmsg_t *
-codec_profile_nvenc_class_profile_list(void *obj, const char *lang)
-{
-    TVHCodec *codec = tvh_codec_profile_get_codec(obj);
-    return tvh_codec_get_list(codec, profiles);
 }
 
 static htsmsg_t *
 codec_profile_nvenc_class_preset_list(void *obj, const char *lang)
 {
     static const struct strtab tab[] = {
-        {N_("Default"),		PRESET_DEFAULT},
-        {N_("Slow"),		PRESET_SLOW},
-        {N_("Medium"),		PRESET_MEDIUM},
-        {N_("Fast"),		PRESET_FAST},
-        {N_("HP"),		PRESET_HP},
-        {N_("HQ"),		PRESET_HQ},
-        {N_("BD"),		PRESET_BD},
-        {N_("Low latency"),	PRESET_LOW_LATENCY_DEFAULT},
-        {N_("Low latency HQ"),	PRESET_LOW_LATENCY_HQ},
-        {N_("Low latency HP"),	PRESET_LOW_LATENCY_HP},
-        {N_("Lossless"),	PRESET_LOSSLESS_DEFAULT},
-        {N_("Lossless HP"),	PRESET_LOSSLESS_HP},
+        {N_("skip"),                    PRESET_SKIP},
+        {N_("Default"),                 PRESET_DEFAULT},
+        {N_("Slow"),                    PRESET_SLOW},
+        {N_("Medium"),                  PRESET_MEDIUM},
+        {N_("Fast"),                    PRESET_FAST},
+#if NVENCAPI_MAJOR_VERSION < 10
+        {N_("HP"),                      PRESET_HP},
+        {N_("HQ"),                      PRESET_HQ},
+        {N_("BD"),                      PRESET_BD},
+        {N_("Low latency"),             PRESET_LOW_LATENCY_DEFAULT},
+        {N_("Low latency HQ"),          PRESET_LOW_LATENCY_HQ},
+        {N_("Low latency HP"),          PRESET_LOW_LATENCY_HP},
+        {N_("Lossless"),                PRESET_LOSSLESS_DEFAULT},
+        {N_("Lossless HP"),             PRESET_LOSSLESS_HP},
+#else
+        {N_("P1 (lowest quality)"),     PRESET_P1},
+        {N_("P2"),                      PRESET_P2},
+        {N_("P3"),                      PRESET_P3},
+        {N_("P4"),                      PRESET_P4},
+        {N_("P5"),                      PRESET_P5},
+        {N_("P6"),                      PRESET_P6},
+        {N_("P7 (highest quality)"),    PRESET_P7},
+#endif
     };
     return strtab2htsmsg(tab, 1, lang);
 }
+
+#if NVENCAPI_MAJOR_VERSION >= 10
+static htsmsg_t *
+codec_profile_nvenc_class_tune_list(void *obj, const char *lang)
+{
+    static const struct strtab tab[] = {
+        {N_("skip"),		        NV_ENC_TUNING_INFO_UNDEFINED},
+        {N_("High quality"),		NV_ENC_TUNING_INFO_HIGH_QUALITY},
+        {N_("Low latency"),	        NV_ENC_TUNING_INFO_LOW_LATENCY},
+        {N_("Ultra low latency"),	NV_ENC_TUNING_INFO_ULTRA_LOW_LATENCY},
+        {N_("Lossless"),	        NV_ENC_TUNING_INFO_LOSSLESS},
+    };
+    return strtab2htsmsg(tab, 1, lang);
+}
+#endif
 
 static htsmsg_t *
 codec_profile_nvenc_class_rc_list(void *obj, const char *lang)
 {
     static const struct strtab tab[] = {
-        {N_("Auto"),				  NV_ENC_PARAMS_RC_AUTO},
-        {N_("Constant QP mode"),      NV_ENC_PARAMS_RC_CONSTQP},
-        {N_("VBR mode"),   			  NV_ENC_PARAMS_RC_VBR},
-        {N_("CBR mode"), 	  		  NV_ENC_PARAMS_RC_CBR},
-        {N_("CBR LD HQ"),			  NV_ENC_PARAMS_RC_CBR_LD_HQ},
-        {N_("CBR High Quality"),	  NV_ENC_PARAMS_RC_CBR_HQ},
-        {N_("VBR High Quality"),   	  NV_ENC_PARAMS_RC_VBR_HQ},
+        {N_("auto"),                            NV_ENC_PARAMS_RC_AUTO},
+        {N_("Constant QP"),                     NV_ENC_PARAMS_RC_CONSTQP},
+        {N_("Variable Bitrate"),                NV_ENC_PARAMS_RC_VBR},
+        {N_("Constant Bitrate"),                NV_ENC_PARAMS_RC_CBR},
+#if NVENCAPI_MAJOR_VERSION < 10
+        {N_("VBR min Q (deprecated)"),          NV_ENC_PARAMS_RC_VBR_MINQP},
+        {N_("CBR LD HQ (deprecated)"),          NV_ENC_PARAMS_RC_CBR_LD_HQ},
+        {N_("CBR High Quality (deprecated)"),   NV_ENC_PARAMS_RC_CBR_HQ},
+        {N_("VBR High Quality (deprecated)"),   NV_ENC_PARAMS_RC_VBR_HQ},
+#endif
     };
     return strtab2htsmsg(tab, 1, lang);
 }
 
+// NOTE:
+// the names below are used in codec.js (/src/webui/static/app/codec.js)
 static const codec_profile_class_t codec_profile_nvenc_class = {
     {
         .ic_super      = (idclass_t *)&codec_profile_video_class,
@@ -198,28 +410,18 @@ static const codec_profile_class_t codec_profile_nvenc_class = {
         .ic_properties = (const property_t[]){
             {
                 .type     = PT_INT,
-                .id       = "devicenum",
+                .id       = "devicenum",     // Don't change
                 .name     = N_("GPU number"),
                 .group    = 3,
-                .desc     = N_("GPU number (starts with zero)."),
+                .desc     = N_("Select GPU number (from 0 to 15, -1=any, -2=skip)."),
                 .get_opts = codec_profile_class_get_opts,
                 .off      = offsetof(tvh_codec_profile_nvenc_t, devicenum),
+                .intextra = INTEXTRA_RANGE(-2, 15, 1),
+                .def.i    = -1,
             },
             {
                 .type     = PT_INT,
-                .id       = "profile",
-                .name     = N_("Profile"),
-                .desc     = N_("Profile."),
-                .group    = 4,
-                .opts     = PO_ADVANCED | PO_PHIDDEN,
-                .get_opts = codec_profile_class_profile_get_opts,
-                .off      = offsetof(tvh_codec_profile_nvenc_t, nvenc_profile),
-                .list     = codec_profile_nvenc_class_profile_list,
-                .def.i    = FF_AV_PROFILE_UNKNOWN,
-            },
-            {
-                .type     = PT_INT,
-                .id       = "preset",
+                .id       = "preset",     // Don't change
                 .name     = N_("Preset"),
                 .group    = 3,
                 .desc     = N_("Override the preset rate control."),
@@ -228,29 +430,19 @@ static const codec_profile_class_t codec_profile_nvenc_class = {
                 .list     = codec_profile_nvenc_class_preset_list,
                 .def.i    = PRESET_DEFAULT,
             },
-            {
-                .type     = PT_DBL,
-                .id       = "bit_rate",
-                .name     = N_("Bitrate (kb/s) (0=auto)"),
-                .desc     = N_("Target bitrate."),
-                .group    = 3,
-                .get_opts = codec_profile_class_get_opts,
-                .off      = offsetof(TVHCodecProfile, bit_rate),
-                .def.d    = 0,
-            },
+#if NVENCAPI_MAJOR_VERSION >= 10
             {
                 .type     = PT_INT,
-                .id       = "quality",
-                .name     = N_("Quality (0=auto)"),
-                .desc     = N_("Set encode quality (trades off against speed, "
-                               "higher is faster) [0-51]."),
-                .group    = 5,
-                .opts     = PO_EXPERT,
+                .id       = "tune",     // Don't change
+                .name     = N_("Tune"),
+                .group    = 3,
+                .desc     = N_("Set the encoding tuning info."),
                 .get_opts = codec_profile_class_get_opts,
-                .off      = offsetof(tvh_codec_profile_nvenc_t, quality),
-                .intextra = INTEXTRA_RANGE(0, 51, 1),
-                .def.i    = 0,
+                .off      = offsetof(tvh_codec_profile_nvenc_t, tune),
+                .list     = codec_profile_nvenc_class_tune_list,
+                .def.i    = PRESET_DEFAULT,
             },
+#endif
             {
                 .type     = PT_INT,
                 .id       = "gop_size",     // Don't change
@@ -264,14 +456,110 @@ static const codec_profile_class_t codec_profile_nvenc_class = {
             },
             {
                 .type     = PT_INT,
-                .id       = "rc",
-                .name     = N_("Rate control"),
+                .id       = "rc_mode",     // Don't change
+                .name     = N_("Rate control mode"),
                 .group    = 3,
                 .desc     = N_("Override the preset rate control."),
                 .opts     = PO_EXPERT,
                 .off      = offsetof(tvh_codec_profile_nvenc_t, rc),
                 .list     = codec_profile_nvenc_class_rc_list,
                 .def.i    = NV_ENC_PARAMS_RC_AUTO,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "qp",     // Don't change
+                .name     = N_("Constant QP"),
+                .group    = 3,
+                .desc     = N_("Fixed QP of P frames (from 0 to 51, 0=skip).[if disabled will not send parameter to libav]"),
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_nvenc_t, qp),
+                .intextra = INTEXTRA_RANGE(0, 51, 1),
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "qmin",     // Don't change
+                .name     = N_("Minimum QP"),
+                .group    = 5,
+                .desc     = N_("Minimum QP of P frames (from 0 to 51, 0=skip)"),
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_nvenc_t, qmin),
+                .intextra = INTEXTRA_RANGE(0, 51, 1),
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "qmax",     // Don't change
+                .name     = N_("Maximum QP"),
+                .group    = 5,
+                .desc     = N_("Maximum QP of P frames (from 0 to 51, 0=skip)"),
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_nvenc_t, qmax),
+                .intextra = INTEXTRA_RANGE(0, 51, 1),
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "qdiff",     // Don't change
+                .name     = N_("QP difference"),
+                .group    = 5,
+                .desc     = N_("Maximum QP change between adjacent frames (from -2 to 69, -1=default, -2=skip)"),
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_nvenc_t, qdiff),
+                .intextra = INTEXTRA_RANGE(-2, 69, 1),
+                .def.i    = -2,
+            },
+            {
+                .type     = PT_DBL,
+                .id       = "bit_rate",     // Don't change
+                .name     = N_("Bitrate (kb/s) (0=auto)"),
+                .desc     = N_("Target bitrate."),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(TVHCodecProfile, bit_rate),
+                .def.d    = 0,
+            },
+            {
+                .type     = PT_DBL,
+                .id       = "max_bit_rate",     // Don't change
+                .name     = N_("Max bitrate (kb/s)"),
+                .desc     = N_("Maximum bitrate (0=skip).[if disabled will not send parameter to libav]"),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_nvenc_t, max_bit_rate),
+                .def.d    = 0,
+            },
+            {
+                .type     = PT_DBL,
+                .id       = "bit_rate_scale_factor",     // Don't change
+                .name     = N_("Bitrate scale factor"),
+                .desc     = N_("Bitrate & Max bitrate scaler with resolution (0=no scale; 1=proportional_change). Relative to 480."),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_nvenc_t, bit_rate_scale_factor),
+                .def.d    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "cq",     // Don't change
+                .name     = N_("Quality (0=auto)"),
+                .desc     = N_("Set target quality level (0 to 51, 0 means automatic) for constant quality mode in VBR rate control."),
+                .group    = 3,
+                .opts     = PO_EXPERT,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_nvenc_t, cq),
+                .intextra = INTEXTRA_RANGE(0, 51, 1),
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "encoder_hwaccel_type",
+                .name     = N_("Encoder hardware acceleration type"),
+                .desc     = N_("Encoder hardware acceleration type"),
+                .group    = 2,
+                .opts     = PO_PHIDDEN,
+                .off      = offsetof(TVHVideoCodecProfile, encoder_hwaccel_type),
+                .def.i    = AV_HWDEVICE_TYPE_CUDA,
             },
             {}
         }
@@ -295,15 +583,8 @@ static int
 tvh_codec_profile_nvenc_h264_open(tvh_codec_profile_nvenc_t *self,
                                   AVDictionary **opts)
 {
-    static const struct strtab profiletab[] = {
-        {"baseline",    NV_ENC_H264_PROFILE_BASELINE},
-        {"main",        NV_ENC_H264_PROFILE_MAIN},
-        {"high",        NV_ENC_H264_PROFILE_HIGH},
-        {"high444p",    NV_ENC_H264_PROFILE_HIGH_444P},
-    };
- 
     static const struct strtab leveltab[] = {
-        {"Auto",	      NV_ENC_LEVEL_AUTOSELECT},
+        {"auto",	      NV_ENC_LEVEL_AUTOSELECT},
         {"1.0",           NV_ENC_LEVEL_H264_1},
         {"1.0b",          NV_ENC_LEVEL_H264_1b},
         {"1.1",           NV_ENC_LEVEL_H264_11},
@@ -320,9 +601,11 @@ tvh_codec_profile_nvenc_h264_open(tvh_codec_profile_nvenc_t *self,
         {"4.2",           NV_ENC_LEVEL_H264_42},
         {"5.0",           NV_ENC_LEVEL_H264_5},
         {"5.1",           NV_ENC_LEVEL_H264_51},
+#if NVENCAPI_MAJOR_VERSION >= 10
         {"6.0",           NV_ENC_LEVEL_H264_6},
         {"6.1",           NV_ENC_LEVEL_H264_61},
         {"6.2",           NV_ENC_LEVEL_H264_62},
+#endif
     };
 
     const char *s;
@@ -331,20 +614,15 @@ tvh_codec_profile_nvenc_h264_open(tvh_codec_profile_nvenc_t *self,
         (s = val2str(self->level, leveltab)) != NULL) {
         AV_DICT_SET(LST_NVENC, opts, "level", s, 0);
     }
-
-    if (self->nvenc_profile != FF_AV_PROFILE_UNKNOWN &&
-        (s = val2str(self->nvenc_profile, profiletab)) != NULL) {
-        AV_DICT_SET(LST_NVENC, opts, "profile", s, 0);
-    }
     
     // ------ Set Defaults ---------
-    AV_DICT_SET_INT(LST_NVENC, opts, "qmin", -1, 0);
-    AV_DICT_SET_INT(LST_NVENC, opts, "qmax", -1, 0);
-    AV_DICT_SET_INT(LST_NVENC, opts, "qdiff", -1, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "qblur", -1, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "qcomp", -1, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "bf", 0, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "refs", 0, 0);
+    
+    // force keyframe at t=0, t=1s and t=2s (used for flashing the encoder)
+    AV_DICT_SET(LST_NVENC, opts, "force_key_frames", "expr:eq(t,0)+eq(t,1)+eq(t,2)", AV_DICT_DONT_OVERWRITE);
     return 0;
 }
 
@@ -352,7 +630,7 @@ static htsmsg_t *
 codec_profile_nvenc_class_level_list_h264(void *obj, const char *lang)
 {
     static const struct strtab tab[] = {
-        {N_("Auto"),	      NV_ENC_LEVEL_AUTOSELECT},
+        {N_("auto"),	      NV_ENC_LEVEL_AUTOSELECT},
         {N_("1.0"),           NV_ENC_LEVEL_H264_1},
         {N_("1.0b"),          NV_ENC_LEVEL_H264_1b},
         {N_("1.1"),           NV_ENC_LEVEL_H264_11},
@@ -369,13 +647,17 @@ codec_profile_nvenc_class_level_list_h264(void *obj, const char *lang)
         {N_("4.2"),           NV_ENC_LEVEL_H264_42},
         {N_("5.0"),           NV_ENC_LEVEL_H264_5},
         {N_("5.1"),           NV_ENC_LEVEL_H264_51},
+#if NVENCAPI_MAJOR_VERSION >= 10
         {N_("6.0"),           NV_ENC_LEVEL_H264_6},
         {N_("6.1"),           NV_ENC_LEVEL_H264_61},
         {N_("6.2"),           NV_ENC_LEVEL_H264_62},
+#endif
     };
     return strtab2htsmsg(tab, 1, lang);
 }
 
+// NOTE:
+// the names below are used in codec.js (/src/webui/static/app/codec.js)
 static const codec_profile_class_t codec_profile_nvenc_h264_class = {
     {
         .ic_super      = (idclass_t *)&codec_profile_nvenc_class,
@@ -384,9 +666,9 @@ static const codec_profile_class_t codec_profile_nvenc_h264_class = {
         .ic_properties = (const property_t[]){
             {
                 .type     = PT_INT,
-                .id       = "level",
+                .id       = "level",     // Don't change
                 .name     = N_("Level"),
-                .group    = 4,
+                .group    = 5,
                 .desc     = N_("Override the preset level."),
                 .opts     = PO_EXPERT,
                 .off      = offsetof(tvh_codec_profile_nvenc_t, level),
@@ -405,6 +687,8 @@ TVHVideoCodec tvh_codec_nvenc_h264 = {
     .size     = sizeof(tvh_codec_profile_nvenc_t),
     .idclass  = &codec_profile_nvenc_h264_class,
     .profiles = nvenc_h264_profiles,
+    .profile_init = tvh_codec_profile_video_init,
+    .profile_destroy = tvh_codec_profile_video_destroy,
 };
 
 
@@ -421,14 +705,8 @@ static int
 tvh_codec_profile_nvenc_hevc_open(tvh_codec_profile_nvenc_t *self,
                                   AVDictionary **opts)
 {
-    static const struct strtab profiletab[] = {
-        {"main",        NV_ENC_HEVC_PROFILE_MAIN},
-        {"main10",      NV_ENC_HEVC_PROFILE_MAIN_10},
-        {"rext",        NV_ENC_HEVC_PROFILE_REXT},
-    };
-
     static const struct strtab leveltab[] = {
-        {"Auto",	   NV_ENC_LEVEL_AUTOSELECT},
+        {"auto",	      NV_ENC_LEVEL_AUTOSELECT},
         {"1.0",           NV_ENC_LEVEL_HEVC_1},
         {"2.0",           NV_ENC_LEVEL_HEVC_2},
         {"2.1",           NV_ENC_LEVEL_HEVC_21},
@@ -439,9 +717,11 @@ tvh_codec_profile_nvenc_hevc_open(tvh_codec_profile_nvenc_t *self,
         {"5.0",           NV_ENC_LEVEL_HEVC_5},
         {"5.1",           NV_ENC_LEVEL_HEVC_51},
         {"5.2",           NV_ENC_LEVEL_HEVC_52},
+#if NVENCAPI_MAJOR_VERSION >= 10
         {"6.0",           NV_ENC_LEVEL_HEVC_6},
         {"6.1",           NV_ENC_LEVEL_HEVC_61},
         {"6.2",           NV_ENC_LEVEL_HEVC_62},
+#endif
     };
 
     const char *s;
@@ -450,20 +730,15 @@ tvh_codec_profile_nvenc_hevc_open(tvh_codec_profile_nvenc_t *self,
         (s = val2str(self->level, leveltab)) != NULL) {
         AV_DICT_SET(LST_NVENC, opts, "level", s, 0);
         }
-
-    if (self->nvenc_profile != FF_AV_PROFILE_UNKNOWN &&
-        (s = val2str(self->nvenc_profile, profiletab)) != NULL) {
-        AV_DICT_SET(LST_NVENC, opts, "profile", s, 0);
-        }
     
     // ------ Set Defaults ---------
-    AV_DICT_SET_INT(LST_NVENC, opts, "qmin", -1, 0);
-    AV_DICT_SET_INT(LST_NVENC, opts, "qmax", -1, 0);
-    AV_DICT_SET_INT(LST_NVENC, opts, "qdiff", -1, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "qblur", -1, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "qcomp", -1, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "bf", 0, 0);
     AV_DICT_SET_INT(LST_NVENC, opts, "refs", 0, 0);
+    
+    // force keyframe at t=0, t=1s and t=2s (used for flashing the encoder)
+    AV_DICT_SET(LST_NVENC, opts, "force_key_frames", "expr:eq(t,0)+eq(t,1)+eq(t,2)", AV_DICT_DONT_OVERWRITE);
     return 0;
 }
 
@@ -471,7 +746,7 @@ static htsmsg_t *
 codec_profile_nvenc_class_level_list_hevc(void *obj, const char *lang)
 {
     static const struct strtab tab[] = {
-        {N_("Auto"),	      NV_ENC_LEVEL_AUTOSELECT},
+        {N_("auto"),	      NV_ENC_LEVEL_AUTOSELECT},
         {N_("1.0"),           NV_ENC_LEVEL_HEVC_1},
         {N_("2.0"),           NV_ENC_LEVEL_HEVC_2},
         {N_("2.1"),           NV_ENC_LEVEL_HEVC_21},
@@ -482,13 +757,17 @@ codec_profile_nvenc_class_level_list_hevc(void *obj, const char *lang)
         {N_("5.0"),           NV_ENC_LEVEL_HEVC_5},
         {N_("5.1"),           NV_ENC_LEVEL_HEVC_51},
         {N_("5.2"),           NV_ENC_LEVEL_HEVC_52},
+#if NVENCAPI_MAJOR_VERSION >= 10
         {N_("6.0"),           NV_ENC_LEVEL_HEVC_6},
         {N_("6.1"),           NV_ENC_LEVEL_HEVC_61},
         {N_("6.2"),           NV_ENC_LEVEL_HEVC_62},
+#endif
     };
     return strtab2htsmsg(tab, 1, lang);
 }
 
+// NOTE:
+// the names below are used in codec.js (/src/webui/static/app/codec.js)
 static const codec_profile_class_t codec_profile_nvenc_hevc_class = {
     {
         .ic_super      = (idclass_t *)&codec_profile_nvenc_class,
@@ -497,9 +776,9 @@ static const codec_profile_class_t codec_profile_nvenc_hevc_class = {
         .ic_properties = (const property_t[]){
             {
                 .type     = PT_INT,
-                .id       = "level",
+                .id       = "level",     // Don't change
                 .name     = N_("Level"),
-                .group    = 4,
+                .group    = 5,
                 .desc     = N_("Override the preset level."),
                 .opts     = PO_EXPERT,
                 .off      = offsetof(tvh_codec_profile_nvenc_t, level),

--- a/src/transcoding/codec/codecs/libs/omx.c
+++ b/src/transcoding/codec/codecs/libs/omx.c
@@ -97,6 +97,16 @@ static const codec_profile_class_t codec_profile_omx_class = {
                 .off      = offsetof(tvh_codec_profile_omx_t, zerocopy),
                 .def.i    = 0,
             },
+            {
+                .type     = PT_INT,
+                .id       = "encoder_hwaccel_type",
+                .name     = N_("Encoder hardware acceleration type"),
+                .desc     = N_("Encoder hardware acceleration type"),
+                .group    = 2,
+                .opts     = PO_PHIDDEN,
+                .off      = offsetof(TVHVideoCodecProfile, encoder_hwaccel_type),
+                .def.i    = 100, //AV_HWDEVICE_TYPE_OMX
+            },
             {}
         }
     },

--- a/src/transcoding/codec/codecs/libs/qsv.c
+++ b/src/transcoding/codec/codecs/libs/qsv.c
@@ -1,0 +1,878 @@
+/*
+ *  tvheadend - Codec Profiles
+ *
+ *  Copyright (C) 2026 Tvheadend
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "transcoding/codec/internals.h"
+#include "transcoding/codec/drmdev.h"
+
+#include "idnode.h"
+#include "htsmsg.h"
+
+/* defines */
+
+// for preset
+#define QSV_ENC_PRESET_SKIP         0
+#define QSV_ENC_PRESET_VERYSLOW     1
+#define QSV_ENC_PRESET_SLOWER       2
+#define QSV_ENC_PRESET_SLOW         3
+#define QSV_ENC_PRESET_MEDIUM       4
+#define QSV_ENC_PRESET_FAST         5
+#define QSV_ENC_PRESET_FASTER       6
+#define QSV_ENC_PRESET_VERYFAST     7
+
+// for b_strategy
+#define QSV_ENC_B_STRATEGY_SKIP     -1
+#define QSV_ENC_B_STRATEGY_OFF      0
+#define QSV_ENC_B_STRATEGY_ON       1
+
+#define QSV_ENC_HEVC_TIER_SKIP	    -1
+#define QSV_ENC_HEVC_TIER_MAIN		0
+#define QSV_ENC_HEVC_TIER_HIGH 		1
+
+enum CODEC{
+    H264 = 1,
+    HEVC = 2,
+    VP8 = 3,
+    VP9 = 4
+};
+
+/* hts ==================================================================== */
+
+// h264
+
+
+static htsmsg_t *
+preset_get_list( void *o, const char *lang )
+{
+    static const struct strtab tab[] = {
+        { N_("skip"), QSV_ENC_PRESET_SKIP },
+        { N_("veryslow"),  QSV_ENC_PRESET_VERYSLOW },
+        { N_("slower"),  QSV_ENC_PRESET_SLOWER },
+        { N_("slow"),  QSV_ENC_PRESET_SLOW },
+        { N_("medium"),  QSV_ENC_PRESET_MEDIUM },
+        { N_("fast"),  QSV_ENC_PRESET_FAST },
+        { N_("faster"),  QSV_ENC_PRESET_FASTER },
+        { N_("veryfast"),  QSV_ENC_PRESET_VERYFAST },
+    };
+    return strtab2htsmsg(tab, 1, lang);
+}
+
+static htsmsg_t *
+b_strategy_get_list( void *o, const char *lang )
+{
+    static const struct strtab tab[] = {
+        { N_("skip"), QSV_ENC_B_STRATEGY_SKIP },
+        { N_("disabled"),  QSV_ENC_B_STRATEGY_OFF },
+        { N_("enabled"),  QSV_ENC_B_STRATEGY_ON },
+    };
+    return strtab2htsmsg(tab, 1, lang);
+}
+
+// hevc 
+
+static htsmsg_t *
+hevc_tier_get_list( void *o, const char *lang )
+{
+    static const struct strtab tab[] = {
+        { N_("skip"), QSV_ENC_HEVC_TIER_SKIP },
+        { N_("main"), QSV_ENC_HEVC_TIER_MAIN },
+        { N_("high"), QSV_ENC_HEVC_TIER_HIGH },
+    };
+    return strtab2htsmsg(tab, 1, lang);
+}
+
+/* qsv ==================================================================== */
+
+static int
+tvh_codec_profile_qsv_open(tvh_codec_profile_qsv_t *self,
+                             AVDictionary **opts)
+{
+    const TVHVideoCodecProfile *vp = (TVHVideoCodecProfile *)self;
+    
+    // pix_fmt
+    AV_DICT_SET_PIX_FMT(LST_QSV, opts, vp->pix_fmt, AV_PIX_FMT_QSV);
+    return 0;
+}
+
+
+/**
+ * Derive QSV encoder rate-control parameters from the UI profile and output height.
+ *
+ * Reads @c TVHCodecProfile::bit_rate (kb/s) and @c TVHVideoCodecProfile::size.den
+ * (treated here as the active picture height in pixels), together with
+ * @c tvh_codec_profile_qsv_t::bit_rate_scale_factor, @c max_bit_rate, and
+ * @c buff_factor. All three outputs are integer values in the scaled
+ * space used when passing @c b / @c bufsize / @c maxrate into libav
+ * (using the @c *1024 and @c *2048 scaling factors).
+ *
+ * Resolution scaling: relative to a 480-line baseline, the effective target bitrate
+ * is multiplied by `1 + bit_rate_scale_factor * (height - 480) / 480` so higher
+ * resolutions proportionally increase the requested rate and buffer size.
+ *
+ * Buffer size additionally scales by @c buff_factor (forced to 3 if unset or
+ * non-positive).
+ *
+ * If the computed average bitrate exceeds the computed max bitrate, this logs an error
+ * and raises @p *max_bitrate to @p *bitrate to ensure consistency and prevent crashes.
+ *
+ * @param self         QSV codec profile (also carries base @c TVHCodecProfile and
+ *                     @c TVHVideoCodecProfile fields).
+ * @param bitrate      Out: scaled average / target bitrate.
+ * @param buffer_size  Out: scaled VBV buffer size (@c bufsize).
+ * @param max_bitrate  Out: scaled peak / max rate; may be bumped up to @p *bitrate.
+ */
+static void
+compute_bitrates(tvh_codec_profile_qsv_t *self, int *bitrate, int *buffer_size, int *max_bitrate){
+    const TVHCodecProfile *p = (TVHCodecProfile *)self;
+    const TVHVideoCodecProfile *vp = (TVHVideoCodecProfile *)self;
+
+    // to avoid issues we have this check:
+    if (self->buff_factor <= 0) {
+        self->buff_factor = 3;
+    }
+    *bitrate = (int)((p->bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(vp->size.den) - 480.0) / 480.0)));
+    *buffer_size = (int)((p->bit_rate) * 2048.0 * self->buff_factor * (1.0 + self->bit_rate_scale_factor * ((double)(vp->size.den) - 480.0) / 480));
+    *max_bitrate = (int)((self->max_bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(vp->size.den) - 480.0) / 480.0)));
+    // force max_bitrate to be >= with bitrate (to avoid crash)
+    if (*bitrate > *max_bitrate) {
+        tvherror_transcode(LST_QSV, "Bitrate %d kbps is greater than Max bitrate %d kbps, increase Max bitrate to %d kbps", 
+            *bitrate / 1024, *max_bitrate / 1024, *bitrate / 1024);
+        *max_bitrate = *bitrate;
+    }
+    tvhinfo_transcode(LST_QSV, "Bitrate = %d kbps; Buffer size = %d kbps; Max bitrate = %d kbps", 
+        *bitrate / 1024, *buffer_size / 1024, *max_bitrate / 1024);
+}
+
+
+/**
+ * Append “baseline” libavcodec / QSV encoder options into @p opts.
+ *
+ * All entries use @c AV_DICT_DONT_OVERWRITE so existing dictionary keys win.
+ * Options are generally only appended if their corresponding fields in @p self
+ * are non-zero.
+ *
+ * Behavior and constraints:
+ * - B-frames (@c bf): Set to @c desired_b_depth, but only if @c low_power is disabled (0).
+ * - Lookahead: If @c look_ahead_depth is configured, it automatically enables
+ *   @c look_ahead. To prevent encoder issues, the depth is strictly forced to be
+ *   at least @c desired_b_depth + 1. If the codec is @c H264, it additionally
+ *   enables @c look_ahead_downsampling.
+ * - H264 specifics: Sets @c vcm (Video Conferencing Mode) if enabled.
+ * - General QSV tuning: Passes through @c b_strategy, @c global_quality, @c low_power,
+ *   @c async_depth, @c preset, @c ext_brc, @c qmin, and @c qmax if they are set.
+ *
+ * @param self  QSV profile carrying the tuning fields above.
+ * @param opts  Target option dictionary for @c avcodec_open2 (or a helper that forwards it).
+ * @param codec Which elementary codec is being configured (@c H264, @c HEVC, etc.).
+ * @return      Always @c 0 (no failure path).
+ */
+static int
+setup_baseline_opts(const tvh_codec_profile_qsv_t *self, AVDictionary **opts, enum CODEC codec){
+    // Always pin the max B-frame count. With no explicit value the qsv encoder
+    // falls back to an aggressive default (hevc_qsv: GopRefDist=5, BRefType=
+    // pyramid), whose reorder delay makes frames arrive late ("picture is too
+    // late to be displayed") and degrades live quality (pixellation). The
+    // profile's desired_b_depth defaults to 0 -> bf=0 (no B-frames), matching
+    // the VAAPI encoders; set it >0 in the profile to re-enable B-frames.
+    AV_DICT_SET_INT(LST_QSV, opts, "bf", self->desired_b_depth, AV_DICT_DONT_OVERWRITE);
+    if (self->b_strategy) {
+        AV_DICT_SET_INT(LST_QSV, opts, "b_strategy", self->b_strategy, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->adaptive_i) {
+        AV_DICT_SET_INT(LST_QSV, opts, "adaptive_i", self->adaptive_i, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->adaptive_b) {
+        AV_DICT_SET_INT(LST_QSV, opts, "adaptive_b", self->adaptive_b, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->global_quality) {
+        AV_DICT_SET_INT(LST_QSV, opts, "global_quality", self->global_quality, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->low_power) {
+        AV_DICT_SET_INT(LST_QSV, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->async_depth) {
+        AV_DICT_SET_INT(LST_QSV, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->preset) {
+        AV_DICT_SET_INT(LST_QSV, opts, "preset", self->preset, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->ext_brc) {
+        AV_DICT_SET_INT(LST_QSV, opts, "extbrc", self->ext_brc, AV_DICT_DONT_OVERWRITE);
+    }
+    if ((codec == H264) && (self->vcm)) {
+        AV_DICT_SET_INT(LST_QSV, opts, "vcm", self->vcm, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->look_ahead_depth) {
+        if (self->look_ahead_depth < (self->desired_b_depth + 1))
+            // we have to force look_ahead_depth to bf + 1
+            // https://forum.level1techs.com/t/ffmpeg-av1-encoding-using-intel-arc-gpu-tips/205120/2
+            AV_DICT_SET_INT(LST_QSV, opts, "look_ahead_depth", self->desired_b_depth + 1, AV_DICT_DONT_OVERWRITE);
+        else
+            AV_DICT_SET_INT(LST_QSV, opts, "look_ahead_depth", self->look_ahead_depth, AV_DICT_DONT_OVERWRITE);
+        AV_DICT_SET_INT(LST_QSV, opts, "look_ahead", 1, AV_DICT_DONT_OVERWRITE);
+        if (codec == H264)
+            AV_DICT_SET_INT(LST_QSV, opts, "look_ahead_downsampling", 1, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->qmin) {
+        AV_DICT_SET_INT(LST_QSV, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->qmax) {
+        AV_DICT_SET_INT(LST_QSV, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
+    }
+    return 0;
+}
+
+
+/**
+ * Push rate-control and fixed-QP libavcodec options into @p opts for the
+ * QSV encoder.
+ *
+ * Uses @c AV_DICT_DONT_OVERWRITE on every key so callers can pre-seed the dictionary
+ * without these defaults overriding existing configurations.
+ *
+ * Behavior:
+ * - If the base profile (@c TVHCodecProfile) has a non-zero @c bit_rate, sets
+ *   @c b to @p bitrate and @c bufsize to @p buffer_size. These are typically
+ *   the scaled values produced by @ref compute_bitrates.
+ * - If @c max_bit_rate on the QSV profile is non-zero, sets @c maxrate to @p max_bitrate.
+ * - If @c qp on the QSV profile is non-zero, sets the constant quantizer parameter @c qp.
+ *
+ * @param self         QSV codec profile (and embedded base @c TVHCodecProfile).
+ * @param opts         Target encoder option dictionary.
+ * @param bitrate      Target average bitrate for @c b (scaled units).
+ * @param buffer_size  VBV buffer size for @c bufsize (scaled units).
+ * @param max_bitrate  Peak bitrate for @c maxrate (scaled units).
+ * @return             Always @c 0 (no failure path).
+ */
+static int
+setup_bitrate_qp_opts(const tvh_codec_profile_qsv_t *self, AVDictionary **opts, int bitrate, int buffer_size, int max_bitrate){
+    const TVHCodecProfile *p = (TVHCodecProfile *)self;
+
+    if (p->bit_rate) {
+        AV_DICT_SET_INT(LST_QSV, opts, "b", bitrate, AV_DICT_DONT_OVERWRITE);
+        AV_DICT_SET_INT(LST_QSV, opts, "bufsize", buffer_size, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->max_bit_rate) {
+        AV_DICT_SET_INT(LST_QSV, opts, "maxrate", max_bitrate, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->qp) {
+        AV_DICT_SET_INT(LST_QSV, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+    }
+    return 0;
+}
+
+// NOTE:
+// the names below are used in codec.js (/src/webui/static/app/codec.js)
+static const codec_profile_class_t codec_profile_qsv_class = {
+    {
+        .ic_super      = (idclass_t *)&codec_profile_video_class,
+        .ic_class      = "codec_profile_qsv",
+        .ic_caption    = N_("qsv"),
+        .ic_properties = (const property_t[]){
+            {
+                .type     = PT_STR,
+                .id       = "device",     // Don't change
+                .name     = N_("Device name"),
+                .desc     = N_("Device name (e.g. /dev/dri/renderD128)."),
+                .group    = 3,
+                .off      = offsetof(TVHCodecProfile, device),
+                .list     = tvh_drm_device_list,
+            },
+            {
+                .type     = PT_BOOL,
+                .id       = "low_power",     // Don't change
+                .name     = N_("Low Power"),
+                .desc     = N_("Set low power mode.[if disabled will not send parameter to libav, if enabled codec will disable B frames]"),
+                .group    = 3,
+                .opts     = PO_EXPERT,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_qsv_t, low_power),
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "async_depth",     // Don't change
+                .name     = N_("Maximum processing parallelism"),
+                .desc     = N_("Set maximum process in parallel (0=skip, 2=default).[driver must implement vaSyncBuffer function]"),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_qsv_t, async_depth),
+                .intextra = INTEXTRA_RANGE(0, 64, 1),
+                .def.i    = 2,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "preset",     // Don't change
+                .name     = N_("Preset"),
+                .desc     = N_("This option itemizes a range of choices from veryfast (best speed) to veryslow (best quality) [0=skip 0-7]."),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_qsv_t, preset),
+                .list     = preset_get_list,
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "desired_b_depth",     // Don't change
+                .name     = N_("Maximum B-frame"),
+                .desc     = N_("Maximum B-frame reference depth (from 1 to 3) (default 1)"),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_qsv_t, desired_b_depth),
+                .intextra = INTEXTRA_RANGE(0, 7, 1),
+                .def.i    = 1,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "b_strategy",     // Don't change
+                .name     = N_("B-Pyramid"),
+                .desc     = N_("B-Pyramid (from -1 to 1) (default -1)"),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_qsv_t, b_strategy),
+                .list     = b_strategy_get_list,
+                .def.i    = -1,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "global_quality",     // Don't change
+                .name     = N_("global quality"),
+                .desc     = N_("Set global quality"),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_qsv_t, global_quality),
+                .intextra = INTEXTRA_RANGE(0, 51, 1),
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "gop_size",     // Don't change
+                .name     = N_("GOP size"),
+                .desc     = N_("Sets the Group of Pictures (GOP) size in frame (default 0 is 3 sec.)"),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(TVHVideoCodecProfile, gop_size),
+                .intextra = INTEXTRA_RANGE(0, 1000, 1),
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "qp",     // Don't change
+                .name     = N_("Constant QP"),
+                .group    = 3,
+                .desc     = N_("Fixed QP of P frames (from 0 to 52, 0=skip).[if disabled will not send paramter to libav]"),
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_qsv_t, qp),
+                .intextra = INTEXTRA_RANGE(0, 52, 1),
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "qmin",     // Don't change
+                .name     = N_("Minimum QP"),
+                .group    = 5,
+                .desc     = N_("Minimum QP of P frames (from 0 to 52, 0=skip)"),
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_qsv_t, qmin),
+                .intextra = INTEXTRA_RANGE(0, 52, 1),
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "qmax",     // Don't change
+                .name     = N_("Maximum QP"),
+                .group    = 5,
+                .desc     = N_("Maximum QP of P frames (from 0 to 52, 0=skip)"),
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_qsv_t, qmax),
+                .intextra = INTEXTRA_RANGE(0, 52, 1),
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_DBL,
+                .id       = "bit_rate",     // Don't change
+                .name     = N_("Bitrate (kb/s)"),
+                .desc     = N_("Target bitrate (0=skip).[if disabled will not send paramter to libav]"),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(TVHCodecProfile, bit_rate),
+                .def.d    = 0,
+            },
+            {
+                .type     = PT_DBL,
+                .id       = "max_bit_rate",     // Don't change
+                .name     = N_("Max bitrate (kb/s)"),
+                .desc     = N_("Maximum bitrate (0=skip).[if disabled will not send paramter to libav]"),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_qsv_t, max_bit_rate),
+                .def.d    = 0,
+            },
+            {
+                .type     = PT_DBL,
+                .id       = "buff_factor",     // Don't change
+                .name     = N_("Buffer size factor"),
+                .desc     = N_("Size of transcoding buffer (buffer=bitrate*2048*factor). Good factor is 3."),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_qsv_t, buff_factor),
+                .def.d    = 3,
+            },
+            {
+                .type     = PT_DBL,
+                .id       = "bit_rate_scale_factor",     // Don't change
+                .name     = N_("Bitrate scale factor"),
+                .desc     = N_("Bitrate & Max bitrate scaler with resolution (0=no scale; 1=proportional_change). Relative to 480."),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_qsv_t, bit_rate_scale_factor),
+                .def.d    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "hw_denoise",     // Don't change
+                .name     = N_("Denoise"),
+                .group    = 2,
+                .desc     = N_("Denoise only available with Hardware Acceleration (from 0 to 100, 0=skip, 0 default)"),
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(TVHVideoCodecProfile, filter_hw_denoise),
+                .intextra = INTEXTRA_RANGE(0, 100, 1),
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "hw_sharpness",     // Don't change
+                .name     = N_("Sharpness"),
+                .group    = 2,
+                .desc     = N_("Sharpness only available with Hardware Acceleration (from 0 to 100, 0=skip, 44 default)"),
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(TVHVideoCodecProfile, filter_hw_sharpness),
+                .intextra = INTEXTRA_RANGE(0, 100, 1),
+                .def.i    = 44,
+            },
+            {
+                .type     = PT_BOOL,
+                .id       = "ext_brc",     // Don't change
+                .name     = N_("Extended Bitrate Control"),
+                .desc     = N_("This is highly recommended for Xe graphics to force the hardware to utilize Intel's most modern rate-control algorithms."),
+                .group    = 3,
+                .opts     = PO_EXPERT,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_qsv_t, ext_brc),
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "look_ahead_depth",     // Don't change
+                .name     = N_("Depth of look ahead"),
+                .desc     = N_("Depth of look ahead in number frames [0=skip 1-100]."),
+                .group    = 3,
+                .opts     = PO_EXPERT,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_qsv_t, look_ahead_depth),
+                .intextra = INTEXTRA_RANGE(0, 100, 1),
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_BOOL,
+                .id       = "adaptive_i",     // Don't change
+                .name     = N_("Adaptive I-frame placement"),
+                .desc     = N_("Adaptive I-frame placement (from -1 to 1) (default -1)"),
+                .group    = 5,
+                .opts     = PO_EXPERT,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_qsv_t, adaptive_i),
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_BOOL,
+                .id       = "adaptive_b",     // Don't change
+                .name     = N_("Adaptive B-frame placement"),
+                .desc     = N_("Adaptive B-frame placement (from -1 to 1) (default -1)"),
+                .group    = 5,
+                .opts     = PO_EXPERT,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_qsv_t, adaptive_b),
+                .def.i    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "encoder_hwaccel_type",
+                .name     = N_("Encoder hardware acceleration type"),
+                .desc     = N_("Encoder hardware acceleration type"),
+                .group    = 2,
+                .opts     = PO_PHIDDEN,
+                .off      = offsetof(TVHVideoCodecProfile, encoder_hwaccel_type),
+                .def.i    = AV_HWDEVICE_TYPE_QSV,
+            },
+            {}
+        }
+    },
+    .open = (codec_profile_open_meth)tvh_codec_profile_qsv_open,
+};
+
+
+/* h264_qsv =============================================================== */
+
+static const AVProfile qsv_h264_profiles[] = {
+    { FF_AV_PROFILE_H264_CONSTRAINED_BASELINE, "Constrained Baseline" },
+    { FF_AV_PROFILE_H264_MAIN,                 "Main" },
+    { FF_AV_PROFILE_H264_HIGH,                 "High" },
+    { FF_AV_PROFILE_UNKNOWN },
+};
+
+static int
+tvh_codec_profile_qsv_h264_open(tvh_codec_profile_qsv_t *self,
+                                  AVDictionary **opts)
+{
+    int int_bitrate = 0;
+    int int_buffer_size = 0;
+    int int_max_bitrate = 0;
+    int ret = 0;
+
+    compute_bitrates(self, &int_bitrate, &int_buffer_size, &int_max_bitrate);
+
+    // to find available parameters use:
+    // ffmpeg -hide_banner -h encoder=h264_qsv
+/*
+ffmpeg -hide_banner -h encoder=h264_qsv
+Encoder h264_qsv [H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (Intel Quick Sync Video acceleration)]:
+    General capabilities: delay hybrid
+    Threading capabilities: none
+    Supported hardware devices: qsv qsv qsv
+    Supported pixel formats: nv12 p010le qsv
+h264_qsv encoder AVOptions:
+  -async_depth       <int>        E..V....... Maximum processing parallelism (from 1 to INT_MAX) (default 4)
+  -avbr_accuracy     <int>        E..V....... Accuracy of the AVBR ratecontrol (unit of tenth of percent) (from 1 to 65535) (default 1)
+  -avbr_convergence  <int>        E..V....... Convergence of the AVBR ratecontrol (unit of 100 frames) (from 1 to 65535) (default 1)
+  -preset            <int>        E..V....... (from 1 to 7) (default medium)
+     veryfast        7            E..V.......
+     faster          6            E..V.......
+     fast            5            E..V.......
+     medium          4            E..V.......
+     slow            3            E..V.......
+     slower          2            E..V.......
+     veryslow        1            E..V.......
+  -forced_idr        <boolean>    E..V....... Forcing I frames as IDR frames (default false)
+  -low_power         <boolean>    E..V....... enable low power mode(experimental: many limitations by mfx version, BRC modes, etc.) (default auto)
+  -rdo               <int>        E..V....... Enable rate distortion optimization (from -1 to 1) (default -1)
+  -max_frame_size    <int>        E..V....... Maximum encoded frame size in bytes (from -1 to INT_MAX) (default -1)
+  -max_frame_size_i  <int>        E..V....... Maximum encoded I frame size in bytes (from -1 to INT_MAX) (default -1)
+  -max_frame_size_p  <int>        E..V....... Maximum encoded P frame size in bytes (from -1 to INT_MAX) (default -1)
+  -max_slice_size    <int>        E..V....... Maximum encoded slice size in bytes (from -1 to INT_MAX) (default -1)
+  -bitrate_limit     <int>        E..V....... Toggle bitrate limitations (from -1 to 1) (default -1)
+  -mbbrc             <int>        E..V....... MB level bitrate control (from -1 to 1) (default -1)
+  -extbrc            <int>        E..V....... Extended bitrate control (from -1 to 1) (default -1)
+  -adaptive_i        <int>        E..V....... Adaptive I-frame placement (from -1 to 1) (default -1)
+  -adaptive_b        <int>        E..V....... Adaptive B-frame placement (from -1 to 1) (default -1)
+  -p_strategy        <int>        E..V....... Enable P-pyramid: 0-default 1-simple 2-pyramid(bf need to be set to 0). (from 0 to 2) (default 0)
+  -b_strategy        <int>        E..V....... Strategy to choose between I/P/B-frames (from -1 to 1) (default -1)
+  -dblk_idc          <int>        E..V....... This option disable deblocking. It has value in range 0~2. (from 0 to 2) (default 0)
+  -low_delay_brc     <boolean>    E..V....... Allow to strictly obey avg frame size (default auto)
+  -max_qp_i          <int>        E..V....... Maximum video quantizer scale for I frame (from -1 to 51) (default -1)
+  -min_qp_i          <int>        E..V....... Minimum video quantizer scale for I frame (from -1 to 51) (default -1)
+  -max_qp_p          <int>        E..V....... Maximum video quantizer scale for P frame (from -1 to 51) (default -1)
+  -min_qp_p          <int>        E..V....... Minimum video quantizer scale for P frame (from -1 to 51) (default -1)
+  -max_qp_b          <int>        E..V....... Maximum video quantizer scale for B frame (from -1 to 51) (default -1)
+  -min_qp_b          <int>        E..V....... Minimum video quantizer scale for B frame (from -1 to 51) (default -1)
+  -cavlc             <boolean>    E..V....... Enable CAVLC (default false)
+  -idr_interval      <int>        E..V....... Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
+  -pic_timing_sei    <boolean>    E..V....... Insert picture timing SEI with pic_struct_syntax element (default true)
+  -single_sei_nal_unit <int>        E..V....... Put all the SEI messages into one NALU (from -1 to 1) (default -1)
+  -max_dec_frame_buffering <int>        E..V....... Maximum number of frames buffered in the DPB (from 0 to 65535) (default 0)
+  -look_ahead        <boolean>    E..V....... Use VBR algorithm with look ahead (default false)
+  -look_ahead_depth  <int>        E..V....... Depth of look ahead in number frames (from 0 to 100) (default 0)
+  -look_ahead_downsampling <int>        E..V....... Downscaling factor for the frames saved for the lookahead analysis (from 0 to 3) (default unknown)
+     unknown         0            E..V.......
+     auto            0            E..V.......
+     off             1            E..V.......
+     2x              2            E..V.......
+     4x              3            E..V.......
+  -int_ref_type      <int>        E..V....... Intra refresh type. B frames should be set to 0. (from -1 to 65535) (default -1)
+     none            0            E..V.......
+     vertical        1            E..V.......
+     horizontal      2            E..V.......
+  -int_ref_cycle_size <int>        E..V....... Number of frames in the intra refresh cycle (from -1 to 65535) (default -1)
+  -int_ref_qp_delta  <int>        E..V....... QP difference for the refresh MBs (from -32768 to 32767) (default -32768)
+  -recovery_point_sei <int>        E..V....... Insert recovery point SEI messages (from -1 to 1) (default -1)
+  -int_ref_cycle_dist <int>        E..V....... Distance between the beginnings of the intra-refresh cycles in frames (from -1 to 32767) (default -1)
+  -profile           <int>        E..V....... (from 0 to INT_MAX) (default unknown)
+     unknown         0            E..V.......
+     baseline        66           E..V.......
+     main            77           E..V.......
+     high            100          E..V.......
+  -a53cc             <boolean>    E..V....... Use A53 Closed Captions (if available) (default true)
+  -aud               <boolean>    E..V....... Insert the Access Unit Delimiter NAL (default false)
+  -mfmode            <int>        E..V....... Multi-Frame Mode (from 0 to 2) (default auto)
+     off             1            E..V.......
+     auto            2            E..V.......
+  -repeat_pps        <boolean>    E..V....... repeat pps for every frame (default false)
+*/
+
+/*
+The ratecontrol method is selected as follows:
+
+    When global_quality is specified, a quality-based mode is used. Specifically this means either
+        - CQP - constant quantizer scale, when the qscale codec flag is also set (the -qscale ffmpeg option).
+        - LA_ICQ - intelligent constant quality with lookahead, when the look_ahead option is also set.
+        - ICQ – intelligent constant quality otherwise. For the ICQ modes, global quality range is 1 to 51, with 1 being the best quality. 
+    Otherwise when the desired average bitrate is specified with the b option, a bitrate-based mode is used.
+        - LA - VBR with lookahead, when the look_ahead option is specified.
+        - VCM - video conferencing mode, when the vcm option is set.
+        - CBR - constant bitrate, when maxrate is specified and equal to the average bitrate.
+        - VBR - variable bitrate, when maxrate is specified, but is higher than the average bitrate.
+        - AVBR - average VBR mode, when maxrate is not specified, both avbr_accuracy and avbr_convergence are set to non-zero. This mode is available for H264 and HEVC on Windows. 
+    Otherwise the default ratecontrol method CQP is used. 
+
+Note that depending on your system, a different mode than the one you specified may be selected by the encoder. Set the verbosity level to verbose or higher to see the actual settings used by the QSV runtime. 
+*/
+    if ((ret = setup_bitrate_qp_opts(self, opts, int_bitrate, int_buffer_size, int_max_bitrate))) {
+        return ret;
+    }
+    if ((ret = setup_baseline_opts(self, opts, H264))) {
+        return ret;
+    }
+    // force keyframe at t=0, t=1s and t=2s (used for flashing the encoder)
+    AV_DICT_SET(LST_QSV, opts, "force_key_frames", "expr:eq(t,0)+eq(t,1)+eq(t,2)", AV_DICT_DONT_OVERWRITE);
+    return 0;
+}
+
+// NOTE:
+// the names below are used in codec.js (/src/webui/static/app/codec.js)
+static const codec_profile_class_t codec_profile_qsv_h264_class = {
+    {
+        .ic_super      = (idclass_t *)&codec_profile_qsv_class,
+        .ic_class      = "codec_profile_qsv_h264",
+        .ic_caption    = N_("qsv_h264"),
+        .ic_properties = (const property_t[]){
+            {
+                .type     = PT_BOOL,
+                .id       = "vcm",     // Don't change
+                .name     = N_("Video conferencing mode"),
+                .desc     = N_("Video conferencing mode, when the vcm option is set."),
+                .group    = 5,
+                .opts     = PO_EXPERT,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_qsv_t, vcm),
+                .def.i    = 0,
+            },
+            {}
+        }
+    },
+    .open = (codec_profile_open_meth)tvh_codec_profile_qsv_h264_open,
+};
+
+
+TVHVideoCodec tvh_codec_qsv_h264 = {
+    .name     = "h264_qsv",
+    .size     = sizeof(tvh_codec_profile_qsv_t),
+    .idclass  = &codec_profile_qsv_h264_class,
+    .profiles = qsv_h264_profiles,
+    .profile_init = tvh_codec_profile_video_init,
+    .profile_destroy = tvh_codec_profile_video_destroy,
+};
+
+
+/* hevc_qsv =============================================================== */
+
+static const AVProfile qsv_hevc_profiles[] = {
+    { FF_AV_PROFILE_HEVC_MAIN,          "Main" },
+    { FF_AV_PROFILE_HEVC_MAIN_10,       "Main 10" },
+    { FF_AV_PROFILE_HEVC_REXT,          "Rext" },
+    { FF_AV_PROFILE_UNKNOWN },
+};
+
+
+static int
+tvh_codec_profile_qsv_hevc_open(tvh_codec_profile_qsv_t *self,
+                                  AVDictionary **opts)
+{
+    int int_bitrate = 0;
+    int int_buffer_size = 0;
+    int int_max_bitrate = 0;
+    int ret = 0;
+
+    compute_bitrates(self, &int_bitrate, &int_buffer_size, &int_max_bitrate);
+
+/*
+ffmpeg -hide_banner -h encoder=hevc_qsv
+Encoder hevc_qsv [HEVC (Intel Quick Sync Video acceleration)]:
+    General capabilities: delay hybrid
+    Threading capabilities: none
+    Supported hardware devices: qsv qsv qsv
+    Supported pixel formats: nv12 p010le yuyv422 y210le qsv bgra x2rgb10le
+hevc_qsv encoder AVOptions:
+  -async_depth       <int>        E..V....... Maximum processing parallelism (from 1 to INT_MAX) (default 4)
+  -avbr_accuracy     <int>        E..V....... Accuracy of the AVBR ratecontrol (unit of tenth of percent) (from 1 to 65535) (default 1)
+  -avbr_convergence  <int>        E..V....... Convergence of the AVBR ratecontrol (unit of 100 frames) (from 1 to 65535) (default 1)
+  -preset            <int>        E..V....... (from 1 to 7) (default medium)
+     veryfast        7            E..V.......
+     faster          6            E..V.......
+     fast            5            E..V.......
+     medium          4            E..V.......
+     slow            3            E..V.......
+     slower          2            E..V.......
+     veryslow        1            E..V.......
+  -forced_idr        <boolean>    E..V....... Forcing I frames as IDR frames (default false)
+  -low_power         <boolean>    E..V....... enable low power mode(experimental: many limitations by mfx version, BRC modes, etc.) (default auto)
+  -rdo               <int>        E..V....... Enable rate distortion optimization (from -1 to 1) (default -1)
+  -max_frame_size    <int>        E..V....... Maximum encoded frame size in bytes (from -1 to INT_MAX) (default -1)
+  -max_frame_size_i  <int>        E..V....... Maximum encoded I frame size in bytes (from -1 to INT_MAX) (default -1)
+  -max_frame_size_p  <int>        E..V....... Maximum encoded P frame size in bytes (from -1 to INT_MAX) (default -1)
+  -max_slice_size    <int>        E..V....... Maximum encoded slice size in bytes (from -1 to INT_MAX) (default -1)
+  -mbbrc             <int>        E..V....... MB level bitrate control (from -1 to 1) (default -1)
+  -extbrc            <int>        E..V....... Extended bitrate control (from -1 to 1) (default -1)
+  -p_strategy        <int>        E..V....... Enable P-pyramid: 0-default 1-simple 2-pyramid(bf need to be set to 0). (from 0 to 2) (default 0)
+  -b_strategy        <int>        E..V....... Strategy to choose between I/P/B-frames (from -1 to 1) (default -1)
+  -dblk_idc          <int>        E..V....... This option disable deblocking. It has value in range 0~2. (from 0 to 2) (default 0)
+  -low_delay_brc     <boolean>    E..V....... Allow to strictly obey avg frame size (default auto)
+  -max_qp_i          <int>        E..V....... Maximum video quantizer scale for I frame (from -1 to 51) (default -1)
+  -min_qp_i          <int>        E..V....... Minimum video quantizer scale for I frame (from -1 to 51) (default -1)
+  -max_qp_p          <int>        E..V....... Maximum video quantizer scale for P frame (from -1 to 51) (default -1)
+  -min_qp_p          <int>        E..V....... Minimum video quantizer scale for P frame (from -1 to 51) (default -1)
+  -max_qp_b          <int>        E..V....... Maximum video quantizer scale for B frame (from -1 to 51) (default -1)
+  -min_qp_b          <int>        E..V....... Minimum video quantizer scale for B frame (from -1 to 51) (default -1)
+  -idr_interval      <int>        E..V....... Distance (in I-frames) between IDR frames (from -1 to INT_MAX) (default 0)
+     begin_only      -1           E..V....... Output an IDR-frame only at the beginning of the stream
+  -load_plugin       <int>        E..V....... A user plugin to load in an internal session (from 0 to 2) (default hevc_hw)
+     none            0            E..V.......
+     hevc_sw         1            E..V.......
+     hevc_hw         2            E..V.......
+  -load_plugins      <string>     E..V....... A :-separate list of hexadecimal plugin UIDs to load in an internal session (default "")
+  -look_ahead_depth  <int>        E..V....... Depth of look ahead in number frames, available when extbrc option is enabled (from 0 to 100) (default 0)
+  -profile           <int>        E..V....... (from 0 to INT_MAX) (default unknown)
+     unknown         0            E..V.......
+     main            1            E..V.......
+     main10          2            E..V.......
+     mainsp          3            E..V.......
+     rext            4            E..V.......
+     scc             9            E..V.......
+  -gpb               <boolean>    E..V....... 1: GPB (generalized P/B frame); 0: regular P frame (default true)
+  -tile_cols         <int>        E..V....... Number of columns for tiled encoding (from 0 to 65535) (default 0)
+  -tile_rows         <int>        E..V....... Number of rows for tiled encoding (from 0 to 65535) (default 0)
+  -recovery_point_sei <int>        E..V....... Insert recovery point SEI messages (from -1 to 1) (default -1)
+  -aud               <boolean>    E..V....... Insert the Access Unit Delimiter NAL (default false)
+  -pic_timing_sei    <boolean>    E..V....... Insert picture timing SEI with pic_struct_syntax element (default true)
+  -transform_skip    <int>        E..V....... Turn this option ON to enable transformskip (from -1 to 1) (default -1)
+  -int_ref_type      <int>        E..V....... Intra refresh type. B frames should be set to 0 (from -1 to 65535) (default -1)
+     none            0            E..V.......
+     vertical        1            E..V.......
+     horizontal      2            E..V.......
+  -int_ref_cycle_size <int>        E..V....... Number of frames in the intra refresh cycle (from -1 to 65535) (default -1)
+  -int_ref_qp_delta  <int>        E..V....... QP difference for the refresh MBs (from -32768 to 32767) (default -32768)
+  -int_ref_cycle_dist <int>        E..V....... Distance between the beginnings of the intra-refresh cycles in frames (from -1 to 32767) (default -1)
+*/
+
+/*
+The ratecontrol method is selected as follows:
+
+    When global_quality is specified, a quality-based mode is used. Specifically this means either
+        - CQP - constant quantizer scale, when the qscale codec flag is also set (the -qscale ffmpeg option).
+        - LA_ICQ - intelligent constant quality with lookahead, when the look_ahead option is also set.
+        - ICQ – intelligent constant quality otherwise. For the ICQ modes, global quality range is 1 to 51, with 1 being the best quality. 
+    Otherwise when the desired average bitrate is specified with the b option, a bitrate-based mode is used.
+        - LA - VBR with lookahead, when the look_ahead option is specified.
+        - VCM - video conferencing mode, when the vcm option is set.
+        - CBR - constant bitrate, when maxrate is specified and equal to the average bitrate.
+        - VBR - variable bitrate, when maxrate is specified, but is higher than the average bitrate.
+        - AVBR - average VBR mode, when maxrate is not specified, both avbr_accuracy and avbr_convergence are set to non-zero. This mode is available for H264 and HEVC on Windows. 
+    Otherwise the default ratecontrol method CQP is used. 
+
+Note that depending on your system, a different mode than the one you specified may be selected by the encoder. Set the verbosity level to verbose or higher to see the actual settings used by the QSV runtime. 
+*/
+    if ((ret = setup_bitrate_qp_opts(self, opts, int_bitrate, int_buffer_size, int_max_bitrate))) {
+        return ret;
+    }
+    if ((ret = setup_baseline_opts(self, opts, HEVC))) {
+        return ret;
+    }
+    if (self->tier >= 0) {
+        AV_DICT_SET_INT(LST_QSV, opts, "tier", self->tier, AV_DICT_DONT_OVERWRITE);
+    }
+    // force keyframe at t=0, t=1s and t=2s (used for flashing the encoder)
+    AV_DICT_SET(LST_QSV, opts, "force_key_frames", "expr:eq(t,0)+eq(t,1)+eq(t,2)", AV_DICT_DONT_OVERWRITE);
+    return 0;
+}
+
+
+static const codec_profile_class_t codec_profile_qsv_hevc_class = {
+    {
+        .ic_super      = (idclass_t *)&codec_profile_qsv_class,
+        .ic_class      = "codec_profile_qsv_hevc",
+        .ic_caption    = N_("qsv_hevc"),
+        .ic_properties = (const property_t[]){
+            {
+                .type     = PT_INT,
+                .id       = "tier",     // Don't change
+                .name     = N_("Tier"),
+                .desc     = N_("Set tier (general_tier_flag) (from 0 to 1) (default main)"),
+                .group    = 5,
+                .opts     = PO_EXPERT,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_qsv_t, tier),
+                .list     = hevc_tier_get_list,
+                .def.i    = 0,
+            },
+            {}
+        }
+    },
+    .open = (codec_profile_open_meth)tvh_codec_profile_qsv_hevc_open,
+};
+
+
+TVHVideoCodec tvh_codec_qsv_hevc = {
+    .name     = "hevc_qsv",
+    .size     = sizeof(tvh_codec_profile_qsv_t),
+    .idclass  = &codec_profile_qsv_hevc_class,
+    .profiles = qsv_hevc_profiles,
+    .profile_init = tvh_codec_profile_video_init,
+    .profile_destroy = tvh_codec_profile_video_destroy,
+};
+
+
+/*
+ffmpeg -hide_banner -h encoder=vp9_qsv
+Encoder vp9_qsv [VP9 video (Intel Quick Sync Video acceleration)]:
+    General capabilities: delay hybrid
+    Threading capabilities: none
+    Supported hardware devices: qsv qsv qsv
+    Supported pixel formats: nv12 p010le qsv
+vp9_qsv encoder AVOptions:
+  -async_depth       <int>        E..V....... Maximum processing parallelism (from 1 to INT_MAX) (default 4)
+  -avbr_accuracy     <int>        E..V....... Accuracy of the AVBR ratecontrol (unit of tenth of percent) (from 1 to 65535) (default 1)
+  -avbr_convergence  <int>        E..V....... Convergence of the AVBR ratecontrol (unit of 100 frames) (from 1 to 65535) (default 1)
+  -preset            <int>        E..V....... (from 1 to 7) (default medium)
+     veryfast        7            E..V.......
+     faster          6            E..V.......
+     fast            5            E..V.......
+     medium          4            E..V.......
+     slow            3            E..V.......
+     slower          2            E..V.......
+     veryslow        1            E..V.......
+  -forced_idr        <boolean>    E..V....... Forcing I frames as IDR frames (default false)
+  -low_power         <boolean>    E..V....... enable low power mode(experimental: many limitations by mfx version, BRC modes, etc.) (default auto)
+  -profile           <int>        E..V....... (from 0 to INT_MAX) (default unknown)
+     unknown         0            E..V.......
+     profile0        1            E..V.......
+     profile1        2            E..V.......
+     profile2        3            E..V.......
+     profile3        4            E..V.......
+  -tile_cols         <int>        E..V....... Number of columns for tiled encoding (from 0 to 32) (default 0)
+  -tile_rows         <int>        E..V....... Number of rows for tiled encoding (from 0 to 4) (default 0)
+*/

--- a/src/transcoding/codec/codecs/libs/v4l2-m2m.c
+++ b/src/transcoding/codec/codecs/libs/v4l2-m2m.c
@@ -1,0 +1,151 @@
+/*
+ *  tvheadend - Codec Profiles
+ *
+ *  Copyright (C) 2016 Tvheadend
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "transcoding/codec/internals.h"
+
+#define V4L2_H264_PROFILE_BASELINE			    0
+#define V4L2_H264_PROFILE_MAIN			        1
+#define V4L2_H264_PROFILE_HIGH			        2
+
+/* h264 v4l2m2m ====================================================================== */
+
+typedef struct {
+    TVHVideoCodecProfile;
+    int num_output_buffers;
+    int num_capture_buffers;
+} tvh_codec_profile_v4l2m2m_t;
+
+
+static const AVProfile v4l2m2m_h264_profiles[] = {
+    { V4L2_H264_PROFILE_BASELINE,  "Baseline" },
+    { V4L2_H264_PROFILE_MAIN,      "Main" },
+    { V4L2_H264_PROFILE_HIGH,      "High" },
+    { FF_AV_PROFILE_UNKNOWN },
+};
+
+static int
+tvh_codec_profile_v4l2m2m_open(tvh_codec_profile_v4l2m2m_t *self, AVDictionary **opts)
+{
+    // pix_fmt
+    AV_DICT_SET_PIX_FMT(LST_V4l2M2M, opts, ((TVHVideoCodecProfile *)self)->pix_fmt, AV_PIX_FMT_NV12);
+
+    AV_DICT_SET_FLAGS_GLOBAL_HEADER(LST_V4l2M2M, opts);
+    // bit_rate
+    if (((TVHCodecProfile *)self)->bit_rate) {
+        AV_DICT_SET_BIT_RATE(LST_V4l2M2M, opts, ((TVHCodecProfile *)self)->bit_rate);
+    }
+
+    // max_b_frames
+    // Encoder does not support b-frames yet, setting to 0
+    AV_DICT_SET_INT(LST_V4l2M2M, opts, "bf", 0, 0);
+
+    if (self->num_output_buffers > -1){
+        AV_DICT_SET_INT(LST_V4l2M2M, opts, "num_output_buffers", self->num_output_buffers, 0);
+    }
+
+    if (self->num_capture_buffers > -1){
+        AV_DICT_SET_INT(LST_V4l2M2M, opts, "num_capture_buffers", self->num_capture_buffers, 0);
+    }
+    // force keyframe at t=0 and t=1s (used for flashing the encoder)
+    //AV_DICT_SET(LST_VAAPI, opts, "force_key_frames", "expr:eq(t,0)+eq(t,1)+eq(t,2)", AV_DICT_DONT_OVERWRITE);
+
+//ffmpeg -hide_banner -h encoder=h264_v4l2m2m
+// Encoder h264_v4l2m2m [V4L2 mem2mem H.264 encoder wrapper]:
+//    General capabilities: delay hardware
+//    Threading capabilities: none
+// h264_v4l2m2m_encoder AVOptions:
+//  -num_output_buffers <int>        E..V....... Number of buffers in the output context (from 0 to INT_MAX) (default 0)
+//  -num_capture_buffers <int>        E..V....... Number of buffers in the capture context (from 8 to INT_MAX) (default 8)
+
+    return 0;
+}
+
+
+static const codec_profile_class_t codec_profile_v4l2m2m_class = {
+    {
+        .ic_super   = (idclass_t *)&codec_profile_video_class,
+        .ic_class   = "codec_profile_v4l2m2m",
+        .ic_caption = N_("v4l2m2m_h264"),
+        .ic_properties = (const property_t[]){
+            {
+                .type     = PT_DBL,
+                .id       = "bit_rate",
+                .name     = N_("Bitrate (kb/s) (0=auto)"),
+                .desc     = N_("Constant bitrate (CBR) mode."),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(TVHCodecProfile, bit_rate),
+                .def.d    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "num_output_buffers",
+                .name     = N_("Number of output buffers"),
+                .desc     = N_("Number of buffers in the output context"),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_v4l2m2m_t, num_output_buffers),
+                .intextra = INTEXTRA_RANGE(-1, 64, 1),
+                .def.i    = 4,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "num_capture_buffers",
+                .name     = N_("Number of capture buffers"),
+                .desc     = N_("Number of buffers in the capture context"),
+                .group    = 3,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(tvh_codec_profile_v4l2m2m_t, num_capture_buffers),
+                .intextra = INTEXTRA_RANGE(-1, 64, 1),
+                .def.i    = 8,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "encoder_hwaccel_type",
+                .name     = N_("Encoder hardware acceleration type"),
+                .desc     = N_("Encoder hardware acceleration type"),
+                .group    = 2,
+                .opts     = PO_PHIDDEN,
+                .off      = offsetof(TVHVideoCodecProfile, encoder_hwaccel_type),
+                .def.i    = AV_HWDEVICE_TYPE_DRM,
+            },
+            {}
+        }
+    },
+    .open = (codec_profile_open_meth)tvh_codec_profile_v4l2m2m_open,
+};
+
+
+/* h264_v4l2m2m ================================================================= */
+
+static void
+tvh_codec_profile_v4l2m2m_destroy(TVHCodecProfile *_self)
+{
+    tvh_codec_profile_video_destroy(_self);
+}
+
+TVHVideoCodec tvh_codec_v4l2m2m_h264 = {
+    .name    = "h264_v4l2m2m",
+    .size    = sizeof(tvh_codec_profile_v4l2m2m_t),
+    .idclass = &codec_profile_v4l2m2m_class,
+    .profiles = v4l2m2m_h264_profiles,
+    .profile_init = tvh_codec_profile_video_init,
+    .profile_destroy = tvh_codec_profile_v4l2m2m_destroy,
+};

--- a/src/transcoding/codec/codecs/libs/vaapi.c
+++ b/src/transcoding/codec/codecs/libs/vaapi.c
@@ -19,8 +19,7 @@
 
 
 #include "transcoding/codec/internals.h"
-#include <fcntl.h>
-#include <sys/ioctl.h>
+#include "transcoding/codec/drmdev.h"
 
 #include "idnode.h"
 #include "htsmsg.h"
@@ -92,6 +91,13 @@
     (vainfo_encoder_isavailable(VAINFO_##codec)) + \
     (vainfo_encoder_maxBfreames(VAINFO_##codec) << UI_MAX_B_FRAMES_OFFSET) + \
     (vainfo_encoder_maxQuality(VAINFO_##codec) << UI_MAX_QUALITY_OFFSET)
+
+enum CODEC{
+    H264 = 1,
+    HEVC = 2,
+    VP8 = 3,
+    VP9 = 4
+};
 
 /* hts ==================================================================== */
 
@@ -201,79 +207,6 @@ hevc_level_get_list( void *o, const char *lang )
 
 /* vaapi ==================================================================== */
 
-#if defined(__linux__)
-#include <linux/types.h>
-#include <asm/ioctl.h>
-#else
-#include <sys/ioccom.h>
-#include <sys/types.h>
-typedef size_t   __kernel_size_t;
-#endif
-
-typedef struct drm_version {
-   int version_major;        /**< Major version */
-   int version_minor;        /**< Minor version */
-   int version_patchlevel;   /**< Patch level */
-   __kernel_size_t name_len; /**< Length of name buffer */
-   char *name;               /**< Name of driver */
-   __kernel_size_t date_len; /**< Length of date buffer */
-   char *date;               /**< User-space buffer to hold date */
-   __kernel_size_t desc_len; /**< Length of desc buffer */
-   char *desc;               /**< User-space buffer to hold desc */
-} drm_version_t;
-
-#define DRM_IOCTL_VERSION _IOWR('d', 0x00, struct drm_version)
-
-
-static int
-probe_vaapi_device(const char *device, char *name, size_t namelen)
-{
-    drm_version_t dv;
-    char dname[128];
-    int fd;
-
-    if ((fd = open(device, O_RDWR)) < 0)
-        return -1;
-    memset(&dv, 0, sizeof(dv));
-    memset(dname, 0, sizeof(dname));
-    dv.name = dname;
-    dv.name_len = sizeof(dname)-1;
-    if (ioctl(fd, DRM_IOCTL_VERSION, &dv) < 0) {
-        close(fd);
-        return -1;
-    }
-    snprintf(name, namelen, "%s v%d.%d.%d (%s)",
-             dv.name, dv.version_major, dv.version_minor,
-             dv.version_patchlevel, device);
-    close(fd);
-    return 0;
-}
-
-static htsmsg_t *
-tvh_codec_profile_vaapi_device_list(void *obj, const char *lang)
-{
-    static const char *renderD_fmt = "/dev/dri/renderD%d";
-    static const char *card_fmt = "/dev/dri/card%d";
-    htsmsg_t *result = htsmsg_create_list();
-    char device[PATH_MAX];
-    char name[128];
-    int i, dev_num;
-
-    for (i = 0; i < 32; i++) {
-        dev_num = i + 128;
-        snprintf(device, sizeof(device), renderD_fmt, dev_num);
-        if (probe_vaapi_device(device, name, sizeof(name)) == 0)
-            htsmsg_add_msg(result, NULL, htsmsg_create_key_val(device, name));
-    }
-    for (i = 0; i < 32; i++) {
-        dev_num = i + 128;
-        snprintf(device, sizeof(device), card_fmt, dev_num);
-        if (probe_vaapi_device(device, name, sizeof(name)) == 0)
-            htsmsg_add_msg(result, NULL, htsmsg_create_key_val(device, name));
-    }
-    return result;
-}
-
 #define TVH_CODEC_PROFILE_VAAPI_CODEC_UI(codec_ui, codec_name) \
     static const int tvh_codec_profile_vaapi_##codec_ui##_ui(void) \
     { \
@@ -308,10 +241,245 @@ static int
 tvh_codec_profile_vaapi_open(tvh_codec_profile_vaapi_t *self,
                              AVDictionary **opts)
 {
+    const TVHVideoCodecProfile *vp = (TVHVideoCodecProfile *)self;
+    
     // pix_fmt
-    AV_DICT_SET_PIX_FMT(LST_VAAPI, opts, self->pix_fmt, AV_PIX_FMT_VAAPI);
+    AV_DICT_SET_PIX_FMT(LST_VAAPI, opts, vp->pix_fmt, AV_PIX_FMT_VAAPI);
     return 0;
 }
+
+/**
+ * Derive VAAPI encoder rate-control numbers from the UI profile and output height.
+ *
+ * Reads @c TVHCodecProfile::bit_rate (kb/s) and @c TVHVideoCodecProfile::size.den
+ * (treated here as the active picture height in pixels), together with
+ * @c tvh_codec_profile_vaapi_t::bit_rate_scale_factor, @c max_bit_rate, and
+ * @c buff_factor. All three outputs are integer values in the same “scaled kb/s”
+ * space the rest of this file uses when passing @c b / @c bufsize / @c maxrate into
+ * libav (see the @c *1024 / @c *2048 factors and the info log that divides by 1024).
+ *
+ * Resolution scaling: relative to a 480-line baseline, the effective target bitrate
+ * is multiplied by @c 1 + bit_rate_scale_factor * (height - 480) / 480 so higher
+ * resolutions increase requested rate and buffer size.
+ *
+ * Buffer size additionally scales by @c buff_factor (forced to @c 3 if unset or
+ * non-positive).
+ *
+ * If the computed average bitrate exceeds the computed max bitrate, logs an error
+ * and raises @p max_bitrate to @p bitrate so the pair is always consistent.
+ *
+ * @param self         VAAPI codec profile (also carries base @c TVHCodecProfile /
+ *                     @c TVHVideoCodecProfile fields).
+ * @param bitrate      Out: scaled average / target bitrate.
+ * @param buffer_size  Out: scaled VBV buffer size (@c bufsize).
+ * @param max_bitrate  Out: scaled peak / max rate; may be bumped up to @p *bitrate.
+ */
+static void
+compute_bitrates(tvh_codec_profile_vaapi_t *self, int *bitrate, int *buffer_size, int *max_bitrate){
+    const TVHCodecProfile *p = (TVHCodecProfile *)self;
+    const TVHVideoCodecProfile *vp = (TVHVideoCodecProfile *)self;
+
+    // to avoid issues we have this check:
+    if (self->buff_factor <= 0) {
+        self->buff_factor = 3;
+    }
+    *bitrate = (int)((p->bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(vp->size.den) - 480.0) / 480.0)));
+    *buffer_size = (int)((p->bit_rate) * 2048.0 * self->buff_factor * (1.0 + self->bit_rate_scale_factor * ((double)(vp->size.den) - 480.0) / 480));
+    *max_bitrate = (int)((self->max_bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(vp->size.den) - 480.0) / 480.0)));
+    // force max_bitrate to be >= with bitrate (to avoid crash)
+    if (*bitrate > *max_bitrate) {
+        tvherror_transcode(LST_VAAPI, "Bitrate %d kbps is greater than Max bitrate %d kbps, increase Max bitrate to %d kbps", 
+            *bitrate / 1024, *max_bitrate / 1024, *bitrate / 1024);
+        *max_bitrate = *bitrate;
+    }
+    tvhinfo_transcode(LST_VAAPI, "Bitrate = %d kbps; Buffer size = %d kbps; Max bitrate = %d kbps", 
+        *bitrate / 1024, *buffer_size / 1024, *max_bitrate / 1024);
+}
+
+/**
+ * Append “baseline” libavcodec / VAAPI encoder options for the unconstrained platform
+ * profile into @p opts.
+ *
+ * All entries use @c AV_DICT_DONT_OVERWRITE so existing dictionary keys win.
+ *
+ * Behavior by @p codec:
+ * - @c VP8 / @c VP9 — if @c loop_filter_level / @c loop_filter_sharpness are @c >= 0,
+ *   set @c loop_filter_level and @c loop_filter_sharpness respectively.
+ * - Any codec — if @c async_depth is non-zero, set @c async_depth.
+ * - @c H264 / @c HEVC — if @c level is not the sentinel @c -100, set @c level.
+ * - Any codec — if @c qmin / @c qmax are non-zero, set @c qmin / @c qmax.
+ *
+ * @param self  VAAPI profile carrying the tuning fields above.
+ * @param opts  Target option dictionary for @c avcodec_open2 (or helper that forwards it).
+ * @param codec Which elementary codec is being configured (@c H264, @c HEVC, @c VP8, @c VP9, …).
+ * @return      Always @c 0 (no failure path).
+ */
+static int
+setup_baseline_opts_unconstrained(const tvh_codec_profile_vaapi_t *self, AVDictionary **opts, enum CODEC codec){
+    if (codec == VP8 || codec == VP9) {
+        if (self->loop_filter_level >= 0) {
+            AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_level", self->loop_filter_level, AV_DICT_DONT_OVERWRITE);
+        }
+        if (self->loop_filter_sharpness >= 0) {
+            AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_sharpness", self->loop_filter_sharpness, AV_DICT_DONT_OVERWRITE);
+        }
+    }
+    if (self->async_depth) {
+        AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
+    }
+    // Only send an explicit level when it is a real H264/HEVC level value.
+    // Valid levels are > 0 (h264: 10..62, hevc: 30..186); the "skip" sentinel is
+    // -100 and an unset level field defaults to 0. Both mean "let the encoder pick
+    // the level from resolution/bitrate". Sending level=0 makes the VAAPI driver
+    // fail every frame with VA_STATUS_ERROR_ENCODING_ERROR (24).
+    if ((codec == H264 || codec == HEVC) &&
+        self->level > 0) {
+            AV_DICT_SET_INT(LST_VAAPI, opts, "level", self->level, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->qmin) {
+        AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->qmax) {
+        AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
+    }
+    return 0;
+}
+
+/**
+ * Push rate-control and fixed-QP libavcodec options into @p opts for the unconstrained
+ * VAAPI platform path.
+ *
+ * Uses @c AV_DICT_DONT_OVERWRITE on every key so callers can pre-seed the dictionary.
+ *
+ * - If the base profile has a non-zero @c bit_rate (@c TVHCodecProfile), sets
+ *   @c b to @p bitrate and @c bufsize to @p buffer_size (typically produced by
+ *   @ref compute_bitrates).
+ * - If @c max_bit_rate on the VAAPI profile is non-zero, sets @c maxrate to @p max_bitrate.
+ * - If @c qp on the VAAPI profile is non-zero, sets @c qp.
+ *
+ * @param self         VAAPI codec profile (and embedded @c TVHCodecProfile).
+ * @param opts         Encoder option dictionary.
+ * @param bitrate      Target average bitrate for @c b (same units as @ref compute_bitrates).
+ * @param buffer_size  VBV buffer size for @c bufsize.
+ * @param max_bitrate  Peak bitrate for @c maxrate.
+ * @return             Always @c 0 (no failure path in this helper).
+ */
+static int
+setup_bitrate_qp_opts_unconstrained(const tvh_codec_profile_vaapi_t *self, AVDictionary **opts, int bitrate, int buffer_size, int max_bitrate){
+    const TVHCodecProfile *p = (TVHCodecProfile *)self;
+
+    if (p->bit_rate) {
+        AV_DICT_SET_INT(LST_VAAPI, opts, "b", bitrate, AV_DICT_DONT_OVERWRITE);
+        AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", buffer_size, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->max_bit_rate) {
+        AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", max_bitrate, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->qp) {
+        AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+    }
+    return 0;
+}
+
+/**
+ * Layered helper for the unconstrained VAAPI platform: applies bitrate / QP options,
+ * then a few codec-specific toggles, then baseline tuning.
+ *
+ * Steps:
+ * 1. @ref setup_bitrate_qp_opts_unconstrained — forwards @p bitrate, @p buffer_size,
+ *    and @p max_bitrate into @c b / @c bufsize / @c maxrate (and optional @c qp).
+ * 2. @c HEVC only — if @c tier >= 0, sets @c tier.
+ * 3. If @c quality >= 0, sets @c quality.
+ * 4. @c VP8 / @c VP9 only — if @c global_quality >= 0, sets @c global_quality.
+ * 5. If @c low_power is non-zero, sets @c low_power.
+ * 6. @ref setup_baseline_opts_unconstrained — invoked with the outer @p codec, so
+ *    the baseline fields (e.g. @c level / @c qmin) follow each codec's own rules.
+ *
+ * @param self         VAAPI profile.
+ * @param opts         Encoder option dictionary.
+ * @param codec        Elementary codec being opened (@c HEVC, @c VP8, @c VP9, …).
+ * @param bitrate      Passed through to @ref setup_bitrate_qp_opts_unconstrained.
+ * @param buffer_size  Passed through to @ref setup_bitrate_qp_opts_unconstrained.
+ * @param max_bitrate  Passed through to @ref setup_bitrate_qp_opts_unconstrained.
+ * @return             @c 0 on success; otherwise the first non-zero return from a callee
+ *                     (today only the baseline helper can propagate, and it always returns 0).
+ */
+static int
+setup_common_opts_unconstrained(const tvh_codec_profile_vaapi_t *self, AVDictionary **opts, enum CODEC codec, int bitrate, int buffer_size, int max_bitrate){
+    int ret = 0;
+
+    if ((ret = setup_bitrate_qp_opts_unconstrained(self, opts, bitrate, buffer_size, max_bitrate))) {
+        return ret;
+    }
+
+    if ((codec == HEVC) &&
+        self->tier >= 0) {
+            AV_DICT_SET_INT(LST_VAAPI, opts, "tier", self->tier, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->quality >= 0) {
+        AV_DICT_SET_INT(LST_VAAPI, opts, "quality", self->quality, AV_DICT_DONT_OVERWRITE);
+    }
+    if ((codec == VP8 || codec == VP9) &&
+        self->global_quality >= 0) {
+            AV_DICT_SET_INT(LST_VAAPI, opts, "global_quality", self->global_quality, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->low_power) {
+        AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
+    }
+    if ((ret = setup_baseline_opts_unconstrained(self, opts, codec))) {
+        return ret;
+    }
+    return 0;
+}
+
+/**
+ * Populate @p opts for @c VAAPI_ENC_PLATFORM_UNCONSTRAINED: “anything goes” mode for
+ * new platforms or debugging (invalid combinations are not filtered here).
+ *
+ * Does the following in order:
+ * - If @c b_reference is non-zero, set @c b_depth.
+ * - If @c desired_b_depth >= 0, set @c bf (max B-frames).
+ * - For @c VP9, if @c super_frame is enabled, set @c bsf to
+ *   @c "vp9_raw_reorder,vp9_superframe" (per FFmpeg VAAPI VP9 notes).
+ * - Calls @ref setup_common_opts_unconstrained with the outer @p codec, so the
+ *   common / baseline branches follow each codec's own rules.
+ *
+ * @param self         VAAPI profile.
+ * @param opts         Encoder option dictionary.
+ * @param codec        Which codec is being set up (@c H264, @c HEVC, @c VP8, @c VP9, …).
+ * @param bitrate      Passed through to @ref setup_common_opts_unconstrained.
+ * @param buffer_size  Passed through to @ref setup_common_opts_unconstrained.
+ * @param max_bitrate  Passed through to @ref setup_common_opts_unconstrained.
+ * @return             @c 0 on success, or the first non-zero return from the common
+ *                     helper (currently always @c 0 from downstream helpers).
+ */
+static int
+setup_opts_unconstrained(const tvh_codec_profile_vaapi_t *self, AVDictionary **opts, enum CODEC codec, int bitrate, int buffer_size, int max_bitrate){
+    int ret = 0;
+
+    // Uncontrained --> will allow any combination of parameters (valid or invalid)
+    // this mode is useful for future platform and for debugging.
+    if (self->b_reference) {
+        // b_depth
+        AV_DICT_SET_INT(LST_VAAPI, opts, "b_depth", self->b_reference, AV_DICT_DONT_OVERWRITE);
+    }
+    if (self->desired_b_depth >= 0) {
+        // max_b_frames
+        AV_DICT_SET_INT(LST_VAAPI, opts, "bf", self->desired_b_depth, AV_DICT_DONT_OVERWRITE);
+    }
+    if (codec == VP9 &&
+        self->super_frame) {
+            // according to example from https://trac.ffmpeg.org/wiki/Hardware/VAAPI
+            // -bsf:v vp9_raw_reorder,vp9_superframe
+            AV_DICT_SET(LST_VAAPI, opts, "bsf", "vp9_raw_reorder,vp9_superframe", AV_DICT_DONT_OVERWRITE);
+    }
+    if ((ret = setup_common_opts_unconstrained(self, opts, codec, bitrate, buffer_size, max_bitrate))) {
+        return ret;
+    }
+    return 0;
+}
+
+/* external ==================================================================== */
 
 // NOTE:
 // the names below are used in codec.js (/src/webui/static/app/codec.js)
@@ -339,7 +507,7 @@ static const codec_profile_class_t codec_profile_vaapi_class = {
                 .desc     = N_("Device name (e.g. /dev/dri/renderD128)."),
                 .group    = 3,
                 .off      = offsetof(TVHCodecProfile, device),
-                .list     = tvh_codec_profile_vaapi_device_list,
+                .list     = tvh_drm_device_list,
             },
             {
                 .type     = PT_BOOL,
@@ -515,6 +683,16 @@ static const codec_profile_class_t codec_profile_vaapi_class = {
                 .intextra = INTEXTRA_RANGE(-1, 15, 1),
                 .def.i    = 0,
             },
+            {
+                .type     = PT_INT,
+                .id       = "encoder_hwaccel_type",
+                .name     = N_("Encoder hardware acceleration type"),
+                .desc     = N_("Encoder hardware acceleration type"),
+                .group    = 2,
+                .opts     = PO_PHIDDEN,
+                .off      = offsetof(TVHVideoCodecProfile, encoder_hwaccel_type),
+                .def.i    = AV_HWDEVICE_TYPE_VAAPI,
+            },
             {}
         }
     },
@@ -535,114 +713,22 @@ static int
 tvh_codec_profile_vaapi_h264_open(tvh_codec_profile_vaapi_t *self,
                                   AVDictionary **opts)
 {
-    // to avoid issues we have this check:
-    if (self->buff_factor <= 0) {
-        self->buff_factor = 3;
-    }
-    int int_bitrate = (int)((double)(self->bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
-    int int_buffer_size = (int)((double)(self->bit_rate) * 2048.0 * self->buff_factor * (1.0 + self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480));
-    int int_max_bitrate = (int)((double)(self->max_bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
-    // force max_bitrate to be >= with bitrate (to avoid crash)
-    if (int_bitrate > int_max_bitrate) {
-        tvherror_transcode(LST_VAAPI, "Bitrate %d kbps is greater than Max bitrate %d kbps, increase Max bitrate to %d kbps", int_bitrate / 1024, int_max_bitrate / 1024, int_bitrate / 1024);
-        int_max_bitrate = int_bitrate;
-    }
-    tvhinfo_transcode(LST_VAAPI, "Bitrate = %d kbps; Buffer size = %d kbps; Max bitrate = %d kbps", int_bitrate / 1024, int_buffer_size / 1024, int_max_bitrate / 1024);
-    // https://wiki.libav.org/Hardware/vaapi
-    // https://blog.wmspanel.com/2017/03/vaapi-libva-support-nimble-streamer.html
-    // to find available parameters use:
-    // ffmpeg -hide_banner -h encoder=h264_vaapi
-    // h264_vaapi AVOptions:
-    // -low_power         <boolean>    E..V....... Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
-    // -idr_interval      <int>        E..V....... Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
-    // -b_depth           <int>        E..V....... Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
-    // -rc_mode           <int>        E..V....... Set rate control mode (from 0 to 6) (default auto)
-    //    auto            0            E..V....... Choose mode automatically based on other parameters
-    //    CQP             1            E..V....... Constant-quality
-    //    CBR             2            E..V....... Constant-bitrate
-    //    VBR             3            E..V....... Variable-bitrate
-    //    ICQ             4            E..V....... Intelligent constant-quality
-    //    QVBR            5            E..V....... Quality-defined variable-bitrate
-    //    AVBR            6            E..V....... Average variable-bitrate
-    // -qp                <int>        E..V....... Constant QP (for P-frames; scaled by qfactor/qoffset for I/B) (from 0 to 52) (default 0)
-    // -quality           <int>        E..V....... Set encode quality (trades off against speed, higher is faster) (from -1 to INT_MAX) (default -1)
-    // -coder             <int>        E..V....... Entropy coder type (from 0 to 1) (default cabac)
-    //    cavlc           0            E..V.......
-    //    cabac           1            E..V.......
-    //    vlc             0            E..V.......
-    //    ac              1            E..V.......
-    // -aud               <boolean>    E..V....... Include AUD (default false)
-    // -sei               <flags>      E..V....... Set SEI to include (default identifier+timing+recovery_point)
-    //    identifier                   E..V....... Include encoder version identifier
-    //    timing                       E..V....... Include timing parameters (buffering_period and pic_timing)
-    //    recovery_point               E..V....... Include recovery points where appropriate
-    // -profile           <int>        E..V....... Set profile (profile_idc and constraint_set*_flag) (from -99 to 65535) (default -99)
-    //    constrained_baseline 578          E..V.......
-    //    main            77           E..V.......
-    //    high            100          E..V.......
-    // -level             <int>        E..V....... Set level (level_idc) (from -99 to 255) (default -99)
-    //    1               10           E..V.......
-    //    1.1             11           E..V.......
-    //    1.2             12           E..V.......
-    //    1.3             13           E..V.......
-    //    2               20           E..V.......
-    //    2.1             21           E..V.......
-    //    2.2             22           E..V.......
-    //    3               30           E..V.......
-    //    3.1             31           E..V.......
-    //    3.2             32           E..V.......
-    //    4               40           E..V.......
-    //    4.1             41           E..V.......
-    //    4.2             42           E..V.......
-    //    5               50           E..V.......
-    //    5.1             51           E..V.......
-    //    5.2             52           E..V.......
-    //    6               60           E..V.......
-    //    6.1             61           E..V.......
-    //    6.2             62           E..V.......
+    TVHCodecProfile *p = (TVHCodecProfile *)self;
+    int int_bitrate = 0;
+    int int_buffer_size = 0;
+    int int_max_bitrate = 0;
+    int ret = 0;
+
+    compute_bitrates(self, &int_bitrate, &int_buffer_size, &int_max_bitrate);
+
     if (self->rc_mode != VAAPI_ENC_PARAMS_RC_SKIP) {
         AV_DICT_SET_INT(LST_VAAPI, opts, "rc_mode", self->rc_mode, AV_DICT_DONT_OVERWRITE);
     }
     int tempSupport = 0;
     switch (self->platform) {
         case VAAPI_ENC_PLATFORM_UNCONSTRAINED:
-            // Uncontrained --> will allow any combination of parameters (valid or invalid)
-            // this mode is useful for future platform and for debugging.
-            if (self->b_reference) {
-                // b_depth
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b_depth", self->b_reference, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->desired_b_depth >= 0) {
-                // max_b_frames
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bf", self->desired_b_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->max_bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qp) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "quality", self->quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->low_power) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->level != -100) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "level", self->level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_opts_unconstrained(self, opts, H264, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                return ret;
             }
             break;
         case VAAPI_ENC_PLATFORM_INTEL:
@@ -673,15 +759,8 @@ tvh_codec_profile_vaapi_h264_open(tvh_codec_profile_vaapi_t *self,
                     // same like 0 but is not sending 'rc_mode'
                 case VAAPI_ENC_PARAMS_RC_AUTO:
                     // for auto --> let the driver decide as requested by documentation
-                    if (self->bit_rate) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-                    }
-                    if (self->max_bit_rate) {
-                            AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-                        }
-                    if (self->qp) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+                    if ((ret = setup_bitrate_qp_opts_unconstrained(self, opts, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                        return ret;
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_CONSTQP:
@@ -693,14 +772,14 @@ tvh_codec_profile_vaapi_h264_open(tvh_codec_profile_vaapi_t *self,
                     break;
                 case VAAPI_ENC_PARAMS_RC_CBR:
                     // for constant bitrate: CBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_VBR:
                     // for variable bitrate: VBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
@@ -708,18 +787,13 @@ tvh_codec_profile_vaapi_h264_open(tvh_codec_profile_vaapi_t *self,
                     break;
                 case VAAPI_ENC_PARAMS_RC_QVBR:
                     // for variable bitrate: QVBR we use bitrate + qp
-                    if (self->bit_rate && self->buff_factor) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-                    }
-                    if (self->qp) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+                    if ((ret = setup_bitrate_qp_opts_unconstrained(self, opts, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                        return ret;
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_AVBR:
                     // for variable bitrate: AVBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
                     }
@@ -737,54 +811,22 @@ tvh_codec_profile_vaapi_h264_open(tvh_codec_profile_vaapi_t *self,
             if (self->low_power) {
                 AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
             }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->level != -100) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "level", self->level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_baseline_opts_unconstrained(self, opts, H264))) {
+                return ret;
             }
             break;
         case VAAPI_ENC_PLATFORM_AMD:
             // AMD --> will allow any combination of parameters
             // I am unable to confirm this platform because I don't have the HW
             // Is only going to override bf to 0 (as highlited by the previous implementation)
-            if (self->bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->max_bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qp) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_common_opts_unconstrained(self, opts, H264, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                return ret;
             }
             AV_DICT_SET_INT(LST_VAAPI, opts, "bf", 0, 0);
-            if (self->quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "quality", self->quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->low_power) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->level != -100) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "level", self->level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
-            }
             break;
     }
+    // force keyframe at t=0 and t=1s (used for flashing the encoder)
+    AV_DICT_SET(LST_VAAPI, opts, "force_key_frames", "expr:eq(t,0)+eq(t,1)", AV_DICT_DONT_OVERWRITE);
     return 0;
 }
 
@@ -858,106 +900,21 @@ static int
 tvh_codec_profile_vaapi_hevc_open(tvh_codec_profile_vaapi_t *self,
                                   AVDictionary **opts)
 {
-    // to avoid issues we have this check:
-    if (self->buff_factor <= 0) {
-        self->buff_factor = 3;
-    }
-    int int_bitrate = (int)((double)(self->bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
-    int int_buffer_size = (int)((double)(self->bit_rate) * 2048.0 * self->buff_factor * (1.0 + self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480));
-    int int_max_bitrate = (int)((double)(self->max_bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
-    // force max_bitrate to be >= with bitrate (to avoid crash)
-    if (int_bitrate > int_max_bitrate) {
-        tvherror_transcode(LST_VAAPI, "Bitrate %d kbps is greater than Max bitrate %d kbps, increase Max bitrate to %d kbps", int_bitrate / 1024, int_max_bitrate / 1024, int_bitrate / 1024);
-        int_max_bitrate = int_bitrate;
-    }
-    tvhinfo_transcode(LST_VAAPI, "Bitrate = %d kbps; Buffer size = %d kbps; Max bitrate = %d kbps", int_bitrate / 1024, int_buffer_size / 1024, int_max_bitrate / 1024);
-    // https://wiki.libav.org/Hardware/vaapi
-    // to find available parameters use:
-    // ffmpeg -hide_banner -h encoder=hevc_vaapi
-    //   h265_vaapi AVOptions:
-    // -low_power         <boolean>    E..V....... Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
-    // -idr_interval      <int>        E..V....... Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
-    // -b_depth           <int>        E..V....... Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
-    // -rc_mode           <int>        E..V....... Set rate control mode (from 0 to 6) (default auto)
-    //    auto            0            E..V....... Choose mode automatically based on other parameters
-    //    CQP             1            E..V....... Constant-quality
-    //    CBR             2            E..V....... Constant-bitrate
-    //    VBR             3            E..V....... Variable-bitrate
-    //    ICQ             4            E..V....... Intelligent constant-quality
-    //    QVBR            5            E..V....... Quality-defined variable-bitrate
-    //    AVBR            6            E..V....... Average variable-bitrate
-    // -qp                <int>        E..V....... Constant QP (for P-frames; scaled by qfactor/qoffset for I/B) (from 0 to 52) (default 0)
-    // -aud               <boolean>    E..V....... Include AUD (default false)
-    // -profile           <int>        E..V....... Set profile (general_profile_idc) (from -99 to 255) (default -99)
-    //    main            1            E..V.......
-    //    main10          2            E..V.......
-    //    rext            4            E..V.......
-    // -tier              <int>        E..V....... Set tier (general_tier_flag) (from 0 to 1) (default main)
-    //    main            0            E..V.......
-    //    high            1            E..V.......
-    // -level             <int>        E..V....... Set level (general_level_idc) (from -99 to 255) (default -99)
-    //    1               30           E..V.......
-    //    2               60           E..V.......
-    //    2.1             63           E..V.......
-    //    3               90           E..V.......
-    //    3.1             93           E..V.......
-    //    4               120          E..V.......
-    //    4.1             123          E..V.......
-    //    5               150          E..V.......
-    //    5.1             153          E..V.......
-    //    5.2             156          E..V.......
-    //    6               180          E..V.......
-    //    6.1             183          E..V.......
-    //    6.2             186          E..V.......
-    // -sei               <flags>      E..V....... Set SEI to include (default hdr)
-    //    hdr                          E..V....... Include HDR metadata for mastering display colour volume and content light level information
-    // -tiles             <image_size> E..V....... Tile columns x rows
+    TVHCodecProfile *p = (TVHCodecProfile *)self;
+    int int_bitrate = 0;
+    int int_buffer_size = 0;
+    int int_max_bitrate = 0;
+    int ret = 0;
+
+    compute_bitrates(self, &int_bitrate, &int_buffer_size, &int_max_bitrate);
 
     if (self->rc_mode != VAAPI_ENC_PARAMS_RC_SKIP) {
         AV_DICT_SET_INT(LST_VAAPI, opts, "rc_mode", self->rc_mode, AV_DICT_DONT_OVERWRITE);
     }
     switch (self->platform) {
         case VAAPI_ENC_PLATFORM_UNCONSTRAINED:
-            // Unconstrained --> will allow any combination of parameters (valid or invalid)
-            // this mode is useful for future platform and for debugging.
-            if (self->b_reference) {
-                // b_depth
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b_depth", self->b_reference, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->desired_b_depth >= 0) {
-                // max_b_frames
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bf", self->desired_b_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->max_bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qp) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->tier >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "tier", self->tier, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "quality", self->quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->low_power) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->level != -100) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "level", self->level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_opts_unconstrained(self, opts, HEVC, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                return ret;
             }
             break;
         case VAAPI_ENC_PLATFORM_INTEL:
@@ -975,15 +932,8 @@ tvh_codec_profile_vaapi_hevc_open(tvh_codec_profile_vaapi_t *self,
                     // same like 0 but is not sending 'rc_mode'
                 case VAAPI_ENC_PARAMS_RC_AUTO:
                     // for auto --> let the driver decide as requested by documentation
-                    if (self->bit_rate) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-                    }
-                    if (self->max_bit_rate) {
-                            AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-                        }
-                    if (self->qp) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+                    if ((ret = setup_bitrate_qp_opts_unconstrained(self, opts, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                        return ret;
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_CONSTQP:
@@ -995,14 +945,14 @@ tvh_codec_profile_vaapi_hevc_open(tvh_codec_profile_vaapi_t *self,
                     break;
                 case VAAPI_ENC_PARAMS_RC_CBR:
                     // for constant bitrate: CBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_VBR:
                     // for variable bitrate: VBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
@@ -1010,18 +960,13 @@ tvh_codec_profile_vaapi_hevc_open(tvh_codec_profile_vaapi_t *self,
                     break;
                 case VAAPI_ENC_PARAMS_RC_QVBR:
                     // for variable bitrate: QVBR we use bitrate + qp
-                    if (self->bit_rate && self->buff_factor) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-                    }
-                    if (self->qp) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+                    if ((ret = setup_bitrate_qp_opts_unconstrained(self, opts, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                        return ret;
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_AVBR:
                     // for variable bitrate: AVBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
                     }
@@ -1036,57 +981,22 @@ tvh_codec_profile_vaapi_hevc_open(tvh_codec_profile_vaapi_t *self,
             if (self->low_power) {
                 AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
             }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->level != -100) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "level", self->level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_baseline_opts_unconstrained(self, opts, HEVC))) {
+                return ret;
             }
             break;
         case VAAPI_ENC_PLATFORM_AMD:
             // AMD --> will allow any combination of parameters
             // I am unable to confirm this platform because I don't have the HW
             // Is only going to override bf to 0 (as highlited by the previous implementation)
-            if (self->bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->max_bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qp) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_common_opts_unconstrained(self, opts, HEVC, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                return ret;
             }
             AV_DICT_SET_INT(LST_VAAPI, opts, "bf", 0, 0);
-            if (self->tier >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "tier", self->tier, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "quality", self->quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->low_power) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->level != -100) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "level", self->level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
-            }
             break;
     }
+    // force keyframe at t=0 and t=1s (used for flashing the encoder)
+    AV_DICT_SET(LST_VAAPI, opts, "force_key_frames", "expr:eq(t,0)+eq(t,1)", AV_DICT_DONT_OVERWRITE);
     return 0;
 }
 
@@ -1168,85 +1078,21 @@ static int
 tvh_codec_profile_vaapi_vp8_open(tvh_codec_profile_vaapi_t *self,
                                   AVDictionary **opts)
 {
-    // to avoid issues we have this check:
-    if (self->buff_factor <= 0) {
-        self->buff_factor = 3;
-    }
-    int int_bitrate = (int)((double)(self->bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
-    int int_buffer_size = (int)((double)(self->bit_rate) * 2048.0 * self->buff_factor * (1.0 + self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480));
-    int int_max_bitrate = (int)((double)(self->max_bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
-    // force max_bitrate to be >= with bitrate (to avoid crash)
-    if (int_bitrate > int_max_bitrate) {
-        tvherror_transcode(LST_VAAPI, "Bitrate %d kbps is greater than Max bitrate %d kbps, increase Max bitrate to %d kbps", int_bitrate / 1024, int_max_bitrate / 1024, int_bitrate / 1024);
-        int_max_bitrate = int_bitrate;
-    }
-    tvhinfo_transcode(LST_VAAPI, "Bitrate = %d kbps; Buffer size = %d kbps; Max bitrate = %d kbps", int_bitrate / 1024, int_buffer_size / 1024, int_max_bitrate / 1024);
-    // https://wiki.libav.org/Hardware/vaapi
-    // to find available parameters use:
-    // ffmpeg -hide_banner -h encoder=vp8_vaapi
-    //   vp8_vaapi AVOptions:
-    // -low_power         <boolean>    E..V....... Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
-    // -idr_interval      <int>        E..V....... Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
-    // -b_depth           <int>        E..V....... Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
-    // -rc_mode           <int>        E..V....... Set rate control mode (from 0 to 6) (default auto)
-    //    auto            0            E..V....... Choose mode automatically based on other parameters
-    //    CQP             1            E..V....... Constant-quality
-    //    CBR             2            E..V....... Constant-bitrate
-    //    VBR             3            E..V....... Variable-bitrate
-    //    ICQ             4            E..V....... Intelligent constant-quality
-    //    QVBR            5            E..V....... Quality-defined variable-bitrate
-    //    AVBR            6            E..V....... Average variable-bitrate
-    // -loop_filter_level <int>        E..V....... Loop filter level (from 0 to 63) (default 16)
-    // -loop_filter_sharpness <int>        E..V....... Loop filter sharpness (from 0 to 15) (default 4)
+    TVHCodecProfile *p = (TVHCodecProfile *)self;
+    int int_bitrate = 0;
+    int int_buffer_size = 0;
+    int int_max_bitrate = 0;
+    int ret = 0;
+
+    compute_bitrates(self, &int_bitrate, &int_buffer_size, &int_max_bitrate);
 
     if (self->rc_mode != VAAPI_ENC_PARAMS_RC_SKIP) {
         AV_DICT_SET_INT(LST_VAAPI, opts, "rc_mode", self->rc_mode, AV_DICT_DONT_OVERWRITE);
     }
     switch (self->platform) {
         case VAAPI_ENC_PLATFORM_UNCONSTRAINED:
-            // Unconstrained --> will allow any combination of parameters (valid or invalid)
-            // this mode is useful for future platform and for debugging.
-            if (self->b_reference) {
-                // b_depth
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b_depth", self->b_reference, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->desired_b_depth >= 0) {
-                // max_b_frames
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bf", self->desired_b_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->max_bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qp) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "quality", self->quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->global_quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "global_quality", self->global_quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->low_power) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_level >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_level", self->loop_filter_level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_sharpness >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_sharpness", self->loop_filter_sharpness, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_opts_unconstrained(self, opts, VP8, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                return ret;
             }
             break;
         case VAAPI_ENC_PLATFORM_INTEL:
@@ -1270,15 +1116,8 @@ tvh_codec_profile_vaapi_vp8_open(tvh_codec_profile_vaapi_t *self,
                     // same like 0 but is not sending 'rc_mode'
                 case VAAPI_ENC_PARAMS_RC_AUTO:
                     // for auto --> let the driver decide as requested by documentation
-                    if (self->bit_rate) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-                    }
-                    if (self->max_bit_rate) {
-                            AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-                        }
-                    if (self->qp) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+                    if ((ret = setup_bitrate_qp_opts_unconstrained(self, opts, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                        return ret;
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_CONSTQP:
@@ -1290,14 +1129,14 @@ tvh_codec_profile_vaapi_vp8_open(tvh_codec_profile_vaapi_t *self,
                     break;
                 case VAAPI_ENC_PARAMS_RC_CBR:
                     // for constant bitrate: CBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_VBR:
                     // for variable bitrate: VBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
@@ -1305,18 +1144,13 @@ tvh_codec_profile_vaapi_vp8_open(tvh_codec_profile_vaapi_t *self,
                     break;
                 case VAAPI_ENC_PARAMS_RC_QVBR:
                     // for variable bitrate: QVBR we use bitrate + qp
-                    if (self->bit_rate && self->buff_factor) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-                    }
-                    if (self->qp) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+                    if ((ret = setup_bitrate_qp_opts_unconstrained(self, opts, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                        return ret;
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_AVBR:
                     // for variable bitrate: AVBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
                     }
@@ -1325,63 +1159,23 @@ tvh_codec_profile_vaapi_vp8_open(tvh_codec_profile_vaapi_t *self,
             if (self->low_power) {
                 AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
             }
-            if (self->loop_filter_level >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_level", self->loop_filter_level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_sharpness >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_sharpness", self->loop_filter_sharpness, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_baseline_opts_unconstrained(self, opts, VP8))) {
+                return ret;
             }
             break;
         case VAAPI_ENC_PLATFORM_AMD:
             // AMD --> will allow any combination of parameters
             // I am unable to confirm this platform because I don't have the HW
             // Is only going to override bf to 0 (as highlited by the previous implementation)
-            if (self->bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->max_bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qp) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_common_opts_unconstrained(self, opts, VP8, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                return ret;
             }
             AV_DICT_SET_INT(LST_VAAPI, opts, "bf", 0, 0);
-            if (self->quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "quality", self->quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->global_quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "global_quality", self->global_quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->low_power) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_level >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_level", self->loop_filter_level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_sharpness >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_sharpness", self->loop_filter_sharpness, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
-            }
+
             break;
     }
+    // force keyframe at t=0 and t=1s (used for flashing the encoder)
+    AV_DICT_SET(LST_VAAPI, opts, "force_key_frames", "expr:eq(t,0)+eq(t,1)", AV_DICT_DONT_OVERWRITE);
     return 0;
 }
 
@@ -1474,90 +1268,21 @@ static int
 tvh_codec_profile_vaapi_vp9_open(tvh_codec_profile_vaapi_t *self,
                                   AVDictionary **opts)
 {
-    // to avoid issues we have this check:
-    if (self->buff_factor <= 0) {
-        self->buff_factor = 3;
-    }
-    int int_bitrate = (int)((double)(self->bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
-    int int_buffer_size = (int)((double)(self->bit_rate) * 2048.0 * self->buff_factor * (1.0 + self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480));
-    int int_max_bitrate = (int)((double)(self->max_bit_rate) * 1024.0 * (1.0 + (self->bit_rate_scale_factor * ((double)(self->size.den) - 480.0) / 480.0)));
-    // force max_bitrate to be >= with bitrate (to avoid crash)
-    if (int_bitrate > int_max_bitrate) {
-        tvherror_transcode(LST_VAAPI, "Bitrate %d kbps is greater than Max bitrate %d kbps, increase Max bitrate to %d kbps", int_bitrate / 1024, int_max_bitrate / 1024, int_bitrate / 1024);
-        int_max_bitrate = int_bitrate;
-    }
-    tvhinfo_transcode(LST_VAAPI, "Bitrate = %d kbps; Buffer size = %d kbps; Max bitrate = %d kbps", int_bitrate / 1024, int_buffer_size / 1024, int_max_bitrate / 1024);
-    // https://wiki.libav.org/Hardware/vaapi
-    // to find available parameters use:
-    // ffmpeg -hide_banner -h encoder=vp9_vaapi
-    //   vp9_vaapi AVOptions:
-    // -low_power         <boolean>    E..V....... Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
-    // -idr_interval      <int>        E..V....... Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
-    // -b_depth           <int>        E..V....... Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
-    // -rc_mode           <int>        E..V....... Set rate control mode (from 0 to 6) (default auto)
-    //    auto            0            E..V....... Choose mode automatically based on other parameters
-    //    CQP             1            E..V....... Constant-quality
-    //    CBR             2            E..V....... Constant-bitrate
-    //    VBR             3            E..V....... Variable-bitrate
-    //    ICQ             4            E..V....... Intelligent constant-quality
-    //    QVBR            5            E..V....... Quality-defined variable-bitrate
-    //    AVBR            6            E..V....... Average variable-bitrate
-    // -loop_filter_level <int>        E..V....... Loop filter level (from 0 to 63) (default 16)
-    // -loop_filter_sharpness <int>        E..V....... Loop filter sharpness (from 0 to 15) (default 4)
+    TVHCodecProfile *p = (TVHCodecProfile *)self;
+    int int_bitrate = 0;
+    int int_buffer_size = 0;
+    int int_max_bitrate = 0;
+    int ret = 0;
+
+    compute_bitrates(self, &int_bitrate, &int_buffer_size, &int_max_bitrate);
 
     if (self->rc_mode != VAAPI_ENC_PARAMS_RC_SKIP) {
         AV_DICT_SET_INT(LST_VAAPI, opts, "rc_mode", self->rc_mode, AV_DICT_DONT_OVERWRITE);
     }
     switch (self->platform) {
         case VAAPI_ENC_PLATFORM_UNCONSTRAINED:
-            // Unconstrained --> will allow any combination of parameters (valid or invalid)
-            // this mode is useful for future platform and for debugging.
-            if (self->b_reference) {
-                // b_depth
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b_depth", self->b_reference, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->desired_b_depth >= 0) {
-                // max_b_frames
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bf", self->desired_b_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->super_frame) {
-                // according to example from https://trac.ffmpeg.org/wiki/Hardware/VAAPI
-                // -bsf:v vp9_raw_reorder,vp9_superframe
-                AV_DICT_SET(LST_VAAPI, opts, "bsf", "vp9_raw_reorder,vp9_superframe", AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->max_bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qp) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "quality", self->quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->global_quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "global_quality", self->global_quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->low_power) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_level >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_level", self->loop_filter_level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_sharpness >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_sharpness", self->loop_filter_sharpness, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_opts_unconstrained(self, opts, VP9, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                return ret;
             }
             break;
         case VAAPI_ENC_PLATFORM_INTEL:
@@ -1586,15 +1311,8 @@ tvh_codec_profile_vaapi_vp9_open(tvh_codec_profile_vaapi_t *self,
                     // same like 0 but is not sending 'rc_mode'
                 case VAAPI_ENC_PARAMS_RC_AUTO:
                     // for auto --> let the driver decide as requested by documentation
-                    if (self->bit_rate) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-                    }
-                    if (self->max_bit_rate) {
-                            AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-                        }
-                    if (self->qp) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+                    if ((ret = setup_bitrate_qp_opts_unconstrained(self, opts, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                        return ret;
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_CONSTQP:
@@ -1606,14 +1324,14 @@ tvh_codec_profile_vaapi_vp9_open(tvh_codec_profile_vaapi_t *self,
                     break;
                 case VAAPI_ENC_PARAMS_RC_CBR:
                     // for constant bitrate: CBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_VBR:
                     // for variable bitrate: VBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
@@ -1621,18 +1339,13 @@ tvh_codec_profile_vaapi_vp9_open(tvh_codec_profile_vaapi_t *self,
                     break;
                 case VAAPI_ENC_PARAMS_RC_QVBR:
                     // for variable bitrate: QVBR we use bitrate + qp
-                    if (self->bit_rate && self->buff_factor) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-                    }
-                    if (self->qp) {
-                        AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+                    if ((ret = setup_bitrate_qp_opts_unconstrained(self, opts, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                        return ret;
                     }
                     break;
                 case VAAPI_ENC_PARAMS_RC_AVBR:
                     // for variable bitrate: AVBR we use bitrate
-                    if (self->bit_rate && self->buff_factor) {
+                    if (p->bit_rate && self->buff_factor) {
                         AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
                         AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
                     }
@@ -1641,63 +1354,22 @@ tvh_codec_profile_vaapi_vp9_open(tvh_codec_profile_vaapi_t *self,
             if (self->low_power) {
                 AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
             }
-            if (self->loop_filter_level >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_level", self->loop_filter_level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_sharpness >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_sharpness", self->loop_filter_sharpness, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_baseline_opts_unconstrained(self, opts, VP9))) {
+                return ret;
             }
             break;
         case VAAPI_ENC_PLATFORM_AMD:
             // AMD --> will allow any combination of parameters
             // I am unable to confirm this platform because I don't have the HW
             // Is only going to override bf to 0 (as highlited by the previous implementation)
-            if (self->bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "b", int_bitrate, AV_DICT_DONT_OVERWRITE);
-                AV_DICT_SET_INT(LST_VAAPI, opts, "bufsize", int_buffer_size, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->max_bit_rate) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "maxrate", int_max_bitrate, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qp) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qp", self->qp, AV_DICT_DONT_OVERWRITE);
+            if ((ret = setup_common_opts_unconstrained(self, opts, VP9, int_bitrate, int_buffer_size, int_max_bitrate))) {
+                return ret;
             }
             AV_DICT_SET_INT(LST_VAAPI, opts, "bf", 0, 0);
-            if (self->quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "quality", self->quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->global_quality >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "global_quality", self->global_quality, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->low_power) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "low_power", self->low_power, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_level >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_level", self->loop_filter_level, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->loop_filter_sharpness >= 0) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "loop_filter_sharpness", self->loop_filter_sharpness, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->async_depth) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "async_depth", self->async_depth, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmin) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmin", self->qmin, AV_DICT_DONT_OVERWRITE);
-            }
-            if (self->qmax) {
-                AV_DICT_SET_INT(LST_VAAPI, opts, "qmax", self->qmax, AV_DICT_DONT_OVERWRITE);
-            }
             break;
     }
+    // force keyframe at t=0 and t=1s (used for flashing the encoder)
+    AV_DICT_SET(LST_VAAPI, opts, "force_key_frames", "expr:eq(t,0)+eq(t,1)", AV_DICT_DONT_OVERWRITE);
     return 0;
 }
 

--- a/src/transcoding/codec/codecs/mp2.c
+++ b/src/transcoding/codec/codecs/mp2.c
@@ -72,6 +72,7 @@ TVHAudioCodec tvh_codec_mp2 = {
     .name    = "mp2",
     .size    = sizeof(TVHAudioCodecProfile),
     .idclass = &codec_profile_mp2_class,
+    .profiles        = NULL,
     .profile_init = tvh_codec_profile_audio_init,
     .profile_destroy = tvh_codec_profile_audio_destroy,
 };

--- a/src/transcoding/codec/codecs/mpeg2video.c
+++ b/src/transcoding/codec/codecs/mpeg2video.c
@@ -33,6 +33,8 @@ tvh_codec_profile_mpeg2video_open(TVHCodecProfile *self, AVDictionary **opts)
     else {
         AV_DICT_SET_GLOBAL_QUALITY(LST_MPEG2VIDEO, opts, self->qscale, 5);
     }
+    // MPEG2 only knows max b frames of 2
+    AV_DICT_SET_INT(LST_VAAPI, opts, "bf", 2, AV_DICT_DONT_OVERWRITE);
     return 0;
 }
 
@@ -63,6 +65,16 @@ static const codec_profile_class_t codec_profile_mpeg2video_class = {
                 .off      = offsetof(TVHCodecProfile, qscale),
                 .intextra = INTEXTRA_RANGE(0, 31, 1),
                 .def.d    = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "encoder_hwaccel_type",
+                .name     = N_("Encoder hardware acceleration type"),
+                .desc     = N_("Encoder hardware acceleration type"),
+                .group    = 2,
+                .opts     = PO_PHIDDEN,
+                .off      = offsetof(TVHVideoCodecProfile, encoder_hwaccel_type),
+                .def.i    = AV_HWDEVICE_TYPE_NONE,
             },
             {}
         }

--- a/src/transcoding/codec/codecs/vorbis.c
+++ b/src/transcoding/codec/codecs/vorbis.c
@@ -32,9 +32,11 @@ tvh_codec_profile_vorbis_open(TVHCodecProfile *self, AVDictionary **opts)
 
 
 #if LIBAVCODEC_VERSION_MAJOR > 59
-// see vorbis_encode_init() in ffmpeg-6.0/libavcodec/vorbis_data.c
+// see vorbis_encode_init() in ffmpeg-6.1.1/libavcodec/vorbisenc.c
+// av_log(avctx, AV_LOG_ERROR, "Current FFmpeg Vorbis encoder only supports 2 channels.\n");
 static const AVChannelLayout vorbis_channel_layouts[] = {
-    AV_CHANNEL_LAYOUT_STEREO
+    AV_CHANNEL_LAYOUT_STEREO,
+    { 0 }
 };
 #else
 // see vorbis_encode_init() in ffmpeg-3.0.2/libavcodec/vorbisenc.c
@@ -73,6 +75,7 @@ TVHAudioCodec tvh_codec_vorbis = {
     .name            = "vorbis",
     .size            = sizeof(TVHAudioCodecProfile),
     .idclass         = &codec_profile_vorbis_class,
+    .profiles        = NULL,
     .profile_init    = tvh_codec_profile_audio_init,
     .profile_destroy = tvh_codec_profile_audio_destroy,
     .channel_layouts = vorbis_channel_layouts,

--- a/src/transcoding/codec/drmdev.c
+++ b/src/transcoding/codec/drmdev.c
@@ -1,0 +1,100 @@
+/*
+ *  tvheadend - Codec Profiles - shared DRM device enumeration
+ *
+ *  Copyright (C) 2026 Tvheadend
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "drmdev.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <limits.h>
+#include <string.h>
+#include <stdio.h>
+#include <sys/ioctl.h>
+
+#if defined(__linux__)
+#include <linux/types.h>
+#include <asm/ioctl.h>
+#else
+#include <sys/ioccom.h>
+#include <sys/types.h>
+typedef size_t   __kernel_size_t;
+#endif
+
+typedef struct drm_version {
+   int version_major;        /**< Major version */
+   int version_minor;        /**< Minor version */
+   int version_patchlevel;   /**< Patch level */
+   __kernel_size_t name_len; /**< Length of name buffer */
+   char *name;               /**< Name of driver */
+   __kernel_size_t date_len; /**< Length of date buffer */
+   char *date;               /**< User-space buffer to hold date */
+   __kernel_size_t desc_len; /**< Length of desc buffer */
+   char *desc;               /**< User-space buffer to hold desc */
+} drm_version_t;
+
+#define DRM_IOCTL_VERSION _IOWR('d', 0x00, struct drm_version)
+
+static int
+tvh_probe_drm_device(const char *device, char *name, size_t namelen)
+{
+    drm_version_t dv;
+    char dname[128];
+    int fd;
+
+    if ((fd = open(device, O_RDWR)) < 0)
+        return -1;
+    memset(&dv, 0, sizeof(dv));
+    memset(dname, 0, sizeof(dname));
+    dv.name = dname;
+    dv.name_len = sizeof(dname)-1;
+    if (ioctl(fd, DRM_IOCTL_VERSION, &dv) < 0) {
+        close(fd);
+        return -1;
+    }
+    snprintf(name, namelen, "%s v%d.%d.%d (%s)",
+             dv.name, dv.version_major, dv.version_minor,
+             dv.version_patchlevel, device);
+    close(fd);
+    return 0;
+}
+
+htsmsg_t *
+tvh_drm_device_list(void *obj, const char *lang)
+{
+    static const char *renderD_fmt = "/dev/dri/renderD%d";
+    static const char *card_fmt = "/dev/dri/card%d";
+    htsmsg_t *result = htsmsg_create_list();
+    char device[PATH_MAX];
+    char name[128];
+    int i, dev_num;
+
+    for (i = 0; i < 32; i++) {
+        dev_num = i + 128;
+        snprintf(device, sizeof(device), renderD_fmt, dev_num);
+        if (tvh_probe_drm_device(device, name, sizeof(name)) == 0)
+            htsmsg_add_msg(result, NULL, htsmsg_create_key_val(device, name));
+    }
+    for (i = 0; i < 32; i++) {
+        // card nodes are numbered from 0 (render nodes from 128)
+        dev_num = i;
+        snprintf(device, sizeof(device), card_fmt, dev_num);
+        if (tvh_probe_drm_device(device, name, sizeof(name)) == 0)
+            htsmsg_add_msg(result, NULL, htsmsg_create_key_val(device, name));
+    }
+    return result;
+}

--- a/src/transcoding/codec/drmdev.h
+++ b/src/transcoding/codec/drmdev.h
@@ -1,0 +1,31 @@
+/*
+ *  tvheadend - Codec Profiles - shared DRM device enumeration
+ *
+ *  Copyright (C) 2026 Tvheadend
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TVH_TRANSCODING_CODEC_DRMDEV_H__
+#define TVH_TRANSCODING_CODEC_DRMDEV_H__
+
+#include "htsmsg.h"
+
+/* idnode property "list" callback enumerating the available /dev/dri render
+   and card nodes via the DRM VERSION ioctl. Shared by the VAAPI and QSV codec
+   profile classes. */
+htsmsg_t *
+tvh_drm_device_list(void *obj, const char *lang);
+
+#endif // TVH_TRANSCODING_CODEC_DRMDEV_H__

--- a/src/transcoding/codec/internals.h
+++ b/src/transcoding/codec/internals.h
@@ -189,15 +189,15 @@
     AV_DICT_SET_INT((s), (d), "pix_fmt", ((v) != AV_PIX_FMT_NONE) ? (v) : (a), \
                     AV_DICT_DONT_OVERWRITE)
 
-#define HWACCEL_AUTO        0
-#if ENABLE_VAAPI
-#define HWACCEL_PRIORITIZE_VAAPI 1
-#endif
-#if ENABLE_NVENC
-#define HWACCEL_PRIORITIZE_NVDEC 2
-#endif
+// to combine two combobox-s (hwaccel and hwaccel_details) in one we add: AV_AUTO_DEVICE_TYPE
+#define AV_AUTO_DEVICE_TYPE      -1
+
+// this category is not included in /libavutil/hwcontext.h
+// so we create a new category starting 100 that will be used in parallel with new hwcontext 
+// but will have to use Pixel Format as differentiator
 #if ENABLE_MMAL
-#define HWACCEL_PRIORITIZE_MMAL  3
+// use AV_PIX_FMT_MMAL
+#define AV_HWDEVICE_TYPE_MMAL   100
 #endif
 
 #define DEINT_RATE_FRAME         0
@@ -211,6 +211,15 @@
 #define VAAPI_DEINT_MODE_WEAVE   2
 #define VAAPI_DEINT_MODE_MADI    3
 #define VAAPI_DEINT_MODE_MCDI    4
+
+#define QSV_DEINTERLACING_OFF       0
+#define QSV_DEINTERLACING_BOB       1 // MFX_DEINTERLACING_BOB
+#define QSV_DEINTERLACING_ADVANCED  2 // MFX_DEINTERLACING_ADVANCED
+
+#define NVDEC_DEINT_MODE_SEND_FRAME                 0
+#define NVDEC_DEINT_MODE_SEND_FIELD                 1
+#define NVDEC_DEINT_MODE_SEND_FRAME_NONSPATIAL      2
+#define NVDEC_DEINT_MODE_SEND_FIELD_NONSPATIAL      3
 
 
 /* codec_profile_class ====================================================== */
@@ -416,6 +425,29 @@ typedef struct tvh_codec_profile_video {
      */
     int deinterlace_vaapi_mode;
 
+    /**
+     * VAAPI Deinterlace mode [deinterlace_vaapi mode parameter]
+     * https://ffmpeg.org/doxygen/4.1/vf__deinterlace__qsv_8c.html
+     * @note
+     * int:
+     * 0 - Default: Use the highest-numbered (and therefore most advanced) deinterlacing algorithm
+     * 1 - Use the bob deinterlacing algorithm
+     * 2 - Use the motion adaptive algorithm
+     */
+    int deinterlace_qsv_mode;
+
+    /**
+     * NVDEC Deinterlace mode [yadif_cuda mode parameter]
+     * https://ffmpeg.org/ffmpeg-filters.html#yadif_005fcuda
+     * @note
+     * int:
+     * 0 - send_frame: (default) Output one frame for each frame.
+     * 1 - send_field: Output one frame for each field. 
+     * 2 - send_frame_nospatial: Like send_frame, but it skips the spatial interlacing check.
+     * 3 - send_field_nospatial: Like send_field, but it skips the spatial interlacing check. 
+     */
+    int deinterlace_nvdec_mode;
+
     int height;
     /**
      * SW or HW scaling mode  (applies for decoding)
@@ -441,8 +473,27 @@ typedef struct tvh_codec_profile_video {
      * - 1 --> 1000 - gop size in frames
      */
     int gop_size;
-    int hwaccel;
-    int hwaccel_details;
+    /**
+     * SW or HW acceleration type prefered for decoder (applies for decoding)
+     * @note
+     * int: 
+     * VALUE - AVHWDeviceType
+     * 
+     * - -1 - special case: we match decoder and encoder automatically for optimal performance
+     * 
+     * - 0 --> 100+ - are valid AVHWDeviceType from /libavutil/hwcontext.h or fake HWDeviceType defined above in line 212
+     */
+    int decoder_hwaccel_type;
+    /**
+     * SW or HW acceleration type for encoder (applies for encoding)
+     * @note
+     * int: 
+     * VALUE - AVHWDeviceType
+     * 
+     * - 0 --> 100+ - are valid AVHWDeviceType from /libavutil/hwcontext.h or fake HWDeviceType defined above in line 212
+     */
+    int encoder_hwaccel_type;
+
     int pix_fmt;
     int crf;
 #if ENABLE_HWACCELS
@@ -475,11 +526,33 @@ typedef struct tvh_codec_profile_video {
 typedef struct {
     TVHVideoCodecProfile;
     int qp;
+/**
+ * VAAPI quality - typically maps to the encoder’s execution speed preset in VAAPI as Compression Level. [-compression_level]
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#VAAPI-encoders
+ * @note
+ * int:
+ * 1 - (Slower / Best Effort): The GPU spends maximum mathematical effort to pack data efficiently.
+ * 2 - 
+ * ...
+ * 7 - (Fastest / Worst Effort): The GPU takes shortcuts to process frames as fast as possible.
+ */
     int quality;
+/**
+ * VAAPI global quality - controls Visual Fidelity (Rate Control). It determines how much compression artifacts or pixelation you 
+ * are willing to tolerate to save space. [-q] [-qscale]
+ * It acts as the target value for modes like Constant Quantizer Parameter (CQP), or Intelligent Constant Quality (ICQ).
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#VAAPI-encoders
+ * @note
+ * int:
+ * 1 - ... high quality
+ * 18 -> 23 - Higher visual quality, larger file sizes (less lossy compression).
+ * 30 -> 40 - Lower visual quality, smaller file sizes (more aggressive blockiness).
+ * 51 - ... low quality
+ */
     int global_quality;
 /**
  * VAAPI async_depth - Maximum processing parallelism. Increase this to improve single channel performance. [async_depth]
- * https://www.ffmpeg.org/ffmpeg-codecs.html#toc-VAAPI-encoders
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#VAAPI-encoders
  * @note
  * int:
  * VALUE - number of async_depth is used by VAAPI encoder
@@ -501,7 +574,7 @@ typedef struct {
     int uilp;
 /**
  * VAAPI Frame used as reference for B-frame [b_depth]
- * https://www.ffmpeg.org/ffmpeg-codecs.html#toc-VAAPI-encoders
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#VAAPI-encoders
  * @note
  * int:
  * 0 - skip
@@ -511,7 +584,7 @@ typedef struct {
     int b_reference;
 /**
  * VAAPI Maximum consecutive B-frame [bf]
- * https://www.ffmpeg.org/ffmpeg-codecs.html#toc-VAAPI-encoders
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#VAAPI-encoders
  * @note
  * int:
  * 0 - no B-Frames allowed
@@ -520,7 +593,7 @@ typedef struct {
     int desired_b_depth;
 /**
  * VAAPI Maximum bitrate [maxrate]
- * https://www.ffmpeg.org/ffmpeg-codecs.html#toc-VAAPI-encoders
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#VAAPI-encoders
  * @note
  * double:
  * VALUE - max bitrate in bps
@@ -544,7 +617,7 @@ typedef struct {
     int platform;
 /**
  * VAAPI Low power - Some drivers/platforms offer a second encoder for some codecs intended to use less power than the default encoder [low_power]
- * https://www.ffmpeg.org/ffmpeg-codecs.html#toc-VAAPI-encoders
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#VAAPI-encoders
  * @note
  * int:
  * 0 - disabled
@@ -557,7 +630,7 @@ typedef struct {
     double buff_factor;
 /**
  * VAAPI Rate Control Mode - Set the rate control mode to use. A given driver may only support a subset of modes [rc_mode]
- * https://www.ffmpeg.org/ffmpeg-codecs.html#toc-VAAPI-encoders
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#VAAPI-encoders
  * @note
  * int:
  * 0 - auto
@@ -571,7 +644,7 @@ typedef struct {
     int rc_mode;
 /**
  * VAAPI hevc_vaapi Tier - Set general_tier_flag. This may affect the level chosen for the stream if it is not explicitly specified [tier]
- * https://www.ffmpeg.org/ffmpeg-codecs.html#toc-VAAPI-encoders
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#VAAPI-encoders
  * @note
  * int:
  * 0 - Main
@@ -580,7 +653,7 @@ typedef struct {
     int tier;
 /**
  * VAAPI Level - Set level (level_idc)  [level]
- * https://www.ffmpeg.org/ffmpeg-codecs.html#toc-VAAPI-encoders
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#VAAPI-encoders
  * @note
  * int:
  * VALUE - from -99 to 255 (default -99: auto)
@@ -590,6 +663,158 @@ typedef struct {
     int qmax;
     int super_frame;
 } tvh_codec_profile_vaapi_t;
+
+
+typedef struct {
+    TVHVideoCodecProfile;
+    int qp;
+
+// common options
+/**
+ * QSV async_depth - Maximum processing parallelism. Increase this to improve single channel performance. [async_depth]
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#QSV-Encoders
+ * @note
+ * int:
+ * VALUE - number of async_depth is used by VAAPI encoder
+ */
+    int async_depth;
+ /**
+ * QSV Preset - This option itemizes a range of choices from veryfast (best speed) to veryslow (best quality). [preset]
+ * NOTE: quality and preset are the same in QSV, as Target Usage (TU)
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#QSV-Encoders
+ * @note
+ * int: 
+ * 0 - skip
+ * 1 - ‘veryslow’
+ * 2 - ‘slower’
+ * 3 - ‘slow’
+ * 4 - ‘medium’
+ * 5 - ‘fast’
+ * 6 - ‘faster’
+ * 7 - ‘veryfast’
+ */
+    int preset;
+/**
+ * QSV Low power - Some drivers/platforms offer a second encoder for some codecs intended to use less power than the default encoder [low_power]
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#QSV-Encoders
+ * @note
+ * int:
+ * 0 - disabled
+ * 1 - enabled
+ */
+    int low_power;
+
+// runtime options
+/**
+ * QSV global quality - controls Visual Fidelity (Rate Control). It determines how much compression artifacts or pixelation you 
+ * are willing to tolerate to save space. [-q] [-qscale]
+ * It acts as the target value for modes like Constant Quantizer Parameter (CQP), Intelligent Constant Quality (ICQ), or Look-Ahead ICQ (LA_ICQ).
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#QSV-Encoders
+ * @note
+ * int:
+ * 1 - ... high quality
+ * 18 -> 23 - Higher visual quality, larger file sizes (less lossy compression).
+ * 30 -> 40 - Lower visual quality, smaller file sizes (more aggressive blockiness).
+ * 51 - ... low quality
+ */
+    int global_quality;
+/**
+ * QSV Look ahead / Look ahead depth - Depth of look ahead in number frames. [look_ahead] [look_ahead_depth]
+ * look_ahead recommended 1
+ * look_ahead_depth recommended between 40 and 100
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#QSV-Encoders
+ * @note
+ * int:
+ * 0 - disabled
+ * 1 - one frame
+ * ...
+ * 100 - 100 frames
+ */
+    int look_ahead_depth;
+/**
+ * QSV Adaptive I-frame placement (from -1 to 1) (default -1). [adaptive_i]
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#QSV-Encoders
+ * @note
+ * int:
+ * 0 - disabled
+ * 1 - enabled
+ */
+    int adaptive_i;
+/**
+ * QSV Adaptive B-frame placement (from -1 to 1) (default -1). [adaptive_i]
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#QSV-Encoders
+ * @note
+ * int:
+ * 0 - disabled
+ * 1 - enabled
+ */
+    int adaptive_b;
+/**
+ * QSV Extended Bitrate Control - This is highly recommended for Xe graphics to 
+ * force the hardware to utilize Intel's most modern rate-control algorithms. [extbrc]
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#QSV-Encoders
+ * @note
+ * int:
+ * 0 - disabled
+ * 1 - enabled
+ */
+    int ext_brc;
+/**
+ * QSV Maximum consecutive B-frame [bf]
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#QSV-Encoders
+ * @note
+ * int:
+ * 0 - no B-Frames allowed
+ * >0 - number of consecutive B-frames (valid with b_reference = 1 --> "use P- or I-frames")
+ */
+    int desired_b_depth;
+/**
+ * QSV b strategy - This option controls usage of B frames as reference. [b_strategy]
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#QSV-Encoders
+ * @note
+ * int:
+ * 0 - disabled
+ * 1 - enabled
+ */
+    int b_strategy;
+/**
+ * QSV Maximum bitrate [maxrate]
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#QSV-encoders
+ * @note
+ * double:
+ * VALUE - max bitrate in bps
+ */
+    double max_bit_rate;
+/**
+ * QSV Bitrate scale factor [not ffmpeg parameter]
+ * @note
+ * double:
+ * VALUE - bitrate scale factor relative to 480p resolution
+ */
+    double bit_rate_scale_factor;
+/**
+ * QSV Video conferencing mode - VCM - video conferencing mode, when the vcm option is set. [vcm]
+ * https://www.ffmpeg.org/ffmpeg-codecs.html#QSV-Encoders
+ * @note
+ * int:
+ * 0 - disabled
+ * 1 - enabled
+ */
+    int vcm;
+
+    int loop_filter_level;
+    int loop_filter_sharpness;
+    double buff_factor;
+    int rc_mode;
+
+    int tier;
+
+    int super_frame;
+
+    
+    int qmin;
+    int qmax;
+} tvh_codec_profile_qsv_t;
 
 /* audio */
 
@@ -605,6 +830,16 @@ typedef struct tvh_codec_profile_audio {
     int sample_rate;
     // this variable will be used also as ch_layout_u_mask when LIBAVCODEC_VERSION_MAJOR > 59
     int64_t channel_layout;
+/**
+ * asetpts=N/SR/TB — normalizes PTS on the audio link (sample rate / time base) by counting samples. [asetpts]
+ * https://ffmpeg.org/ffmpeg-all.html#setpts_002c-asetpts
+ * @note
+ * int:
+ * 0 - auto (insert filter when reframing/resample/layout/timebase requires it)
+ * 1 - enabled
+ * 2 - disabled
+ */
+    int asetpts;
 } TVHAudioCodecProfile;
 
 

--- a/src/transcoding/codec/profile.c
+++ b/src/transcoding/codec/profile.c
@@ -153,6 +153,12 @@ tvh_codec_profile_create(htsmsg_t *conf, const char *uuid, int save)
         tvherror(LS_CODEC, "failed to insert idnode");
         return EINVAL;
     }
+    /* migrate the pre-"decoder_hwaccel_type" config: "hwaccel" was a bool
+       enabling hardware-accelerated decoding */
+    if (!htsmsg_field_find(conf, "decoder_hwaccel_type") &&
+        htsmsg_get_bool_or_default(conf, "hwaccel", 0)) {
+        htsmsg_set_s32(conf, "decoder_hwaccel_type", AV_AUTO_DEVICE_TYPE);
+    }
     idnode_load(&profile->idnode, conf);
     LIST_INSERT_HEAD(&tvh_codec_profiles, profile, link);
     if (save) {
@@ -276,24 +282,12 @@ tvh_codec_profile_video_destroy(TVHCodecProfile *_self)
 }
 
 int
-tvh_codec_profile_video_get_hwaccel(TVHCodecProfile *self)
+tvh_codec_profile_video_get_decoder_hwaccel_type(TVHCodecProfile *self)
 {
     TVHCodec *codec = tvh_codec_profile_get_codec(self);
     if (codec && tvh_codec_is_enabled(codec) &&
         tvh_codec_get_type(codec) == AVMEDIA_TYPE_VIDEO) {
-        return ((TVHVideoCodecProfile *)self)->hwaccel;
-    }
-    return -1;
-}
-
-
-int
-tvh_codec_profile_video_get_hwaccel_details(TVHCodecProfile *self)
-{
-    TVHCodec *codec = tvh_codec_profile_get_codec(self);
-    if (codec && tvh_codec_is_enabled(codec) &&
-        tvh_codec_get_type(codec) == AVMEDIA_TYPE_VIDEO) {
-        return ((TVHVideoCodecProfile *)self)->hwaccel_details;
+        return ((TVHVideoCodecProfile *)self)->decoder_hwaccel_type;
     }
     return -1;
 }

--- a/src/transcoding/codec/profile_audio_class.c
+++ b/src/transcoding/codec/profile_audio_class.c
@@ -25,6 +25,17 @@
 /* TVHCodec ================================================================= */
 
 static htsmsg_t *
+tvh_codec_audio_get_asetpts( void *o, const char *lang )
+{
+    static const struct strtab tab[] = {
+        { N_("auto"),       0 },
+        { N_("enabled"),    1 },
+        { N_("disabled"),   2 },
+    };
+    return strtab2htsmsg(tab, 1, lang);
+}
+
+static htsmsg_t *
 tvh_codec_audio_get_list_sample_fmts(TVHAudioCodec *self)
 {
     htsmsg_t *list = NULL, *map = NULL;
@@ -359,6 +370,18 @@ const codec_profile_class_t codec_profile_audio_class = {
                 .off      = offsetof(TVHAudioCodecProfile, channel_layout),
                 .list     = codec_profile_audio_class_channel_layout_list,
                 .def.s64  = 0,
+            },
+            {
+                .type     = PT_INT,
+                .id       = "asetpts",
+                .name     = N_("Normalizes PTS"),
+                .desc     = N_("Normalizes PTS on the audio link (sample rate / time base) by counting samples. [asetpts=N/SR/TB]"),
+                .group    = 4,
+                .opts     = PO_ADVANCED,
+                .get_opts = codec_profile_class_get_opts,
+                .off      = offsetof(TVHAudioCodecProfile, asetpts),
+                .list     = tvh_codec_audio_get_asetpts,
+                .def.i    = 0,
             },
             {}
         }

--- a/src/transcoding/codec/profile_class.c
+++ b/src/transcoding/codec/profile_class.c
@@ -111,8 +111,14 @@ static int
 tvh_codec_profile_base_open(TVHCodecProfile *self, AVDictionary **opts)
 {
     AV_DICT_SET_TVH_REQUIRE_META(LST_NONE, opts, 1);
-    // profile is set and is available
-    if (self->profile != FF_AV_PROFILE_UNKNOWN &&
+    // profile is set and is available.
+    // Profile 0 is AAC Main, but it is also the zeroed value of a profile
+    // loaded from a config without an explicit "profile" field (the class
+    // default FF_AV_PROFILE_UNKNOWN is only applied to brand-new nodes). The
+    // native aac encoder rejects Main ("Profile not supported!" -> EINVAL),
+    // so only emit a positive (explicitly chosen) profile and let the encoder
+    // pick its own default otherwise.
+    if (self->profile > 0 &&
         _is_profile_available(self->codec, self->profile)) {
         AV_DICT_SET_INT(LST_CODEC, opts, "profile", self->profile, 0);
     }

--- a/src/transcoding/codec/profile_video_class.c
+++ b/src/transcoding/codec/profile_video_class.c
@@ -34,18 +34,25 @@ scaling_mode_get_list( void *o, const char *lang )
 }
 
 static htsmsg_t *
-hwaccel_get_list( void *o, const char *lang )
+decoder_hwaccel_type_get_list( void *o, const char *lang )
 {
     static const struct strtab tab[] = {
-        { N_("auto (recommended)"),                 HWACCEL_AUTO},
+        { N_("auto (recommended)"),                 AV_AUTO_DEVICE_TYPE},
+        { N_("software (forced)"),                  AV_HWDEVICE_TYPE_NONE},
 #if ENABLE_VAAPI
-        { N_("prioritize VAAPI"),                   HWACCEL_PRIORITIZE_VAAPI},
+        { N_("prioritize VAAPI"),                   AV_HWDEVICE_TYPE_VAAPI},
+#endif
+#if ENABLE_QSV
+        { N_("prioritize QSV"),                     AV_HWDEVICE_TYPE_QSV},
 #endif
 #if ENABLE_NVENC
-        { N_("prioritize NVDEC"),                   HWACCEL_PRIORITIZE_NVDEC},
+        { N_("prioritize NVDEC"),                   AV_HWDEVICE_TYPE_CUDA},
 #endif
 #if ENABLE_MMAL
-        { N_("prioritize MMAL"),                    HWACCEL_PRIORITIZE_MMAL},
+        { N_("prioritize MMAL"),                    AV_HWDEVICE_TYPE_MMAL},
+#endif
+#if ENABLE_V4L2M2M
+        { N_("prioritize V4L2"),                    AV_HWDEVICE_TYPE_DRM},
 #endif
     };
     return strtab2htsmsg(tab, 1, lang);
@@ -61,6 +68,33 @@ deinterlace_vaapi_mode_get_list( void *o, const char *lang )
         { N_("Weave Deinterlacing"),                     VAAPI_DEINT_MODE_WEAVE },
         { N_("Motion Adaptive Deinterlacing (MADI)"),    VAAPI_DEINT_MODE_MADI },
         { N_("Motion Compensated Deinterlacing (MCDI)"), VAAPI_DEINT_MODE_MCDI },
+    };
+    return strtab2htsmsg(tab, 1, lang);
+}
+#endif
+
+#if ENABLE_QSV
+static htsmsg_t *
+deinterlace_qsv_mode_get_list( void *o, const char *lang )
+{
+    static const struct strtab tab[] = {
+        { N_("Disabled"),                                QSV_DEINTERLACING_OFF },
+        { N_("Bob Deinterlacing"),                       QSV_DEINTERLACING_BOB },
+        { N_("Motion Adaptive Deinterlacing"),           QSV_DEINTERLACING_ADVANCED },
+    };
+    return strtab2htsmsg(tab, 1, lang);
+}
+#endif
+
+#if ENABLE_NVENC
+static htsmsg_t *
+deinterlace_nvdec_mode_get_list( void *o, const char *lang )
+{
+    static const struct strtab tab[] = {
+        { N_("Send Frame Deinterlacing"),              NVDEC_DEINT_MODE_SEND_FRAME },
+        { N_("Send Field Deinterlacing"),              NVDEC_DEINT_MODE_SEND_FIELD },
+        { N_("Send Frame Nonspatia Deinterlacing"),    NVDEC_DEINT_MODE_SEND_FRAME_NONSPATIAL },
+        { N_("Send Field Nonspatia Deinterlacing"),    NVDEC_DEINT_MODE_SEND_FIELD_NONSPATIAL },
     };
     return strtab2htsmsg(tab, 1, lang);
 }
@@ -202,9 +236,6 @@ tvh_codec_profile_video_is_copy(TVHVideoCodecProfile *self, tvh_ssc_t *ssc)
 static int
 tvh_codec_profile_video_open(TVHVideoCodecProfile *self, AVDictionary **opts)
 {
-    // video_size
-    AV_DICT_SET_INT(LST_VIDEO, opts, "width", self->size.num, 0);
-    AV_DICT_SET_INT(LST_VIDEO, opts, "height", self->size.den, 0);
     // crf
     if (self->crf) {
         AV_DICT_SET_INT(LST_VIDEO, opts, "crf", self->crf, AV_DICT_DONT_OVERWRITE);
@@ -286,23 +317,14 @@ const codec_profile_class_t codec_profile_video_class = {
                 .def.i    = 0,
             },
             {
-                .type     = PT_BOOL,
-                .id       = "hwaccel",
-                .name     = N_("Hardware acceleration"),
-                .desc     = N_("Use hardware acceleration for decoding if available."),
-                .group    = 2,
-                .off      = offsetof(TVHVideoCodecProfile, hwaccel),
-                .def.i    = 0,
-            },
-            {
                 .type     = PT_INT,
-                .id       = "hwaccel_details",
-                .name     = N_("Hardware acceleration details"),
-                .desc     = N_("Force hardware acceleration."),
+                .id       = "decoder_hwaccel_type",
+                .name     = N_("Decoder hardware acceleration type"),
+                .desc     = N_("Prioritize selected hardware acceleration type (fallback on software decoding)."),
                 .group    = 2,
-                .off      = offsetof(TVHVideoCodecProfile, hwaccel_details),
-                .list     = hwaccel_get_list,
-                .def.i    = 0,
+                .off      = offsetof(TVHVideoCodecProfile, decoder_hwaccel_type),
+                .list     = decoder_hwaccel_type_get_list,
+                .def.i    = AV_AUTO_DEVICE_TYPE,
             },
             {
                 .type     = PT_BOOL,
@@ -326,6 +348,34 @@ const codec_profile_class_t codec_profile_video_class = {
                 .opts     = PO_ADVANCED,
                 .off      = offsetof(TVHVideoCodecProfile, deinterlace_vaapi_mode),
                 .list     = deinterlace_vaapi_mode_get_list,
+                .def.i    = VAAPI_DEINT_MODE_DEFAULT,
+            },
+#endif
+#if ENABLE_QSV
+            {
+                .type     = PT_INT,
+                .id       = "deinterlace_qsv_mode",
+                .name     = N_("QSV Deinterlace mode"),
+                .desc     = N_("Mode to use for QSV Deinterlacing. "
+                               "'Disabled' disable deinterlace feature. "
+                               "Tip: Motion Adaptive usually yield the best results."),
+                .group    = 2,
+                .opts     = PO_ADVANCED,
+                .off      = offsetof(TVHVideoCodecProfile, deinterlace_qsv_mode),
+                .list     = deinterlace_qsv_mode_get_list,
+                .def.i    = VAAPI_DEINT_MODE_DEFAULT,
+            },
+#endif
+#if ENABLE_NVENC
+            {
+                .type     = PT_INT,
+                .id       = "deinterlace_nvdec_mode",
+                .name     = N_("NVDEC Deinterlace mode"),
+                .desc     = N_("Mode to use for NVDEC Deinterlacing."),
+                .group    = 2,
+                .opts     = PO_ADVANCED,
+                .off      = offsetof(TVHVideoCodecProfile, deinterlace_nvdec_mode),
+                .list     = deinterlace_nvdec_mode_get_list,
                 .def.i    = VAAPI_DEINT_MODE_DEFAULT,
             },
 #endif

--- a/src/transcoding/codec/vainfo.c
+++ b/src/transcoding/codec/vainfo.c
@@ -256,7 +256,10 @@ int init(int show_log)
     if (va_status != VA_STATUS_SUCCESS) { 
         tvherror_transcode(LST_VAINFO, "vaInitialize failed with error code %d (%s)", va_status, vaErrorStr(va_status));
         ret_val = 3;
-        goto error_Initialize;
+        /* vaInitialize() failed, so the display was never initialised: jump
+           past vaTerminate(), which is only valid on an initialised display
+           and dereferences driver context that does not exist here. */
+        goto error_open_display;
     }
     if (show_log)
         tvhinfo_transcode(LST_VAINFO, "VA-API version: %d.%d", major_version, minor_version);
@@ -389,7 +392,6 @@ error_profile_list:
     free(profile_list);
 error_entrypoints:
     free(entrypoints);
-error_Initialize:
     vaTerminate(va_dpy);
 error_open_display:
     va_close_display_drm(va_dpy);

--- a/src/transcoding/transcode/audio.c
+++ b/src/transcoding/transcode/audio.c
@@ -19,6 +19,7 @@
 
 
 #include "internals.h"
+#include "../codec/internals.h"
 
 
 static enum AVSampleFormat
@@ -80,6 +81,166 @@ _audio_context_sample_rate(TVHContext *self, AVDictionary **opts)
 
 
 #if LIBAVCODEC_VERSION_MAJOR > 59
+static int
+_audio_encoder_frame_size(TVHContext *self)
+{
+    const char *name;
+    if (!self->oavctx->codec ||
+        (self->oavctx->codec->capabilities & AV_CODEC_CAP_VARIABLE_FRAME_SIZE))
+        return 0;
+    if (self->oavctx->frame_size > 0)
+        return self->oavctx->frame_size;
+    /* OPEN_FILTERS runs before avcodec_open2(); use known fixed frame sizes. */
+    name = self->oavctx->codec->name;
+    if (!name)
+        return 0;
+    if (!strcmp(name, "aac") || !strcmp(name, "libfdk_aac"))
+        return 1024;
+    if (!strcmp(name, "mp2"))
+        return 1152;
+    return 0;
+}
+
+static int
+_audio_ch_layout_differs(TVHContext *self)
+{
+    /* u.mask is only the channel bitmask for AV_CHANNEL_ORDER_NATIVE and
+       AV_CHANNEL_ORDER_AMBISONIC.  For AV_CHANNEL_ORDER_CUSTOM the same union
+       member is the AVChannelCustom *map pointer, so comparing u.mask there
+       compares two pointer values as if they were masks.  Let libavutil decide
+       instead: av_channel_layout_compare() dispatches on the order. */
+    return av_channel_layout_compare(&self->iavctx->ch_layout,
+                                     &self->oavctx->ch_layout) != 0;
+}
+
+static int
+_audio_needs_reframe_asetpts(TVHContext *self)
+{
+    int out_fs = _audio_encoder_frame_size(self);
+    int in_fs  = self->iavctx->frame_size;
+    if (out_fs <= 0)
+        return 0;
+    if (in_fs <= 0)
+        return 1;
+    return in_fs != out_fs;
+}
+
+static int
+_audio_needs_timebase_asetpts(TVHContext *self)
+{
+    AVRational flt_tb;
+
+    flt_tb = av_make_q(1, self->iavctx->sample_rate);
+    return av_cmp_q(self->iavctx->time_base, flt_tb) != 0;
+}
+
+static int
+_audio_requires_asetpts(TVHContext *self)
+{
+    TVHAudioCodecProfile *ap = (TVHAudioCodecProfile *)self->profile;
+
+    if (ap->asetpts == 2)          /* force off */
+        return 0;
+    if (ap->asetpts == 1)          /* force on */
+        return 1;
+    /* ap->asetpts == 0  →  "auto" */
+    return _audio_needs_reframe_asetpts(self)
+        || (self->iavctx->sample_rate != self->oavctx->sample_rate)
+        || (self->iavctx->sample_fmt != self->oavctx->sample_fmt)
+        || _audio_ch_layout_differs(self)
+        || _audio_needs_timebase_asetpts(self);
+}
+
+/**
+ * Build the libavfilter chain string used between @c abuffer and @c abuffersink
+ * for FFmpeg/libavcodec major version &gt; 59.
+ *
+ * The result is a comma-separated list of filter descriptions allocated into
+ * @p *filters (caller must free via whatever owns the graph string lifecycle).
+ *
+ * Pieces (in join order):
+ * - @c asetpts=N/SR/TB — normalizes PTS on the audio link (sample rate / time base).
+ * - Optional @c aresample=@<output_sample_rate@> when input and output sample
+ *   rates differ.
+ * - Optional @c aformat=… when input and output differ in @c sample_fmt and/or
+ *   channel count: adds @c sample_fmts=… and/or @c channel_layouts=… as required
+ *   by the @c aformat filter.
+ *
+ * @param self    Transcode context; uses @c iavctx / @c oavctx sample format, rate,
+ *                and channel layout to decide which segments are needed.
+ * @param filters Receives a newly built filter string (e.g. from @c str_join), or
+ *                is left untouched on failure.
+ * @return        0 on success; -1 if a buffer would overflow or allocation/join fails.
+ */
+static int
+_audio_filters_get_filters(TVHContext *self, char **filters)
+{
+    char sample_rate[32];
+    char sample_fmt[32];
+    char obuf[64];
+    char channel_layouts[64];
+    char aformat[128];
+    char asetpts[24];
+    int aformat_tokens = 0;
+
+    // sample_rate
+    memset(sample_rate, 0, sizeof(sample_rate));
+    if ((self->iavctx->sample_rate != self->oavctx->sample_rate) &&
+        str_snprintf(sample_rate, sizeof(sample_rate), "aresample=%d", self->oavctx->sample_rate))
+        return -1;    
+
+    // https://ayosec.github.io/ffmpeg-filters-docs/8.1/Filters/Audio/aformat.html
+    // sample_fmt
+    memset(sample_fmt, 0, sizeof(sample_fmt));
+    if (self->iavctx->sample_fmt != self->oavctx->sample_fmt) {
+        if(str_snprintf(sample_fmt, sizeof(sample_fmt), "sample_fmts=%s", av_get_sample_fmt_name(self->oavctx->sample_fmt)))
+            return -1;
+        else 
+            aformat_tokens++; 
+    }
+
+    // channel_layouts
+    memset(channel_layouts, 0, sizeof(channel_layouts));
+    // if channel number is different OR
+    //    channel number is the same but the layout is different
+    // NOTE: this is required to force conversion from 5.1(side) to 5.1(back) or vice versa
+    if (_audio_ch_layout_differs(self)) {
+        av_channel_layout_describe(&self->oavctx->ch_layout, obuf, sizeof(obuf));
+        if(str_snprintf(channel_layouts, sizeof(channel_layouts), "channel_layouts=%s", obuf)) 
+            return -1;
+        else 
+            aformat_tokens++; 
+    }
+
+    memset(aformat, 0, sizeof(aformat));
+    switch (aformat_tokens) {
+        case 2:
+            // we have to update both settings
+            if(str_snprintf(aformat, sizeof(aformat), "aformat=%s:%s", sample_fmt, channel_layouts))
+                return -1;
+            break;
+        case 1:
+            // we have to update only one setting
+            if(str_snprintf(aformat, sizeof(aformat), "aformat=%s%s", sample_fmt, channel_layouts)) 
+                return -1;
+            break;
+        default:
+            break;
+    }
+
+    memset(asetpts, 0, sizeof(asetpts));
+    if (_audio_requires_asetpts(self) &&
+        // normalizes PTS on the audio link (sample rate / time base) by counting samples.
+        str_snprintf(asetpts, sizeof(asetpts), "asetpts=N/SR/TB"))
+        return -1;
+
+    // context filters
+    if (!(*filters = str_join(",", asetpts, sample_rate, aformat, NULL)))
+        return -1;
+    
+    return 0;
+}
+
 static void
 _audio_context_channel_layout(TVHContext *self, AVDictionary **opts, AVChannelLayout *dst)
 {
@@ -254,6 +415,25 @@ tvh_audio_context_open_encoder(TVHContext *self, AVDictionary **opts)
 static int
 tvh_audio_context_open_filters(TVHContext *self, AVDictionary **opts)
 {
+#if LIBAVCODEC_VERSION_MAJOR > 59
+    char *filters2 = NULL;
+
+    // filters
+    if (_audio_filters_get_filters(self, &filters2)) {
+        tvherror(LS_TRANSCODE, "filters: audio: function _audio_filters_get_filters() returned with error.");
+        str_clear(filters2);
+        return -1;
+    }
+    
+    tvhinfo(LS_TRANSCODE, "filters: audio: '%s'", filters2);
+
+    int ret = tvh_context_open_filters2(self,
+        "abuffer",                                             // source
+        (filters2 && filters2[0] != '\0') ? filters2 : "anull",// filters
+        "abuffersink"                                          // sink
+    );
+    str_clear(filters2);
+#else
     char source_args[128];
     char filters[16];
     char layout[32];
@@ -261,11 +441,7 @@ tvh_audio_context_open_filters(TVHContext *self, AVDictionary **opts)
 
     // source args
     memset(source_args, 0, sizeof(source_args));
-#if LIBAVCODEC_VERSION_MAJOR > 59
-    av_channel_layout_describe(&self->iavctx->ch_layout, layout, sizeof(layout));
-#else
     av_get_channel_layout_string(layout, sizeof(layout), self->iavctx->channels, self->iavctx->channel_layout);
-#endif
     if (str_snprintf(source_args, sizeof(source_args),
             "time_base=%d/%d:sample_rate=%d:sample_fmt=%s:channel_layout=%s",
             self->iavctx->time_base.num,
@@ -287,25 +463,6 @@ tvh_audio_context_open_filters(TVHContext *self, AVDictionary **opts)
         return -1;
     }
 
-#if LIBAVCODEC_VERSION_MAJOR > 59
-    char ch_layout[64];
-    av_channel_layout_describe(&self->oavctx->ch_layout, ch_layout, sizeof(ch_layout));
-    
-    int ret = tvh_context_open_filters(self,
-        "abuffer", source_args,                           // source
-        filters,                                          // filters
-        "abuffersink",                                    // sink
-        "ch_layouts",   AV_OPT_SET_STRING,                // sink option: channel_layout
-        sizeof(ch_layout),
-        ch_layout,
-        "sample_fmts",  AV_OPT_SET_BIN,                   // sink option: sample_fmt
-        sizeof(self->oavctx->sample_fmt),
-        &self->oavctx->sample_fmt,
-        "sample_rates", AV_OPT_SET_BIN,                   // sink option: sample_rate
-        sizeof(self->oavctx->sample_rate),
-        &self->oavctx->sample_rate,
-        NULL);                                            // _IMPORTANT!_
-#else
     int ret = tvh_context_open_filters(self,
         "abuffer", source_args,                           // source
         filters,                                          // filters
@@ -317,26 +474,50 @@ tvh_audio_context_open_filters(TVHContext *self, AVDictionary **opts)
         "sample_rates", &self->oavctx->sample_rate,       // sink option: sample_rate
         sizeof(self->oavctx->sample_rate),
         NULL);                                            // _IMPORTANT!_
-#endif
-    if (!ret) {
+    if (!ret && self->oavctx->frame_size > 0) {
         av_buffersink_set_frame_size(self->oavfltctx, self->oavctx->frame_size);
     }
+#endif
     return ret;
 }
 
-
+/**
+ * Audio half of the transcoder open state machine: dispatches @p phase to the
+ * right setup step for the audio path.
+ *
+ * Handled phases:
+ * - PREPARE_ENCODER — configure output @c AVCodecContext (sample format, rate,
+ *   time base, channel layout) via @c tvh_audio_context_open_encoder.
+ * - OPEN_FILTERS — build the libavfilter graph (@c abuffer → filters →
+ *   @c abuffersink), including @c asetpts / @c aresample / @c aformat when needed
+ *   (@c tvh_audio_context_open_filters).
+ * - OPEN_ENCODER — post @c avcodec_open2 hook: for fixed-frame encoders only,
+ *   sets @c abuffersink frame size to @c oavctx->frame_size when @c frame_size > 0.
+ *   Variable-frame codecs (e.g. Opus, Vorbis) are left to the filter graph.
+ *
+ * Decoder-side phases (@c PREPARE_DECODER, @c OPEN_DECODER, @c NOTIFY_GLOBALHEADER)
+ * are handled in @c context.c, not here. Unknown @p phase is a no-op (returns 0).
+ *
+ * @param self  Transcode context.
+ * @param phase Open step (@c TVHOpenPhase).
+ * @param opts  Codec/profile options (used by @c PREPARE_ENCODER).
+ * @return      0 on success or no-op; negative @c AVERROR from
+ *              @c tvh_audio_context_open_encoder or @c tvh_audio_context_open_filters.
+ */
 static int
 tvh_audio_context_open(TVHContext *self, TVHOpenPhase phase, AVDictionary **opts)
 {
     switch (phase) {
-        case OPEN_ENCODER:
+        case PREPARE_ENCODER:
             return tvh_audio_context_open_encoder(self, opts);
-        case OPEN_ENCODER_POST:
-            self->delta = av_rescale_q_rnd(self->oavctx->frame_size,
-                                           self->oavctx->time_base,
-                                           self->iavctx->time_base,
-                                           AV_ROUND_NEAR_INF|AV_ROUND_PASS_MINMAX);
+        case OPEN_FILTERS:
             return tvh_audio_context_open_filters(self, opts);
+        case OPEN_ENCODER:
+            if (!(self->oavctx->codec->capabilities & AV_CODEC_CAP_VARIABLE_FRAME_SIZE) &&
+                (self->oavctx->frame_size > 0)){
+                av_buffersink_set_frame_size(self->oavfltctx, self->oavctx->frame_size);
+            }
+            break;
         default:
             break;
     }
@@ -349,15 +530,35 @@ tvh_audio_context_decode(TVHContext *self, AVPacket *avpkt)
 {
     int64_t prev_pts = self->pts;
     int64_t new_pts = avpkt->pts - self->duration;
+    
+    int64_t drift = new_pts - prev_pts;
 
-    // rounding error?
-    if (new_pts - 10 <= prev_pts && new_pts + 10 >= prev_pts) {
-      prev_pts = new_pts;
+    if (drift < 0)
+        drift = -drift;
+
+    // Tolerance: 3 AC3 frames at 48 kHz (3 × 1536 = 4608 samples).
+    // IPTV streams often have slightly irregular packet durations causing
+    // sub-frame PTS drift of up to 2880 samples (2 AC3 frames).  Rather than
+    // hard-jumping self->pts on every small deviation (which produces an
+    // audible skip), absorb deviations up to 3 frames by correcting
+    // self->duration instead, keeping the clock continuous.  Only log +
+    // hard-reset for genuine discontinuities larger than that.
+    // Small drift: re-anchor duration, keep PTS (AC3 etc.)
+    if (prev_pts && drift <= 4608) {
+        self->duration = avpkt->pts - prev_pts + avpkt->duration;
+        self->pts = prev_pts;
+        return 0;
     }
 
-    if (prev_pts != (self->pts = new_pts) && prev_pts > 12000) {
-        tvh_context_log(self, LOG_WARNING, "Detected framedrop in audio (%"PRId64" != %"PRId64")", prev_pts, new_pts);
+    // Real problems only — not filter vs packet offset
+    if (prev_pts > 0) {
+        if (new_pts < prev_pts - 4608) {
+            tvh_context_log(self, LOG_WARNING, "Audio PTS went backward (%" PRId64 " -> %" PRId64 ")", prev_pts, new_pts);
+        } else if (new_pts - prev_pts > 90000 * 2) {  // > 2 s gap @ 90 kHz
+            tvh_context_log(self, LOG_WARNING, "Audio discontinuity (%" PRId64 " -> %" PRId64 "), gap=%" PRId64, prev_pts, new_pts, new_pts - prev_pts);
+        }
     }
+    self->pts = new_pts;
     self->duration += avpkt->duration;
     return 0;
 }
@@ -366,10 +567,80 @@ tvh_audio_context_decode(TVHContext *self, AVPacket *avpkt)
 static int
 tvh_audio_context_encode(TVHContext *self, AVFrame *avframe)
 {
-    avframe->nb_samples = self->oavctx->frame_size;
-    avframe->pts = self->pts;
-    self->pts += self->delta;
-    self->duration -= self->delta;
+    AVRational src_time_base;
+    int64_t flt_pts;
+    int64_t consumed;
+    if (!self || !self->oavctx || !avframe)
+        return -1;
+    // Filter output timebase (same idea as tvh_video_context_encode)
+#if LIBAVUTIL_VERSION_MAJOR >= 58
+    if (self->oavfltctx && self->oavfltctx->nb_inputs > 0) {
+        src_time_base = self->oavfltctx->inputs[0]->time_base;
+    } else
+    {
+#endif
+        // abuffer is configured with iavctx->time_base in open_filters()
+        src_time_base = self->iavctx->time_base;
+        if (!src_time_base.den)
+            src_time_base = av_make_q(1, 90000);
+#if LIBAVUTIL_VERSION_MAJOR >= 58
+    }
+#endif
+    if (tvhtrace_enabled()) {
+        tvh_context_log(self, LOG_TRACE,
+            "Filter frame: pts=%" PRId64 ", nb_samples=%d, time_base=%d/%d",
+            avframe->pts, avframe->nb_samples,
+            src_time_base.num, src_time_base.den);
+    }
+    // Use PTS from aresample/abuffersink; fallback only if missing
+    // Only if there is no last_flt_pts yet (e.g. first frame), fall back to decode self->pts.
+    flt_pts = avframe->pts;
+    if (flt_pts == AV_NOPTS_VALUE) {
+        if (self->last_flt_pts && avframe->nb_samples > 0) {
+            flt_pts = self->last_flt_pts + av_rescale_q(avframe->nb_samples, av_make_q(1, self->oavctx->sample_rate), src_time_base);
+        } else if (self->pts != AV_NOPTS_VALUE && self->pts != 0) {
+            flt_pts = self->pts;  // first frame: decode packet timeline
+        } else {
+            return AVERROR(EINVAL);
+        }
+        avframe->pts = flt_pts;
+    }
+    //check for duplicate PTS from the filter
+    if (flt_pts != AV_NOPTS_VALUE && self->last_flt_pts &&
+        flt_pts <= self->last_flt_pts)
+        return AVERROR(EAGAIN);
+    // Track last PTS in filter/input time_base
+    self->last_flt_pts = flt_pts;
+    // Rescale PTS: filter time_base -> encoder time_base (1/sample_rate)
+    if (av_cmp_q(src_time_base, self->oavctx->time_base) != 0) {
+        avframe->pts = av_rescale_q(flt_pts, src_time_base, self->oavctx->time_base);
+    } else {
+        avframe->pts = flt_pts;
+    }
+#if LIBAVUTIL_VERSION_MAJOR >= 58
+    if (avframe->duration > 0 &&
+        av_cmp_q(src_time_base, self->oavctx->time_base) != 0) {
+        avframe->duration = av_rescale_q(avframe->duration, src_time_base, self->oavctx->time_base);
+    }
+#else
+    if (avframe->pkt_duration > 0 &&
+        av_cmp_q(src_time_base, self->oavctx->time_base) != 0) {
+        avframe->pkt_duration = av_rescale_q(avframe->pkt_duration, src_time_base, self->oavctx->time_base);
+    }
+#endif
+    if (tvhtrace_enabled()) {
+        tvh_context_log(self, LOG_TRACE,
+            "Rescaled audio {%d/%d}->{%d/%d}: pts=%" PRId64 ", nb_samples=%d",
+            src_time_base.num, src_time_base.den,
+            self->oavctx->time_base.num, self->oavctx->time_base.den,
+            avframe->pts, avframe->nb_samples);
+    }
+    // Duration bookkeeping in input time_base, from actual samples
+    if (avframe->nb_samples > 0 && self->iavctx->time_base.den) {
+        consumed = av_rescale_q(avframe->nb_samples, av_make_q(1, self->oavctx->sample_rate), self->iavctx->time_base);
+        if (consumed > 0)
+            self->duration -= consumed;
+    }
     return 0;
 }
 
@@ -384,7 +655,19 @@ tvh_audio_context_ship(TVHContext *self, AVPacket *avpkt)
 static int
 tvh_audio_context_wrap(TVHContext *self, AVPacket *avpkt, th_pkt_t *pkt)
 {
-    pkt->pkt_duration   = avpkt->duration;
+    static const AVRational mpeg_ts_tb = { 1, 90000 };
+    if (avpkt->pts != AV_NOPTS_VALUE)
+        pkt->pkt_pts = av_rescale_q(avpkt->pts,
+                                    self->oavctx->time_base,
+                                    mpeg_ts_tb);
+    if (avpkt->dts != AV_NOPTS_VALUE)
+        pkt->pkt_dts = av_rescale_q(avpkt->dts,
+                                    self->oavctx->time_base,
+                                    mpeg_ts_tb);
+    if (avpkt->duration > 0)
+        pkt->pkt_duration = av_rescale_q(avpkt->duration,
+                                         self->oavctx->time_base,
+                                         mpeg_ts_tb);
 #if LIBAVCODEC_VERSION_MAJOR > 59
     pkt->a.pkt_channels = self->oavctx->ch_layout.nb_channels;
 #else
@@ -393,7 +676,6 @@ tvh_audio_context_wrap(TVHContext *self, AVPacket *avpkt, th_pkt_t *pkt)
     pkt->a.pkt_sri      = self->sri;
     return 0;
 }
-
 
 TVHContextType TVHAudioContext = {
     .media_type = AVMEDIA_TYPE_AUDIO,

--- a/src/transcoding/transcode/context.c
+++ b/src/transcoding/transcode/context.c
@@ -19,6 +19,13 @@
 
 
 #include "internals.h"
+#if ENABLE_HWACCELS
+#include "hwaccels/hwaccels.h"
+#endif
+
+#if LIBAVCODEC_VERSION_MAJOR > 59
+#include <libavutil/avstring.h>
+#endif
 
 #include <libavutil/opt.h>
 
@@ -194,22 +201,152 @@ _context_encode(TVHContext *self, AVFrame *avframe)
 static int
 _context_meta(TVHContext *self, AVPacket *avpkt, th_pkt_t *pkt)
 {
-    if ((avpkt->flags & AV_PKT_FLAG_KEY) == 0)
+    // this implementation is adding AV_PKT_DATA_NEW_EXTRADATA required for V4L2-M2M (DRM)
+    if (!self->require_meta)
         return 0;
-    if (self->require_meta) {
-        if (self->helper && self->helper->meta) {
-            self->require_meta = self->helper->meta(self, avpkt, pkt);
-            if (self->require_meta == 0)
-                self->require_meta = 1;
-        }
-        else if (self->oavctx->extradata_size) {
-            pkt->pkt_meta = pktbuf_alloc(self->oavctx->extradata,
-                                         self->oavctx->extradata_size);
+
+    if (self->use_pkt_data_new_extradata) {
+        // 1) NEW: prefer side-data extradata updates
+        size_t side_size = 0;
+        const uint8_t *side = av_packet_get_side_data(avpkt, AV_PKT_DATA_NEW_EXTRADATA, &side_size);
+        if (side && side_size > 0) {
+            pkt->pkt_meta = pktbuf_alloc(side, side_size);
             self->require_meta = (pkt->pkt_meta) ? 1 : -1;
+            return (self->require_meta < 0) ? -1 : 0;
         }
     }
-    return (self->require_meta < 0) ? -1 : 0;
+    else{
+        // 2) For everything else (Helper/Fallback), 
+        // ONLY proceed if it's a KEYFRAME for non use_pkt_data_new_extradata
+        if ((avpkt->flags & AV_PKT_FLAG_KEY) == 0)
+            return 0;
+    }
+
+    // 3) Existing: helper (in-band SPS/PPS scan)
+    if (self->helper && self->helper->meta) {
+        int r = self->helper->meta(self, avpkt, pkt);
+        // If helper succeeded it returns 0 and pkt->pkt_meta is set
+        if (r == 0 && pkt->pkt_meta) {
+            self->require_meta = 1;
+            return 0;
+        }
+        // If helper “didn’t find it” (returns 1), do NOT stop here.
+        // Fall through to extradata fallback.
+    }
+    // 4) NEW/strengthened: fallback to extradata if present
+    if (self->oavctx->extradata_size > 0 && self->oavctx->extradata) {
+        pkt->pkt_meta = pktbuf_alloc(self->oavctx->extradata, self->oavctx->extradata_size);
+        self->require_meta = (pkt->pkt_meta) ? 1 : -1;
+        return (self->require_meta < 0) ? -1 : 0;
+    }
+    // Still require meta; try again on next frame/keyframe
+    return 0;
 }
+
+#if LIBAVCODEC_VERSION_MAJOR > 59
+/**
+ * Builds a linear filter graph from a comma-separated string,
+ * injecting the hardware context where necessary.
+ * * @param graph The allocated AVFilterGraph
+ * @param filter_str The comma-separated filter string (e.g., "format=nv12,hwupload,scale")
+ * @param in_ctx The input filter context (e.g., the "buffer" filter)
+ * @param out_ctx The output filter context (e.g., the "buffersink" filter)
+ * @param hw_device_octx The hardware device context to inject
+ * @return 0 on success, negative AVERROR on failure
+ * NOTE: is not working with complex filters
+ */
+static int build_linear_hw_filter_graph(AVFilterGraph *graph, const char *filter_str, 
+                                 AVFilterContext *in_ctx, AVFilterContext *out_ctx, 
+                                 AVBufferRef *hw_device_octx) {
+    int ret = 0;
+    AVFilterContext *prev_ctx = in_ctx;
+    
+    // Duplicate the string because av_strtok modifies it
+    char *str_copy = av_strdup(filter_str);
+    if (!str_copy) return AVERROR(ENOMEM);
+
+    char *saveptr = NULL;
+    // Tokenize the string by commas
+    char *filter_token = av_strtok(str_copy, ",", &saveptr);
+
+    while (filter_token) {
+        char *filter_name = filter_token;
+        char *filter_args = NULL;
+
+        // Find the first '=' to split the filter name from its arguments
+        char *eq_ptr = strchr(filter_name, '=');
+        if (eq_ptr) {
+            *eq_ptr = '\0';       // Null-terminate the name
+            filter_args = eq_ptr + 1; // The rest is the arguments string
+        }
+
+        // 1. Find the filter by name
+        const AVFilter *filter = avfilter_get_by_name(filter_name);
+        if (!filter) {
+            // Log error: Filter not found
+            ret = AVERROR_FILTER_NOT_FOUND;
+            goto cleanup;
+        }
+
+        // 2. Create the filter (Allocates context AND calls init)
+        AVFilterContext *current_ctx = NULL;
+        
+        // --- THE CRITICAL INJECTION STEP ---
+        // If the filter requires a hardware context (like hwupload), we cannot use 
+        // avfilter_graph_create_filter directly because it calls init() immediately.
+        // Instead, we must use the two-step allocation/init process manually.
+        
+        current_ctx = avfilter_graph_alloc_filter(graph, filter, filter_name);
+        if (!current_ctx) {
+            ret = AVERROR(ENOMEM);
+            goto cleanup;
+        }
+
+        // Inject the hardware context BEFORE initialization
+        if (hw_device_octx && (strstr(filter->name, "hwupload") || strstr(filter->name, "hwmap"))) {
+            current_ctx->hw_device_ctx = av_buffer_ref(hw_device_octx);
+            if (!current_ctx->hw_device_ctx) {
+                ret = AVERROR(ENOMEM);
+                goto cleanup;
+            }
+        }
+
+        // Now initialize the filter with its arguments
+        ret = avfilter_init_str(current_ctx, filter_args);
+        if (ret < 0) {
+            // Log error: Failed to initialize filter
+            goto cleanup;
+        }
+
+        // 3. Link this filter to the previous one in the chain
+        if (prev_ctx) {
+            ret = avfilter_link(prev_ctx, 0, current_ctx, 0);
+            if (ret < 0) {
+                // Log error: Failed to link filters
+                goto cleanup;
+            }
+        }
+
+        prev_ctx = current_ctx;
+        
+        // Get the next filter token
+        filter_token = av_strtok(NULL, ",", &saveptr);
+    }
+
+    // Finally, link the last created filter to the output context (buffersink)
+    if (prev_ctx && out_ctx) {
+        ret = avfilter_link(prev_ctx, 0, out_ctx, 0);
+        if (ret < 0) {
+            // Log error: Failed to link to output
+            goto cleanup;
+        }
+    }
+
+cleanup:
+    av_free(str_copy);
+    return ret;
+}
+#endif
 
 
 static int
@@ -259,51 +396,204 @@ tvh_context_setup(TVHContext *self, const AVCodec *iavcodec, const AVCodec *oavc
 
 
 // open
-
+/**
+ * Central open step for a @c TVHContext: validates which @c AVCodecContext is in
+ * scope for @p phase, then runs the matching libav setup sequence.
+ *
+ * Phase 1 selects the working context and refuses to continue if no @c codec
+ * is bound:
+ * - Decoder phases (@c PREPARE_DECODER, @c OPEN_DECODER, @c NOTIFY_GLOBALHEADER)
+ *   use @c self->iavctx.
+ * - Encoder phases (@c PREPARE_ENCODER, @c OPEN_FILTERS, @c OPEN_ENCODER)
+ *   use @c self->oavctx.
+ *
+ * Phase 2 (per @p phase):
+ * - @c PREPARE_DECODER — read @c tvh_require_meta, call @c _context_open (media-type
+ *   hooks), then optional decoder @c helper->open.
+ * - @c OPEN_DECODER — @c avcodec_open2 on the decoder, then @c _context_open for
+ *   post-open work; logs options on success.
+ * - @c NOTIFY_GLOBALHEADER — @c _context_open only; frees @c self->temp_opts afterward.
+ * - @c PREPARE_ENCODER — profile @c tvh_codec_profile_open, @c tvh_require_meta,
+ *   @c _context_open, then optional encoder @c helper->open; stores @c self->helper.
+ *   and logs options on success.
+ * - @c OPEN_FILTERS — @c _context_open only (typically builds the libavfilter graph).
+ * - @c OPEN_ENCODER — @c avcodec_open2 on the encoder, then @c _context_open (e.g. audio
+ *   computes @c delta / sink frame size after @c frame_size is known); logs options
+ *   on success, then frees @c self->temp_opts.
+ *
+ * Intended call order for a full pipeline is implemented by @c tvh_context_open_decoder
+ * and @c tvh_context_open_encoder (decoder: prepare → open → notify; encoder:
+ * prepare → filters → encoder).
+ *
+ * @param self  Transcode context (decoder, encoder, profile, temp options).
+ * @param phase Which @c TVHOpenPhase step to execute.
+ * @return      0 on success; a negative @c AVERROR or other error code from the failing
+ *              libav or Tvheadend step; @c AVERROR(EINVAL) for unknown phase or missing codec.
+ */
 static int
 tvh_context_open(TVHContext *self, TVHOpenPhase phase)
 {
     AVCodecContext *avctx = NULL;
     TVHContextHelper *helper = NULL;
-    AVDictionary *opts = NULL;
     int ret = 0;
 
+    // Phase 1: we check that we have codecs
     switch (phase) {
+        case PREPARE_DECODER:
         case OPEN_DECODER:
+        case NOTIFY_GLOBALHEADER:
             avctx = self->iavctx;
             if (!avctx->codec) {
                 tvh_context_log(self, LOG_ERR, "no decoder available");
                 return AVERROR(EINVAL);
             }
-            helper = tvh_decoder_helper_find(avctx->codec);
             break;
+        case PREPARE_ENCODER:
+        case OPEN_FILTERS:
         case OPEN_ENCODER:
             avctx = self->oavctx;
             if (!avctx->codec) {
                 tvh_context_log(self, LOG_ERR, "no encoder available");
                 return AVERROR(EINVAL);
             }
-            helper = self->helper = tvh_encoder_helper_find(avctx->codec);
-            ret = tvh_codec_profile_open(self->profile, &opts);
             break;
         default:
-            tvh_context_log(self, LOG_ERR, "invalid open phase");
+            tvh_context_log(self, LOG_ERR, "invalid open phase: %d", (int)phase);
             ret = AVERROR(EINVAL);
             break;
     }
-    if (!ret) {
-        _context_print_opts(self, opts);
-        ret = tvh_context_get_int_opt(&opts, "tvh_require_meta",
-                                      &self->require_meta);
-        if (!ret && !(ret = _context_open(self, phase, &opts)) && // pre open
-            !(ret = (helper && helper->open) ? helper->open(self, &opts) : 0) && // pre open
-            !(ret = avcodec_open2(avctx, NULL, &opts))) { // open
-            ret = _context_open(self, phase + 1, &opts); // post open
-        }
-        _context_print_opts(self, opts);
+    // Phase 2: we call proper functions (according to the state machine)
+    switch (phase) {
+        case PREPARE_DECODER:
+            helper = tvh_decoder_helper_find(avctx->codec);
+            if (!(ret = tvh_context_get_int_opt(&self->temp_opts, "tvh_require_meta", &self->require_meta)) &&
+                !(ret = _context_open(self, phase, &self->temp_opts))){
+                ret = (helper && helper->open) ? helper->open(self, &self->temp_opts) : 0;
+            } else {
+                tvh_context_log(self, LOG_ERR, "OpenPhase PREPARE_DECODER returned error: %d", ret);
+            }
+            break;
+        case OPEN_DECODER:
+            if (!(ret = avcodec_open2(avctx, NULL, &self->temp_opts)) && 
+                !(ret = _context_open(self, phase, &self->temp_opts))){
+                // print the dict for decoder
+                _context_print_opts(self, self->temp_opts);
+            } else {
+                tvh_context_log(self, LOG_ERR, "OpenPhase OPEN_DECODER returned error: %d", ret);
+            }
+            break;
+        case NOTIFY_GLOBALHEADER:
+            if ((ret = _context_open(self, phase, &self->temp_opts))){
+                tvh_context_log(self, LOG_ERR, "OpenPhase NOTIFY_GLOBALHEADER returned error: %d", ret);
+            }
+            // we no longer need dict for decoder
+            if (self->temp_opts) {
+                av_dict_free(&self->temp_opts);
+                self->temp_opts = NULL;
+            }
+            break;
+        case PREPARE_ENCODER:
+            helper = self->helper = tvh_encoder_helper_find(avctx->codec);
+            if (!(ret = tvh_codec_profile_open(self->profile, &self->temp_opts)) &&
+                !(ret = tvh_context_get_int_opt(&self->temp_opts, "tvh_require_meta", &self->require_meta)) &&
+                !(ret = _context_open(self, phase, &self->temp_opts)) && // pre open
+                !(ret = (helper && helper->open) ? helper->open(self, &self->temp_opts) : 0)){  // pre open
+                // print the dict for encoder
+                _context_print_opts(self, self->temp_opts);
+            } else {
+                tvh_context_log(self, LOG_ERR, "OpenPhase PREPARE_ENCODER returned error: %d", ret);
+            }
+            break;
+        case OPEN_FILTERS:
+            if ((ret = _context_open(self, phase, &self->temp_opts))){
+                tvh_context_log(self, LOG_ERR, "OpenPhase OPEN_FILTERS returned error: %d", ret);
+            }
+            break;
+        case OPEN_ENCODER:
+            if (!(ret = avcodec_open2(avctx, NULL, &self->temp_opts)) && 
+                !(ret = _context_open(self, phase, &self->temp_opts))){
+                // print the dict for encoder
+                _context_print_opts(self, self->temp_opts);
+            } else {
+                tvh_context_log(self, LOG_ERR, "OpenPhase OPEN_ENCODER returned error: %d", ret);
+            }
+            // we no longer need dict for encoder
+            if (self->temp_opts) {
+                av_dict_free(&self->temp_opts);
+                self->temp_opts = NULL;
+            }
+            break;
+        default:
+            tvh_context_log(self, LOG_ERR, "invalid open phase: %d", (int)phase);
+            ret = AVERROR(EINVAL);
+            break;
     }
-    if (opts) {
-        av_dict_free(&opts);
+    return ret;     
+}
+
+/**
+ * Run the encoder-side open sequence for @p self in the correct order.
+ *
+ * Calls @ref tvh_context_open with:
+ * 1. @c PREPARE_ENCODER — profile and type-specific preparation (@c sample_fmt,
+ *    rates, layouts, bit rate / quality, HW hooks, etc.).
+ * 2. @c OPEN_FILTERS — build and configure the libavfilter graph feeding the encoder
+ *    (only if step 1 succeeds).
+ * 3. @c OPEN_ENCODER — @c avcodec_open2 on the output codec, then type-specific
+ *    post-open work (only if step 2 succeeds).
+ *
+ * On failure, logs which phase failed and returns that error; later phases are skipped.
+ *
+ * @param self Transcode context whose @c oavctx and filter graph are being set up.
+ * @return     0 if all three phases succeed; otherwise the first non-zero return value
+ *             from @ref tvh_context_open (typically a negative @c AVERROR).
+ */
+static int
+tvh_context_open_encoder(TVHContext *self){
+    int ret = 0;
+
+    if ((ret = tvh_context_open(self, PREPARE_ENCODER))){
+        tvh_context_log(self, LOG_ERR, "PREPARE_ENCODER returned error: %d", ret);
+    }
+    if (!ret && (ret = tvh_context_open(self, OPEN_FILTERS))){
+        tvh_context_log(self, LOG_ERR, "OPEN_FILTERS returned error: %d", ret);
+    }
+    if (!ret && (ret = tvh_context_open(self, OPEN_ENCODER))){
+        tvh_context_log(self, LOG_ERR, "OPEN_ENCODER returned error: %d", ret);
+    }
+    return ret;
+}
+
+/**
+ * Run the decoder-side open sequence for @p self in the correct order.
+ *
+ * Calls @c tvh_context_open with:
+ * 1. @c PREPARE_DECODER — type-specific decoder preparation and optional decoder
+ *    helper setup (@c _context_open plus @c helper->open when present).
+ * 2. @c OPEN_DECODER — @c avcodec_open2 on the input codec, then decoder post-open
+ *    (@c _context_open) if step 1 succeeded.
+ * 3. @c NOTIFY_GLOBALHEADER — global-header / extradata notification via
+ *    @c _context_open if step 2 succeeded; @c tvh_context_open then clears
+ *    @c self->temp_opts for the decoder path.
+ *
+ * On failure, logs which phase failed and returns that error; later phases are skipped.
+ *
+ * @param self Transcode context whose @c iavctx is being opened.
+ * @return     0 if all three phases succeed; otherwise the first non-zero return value
+ *             from @c tvh_context_open (typically a negative @c AVERROR).
+ */
+static int
+tvh_context_open_decoder(TVHContext *self){
+    int ret = 0;
+
+    if ((ret = tvh_context_open(self, PREPARE_DECODER))){
+        tvh_context_log(self, LOG_ERR, "PREPARE_DECODER returned error: %d", ret);
+    }
+    if (!ret && (ret = tvh_context_open(self, OPEN_DECODER))){
+        tvh_context_log(self, LOG_ERR, "OPEN_DECODER returned error: %d", ret);
+    }
+    if (!ret && (ret = tvh_context_open(self, NOTIFY_GLOBALHEADER))){
+        tvh_context_log(self, LOG_ERR, "NOTIFY_GLOBALHEADER returned error: %d", ret);
     }
     return ret;
 }
@@ -319,7 +609,30 @@ tvh_context_pack(TVHContext *self, AVPacket *avpkt)
     if (self->helper && self->helper->pack) {
         pkt = self->helper->pack(self, avpkt);
     } else {
-        pkt = pkt_alloc(self->stream->type, avpkt->data, avpkt->size, avpkt->pts, avpkt->dts, 0);
+        // th_pkt_t timestamps are expected to be in MPEG-TS 90kHz ticks.
+        // Encoder packets are in self->oavctx->time_base and can change if filter is changing the frame_rate
+        // (for example deinterlace_qsv can double the frame rate),
+        // so rescale here.
+        const AVRational tb90k = { 1, 90000 };
+        int64_t pts90 = avpkt->pts;
+        int64_t dts90 = avpkt->dts;
+        if (pts90 != AV_NOPTS_VALUE)
+            pts90 = av_rescale_q_rnd(pts90, self->oavctx->time_base, tb90k,
+                                    AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX);
+        if (dts90 != AV_NOPTS_VALUE)
+            dts90 = av_rescale_q_rnd(dts90, self->oavctx->time_base, tb90k,
+                                    AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX);
+        int64_t dur90 = 0;
+        if (avpkt->duration > 0) {
+            dur90 = av_rescale_q_rnd(avpkt->duration, self->oavctx->time_base, tb90k,
+                                    AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX);
+        } else if (self->oavctx->framerate.num > 0 && self->oavctx->framerate.den > 0) {
+            dur90 = av_rescale_q(1, av_inv_q(self->oavctx->framerate), tb90k); // 3000@30fps, 1500@60fps
+        }
+
+        pkt = pkt_alloc(self->stream->type, avpkt->data, avpkt->size, pts90, dts90, 0);
+        if (pkt && dur90 > 0)
+            pkt->pkt_duration = dur90;
     }
     if (!pkt) {
         tvh_context_log(self, LOG_ERR, "failed to create packet");
@@ -372,6 +685,9 @@ tvh_context_receive_packet(TVHContext *self)
     return (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) ? 0 : ret;
 }
 
+// Number of consecutive encode failures tolerated before the stream is stopped.
+// selected 50 because terestrial DVB can have longer chunks of error; so allow 1 sec of curruption
+#define TVH_MAX_ENCODE_ERRORS 50
 
 static int
 tvh_context_encode_frame(TVHContext *self, AVFrame *avframe)
@@ -390,6 +706,29 @@ tvh_context_encode_frame(TVHContext *self, AVFrame *avframe)
     }
     if ((ret = (ret == AVERROR_EOF) ? 0 : ret)) {
         av_frame_unref(avframe);
+        // Track consecutive encode failures. A hardware encoder (e.g. h264_vaapi)
+        // can enter a persistent error state and return -EIO on every frame; without
+        // a recovery path tvheadend would loop forever calling this on each input
+        // packet. avframe is NULL only during flush, which must not count as an error.
+        if (avframe) {
+            self->encode_errors++;
+            tvh_context_log(self, LOG_WARNING,
+                "encode error %d/%d", self->encode_errors, TVH_MAX_ENCODE_ERRORS);
+            if (self->encode_errors >= TVH_MAX_ENCODE_ERRORS) {
+                tvh_context_log(self, LOG_ERR,
+                    "too many consecutive encode errors, stopping stream");
+                self->encode_errors = 0;
+                // Return a fatal error that tvh_context_decode() does NOT remap to 0
+                // (unlike EAGAIN/EINVAL/EIO/INVALIDDATA). It then propagates up to
+                // tvh_transcoder_handle(), which calls tvh_stream_stop() to tear the
+                // stream down cleanly via tvh_context_close(). Do not free oavctx here:
+                // teardown is the stop path's responsibility, and freeing it would let
+                // a later packet re-enter tvh_context_encode() with oavctx == NULL.
+                ret = AVERROR(ENODEV);
+            }
+        }
+    } else {
+        self->encode_errors = 0;
     }
     return ret;
 }
@@ -421,8 +760,10 @@ tvh_context_encode(TVHContext *self, AVFrame *avframe)
 {
     int ret = 0;
 
-    if (!avcodec_is_open(self->oavctx)) {
-        ret = tvh_context_open(self, OPEN_ENCODER);
+    // Guard against a NULL encoder context: avcodec_is_open() dereferences its
+    // argument, so a missing oavctx would otherwise segfault here.
+    if (!self->oavctx || !avcodec_is_open(self->oavctx)) {
+        ret = tvh_context_open_encoder(self);
     }
     if (!ret && !(ret = tvh_context_push_frame(self, avframe))) {
         while ((ret = tvh_context_pull_frame(self, self->oavframe)) != AVERROR(EAGAIN)) {
@@ -477,7 +818,7 @@ tvh_context_decode(TVHContext *self, AVPacket *avpkt)
     int ret = 0;
 
     if (!avcodec_is_open(self->iavctx)) {
-        ret = tvh_context_open(self, OPEN_DECODER);
+        ret = tvh_context_open_decoder(self);
     }
     if (!ret && !(ret = _context_decode(self, avpkt))) {
         ret = tvh_context_decode_packet(self, avpkt);
@@ -525,6 +866,19 @@ tvh_context_get_str_opt(AVDictionary **opts, const char *key, char **value)
 }
 
 
+
+void
+tvh_context_setup_parser(TVHContext *self)
+{
+    // setup parser
+    self->parser = av_parser_init(self->iavctx->codec_id);
+    if (self->parser)
+        self->parser->flags |= PARSER_FLAG_COMPLETE_FRAMES; // optional depending on container
+    // allocate avpacket
+    self->out_pkt = av_packet_alloc();
+}
+
+
 void
 tvh_context_close(TVHContext *self, int flush)
 {
@@ -536,7 +890,368 @@ tvh_context_close(TVHContext *self, int flush)
     }
 }
 
+#if LIBAVCODEC_VERSION_MAJOR > 59
+int
+tvh_context_open_filters2(TVHContext *self,
+                         const char *source_name,
+                         const char *filters, 
+                         const char *sink_name)
+{
+    static const AVClass logclass = {
+        .class_name = "TVHGraph",
+        .version    = 1,
+    };
+    struct {
+        const AVClass *class;
+    } logctx = { &logclass };
+    const AVFilter *iavflt = NULL;
+    const AVFilter *oavflt = NULL;
+    AVBufferSrcParameters *par = NULL;
+    int ret = -1;
+    enum AVMediaType stream_type = AVMEDIA_TYPE_UNKNOWN;
 
+    tvh_context_log(self, LOG_DEBUG, "filters: '%s'", filters);
+
+    if (!(self->avfltgraph = avfilter_graph_alloc()) ||
+        !(par = av_buffersrc_parameters_alloc())) {
+        ret = AVERROR(ENOMEM);
+        goto finish;
+    }
+
+// source
+    if (!(iavflt = avfilter_get_by_name(source_name))) {
+        tvh_context_log(self, LOG_ERR, "filters: source filter'%s' not found", source_name);
+        ret = AVERROR_FILTER_NOT_FOUND;
+        goto finish;
+    }
+
+    // 1. ALLOCATE (No init yet, so it won't fail due to missing args)
+    self->iavfltctx = avfilter_graph_alloc_filter(self->avfltgraph, iavflt, "in");
+    if (!self->iavfltctx) {
+        tvh_context_log(self, LOG_ERR, "filters: failed to create 'in' filter");
+        goto finish;
+    }
+
+    // additional buffersrc params
+    memset(par, 0, sizeof(AVBufferSrcParameters));
+    
+    switch (self->iavctx->codec_type) {
+        case AVMEDIA_TYPE_VIDEO:
+            stream_type = AVMEDIA_TYPE_VIDEO;
+            break;
+        case AVMEDIA_TYPE_AUDIO:
+            stream_type = AVMEDIA_TYPE_AUDIO;
+            break;
+        default:
+            break;
+    }
+
+    if (stream_type == AVMEDIA_TYPE_UNKNOWN) {
+        ret = -1;
+        tvherror(LS_TRANSCODE, "filter can't process media type: %s", av_get_media_type_string(self->iavctx->codec_type));
+        goto finish;
+    }
+
+    // 2. CONFIGURE PARAMETERS
+    if (stream_type == AVMEDIA_TYPE_VIDEO) {
+        // for Video:
+        int int_pix_fmt = self->iavctx->pix_fmt;
+        AVRational sample_aspect_ratio = self->iavctx->sample_aspect_ratio;
+        if (sample_aspect_ratio.num <= 0 || sample_aspect_ratio.den <= 0) {
+            if (self->sample_aspect_ratio.num > 0 && self->sample_aspect_ratio.den > 0)
+                sample_aspect_ratio = self->sample_aspect_ratio;
+            else if (self->iavframe && 
+                self->iavframe->sample_aspect_ratio.num > 0 &&
+                self->iavframe->sample_aspect_ratio.den > 0)
+                sample_aspect_ratio = self->iavframe->sample_aspect_ratio;
+            else
+                sample_aspect_ratio = (AVRational){1, 1};
+            self->iavctx->sample_aspect_ratio = sample_aspect_ratio;
+        }
+        // Basic video properties
+        par->width                = self->iavctx->width;
+        par->height               = self->iavctx->height;
+        par->sample_aspect_ratio  = sample_aspect_ratio;
+        par->frame_rate           = self->iavctx->framerate;
+        
+        // CRITICAL: Metadata synchronization (fixes the FFmpeg 7 warnings)
+        par->time_base            = av_make_q(self->iavctx->time_base.num, self->iavctx->time_base.den); // or stream->time_base
+#if LIBAVCODEC_VERSION_MAJOR > 60
+        par->color_range          = self->iavctx->color_range;  // Fixes "range: tv" warning
+        par->color_space          = self->iavctx->colorspace;   // Fixes "csp: unknown" warning
+        // to be added later on
+        //par->color_primaries = self->iavctx->color_primaries;
+        //par->color_trc       = self->iavctx->color_trc;
+#endif
+        // If using hardware acceleration (VAAPI/CUDA/etc), pass the frames context
+        if (self->iavctx->hw_frames_ctx){
+            // Increment the reference count so the filter "owns" a piece of the hardware context
+            par->hw_frames_ctx = av_buffer_ref(self->iavctx->hw_frames_ctx);
+            
+            if (!par->hw_frames_ctx) {
+                // Handle allocation error
+                ret = AVERROR(ENOMEM);
+                goto finish;
+            }
+            AVHWFramesContext *frames_ctx = (AVHWFramesContext*)self->iavctx->hw_frames_ctx->data;
+            int_pix_fmt = (int)frames_ctx->format;
+        }
+        par->format               = int_pix_fmt;
+
+        char logs[256];
+        str_snprintf(logs, sizeof(logs),
+            "filter video in configuration:"
+            " video_size=%dx%d"
+            ",pix_fmt=%s"
+            ",time_base=%d/%d"
+            ",frame_rate=%d/%d"
+            ",pixel_aspect:%d/%d"
+#if LIBAVCODEC_VERSION_MAJOR > 60
+            ",color_range:%s"
+            ",color_space:%s"
+#endif
+            ,self->iavctx->width, self->iavctx->height
+            ,av_get_pix_fmt_name(int_pix_fmt)
+            ,self->iavctx->time_base.num, self->iavctx->time_base.den
+            ,self->iavctx->framerate.num, self->iavctx->framerate.den
+            ,sample_aspect_ratio.num, sample_aspect_ratio.den
+#if LIBAVCODEC_VERSION_MAJOR > 60
+            ,av_color_range_name(self->iavctx->color_range)
+            ,av_color_space_name(self->iavctx->colorspace)
+#endif
+        );
+        // log parameters
+        tvh_context_log(self, LOG_DEBUG, "%s", logs);
+
+    } else if (stream_type == AVMEDIA_TYPE_AUDIO) {
+        // for Audio:
+        // Basic audio properties
+        par->format      = self->iavctx->sample_fmt;
+        par->sample_rate = self->iavctx->sample_rate;
+        par->time_base   = (AVRational){1, self->iavctx->sample_rate};
+
+        // Copy channel layout (Crucial for FFmpeg 7/8)
+        ret = av_channel_layout_copy(&par->ch_layout, &self->iavctx->ch_layout);
+        if (ret < 0) {
+            tvh_context_log(self, LOG_ERR, "filters: failed to set av_channel_layout with error %d", ret);
+            goto finish;
+        }
+
+        char logs[256];
+        memset(logs, 0, sizeof(logs));
+        char buf[64];
+        memset(buf, 0, sizeof(buf));
+        av_channel_layout_describe(&par->ch_layout, buf, sizeof(buf));
+        str_snprintf(logs, sizeof(logs),
+            "filter audio in configuration:"
+            " ch_layout=%s"
+            ",sample_fmt=%s"
+            ",sample_rate=%d"
+            ",time_base=%d/%d"
+            ,buf
+            ,av_get_sample_fmt_name(par->format)
+            ,par->sample_rate
+            ,par->time_base.num, par->time_base.den
+        );
+        // log parameters
+        tvh_context_log(self, LOG_DEBUG, "%s", logs);
+    } else tvherror(LS_TRANSCODE, "filter can process only 'buffer' and 'abuffer', most likely will fail.");
+
+    // Push the parameters into the uninitialized filter context
+    ret = av_buffersrc_parameters_set(self->iavfltctx, par);
+    if (ret < 0) {
+        tvh_context_log(self, LOG_ERR, "filters: failed to set AVFilterContext parameters with error %d", ret);
+        goto finish;
+    }
+
+    // 3. MANUALLY INITIALIZE
+    // Now that the params are inside, we call init with NULL
+    ret = avfilter_init_str(self->iavfltctx, NULL);
+    if (ret < 0) {
+        tvh_context_log(self, LOG_ERR, "filters: failed to initialize AVFilterContext with error %d", ret);
+        goto finish;
+    }
+
+// sink
+    if (!(oavflt = avfilter_get_by_name(sink_name))) {
+        tvh_context_log(self, LOG_ERR, "filters: sink filter '%s' not found", sink_name);
+        ret = AVERROR_FILTER_NOT_FOUND;
+        goto finish;
+    }
+
+    ret = avfilter_graph_create_filter(&self->oavfltctx, oavflt, "out", NULL, NULL, self->avfltgraph);
+    if (ret < 0) {
+        tvh_context_log(self, LOG_ERR, "filters: failed to create 'out' filter with error %d", ret);
+        goto finish;
+    }
+
+    // filters
+    // Build the linear chain and inject the hardware context 
+    if (filters && *filters) {
+        ret = build_linear_hw_filter_graph(self->avfltgraph, filters, 
+                                           self->iavfltctx, self->oavfltctx, 
+                                           self->hw_device_octx);
+        if (ret < 0) {
+            // Log error
+            tvh_context_log(self, LOG_ERR, "filters: fail during build_linear_hw_filter_graph() %d", ret);
+            goto finish;
+        }
+    } else {
+        // If there's no filter string, just link input directly to output
+        ret = avfilter_link(self->iavfltctx, 0, self->oavfltctx, 0);
+        if (ret < 0) {
+            // Log error
+            tvh_context_log(self, LOG_ERR, "filters: fail during build_linear_hw_filter_graph() %d", ret);
+            goto finish;
+        }
+    }
+
+    if (ret < 0) {
+        tvh_context_log(self, LOG_ERR, "filters: failed to add filters: '%s' with error %d", filters, ret);
+        goto finish;
+    }
+
+    // insert aditional filters required for conversions
+    avfilter_graph_set_auto_convert(self->avfltgraph, AVFILTER_AUTO_CONVERT_ALL);
+
+    //
+    if ((ret = avfilter_graph_config(self->avfltgraph, &logctx)) < 0) {
+        tvh_context_log(self, LOG_ERR, "filters: failed to config filter graph with error %d", ret);
+        goto finish;
+    }
+
+    stream_type = av_buffersink_get_type(self->oavfltctx);
+
+    // 1. CONFIGURE PARAMETERS
+    if (stream_type == AVMEDIA_TYPE_VIDEO) {
+        // for Video:
+        // Extract negotiated parameters from the sink context and pass them to the encoder context.
+        self->oavctx->pix_fmt   = av_buffersink_get_format(self->oavfltctx);
+        self->oavctx->width     = av_buffersink_get_w(self->oavfltctx);
+        self->oavctx->height    = av_buffersink_get_h(self->oavfltctx);
+        // Important: The filter graph may change the timebase
+        self->oavctx->time_base = av_buffersink_get_time_base(self->oavfltctx);
+        self->oavctx->framerate = av_buffersink_get_frame_rate(self->oavfltctx);
+#if LIBAVCODEC_VERSION_MAJOR > 60
+        // Get the output link to access color metadata
+        const AVFilterLink *outlink = self->oavfltctx->inputs[0];
+        // 1. Extract Color Range (MPEG/TV vs JPEG/PC)
+        self->oavctx->color_range = outlink->color_range;
+        // 2. Extract Color Space (e.g., BT.709, BT.2020)
+        self->oavctx->colorspace = outlink->colorspace;
+        // 3. Extract Color Primaries and Transfer Characteristics (Recommended)
+        // to be added later on
+        //self->oavctx->color_primaries = outlink->color_primaries;
+        //self->oavctx->color_trc       = outlink->color_trc;
+#endif
+        // Handle Sample Aspect Ratio (SAR)
+        AVRational sar = av_buffersink_get_sample_aspect_ratio(self->oavfltctx);
+        if (sar.num > 0 && sar.den > 0)
+            self->oavctx->sample_aspect_ratio = sar;
+
+        // 2. THE HARDWARE LINK
+        // Query the hardware frames context from the sink.
+        AVBufferRef *hw_frames_ctx = av_buffersink_get_hw_frames_ctx(self->oavfltctx);
+        
+        if (hw_frames_ctx) {
+            // We must create a new reference to the context. 
+            // The encoder context will take ownership of this reference. 
+            self->oavctx->hw_frames_ctx = av_buffer_ref(hw_frames_ctx);
+            if (!self->oavctx->hw_frames_ctx) {
+                ret = AVERROR(ENOMEM);
+                goto finish;
+            }
+            
+            // Optimization: Some encoders (like VAAPI) benefit from knowing 
+            // the underlying software format being "hidden" by the hardware surface.
+            const AVHWFramesContext *frames_fctx = (AVHWFramesContext *)hw_frames_ctx->data;
+            self->oavctx->sw_pix_fmt = frames_fctx->sw_format;
+            
+            // Log it so you can see it's working
+            tvh_context_log(self, LOG_DEBUG, "filters: filter sink provided HW frames (pix_fmt: %s, sw_pix_fmt: %s)", 
+                av_get_pix_fmt_name(self->oavctx->pix_fmt), av_get_pix_fmt_name(self->oavctx->sw_pix_fmt));
+        }
+        char logs[256];
+        str_snprintf(logs, sizeof(logs),
+            "filter video out configuration:"
+            " video_size=%dx%d"
+            ",pix_fmt=%s"
+            ",time_base=%d/%d"
+            ",frame_rate=%d/%d"
+            ",pixel_aspect:%d/%d"
+#if LIBAVCODEC_VERSION_MAJOR > 60
+            ",color_range:%s"
+            ",color_space:%s"
+#endif
+            ,self->oavctx->width, self->oavctx->height
+            ,av_get_pix_fmt_name(self->oavctx->pix_fmt)
+            ,self->oavctx->time_base.num, self->oavctx->time_base.den
+            ,self->oavctx->framerate.num, self->oavctx->framerate.den
+            ,self->oavctx->sample_aspect_ratio.num, self->oavctx->sample_aspect_ratio.den
+#if LIBAVCODEC_VERSION_MAJOR > 60
+            ,av_color_range_name(outlink->color_range)
+            ,av_color_space_name(outlink->colorspace)
+#endif
+        );
+        // log parameters
+        tvh_context_log(self, LOG_DEBUG, "%s", logs);
+
+    } else if (stream_type == AVMEDIA_TYPE_AUDIO) {
+        // for Audio:
+        // Extract negotiated parameters from the sink context and pass them to the encoder context.
+        self->oavctx->sample_rate = av_buffersink_get_sample_rate(self->oavfltctx);
+        self->oavctx->sample_fmt = av_buffersink_get_format(self->oavfltctx);
+        // Correct way to set up the audio encoder
+        self->oavctx->time_base = (AVRational){1, self->oavctx->sample_rate};   // CRITICAL
+
+        ret = av_buffersink_get_ch_layout(self->oavfltctx, &self->oavctx->ch_layout);
+        if (ret < 0) {
+            tvh_context_log(self, LOG_ERR, "filters: failed to config AVCodecContext ch_layout with error %d", ret);
+            goto finish;
+        }
+
+        char logs[256];
+        memset(logs, 0, sizeof(logs));
+        char buf[64];
+        memset(buf, 0, sizeof(buf));
+        av_channel_layout_describe(&self->oavctx->ch_layout, buf, sizeof(buf));
+        str_snprintf(logs, sizeof(logs),
+            "filter audio out configuration:"
+            " ch_layout=%s"
+            ",sample_fmt=%s"
+            ",sample_rate=%d"
+            ",time_base=%d/%d"
+            ,buf
+            ,av_get_sample_fmt_name(self->oavctx->sample_fmt)
+            ,self->oavctx->sample_rate
+            ,self->oavctx->time_base.num, self->oavctx->time_base.den
+        );
+        // log parameters
+        tvh_context_log(self, LOG_DEBUG, "%s", logs);
+
+    } else tvherror(LS_TRANSCODE, "filter can process only 'buffersink' and 'abuffersink', most likely will fail.");
+
+    if (ret >= 0 && tvhtrace_enabled()) {
+        char *graph = avfilter_graph_dump(self->avfltgraph, NULL);
+        char *str, *token, *saveptr = NULL;
+        for (str = graph; ; str = NULL) {
+          token = strtok_r(str, "\n", &saveptr);
+          if (token == NULL)
+            break;
+          tvh_context_log(self, LOG_TRACE, "filters dump: %s", token);
+        }
+        av_freep(&graph);
+    }
+
+finish:
+    if (par) {
+        av_channel_layout_uninit(&par->ch_layout);
+        av_buffer_unref(&par->hw_frames_ctx);
+        av_freep(&par);
+    }
+    return (ret > 0) ? 0 : ret;
+}
+#endif
 int
 tvh_context_open_filters(TVHContext *self,
                          const char *source_name, const char *source_args,
@@ -691,13 +1406,41 @@ tvh_context_deliver(TVHContext *self, th_pkt_t *pkt)
 }
 
 
+/**
+ * @brief Processes an incoming media packet, ensuring complete frames and correct timestamps before decoding.
+ *
+ * This function extracts the raw payload from an incoming Tvheadend packet and prepares it 
+ * for the FFmpeg decoder. It safely handles both audio and video streams by branching logic 
+ * based on the availability of a codec parser:
+ * 
+ * - **Parsed Path (e.g., H.264, HEVC, AAC):** If a parser is initialized in the context, 
+ *   the raw byte stream is fed through a parsing loop (`av_parser_parse2`). This safely 
+ *   splits combined streams into discrete frames, calculates proper B-frame reordering delays, 
+ *   and dynamically interpolates missing PTS/DTS timestamps before sending them to the decoder.
+ * 
+ * - **Unparsed Path (e.g., PCM audio):** If the codec does not require or support a parser, 
+ *   the raw data is directly wrapped into an `AVPacket`. The original PTS/DTS timestamps 
+ *   provided by the demuxer are applied directly before decoding.
+ *
+ * @param self Pointer to the TVHContext holding the codec state, parser, and allocated output packet.
+ * @param pkt  Pointer to the incoming packet (`th_pkt_t`) containing the payload, size, 
+ *             and demuxer-level timestamps.
+ *
+ * @return 0 on success, or a negative AVERROR code on failure:
+ *         - AVERROR(EOVERFLOW) if the payload exceeds TVH_INPUT_BUFFER_MAX_SIZE.
+ *         - AVERROR(ENOMEM) if payload copying or packet allocation fails.
+ *         - Negative error codes propagated from the parser or decoder.
+ *
+ * @note This function safely manages the memory of the copied payload. In the parsed path, 
+ *       the temporary buffer is explicitly freed after the parsing loop. In the unparsed path, 
+ *       memory ownership is transferred to the `AVPacket` and released via `av_packet_unref()`.
+ */
 int
 tvh_context_handle(TVHContext *self, th_pkt_t *pkt)
 {
     int ret = 0;
     uint8_t *data = NULL;
     size_t size = 0;
-    AVPacket avpkt;
 
     if ((size = pktbuf_len(pkt->pkt_payload)) && pktbuf_ptr(pkt->pkt_payload)) {
         if (size >= TVH_INPUT_BUFFER_MAX_SIZE) {
@@ -709,26 +1452,84 @@ tvh_context_handle(TVHContext *self, th_pkt_t *pkt)
             ret = AVERROR(ENOMEM);
         }
         else {
-            memset(&avpkt, 0, sizeof(avpkt));
-            avpkt.pts = AV_NOPTS_VALUE;
-            avpkt.dts = AV_NOPTS_VALUE;
-            avpkt.pos = -1;
-            if ((ret = av_packet_from_data(&avpkt, data, size))) { // takes ownership of data
-                tvh_context_log(self, LOG_ERR,
-                                "failed to allocate AVPacket buffer");
-                av_freep(data);
-            }
-            else {
-                if (!self->input_gh && pkt->pkt_meta) {
-                    pktbuf_ref_inc(pkt->pkt_meta);
-                    self->input_gh = pkt->pkt_meta;
+#if ENABLE_V4L2M2M
+            if (!self->skip_width_and_height_initialization && self->parser)
+#else
+            if (self->parser)
+#endif
+            {
+                char _odts[22], _opts[22];
+                pkt_trace(LS_CODEC, pkt,
+                    "before av_parser_parse2 pkt->pkt_dts %s pkt->pkt_pts %s",
+                    pts_to_string(pkt->pkt_dts, _odts), pts_to_string(pkt->pkt_pts, _opts));
+                /* PARSED PATH (H.264, HEVC, AAC, AC3, etc.) */
+                uint8_t *in_data = data;
+                int in_size = (int)size;
+                // save pts and dts for cases when av_parser_parse2() will not provide valid values
+                int64_t old_dts = pkt->pkt_dts;
+                int64_t old_pts = pkt->pkt_pts;
+
+                while (in_size > 0) {
+                    int len = av_parser_parse2(
+                        self->parser,
+                        self->iavctx,
+                        &self->out_pkt->data, &self->out_pkt->size,
+                        in_data, in_size,
+                        pkt->pkt_pts, pkt->pkt_dts, -1
+                    );
+
+                    if (len < 0) {
+                        tvh_context_log(self, LOG_ERR, "av_parser_parse2 failed");
+                        ret = len;
+                        break;
+                    }
+
+                    in_data += len;
+                    in_size -= len;
+
+                    if (self->out_pkt->size > 0) {
+                        if (!self->input_gh && pkt->pkt_meta) {
+                            pktbuf_ref_inc(pkt->pkt_meta);
+                            self->input_gh = pkt->pkt_meta;
+                        }
+
+                        self->out_pkt->pts = (self->parser->pts != PTS_UNSET) ? self->parser->pts : old_pts;
+                        self->out_pkt->dts = (self->parser->dts != PTS_UNSET) ? self->parser->dts : old_dts;
+                        self->out_pkt->duration = self->parser->duration;
+
+                        pkt_trace(LS_CODEC, pkt,
+                            "after av_parser_parse2 out_pkt->pkt_dts %s out_pkt->pkt_pts %s",
+                            pts_to_string(self->out_pkt->dts, _odts), pts_to_string(self->out_pkt->pts, _opts));
+
+                        TVHPKT_SET(self->src_pkt, pkt);
+                        ret = tvh_context_decode(self, self->out_pkt);
+                    }
                 }
-                avpkt.pts = pkt->pkt_pts;
-                avpkt.dts = pkt->pkt_dts;
-                avpkt.duration = pkt->pkt_duration;
-                TVHPKT_SET(self->src_pkt, pkt);
-                ret = tvh_context_decode(self, &avpkt);
-                av_packet_unref(&avpkt); // will free data
+                av_free(data);
+            } 
+            else {
+                /* UNPARSED PATH (PCM Audio, etc.) */
+                /* If no parser exists, we must wrap the data in a packet manually */
+                if ((ret = av_packet_from_data(self->out_pkt, data, (int)size))) {
+                    tvh_context_log(self, LOG_ERR, "failed to allocate AVPacket buffer");
+                    av_free(data);
+                } else {
+                    if (!self->input_gh && pkt->pkt_meta) {
+                        pktbuf_ref_inc(pkt->pkt_meta);
+                        self->input_gh = pkt->pkt_meta;
+                    }
+
+                    self->out_pkt->pts = pkt->pkt_pts;
+                    self->out_pkt->dts = pkt->pkt_dts;
+                    self->out_pkt->duration = pkt->pkt_duration;
+                    self->out_pkt->pos = -1;
+
+                    TVHPKT_SET(self->src_pkt, pkt);
+                    ret = tvh_context_decode(self, self->out_pkt);
+                    
+                    /* Free the packet and its internal data buffer */
+                    av_packet_unref(self->out_pkt); 
+                }
             }
         }
     }
@@ -778,14 +1579,6 @@ tvh_context_destroy(TVHContext *self)
             pktbuf_ref_dec(self->input_gh);
             self->input_gh = NULL;
         }
-        if (self->oavframe) {
-            av_frame_free(&self->oavframe);
-            self->oavframe = NULL;
-        }
-        if (self->iavframe) {
-            av_frame_free(&self->iavframe);
-            self->iavframe = NULL;
-        }
         if (self->oavctx) {
             avcodec_free_context(&self->oavctx); // frees extradata
             self->oavctx = NULL;
@@ -794,6 +1587,25 @@ tvh_context_destroy(TVHContext *self)
             avcodec_free_context(&self->iavctx);
             self->iavctx = NULL;
         }
+        if (self->oavframe) {
+            av_frame_free(&self->oavframe);
+            self->oavframe = NULL;
+        }
+        if (self->parser) {
+            av_parser_close(self->parser);
+            self->parser = NULL;
+        }
+        if (self->iavframe) {
+            av_frame_free(&self->iavframe);
+            self->iavframe = NULL;
+        }
+        if (self->out_pkt) {
+            av_packet_free(&self->out_pkt);
+            self->out_pkt = NULL;
+        }
+#if ENABLE_HWACCELS
+        hwaccels_context_destroy(self);
+#endif
         self->type = NULL;
         self->profile = NULL;
         self->stream = NULL;

--- a/src/transcoding/transcode/helpers.c
+++ b/src/transcoding/transcode/helpers.c
@@ -239,8 +239,22 @@ static TVHContextHelper TVHMPEG2VIDEOEncoder = {
 static int
 tvh_h264_meta(TVHContext *self, AVPacket *avpkt, th_pkt_t *pkt)
 {
+#if ENABLE_V4L2M2M
+    int condition = 0;
+    if (self->use_pkt_data_new_extradata) {
+        // when we use AV_PKT_DATA_NEW_EXTRADATA we need to bypass the AV_PKT_FLAG_KEY condition
+        condition = (avpkt->size > 6);
+    }
+    else {
+        condition = ((avpkt->flags & AV_PKT_FLAG_KEY) && (avpkt->size > 6));
+    }
+    if (condition &&
+        (RB32(avpkt->data) == 0x00000001 || RB24(avpkt->data) == 0x000001))
+#else
     if ((avpkt->flags & AV_PKT_FLAG_KEY) && (avpkt->size > 6) &&
-        (RB32(avpkt->data) == 0x00000001 || RB24(avpkt->data) == 0x000001)) {
+        (RB32(avpkt->data) == 0x00000001 || RB24(avpkt->data) == 0x000001))
+#endif
+    {
         const uint8_t *p = avpkt->data;
         const uint8_t *end = p + avpkt->size;
         const uint8_t *nal_start, *nal_end;

--- a/src/transcoding/transcode/hwaccels/hwaccels.c
+++ b/src/transcoding/transcode/hwaccels/hwaccels.c
@@ -20,8 +20,20 @@
 #include "hwaccels.h"
 #include "../internals.h"
 
+#if ENABLE_NVENC
+#include "nv.h"
+#endif
+
 #if ENABLE_VAAPI
 #include "vaapi.h"
+#endif
+
+#if ENABLE_V4L2M2M
+#include "v4l2-m2m.h"
+#endif
+
+#if ENABLE_QSV
+#include "qsv.h"
 #endif
 
 #include <libavutil/pixdesc.h>
@@ -73,16 +85,28 @@ hwaccels_decode_setup_context(AVCodecContext *avctx,
                               const enum AVPixelFormat pix_fmt)
 {
     const AVPixFmtDescriptor *desc;
+    TVHContext *ctx = avctx->opaque;
 
     if (check_pix_fmt(avctx, pix_fmt)) {
         desc = av_pix_fmt_desc_get(pix_fmt);
         tvherror(LS_TRANSCODE, "no HWAccel for the pixel format '%s'", desc ? desc->name : "<unk>");
         return AVERROR(ENOENT);
     }
-    switch (pix_fmt) {
+    switch (ctx->iavhwdevtype) {
+#if ENABLE_NVENC
+        case AV_HWDEVICE_TYPE_CUDA:
+            return nv_decode_setup_context(avctx);
+#endif
 #if ENABLE_VAAPI
-        case AV_PIX_FMT_VAAPI:
+        case AV_HWDEVICE_TYPE_VAAPI:
             return vaapi_decode_setup_context(avctx);
+#endif
+#if ENABLE_V4L2M2M
+        // DRM does not have v4l2m2m_decode_setup_context(avctx);
+#endif
+#if ENABLE_QSV
+        case AV_HWDEVICE_TYPE_QSV:
+            return qsv_decode_setup_context(avctx);
 #endif
         default:
             break;
@@ -90,7 +114,49 @@ hwaccels_decode_setup_context(AVCodecContext *avctx,
     return -1;
 }
 
+#if LIBAVCODEC_VERSION_MAJOR > 59
+static int is_pix_fmt_in_list(const enum AVPixelFormat check_pix_fmt, const enum AVPixelFormat *pix_fmts) {
+    enum AVPixelFormat pix_fmt = AV_PIX_FMT_NONE;
+    int i;
+    for (i = 0; pix_fmts[i] != AV_PIX_FMT_NONE; i++) {
+        pix_fmt = pix_fmts[i];
+        if (check_pix_fmt == pix_fmt)
+            return 1;
+    }
+    return 0;
+}
+#endif
 
+/**
+ * @brief Negotiates and selects the optimal pixel format for decoding.
+ *
+ * This function is used as the 'get_format' callback for the FFmpeg decoder context. 
+ * Its primary goal is to select a hardware-accelerated pixel format if available 
+ * and supported by the current configuration.
+ *
+ * The selection process follows two distinct logic paths based on the profile:
+ * 1. **Modern API Path (New Implementation)**: If the profile supports 'filter2', 
+ * it iterates through the codec's hardware configurations. It looks for a 
+ * match between the required hardware device type and a configuration using 
+ * a hardware device context. If a match is found and the context is 
+ * successfully set up, the hardware pixel format is returned.
+ * 2. **Legacy Path (Old Implementation)**: If the modern path is unavailable or 
+ * not supported, it iterates through the provided list of candidate pixel 
+ * formats looking for any format marked with the `AV_PIX_FMT_FLAG_HWACCEL` 
+ * flag. It attempts to initialize the hardware context for the first valid 
+ * match found.
+ *
+ * If no hardware acceleration path is successful, the function falls back to the 
+ * first available software format provided in the `pix_fmts` list.
+ *
+ * @param avctx    The codec context being initialized for decoding.
+ * @param pix_fmts A null-terminated list of possible pixel formats acceptable 
+ * by the decoder.
+ *
+ * @return The selected AVPixelFormat. Returns a hardware pixel format if 
+ * acceleration setup is successful; otherwise, returns the software 
+ * fallback format.
+ */
 enum AVPixelFormat
 hwaccels_decode_get_format(AVCodecContext *avctx,
                            const enum AVPixelFormat *pix_fmts)
@@ -99,6 +165,46 @@ hwaccels_decode_get_format(AVCodecContext *avctx,
     const AVPixFmtDescriptor *desc;
     int i;
 
+#if LIBAVCODEC_VERSION_MAJOR > 59
+    TVHContext *ctx = avctx->opaque;
+    // prioritize: new implementation
+    // Guard: delay HW frames context init until dimensions known.
+    // MPEG2 (and others) can call get_format() before sequence header -> width/height still 0.
+    if ((avctx->width <= 0 || avctx->height <= 0) &&
+        (avctx->coded_width <= 0 || avctx->coded_height <= 0)) {
+        // Pick first non-hwaccel format as a safe SW fallback for now.
+        for (i = 0; pix_fmts[i] != AV_PIX_FMT_NONE; i++) {
+            const AVPixFmtDescriptor *d = av_pix_fmt_desc_get(pix_fmts[i]);
+            if (!d) continue;
+            if (!(d->flags & AV_PIX_FMT_FLAG_HWACCEL))
+                return pix_fmts[i];
+        }
+        return pix_fmts[0]; // last-resort
+    }
+    // 1. Iterate through all HW configs supported by this codec
+    for (i = 0; ; i++) {
+        const AVCodecHWConfig *config = avcodec_get_hw_config(avctx->codec, i);
+        if (!config) break;
+        // 2. If the current format in the list matches a format in a 
+        //    Hardware Device Context config, it's a hardware path
+        //    that is matching with input hw device type
+        if (config->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX &&
+            config->device_type == ctx->iavhwdevtype && 
+            is_pix_fmt_in_list(config->pix_fmt, pix_fmts) &&
+            !hwaccels_decode_setup_context(avctx, config->pix_fmt)) {
+            // Because it came from a HW_DEVICE_CTX config, we know 
+            // it's the hardware-accelerated path.
+            if (!avctx->hw_frames_ctx) {
+                // hw_frames_ctx is not initialized most likely will fail
+                tvhwarn(LS_LIBAV,  "Decoder hw_frames_ctx is not available for pix_fmt = %s", av_get_pix_fmt_name(config->pix_fmt));
+            }
+            tvhtrace(LS_TRANSCODE, "hwaccels: [%s] trying pix_fmt: %s", avctx->codec->name, av_get_pix_fmt_name(config->pix_fmt));
+            // return pix_fmt
+            return config->pix_fmt; 
+        }
+    }
+#endif
+    // back up: old implementation
     for (i = 0; pix_fmts[i] != AV_PIX_FMT_NONE; i++) {
         pix_fmt = pix_fmts[i];
         if ((desc = av_pix_fmt_desc_get(pix_fmt))) {
@@ -109,138 +215,147 @@ hwaccels_decode_get_format(AVCodecContext *avctx,
             }
         }
     }
+    /* No hardware pixel format could be set up -- either the device is
+       unusable at runtime, or it simply cannot decode this codec (VP9 on a
+       VAAPI device that lacks a VP9 decode entrypoint is the common case).
+       A software format was selected instead, so drop the hardware intent:
+       otherwise the filter graph is still built for hardware frames, graph
+       configuration fails, and the whole subscription dies -- taking the
+       audio stream down with it instead of degrading to audio only. */
+    {
+        TVHContext *tvhctx = avctx->opaque;
+        if (tvhctx && tvhctx->iavhwdevtype != AV_HWDEVICE_TYPE_NONE &&
+            (pix_fmt == AV_PIX_FMT_NONE ||
+             !((desc = av_pix_fmt_desc_get(pix_fmt)) &&
+               (desc->flags & AV_PIX_FMT_FLAG_HWACCEL)))) {
+            tvhwarn(LS_TRANSCODE, "hwaccels: [%s] hardware decoding unavailable, "
+                    "falling back to software decoding", avctx->codec->name);
+            tvhctx->iavhwdevtype = AV_HWDEVICE_TYPE_NONE;
+        }
+    }
     return pix_fmt;
 }
 
 
-void
-hwaccels_decode_close_context(AVCodecContext *avctx)
-{
-    TVHContext *ctx = avctx->opaque;
-
-    if (ctx->hw_accel_ictx) {
-        switch (avctx->pix_fmt) {
-#if ENABLE_VAAPI
-            case AV_PIX_FMT_VAAPI:
-                vaapi_decode_close_context(avctx);
-                break;
-#endif
-            default:
-                break;
-        }
-        ctx->hw_accel_ictx = NULL;
-    }
-}
-
-
 int
-hwaccels_get_scale_filter(AVCodecContext *iavctx, AVCodecContext *oavctx,
-                          char *filter, size_t filter_len)
+hwaccels_decode_get_filters(TVHContext *self, char *filter, size_t filter_len)    
 {
-    TVHContext *ctx = iavctx->opaque;
 
-    if (ctx->hw_accel_ictx) {
-        switch (iavctx->pix_fmt) {
-#if ENABLE_VAAPI
-            case AV_PIX_FMT_VAAPI:
-                return vaapi_get_scale_filter(iavctx, oavctx, filter, filter_len);
+    switch (self->iavhwdevtype) {
+#if ENABLE_NVENC
+        case AV_HWDEVICE_TYPE_CUDA:
+            return nv_get_filters(self, filter, filter_len);
 #endif
-            default:
-                break;
-        }
+#if ENABLE_VAAPI
+        case AV_HWDEVICE_TYPE_VAAPI:
+            return vaapi_get_filters(self, filter, filter_len);
+#endif
+#if ENABLE_V4L2M2M
+        case AV_HWDEVICE_TYPE_DRM:
+            return v4l2m2m_get_filters(self, filter, filter_len);
+#endif
+#if ENABLE_QSV
+        case AV_HWDEVICE_TYPE_QSV:
+            return qsv_get_filters(self, filter, filter_len);
+#endif
+        default:
+            break;
     }
     
-    return -1;
+    return 0;
 }
 
 
 int
-hwaccels_get_deint_filter(AVCodecContext *avctx, char *filter, size_t filter_len)
+hwaccels_download(TVHContext *self, char *filter, size_t filter_len, int skip_format)    
 {
-    const TVHContext *ctx = avctx->opaque;
 
-    if (ctx->hw_accel_ictx) {
-        switch (avctx->pix_fmt) {
-#if ENABLE_VAAPI
-            case AV_PIX_FMT_VAAPI:
-                return vaapi_get_deint_filter(avctx, filter, filter_len);
+    switch (self->oavhwdevtype) {
+#if ENABLE_NVENC
+        case AV_HWDEVICE_TYPE_CUDA:
+            return nv_get_download(self, skip_format, filter, filter_len);
 #endif
-            default:
-                break;
-        }
+#if ENABLE_VAAPI
+        case AV_HWDEVICE_TYPE_VAAPI:
+            return vaapi_get_download(self, skip_format, filter, filter_len);
+#endif
+#if ENABLE_V4L2M2M
+        case AV_HWDEVICE_TYPE_DRM:
+            return v4l2m2m_get_download(self, filter, filter_len);
+#endif
+#if ENABLE_QSV
+        case AV_HWDEVICE_TYPE_QSV:
+            return qsv_get_download(self, skip_format, filter, filter_len);
+#endif
+        default:
+        // for now we use default for software encoder
+            if (str_snprintf(filter, filter_len, "hwdownload,format=pix_fmts=%s,format=pix_fmts=%s",
+                            av_get_pix_fmt_name(self->iavctx->sw_pix_fmt),
+                            av_get_pix_fmt_name(self->oavctx->pix_fmt))) {
+                return -1;
+            }
+            break;
     }
-
-    return -1;
+    return 0;
 }
 
-int
-hwaccels_get_denoise_filter(AVCodecContext *avctx, int value, char *filter, size_t filter_len)
-{
-    TVHContext *ctx = avctx->opaque;
 
-    if (ctx->hw_accel_ictx) {
-        switch (avctx->pix_fmt) {
-#if ENABLE_VAAPI
-            case AV_PIX_FMT_VAAPI:
-                return vaapi_get_denoise_filter(avctx, value, filter, filter_len);
+int
+hwaccels_upload(TVHContext *self, char *filter, size_t filter_len)    
+{
+
+    switch (self->oavhwdevtype) {
+#if ENABLE_V4L2M2M
+        case AV_HWDEVICE_TYPE_DRM:
+            return v4l2m2m_get_upload(self, filter, filter_len);
 #endif
-            default:
-                break;
-        }
+#if ENABLE_QSV
+        case AV_HWDEVICE_TYPE_QSV:
+            return qsv_get_upload(self, filter, filter_len);
+#endif
+#if ENABLE_NVENC
+        case AV_HWDEVICE_TYPE_CUDA:
+            // NVENC will use default : 
+            // NOTE: this must be left last
+#endif
+#if ENABLE_VAAPI
+        case AV_HWDEVICE_TYPE_VAAPI:
+            // VAAPI will use default : 
+            // NOTE: this must be left last
+#endif
+        default:
+            if (str_snprintf(filter, filter_len, "format=pix_fmts=%s,hwupload",
+                            av_get_pix_fmt_name(self->oavctx->sw_pix_fmt))) {
+                return -1;
+            }
+            break;
     }
     
-    return -1;
+    return 0;
 }
 
-int
-hwaccels_get_sharpness_filter(AVCodecContext *avctx, int value, char *filter, size_t filter_len)
-{
-    TVHContext *ctx = avctx->opaque;
-
-    if (ctx->hw_accel_ictx) {
-        switch (avctx->pix_fmt) {
-#if ENABLE_VAAPI
-            case AV_PIX_FMT_VAAPI:
-                return vaapi_get_sharpness_filter(avctx, value, filter, filter_len);
-#endif
-            default:
-                break;
-        }
-    }
-    
-    return -1;
-}
 
 /* encoding ================================================================= */
 
 int
-hwaccels_initialize_encoder_from_decoder(const AVCodecContext *iavctx, AVCodecContext *oavctx)
+hwaccels_encode_setup_context(TVHContext *self)
 {
-    switch (iavctx->pix_fmt) {
-        case AV_PIX_FMT_VAAPI:
-            /* we need to ref hw_frames_ctx of decoder to initialize encoder's codec.
-            Only after we get a decoded frame, can we obtain its hw_frames_ctx */
-            oavctx->hw_frames_ctx = av_buffer_ref(iavctx->hw_frames_ctx);
-            if (!oavctx->hw_frames_ctx) {
-                return AVERROR(ENOMEM);
-            }
-            return 0;
-        case AV_PIX_FMT_YUV420P:
-            break;
-        default:
-            break;
-    }
-    return 0;
-}
-
-
-int
-hwaccels_encode_setup_context(AVCodecContext *avctx)
-{
-    switch (avctx->pix_fmt) {
+    switch (self->oavhwdevtype) {
+#if ENABLE_NVENC
+        case AV_HWDEVICE_TYPE_CUDA:
+            return nv_encode_setup_context(self->oavctx);
+#endif
 #if ENABLE_VAAPI
-        case AV_PIX_FMT_VAAPI:
-            return vaapi_encode_setup_context(avctx);
+        case AV_HWDEVICE_TYPE_VAAPI:
+            return vaapi_encode_setup_context(self->oavctx);
+#endif
+#if ENABLE_V4L2M2M
+        case AV_HWDEVICE_TYPE_DRM:
+            return v4l2m2m_encode_setup_context(self->oavctx);
+#endif
+#if ENABLE_QSV
+        case AV_HWDEVICE_TYPE_QSV:
+            return qsv_encode_setup_context(self->oavctx);
 #endif
         default:
             break;
@@ -250,17 +365,36 @@ hwaccels_encode_setup_context(AVCodecContext *avctx)
 
 
 void
-hwaccels_encode_close_context(AVCodecContext *avctx)
+hwaccels_context_destroy(TVHContext *self)
 {
-    switch (avctx->pix_fmt) {
+    if (!self)
+        return;
+    switch (self->iavhwdevtype) {
+#if ENABLE_NVENC
+        case AV_HWDEVICE_TYPE_CUDA:
+            nv_decode_destroy(self);
+            break;
+#endif
 #if ENABLE_VAAPI
-        case AV_PIX_FMT_VAAPI:
-            vaapi_encode_close_context(avctx);
+        case AV_HWDEVICE_TYPE_VAAPI:
+            vaapi_decode_destroy(self);
+            break;
+#endif
+#if ENABLE_V4L2M2M
+        case AV_HWDEVICE_TYPE_DRM:
+            v4l2m2m_decode_destroy(self);
+            break;
+#endif
+#if ENABLE_QSV
+        case AV_HWDEVICE_TYPE_QSV:
+            qsv_decode_destroy(self);
             break;
 #endif
         default:
             break;
     }
+    if (self->hw_device_octx)
+        av_buffer_unref(&self->hw_device_octx);
 }
 
 
@@ -275,7 +409,16 @@ hwaccels_init(void)
 void
 hwaccels_done(void)
 {
+#if ENABLE_NVENC
+    nv_done();
+#endif
 #if ENABLE_VAAPI
     vaapi_done();
+#endif
+#if ENABLE_V4L2M2M
+    v4l2m2m_done();
+#endif
+#if ENABLE_QSV
+    qsv_done();
 #endif
 }

--- a/src/transcoding/transcode/hwaccels/hwaccels.h
+++ b/src/transcoding/transcode/hwaccels/hwaccels.h
@@ -33,33 +33,20 @@ enum AVPixelFormat
 hwaccels_decode_get_format(AVCodecContext *avctx,
                            const enum AVPixelFormat *pix_fmts);
 
-void
-hwaccels_decode_close_context(AVCodecContext *avctx);
+int
+hwaccels_decode_get_filters(TVHContext *self, char *filter, size_t filter_len);
 
 int
-hwaccels_get_scale_filter(AVCodecContext *iavctx, AVCodecContext *oavctx,
-                          char *filter, size_t filter_len);
+hwaccels_download(TVHContext *self, char *filter, size_t filter_len, int skip_format);
 
 int
-hwaccels_get_deint_filter(AVCodecContext *avctx, char *filter, size_t filter_len);
-
-int
-hwaccels_get_denoise_filter(AVCodecContext *avctx, int value, char *filter, size_t filter_len);
-
-int
-hwaccels_get_sharpness_filter(AVCodecContext *avctx, int value, char *filter, size_t filter_len);
+hwaccels_upload(TVHContext *self, char *filter, size_t filter_len);
 
 
 /* encoding ================================================================= */
-int
-hwaccels_initialize_encoder_from_decoder(const AVCodecContext *iavctx, AVCodecContext *oavctx);
 
 int
-hwaccels_encode_setup_context(AVCodecContext *avctx);
-
-void
-hwaccels_encode_close_context(AVCodecContext *avctx);
-
+hwaccels_encode_setup_context(TVHContext *self);
 
 /* module =================================================================== */
 
@@ -69,5 +56,11 @@ hwaccels_init(void);
 void
 hwaccels_done(void);
 
+/**
+ * Release TVH-owned hardware resources after @c avcodec_free_context has been
+ * called on both decoder and encoder contexts (see @c tvh_context_destroy).
+ */
+void
+hwaccels_context_destroy(TVHContext *self);
 
 #endif // TVH_TRANSCODING_TRANSCODE_HWACCELS_H__

--- a/src/transcoding/transcode/hwaccels/nv.c
+++ b/src/transcoding/transcode/hwaccels/nv.c
@@ -1,0 +1,287 @@
+/*
+ *  tvheadend - Transcoding
+ *
+ *  Copyright (C) 2026 Tvheadend
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "transcoding/codec/internals.h"
+#include "../internals.h"
+#include "nv.h"
+
+#include <libavutil/hwcontext.h>
+#include <libavutil/pixdesc.h>
+
+
+typedef struct tvh_nv_context_t {
+    AVBufferRef *hw_device_ref;
+} TVNVContext;
+
+
+/* TVNVContext ============================================================= */
+
+static void
+tvh_nv_context_destroy(TVNVContext *self)
+{
+    if (self) {
+        if (self->hw_device_ref) {
+            av_buffer_unref(&self->hw_device_ref);
+        }
+        free(self);
+        self = NULL;
+    }
+}
+
+
+/* internal ================================================================= */
+
+// lifted from ffmpeg-6.1.1/doc/examples/vaapi_encode.c line 41
+static int set_hwframe_ctx(AVCodecContext *ctx, AVBufferRef *hw_device_ctx)
+{
+    AVBufferRef *hw_frames_ref;
+    AVHWFramesContext *frames_ctx = NULL;
+    int err = 0;
+
+    if (!(hw_frames_ref = av_hwframe_ctx_alloc(hw_device_ctx))) {
+        tvherror_transcode(LST_NVENC, "Decode: Failed to create CUDA frame context.");
+        return AVERROR(ENOMEM);
+    }
+    frames_ctx = (AVHWFramesContext *)(hw_frames_ref->data);
+    frames_ctx->format    = AV_PIX_FMT_CUDA;
+    frames_ctx->sw_format = AV_PIX_FMT_NV12;
+    frames_ctx->width     = ctx->width;
+    frames_ctx->height    = ctx->height;
+    frames_ctx->initial_pool_size = 20;
+    if ((err = av_hwframe_ctx_init(hw_frames_ref)) < 0) {
+        tvherror_transcode(LST_NVENC, "Decode: Failed to initialize CUDA frame context."
+                " Error code: %s",av_err2str(err));
+        av_buffer_unref(&hw_frames_ref);
+        return err;
+    }
+    ctx->hw_frames_ctx = av_buffer_ref(hw_frames_ref);
+    if (!ctx->hw_frames_ctx) {
+        err = AVERROR(ENOMEM);
+        tvherror_transcode(LST_NVENC, "Decode: Failed to create a hardware frame context."
+                " Error code: %s",av_err2str(err));
+    }
+    av_buffer_unref(&hw_frames_ref);
+    return err;
+}
+
+static int nv_get_scale_filter(AVCodecContext *iavctx, int height, char *filter, size_t filter_len)
+{
+    // https://ffmpeg.org/ffmpeg-filters.html#scale_005fcuda-1
+    if (str_snprintf(filter, filter_len, "scale_cuda=w=-2:h=%d", height)){
+        return -1;
+    }
+    return 0;
+}
+
+static int nv_get_deint_filter(AVCodecContext *avctx, char *filter, size_t filter_len)
+{
+    const TVHContext *ctx = avctx->opaque;
+    // https://ffmpeg.org/ffmpeg-filters.html#yadif_005fcuda
+    if (str_snprintf(filter, filter_len, "yadif_cuda=mode=%d:deint=%d",
+                     ((TVHVideoCodecProfile *)ctx->profile)->deinterlace_field_rate,
+                     ((TVHVideoCodecProfile *)ctx->profile)->deinterlace_enable_auto )) {
+        return -1;
+    }
+    return 0;
+}
+
+/* decoding ================================================================= */
+
+int
+nv_decode_setup_context(AVCodecContext *avctx)
+{
+    TVHContext *ctx = avctx->opaque;
+
+    TVNVContext *self = NULL;
+    int ret = -1;
+
+    if (!(self = calloc(1, sizeof(TVNVContext)))) {
+        tvherror_transcode(LST_NVENC, "Decode: Failed to allocate CUDA context (TVNVContext)");
+        return AVERROR(ENOMEM);
+    }
+    // Open NV device and create an AVHWDeviceContext for it
+    if ((ret = av_hwdevice_ctx_create(&self->hw_device_ref, AV_HWDEVICE_TYPE_CUDA, ctx->hw_accel_device, NULL, 0)) < 0) {
+        tvherror_transcode(LST_NVENC, "Decode: Failed to Open CUDA device and create an AVHWDeviceContext for device: "
+                            "%s with error code: %s", 
+                            ctx->hw_accel_device, av_err2str(ret));
+        free(self);
+        self = NULL;
+        return ret;
+    }
+    // set hw_frames_ctx for decoder's AVCodecContext
+    avctx->hw_device_ctx = av_buffer_ref(self->hw_device_ref);
+    if (!avctx->hw_device_ctx) {
+        tvherror_transcode(LST_NVENC, "Decode: Failed to create a hardware device reference for device: %s.", 
+                        ctx->hw_accel_device);
+        // unref hw_device_ref
+        av_buffer_unref(&self->hw_device_ref);
+        self->hw_device_ref = NULL;
+        free(self);
+        self = NULL;
+        return AVERROR(ENOMEM);
+    }
+    // set hw_frames_ctx for decoder's AVCodecContext
+    if ((ret = set_hwframe_ctx(avctx, avctx->hw_device_ctx)) < 0) {
+        tvherror_transcode(LST_NVENC, "Decode: Failed to set hwframe context."
+                                      " Error code: %s", av_err2str(ret));
+        av_buffer_unref(&avctx->hw_device_ctx);
+        // unref hw_device_ref
+        av_buffer_unref(&self->hw_device_ref);
+        self->hw_device_ref = NULL;
+        free(self);
+        self = NULL;
+        return ret;
+    }
+    if (ctx->hw_accel_ictx) {
+        nv_decode_destroy(ctx);
+    }
+    ctx->hw_accel_ictx = self;
+    avctx->pix_fmt = AV_PIX_FMT_CUDA;
+    avctx->sw_pix_fmt = AV_PIX_FMT_NV12;
+    return 0;
+}
+
+
+/**
+ * @brief Constructs a NV hardware video filter chain string.
+ *
+ * This function evaluates the current transcoding profile and input/output
+ * contexts to determine which hardware filters (deinterlacing, scaling, 
+ * denoising, and sharpness) are required. It then fetches the individual 
+ * filter strings and concatenates them into a single, comma-separated 
+ * filter string safe for use with FFmpeg/libavcodec.
+ *
+ * @param self       Pointer to the TVHContext containing the transcoding state,
+ * input/output AV contexts, and profile configuration.
+ * @param filter     Pointer to the destination buffer where the final comma-separated
+ * filter string will be written.
+ * @param filter_len The maximum size (in bytes) of the destination filter buffer.
+ *
+ * @return 0 on success, or -1 if an error occurred while retrieving any of the 
+ * individual hardware filter strings.
+ */
+int
+nv_get_filters(TVHContext *self, char *filter, size_t filter_len)    
+{
+    // NOTE: filter_len > sum of all string --> previously used strcat()
+    // Now using snprintf for guaranteed buffer safety
+    char hw_deint[64];
+    char hw_scale[64];
+    size_t len=0;
+
+    int height = ((TVHVideoCodecProfile *)self->profile)->size.den;
+
+    int filter_scale = (self->iavctx->height != height);
+    int filter_deint = ((TVHVideoCodecProfile *)self->profile)->deinterlace;
+
+    memset(hw_deint, 0, sizeof(hw_deint));
+    if (filter_deint){
+        if (nv_get_deint_filter(self->iavctx, hw_deint, sizeof(hw_deint))){
+            tvherror_transcode(LST_NVENC, "Filter: nv_get_deint_filter() returned with error.");
+            return -1;
+        }
+        else {
+            len = strnlen(filter, filter_len);
+            snprintf(filter + len, filter_len - len, "%s%s", (len > 0) ? "," : "", hw_deint);
+        }
+    }
+    
+    memset(hw_scale, 0, sizeof(hw_scale));
+    if (filter_scale){ 
+        if(nv_get_scale_filter(self->iavctx, height, hw_scale, sizeof(hw_scale))){
+            tvherror_transcode(LST_NVENC, "Filter: nv_get_scale_filter() returned with error.");
+            return -1;
+        }
+        else {
+            len = strnlen(filter, filter_len);
+            snprintf(filter + len, filter_len - len, "%s%s", (len > 0) ? "," : "", hw_scale);
+        }
+    }
+    if (filter_deint || filter_scale)
+        // this warnig was added because ffmpeg compile with yadif_cuda will silently drop the filter if clang is missing wthout any warning
+        tvhinfo_transcode(LST_NVENC, "Decode using NVDEC with yadif_cuda or scale_cuda requires clang, instructions can be found on 'Makefile.ffmpeg' section '# NVENC'");
+    return 0;
+}
+
+int
+nv_get_download(TVHContext *self, int skip_format, char *filter, size_t filter_len)
+{
+    if (skip_format) {
+        if (str_snprintf(filter, filter_len, "hwdownload")) {
+            return -1;
+        }
+    }
+    else {
+        if (str_snprintf(filter, filter_len, "hwdownload,format=pix_fmts=%s",
+                        av_get_pix_fmt_name(self->oavctx->sw_pix_fmt))) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/* encoding ================================================================= */
+
+int
+nv_encode_setup_context(AVCodecContext *avctx)
+{
+    TVHContext *ctx = avctx->opaque;
+    int ret = 0;
+
+    // this is required in case encode is called twice
+    if (ctx->hw_device_octx)
+        av_buffer_unref(&ctx->hw_device_octx);
+    // Open NV device and create an AVHWDeviceContext for it
+    if ((ret = av_hwdevice_ctx_create(&ctx->hw_device_octx, AV_HWDEVICE_TYPE_CUDA, NULL, NULL, 0)) < 0) {
+        tvherror_transcode(LST_NVENC, "Encode: Failed to open CUDA device and create an AVHWDeviceContext for it."
+                " Error code: %s",av_err2str(ret));
+        return ret;
+    }
+    avctx->hw_device_ctx = av_buffer_ref(ctx->hw_device_octx);
+    if (!avctx->hw_device_ctx) {
+        av_buffer_unref(&ctx->hw_device_octx);
+        ctx->hw_device_octx = NULL;
+        ret = AVERROR(ENOMEM);
+        tvherror_transcode(LST_NVENC, "Encode: Failed to create a hardware device context."
+                " Error code: %s",av_err2str(ret));
+        return ret;
+    }
+
+    avctx->pix_fmt = AV_PIX_FMT_CUDA;
+    avctx->sw_pix_fmt = AV_PIX_FMT_NV12;
+    return ret;
+}
+
+
+/* module =================================================================== */
+
+void
+nv_decode_destroy(TVHContext *ctx)
+{
+    if (!ctx)
+        return;
+    tvh_nv_context_destroy(ctx->hw_accel_ictx);
+    ctx->hw_accel_ictx = NULL;
+}
+
+void
+nv_done()
+{
+    /* nothing to do */
+}

--- a/src/transcoding/transcode/hwaccels/nv.h
+++ b/src/transcoding/transcode/hwaccels/nv.h
@@ -1,7 +1,7 @@
 /*
  *  tvheadend - Transcoding
  *
- *  Copyright (C) 2016 Tvheadend
+ *  Copyright (C) 2026 Tvheadend
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,8 +18,8 @@
  */
 
 
-#ifndef TVH_TRANSCODING_TRANSCODE_HWACCELS_VAAPI_H__
-#define TVH_TRANSCODING_TRANSCODE_HWACCELS_VAAPI_H__
+#ifndef TVH_TRANSCODING_TRANSCODE_HWACCELS_NV_H__
+#define TVH_TRANSCODING_TRANSCODE_HWACCELS_NV_H__
 
 
 #include "tvheadend.h"
@@ -30,26 +30,26 @@
 /* decoding ================================================================= */
 
 int
-vaapi_decode_setup_context(AVCodecContext *avctx);
+nv_decode_setup_context(AVCodecContext *avctx);
 
 int
-vaapi_get_filters(TVHContext *self, char *filter, size_t filter_len);
+nv_get_filters(TVHContext *self, char *filter, size_t filter_len);
 
 int
-vaapi_get_download(TVHContext *self, int skip_format, char *filter, size_t filter_len);
+nv_get_download(TVHContext *self, int skip_format, char *filter, size_t filter_len);
 
 /* encoding ================================================================= */
 
 int
-vaapi_encode_setup_context(AVCodecContext *avctx);
+nv_encode_setup_context(AVCodecContext *avctx);
 
 /* module =================================================================== */
 
 void
-vaapi_decode_destroy(TVHContext *ctx);
+nv_decode_destroy(TVHContext *ctx);
 
 void
-vaapi_done(void);
+nv_done(void);
 
 
-#endif // TVH_TRANSCODING_TRANSCODE_HWACCELS_VAAPI_H__
+#endif // TVH_TRANSCODING_TRANSCODE_HWACCELS_NV_H__

--- a/src/transcoding/transcode/hwaccels/qsv.c
+++ b/src/transcoding/transcode/hwaccels/qsv.c
@@ -1,0 +1,428 @@
+/*
+ *  tvheadend - Transcoding
+ *
+ *  Copyright (C) 2026 Tvheadend
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "transcoding/codec/internals.h"
+#include "../internals.h"
+#include "qsv.h"
+
+#include <libavutil/hwcontext.h>
+#include <libavutil/hwcontext_qsv.h>
+#include <libavutil/pixdesc.h>
+#include <va/va.h>
+
+#define ver2
+
+typedef struct tvh_qsv_context_t {
+    AVBufferRef *hw_device_ref;
+} TVHQSVContext;
+
+// Shared QSV hardware device, derived once from a VAAPI device and cached for
+// the lifetime of the process (see the patch header). The original code created
+// a fresh "auto" QSV device on every get_format() for both decode and encode;
+// here it is built once and reference-counted out to every user.
+static AVBufferRef *tvh_qsv_device_cache = NULL;
+static tvh_mutex_t tvh_qsv_device_lock = TVH_THREAD_MUTEX_INITIALIZER;
+
+// Return a new reference to the shared QSV device, creating it on first use.
+// On this hardware the Intel QSV runtime sits on top of VAAPI, so the device is
+// derived from a (cheap) VAAPI device; if derivation is unsupported we fall back
+// to the plain "auto" QSV device. Returns NULL on failure; the caller owns the ref.
+static AVBufferRef *
+tvh_qsv_device_get(const char *vaapi_device)
+{
+    AVBufferRef *ref = NULL, *vaapi_ref = NULL;
+    int err = 0;
+
+    tvh_mutex_lock(&tvh_qsv_device_lock);
+    if (!tvh_qsv_device_cache) {
+        err = av_hwdevice_ctx_create(&vaapi_ref, AV_HWDEVICE_TYPE_VAAPI,
+                                     (vaapi_device && *vaapi_device) ? vaapi_device : NULL,
+                                     NULL, 0);
+        if (err >= 0) {
+            err = av_hwdevice_ctx_create_derived(&tvh_qsv_device_cache,
+                                                 AV_HWDEVICE_TYPE_QSV, vaapi_ref, 0);
+            av_buffer_unref(&vaapi_ref);
+        }
+        if (err < 0) {
+            tvh_qsv_device_cache = NULL;
+            err = av_hwdevice_ctx_create(&tvh_qsv_device_cache,
+                                         AV_HWDEVICE_TYPE_QSV, "auto", NULL, 0);
+            tvhtrace_transcode(LST_QSV, "QSV device: %s",
+                               err < 0 ? " creation FAILED" : " created via 'auto' fallback");
+        } else {
+            tvhtrace_transcode(LST_QSV, "QSV device: derived from VAAPI (cached)");
+        }
+    }
+    if (tvh_qsv_device_cache)
+        ref = av_buffer_ref(tvh_qsv_device_cache);
+    tvh_mutex_unlock(&tvh_qsv_device_lock);
+    return ref;
+}
+
+
+
+/* TVHQSVContext ============================================================= */
+
+static void
+tvh_qsv_context_destroy(TVHQSVContext *self)
+{
+    if (self) {
+        if (self->hw_device_ref) {
+            av_buffer_unref(&self->hw_device_ref);
+            self->hw_device_ref = NULL;
+        }
+        free(self);
+        self = NULL;
+    }
+}
+
+/* internal ================================================================= */
+#ifdef ver2
+#else
+// lifted from ffmpeg-6.1.1/doc/examples/vaapi_encode.c line 41
+static int set_hwframe_ctx(AVCodecContext *ctx, AVBufferRef *hw_device_ctx)
+{
+    AVBufferRef *hw_frames_ref;
+    AVHWFramesContext *frames_ctx = NULL;
+    int err = 0;
+
+    if (!(hw_frames_ref = av_hwframe_ctx_alloc(hw_device_ctx))) {
+        tvherror_transcode(LST_QSV, "Decode: Failed to create QSV frame context.");
+        return AVERROR(ENOMEM);
+    }
+    frames_ctx = (AVHWFramesContext *)(hw_frames_ref->data);
+    frames_ctx->format    = AV_PIX_FMT_QSV;
+    frames_ctx->sw_format = AV_PIX_FMT_NV12;
+    frames_ctx->width     = FFALIGN(ctx->coded_width,  32);
+    frames_ctx->height    = FFALIGN(ctx->coded_height, 32);
+    frames_ctx->initial_pool_size = 32; // Pre-allocate 32 surfaces
+    if ((err = av_hwframe_ctx_init(hw_frames_ref)) < 0) {
+        tvherror_transcode(LST_QSV, "Decode: Failed to initialize QSV frame context."
+                " Error code: %s",av_err2str(err));
+        av_buffer_unref(&hw_frames_ref);
+        return err;
+    }
+    ctx->hw_frames_ctx = av_buffer_ref(hw_frames_ref);
+    if (!ctx->hw_frames_ctx) {
+        err = AVERROR(ENOMEM);
+        tvherror_transcode(LST_QSV, "Decode: Failed to create a hardware frame context."
+                " Error code: %s",av_err2str(err));
+    }
+    av_buffer_unref(&hw_frames_ref);
+    return err;
+}
+#endif
+
+static int qsv_get_scale_filter(AVCodecContext *iavctx, int height, char *filter, size_t filter_len)
+{
+    // NOTE: vpp_qsv does not accept -2 (but -1 does the same thing)
+    if (str_snprintf(filter, filter_len, "w=-1:h=%d:scale_mode=2", height)){
+        return -1;
+    }
+    return 0;
+}
+
+static int qsv_get_deint_filter(AVCodecContext *avctx, char *filter, size_t filter_len)
+{
+    const TVHContext *ctx = avctx->opaque;
+
+    int mode = ((TVHVideoCodecProfile *)ctx->profile)->deinterlace_qsv_mode;
+    mode = (mode < 0 || mode > 2) ? 0 : mode;  // check we have valid deinterlace_qsv mode
+
+    if (str_snprintf(filter, filter_len, "deinterlace=%d", mode)) {
+        return -1;
+    }
+    return 0;
+}
+
+
+static int qsv_get_denoise_filter(AVCodecContext *avctx, int value, char *filter, size_t filter_len)
+{
+    if (str_snprintf(filter, filter_len, "denoise=%d", value)){
+        return -1;
+    }
+    return 0;
+}
+
+static int qsv_get_sharpness_filter(AVCodecContext *avctx, int value, char *filter, size_t filter_len)
+{
+    if (str_snprintf(filter, filter_len, "detail=%d", value)){
+        return -1;
+    }
+    return 0;
+}
+
+
+/* decoding ================================================================= */
+
+int qsv_decode_setup_context(AVCodecContext *avctx)
+{
+    TVHContext *ctx = avctx->opaque;
+    TVHQSVContext *self = NULL;
+    int ret = -1;
+
+    // clean up required if you call decode twice
+    if (ctx->hw_accel_ictx) {
+        av_buffer_unref(&avctx->hw_device_ctx);
+        av_buffer_unref(&avctx->hw_frames_ctx);
+        qsv_decode_destroy(ctx);
+    }
+
+    if (!(self = calloc(1, sizeof(TVHQSVContext)))) {
+        tvherror_transcode(LST_QSV, "Decode: Failed to allocate QSV context (TVHQSVContext)");
+        return AVERROR(ENOMEM);
+    }
+
+    // 1. Obtain the shared (cached, VAAPI-derived) QSV device.
+    self->hw_device_ref = tvh_qsv_device_get(ctx->hw_accel_device);
+    if (!self->hw_device_ref) {
+        tvherror_transcode(LST_QSV, "Decode: Failed to obtain QSV device");
+         tvh_qsv_context_destroy(self);
+        return AVERROR(ENODEV);
+     }
+
+    /* set hw_frames_ctx for decoder's AVCodecContext */
+    avctx->hw_device_ctx = av_buffer_ref(self->hw_device_ref);
+    if (!avctx->hw_device_ctx) {
+        tvherror_transcode(LST_QSV, "Decode: Failed to create a hardware device reference");
+        tvh_qsv_context_destroy(self);
+        return AVERROR(ENOMEM);
+    }
+
+#ifdef ver2
+    // 2. CRITICAL: Create the Frames Context
+    if (!avctx->hw_frames_ctx) {
+        AVBufferRef *frames_ref = av_hwframe_ctx_alloc(self->hw_device_ref);
+        if (!frames_ref) {
+            ret = AVERROR(ENOMEM);
+            tvherror_transcode(LST_QSV, "Decode: Failed to initialize HW Frames "
+                            " with error code: %s", av_err2str(ret));
+            av_buffer_unref(&avctx->hw_device_ctx);
+            tvh_qsv_context_destroy(self);
+            return ret;
+        }
+        int width = avctx->coded_width;
+        int height = avctx->coded_height;
+        // check if coded dimensions is populated
+        if (width == 0 || height == 0){
+            width = avctx->width;
+            height = avctx->height;
+        }
+
+        AVHWFramesContext *frames_ctx = (AVHWFramesContext *)frames_ref->data;
+        frames_ctx->format    = AV_PIX_FMT_QSV;
+        frames_ctx->sw_format = AV_PIX_FMT_NV12;
+        // Hardware dimensions MUST be aligned (usually 32 for QSV)
+        // TODO: we should make this adjustable for Intel Gen12+ (Xe) sometime is required 128 or 256
+        frames_ctx->width     = FFALIGN(width,  32);
+        frames_ctx->height    = FFALIGN(height, 32);
+        frames_ctx->initial_pool_size = 32; // Pre-allocate 32 surfaces
+
+        ret = av_hwframe_ctx_init(frames_ref);
+        if (ret < 0) {
+            tvherror_transcode(LST_QSV, "Decode: Failed to initialize HW Frames "
+                            " with error code: %s", av_err2str(ret));
+            av_buffer_unref(&avctx->hw_device_ctx);
+            av_buffer_unref(&frames_ref);
+            tvh_qsv_context_destroy(self);
+            return ret;
+        }
+
+        // Attach the pool to the decoder
+        avctx->hw_frames_ctx = frames_ref;
+    }
+#else
+    
+    // lifted from ffmpeg-6.1.1/doc/examples/vaapi_encode.c line 152
+    /* set hw_frames_ctx for decoder's AVCodecContext */
+    if ((ret = set_hwframe_ctx(avctx, avctx->hw_device_ctx)) < 0) {
+        tvherror_transcode(LST_QSV, "Decode: Failed to set hwframe context."
+                                      " Error code: %s", av_err2str(ret));
+        av_buffer_unref(&avctx->hw_device_ctx);
+        tvh_qsv_context_destroy(self);
+        return ret;
+    }
+#endif
+    
+    ctx->hw_accel_ictx = self;
+    avctx->pix_fmt = AV_PIX_FMT_QSV;
+    avctx->sw_pix_fmt = AV_PIX_FMT_NV12;
+    return 0;
+}
+
+int
+qsv_get_filters(TVHContext *self, char *filter, size_t filter_len)    
+{
+#define TEMP_FILTER_LEN 64*4
+    // NOTE: filter_len > sum of all string
+    // Now using snprintf for guaranteed buffer safety
+    char hw_deint[64];
+    char hw_scale[64];
+    char hw_denoise[64];
+    char hw_sharpness[64];
+    char temp_filter[TEMP_FILTER_LEN];
+    memset(temp_filter, 0, sizeof(temp_filter));
+    size_t len=0;
+
+    int height = ((TVHVideoCodecProfile *)self->profile)->size.den;
+
+    int filter_scale = (self->iavctx->height != height);
+    int filter_deint = ((TVHVideoCodecProfile *)self->profile)->deinterlace;
+    int filter_denoise = ((TVHVideoCodecProfile *)self->profile)->filter_hw_denoise;
+    int filter_sharpness = ((TVHVideoCodecProfile *)self->profile)->filter_hw_sharpness;
+
+    memset(hw_deint, 0, sizeof(hw_deint));
+    if (filter_deint){
+        if (qsv_get_deint_filter(self->iavctx, hw_deint, sizeof(hw_deint))){
+            tvherror_transcode(LST_QSV, "Filter: qsv_get_deint_filter() returned with error.");
+            return -1;
+        }
+        else {
+            len = strnlen(temp_filter, TEMP_FILTER_LEN);
+            snprintf(temp_filter + len, TEMP_FILTER_LEN - len, "%s%s", (len > 0) ? ":" : "", hw_deint);
+        }
+    }
+    
+    memset(hw_scale, 0, sizeof(hw_scale));
+    if (filter_scale){ 
+        if(qsv_get_scale_filter(self->iavctx, height, hw_scale, sizeof(hw_scale))){
+            tvherror_transcode(LST_QSV, "Filter: qsv_get_scale_filter() returned with error.");
+            return -1;
+        }
+        else {
+            len = strnlen(temp_filter, TEMP_FILTER_LEN);
+            snprintf(temp_filter + len, TEMP_FILTER_LEN - len, "%s%s", (len > 0) ? ":" : "", hw_scale);
+        }
+    }
+    
+    memset(hw_denoise, 0, sizeof(hw_denoise));
+    if (filter_denoise) { 
+        if (qsv_get_denoise_filter(self->iavctx, filter_denoise, hw_denoise, sizeof(hw_denoise))){
+            tvherror_transcode(LST_QSV, "Filter: qsv_get_denoise_filter() returned with error.");
+            return -1;
+        }
+        else {
+            len = strnlen(temp_filter, TEMP_FILTER_LEN);
+            snprintf(temp_filter + len, TEMP_FILTER_LEN - len, "%s%s", (len > 0) ? ":" : "", hw_denoise);
+        }
+    }
+
+    memset(hw_sharpness, 0, sizeof(hw_sharpness));
+    if (filter_sharpness){
+        if (qsv_get_sharpness_filter(self->iavctx, filter_sharpness, hw_sharpness, sizeof(hw_sharpness))){
+            tvherror_transcode(LST_QSV, "Filter: qsv_get_sharpness_filter() returned with error.");
+            return -1;
+        }
+        else {
+            len = strnlen(temp_filter, TEMP_FILTER_LEN);
+            snprintf(temp_filter + len, TEMP_FILTER_LEN - len, "%s%s", (len > 0) ? ":" : "", hw_sharpness);
+        }
+    }
+    
+    len = strnlen(temp_filter, TEMP_FILTER_LEN);
+    if (len) {
+        // only if we have filters we add "vpp_qsv=" and we copy the string
+        snprintf(filter, filter_len, "vpp_qsv=%s", temp_filter);
+    }
+    return 0;
+}
+
+
+int
+qsv_get_download(TVHContext *self, int skip_format, char *filter, size_t filter_len)
+{
+    if (skip_format) {
+        if (str_snprintf(filter, filter_len, "hwdownload")) {
+            return -1;
+        }
+    }
+    else {
+        if (str_snprintf(filter, filter_len, "hwdownload,format=pix_fmts=%s",
+                        av_get_pix_fmt_name(self->oavctx->sw_pix_fmt))) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/* encoding ================================================================= */
+
+int
+qsv_encode_setup_context(AVCodecContext *avctx)
+{
+    TVHContext *ctx = avctx->opaque;
+    int ret = 0;
+
+    // this is required in case encode is called twice
+    if (ctx->hw_device_octx)
+        av_buffer_unref(&ctx->hw_device_octx);
+
+    // 1. Share the cached (VAAPI-derived) QSV device with the decoder.
+    ctx->hw_device_octx = tvh_qsv_device_get(ctx->hw_accel_device);
+    if (!ctx->hw_device_octx) {
+        ret = AVERROR(ENODEV);
+        tvherror_transcode(LST_QSV, "Encode: Failed to obtain QSV device");
+        return ret;
+    }
+    avctx->hw_device_ctx = av_buffer_ref(ctx->hw_device_octx);
+    if (!avctx->hw_device_ctx) {
+        av_buffer_unref(&ctx->hw_device_octx);
+        ctx->hw_device_octx = NULL;
+        ret = AVERROR(ENOMEM);
+        tvherror_transcode(LST_QSV, "Encode: Failed to create a hardware device context."
+                " Error code: %s",av_err2str(ret));
+        return ret;
+    }
+    
+    // 2. CRITICAL: Frames Context are created in tvh_context_open_filters2()
+
+    avctx->pix_fmt = AV_PIX_FMT_QSV;
+    avctx->sw_pix_fmt = AV_PIX_FMT_NV12;
+
+    return 0;
+}
+
+int
+qsv_get_upload(TVHContext *self, char *filter, size_t filter_len) {
+    if (str_snprintf(filter, filter_len, "format=pix_fmts=%s,hwupload=extra_hw_frames=100",  // 
+                    av_get_pix_fmt_name(self->oavctx->sw_pix_fmt))) {
+        return -1;
+    }
+    return 0;
+}
+
+/* module =================================================================== */
+
+void
+qsv_decode_destroy(TVHContext *ctx)
+{
+    if (!ctx)
+        return;
+    tvh_qsv_context_destroy(ctx->hw_accel_ictx);
+    ctx->hw_accel_ictx = NULL;
+}
+
+void
+qsv_done()
+{
+    // Release the process-wide cached QSV device.
+    tvh_mutex_lock(&tvh_qsv_device_lock);
+    av_buffer_unref(&tvh_qsv_device_cache);
+    tvh_mutex_unlock(&tvh_qsv_device_lock);
+}

--- a/src/transcoding/transcode/hwaccels/qsv.h
+++ b/src/transcoding/transcode/hwaccels/qsv.h
@@ -1,7 +1,7 @@
 /*
  *  tvheadend - Transcoding
  *
- *  Copyright (C) 2016 Tvheadend
+ *  Copyright (C) 2026 Tvheadend
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,8 +18,8 @@
  */
 
 
-#ifndef TVH_TRANSCODING_TRANSCODE_HWACCELS_VAAPI_H__
-#define TVH_TRANSCODING_TRANSCODE_HWACCELS_VAAPI_H__
+#ifndef TVH_TRANSCODING_TRANSCODE_HWACCELS_QSV_H__
+#define TVH_TRANSCODING_TRANSCODE_HWACCELS_QSV_H__
 
 
 #include "tvheadend.h"
@@ -30,26 +30,29 @@
 /* decoding ================================================================= */
 
 int
-vaapi_decode_setup_context(AVCodecContext *avctx);
+qsv_decode_setup_context(AVCodecContext *avctx);
 
 int
-vaapi_get_filters(TVHContext *self, char *filter, size_t filter_len);
+qsv_get_filters(TVHContext *self, char *filter, size_t filter_len);
 
 int
-vaapi_get_download(TVHContext *self, int skip_format, char *filter, size_t filter_len);
+qsv_get_download(TVHContext *self, int skip_format, char *filter, size_t filter_len);
 
 /* encoding ================================================================= */
 
 int
-vaapi_encode_setup_context(AVCodecContext *avctx);
+qsv_encode_setup_context(AVCodecContext *avctx);
+
+int
+qsv_get_upload(TVHContext *self, char *filter, size_t filter_len);
 
 /* module =================================================================== */
 
 void
-vaapi_decode_destroy(TVHContext *ctx);
+qsv_decode_destroy(TVHContext *ctx);
 
 void
-vaapi_done(void);
+qsv_done(void);
 
 
-#endif // TVH_TRANSCODING_TRANSCODE_HWACCELS_VAAPI_H__
+#endif // TVH_TRANSCODING_TRANSCODE_HWACCELS_QSV_H__

--- a/src/transcoding/transcode/hwaccels/v4l2-m2m.c
+++ b/src/transcoding/transcode/hwaccels/v4l2-m2m.c
@@ -1,0 +1,112 @@
+/*
+ *  tvheadend - Transcoding
+ *
+ *  Copyright (C) 2026 Tvheadend
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "transcoding/codec/internals.h"
+#include "../internals.h"
+#include "v4l2-m2m.h"
+
+#include <libavutil/hwcontext.h>
+ 
+#define ALIGN 32 // 32 for NV12
+
+typedef struct tvh_drm_context_t {
+    AVBufferRef *hw_device_ref;
+} TVDRMContext;
+
+
+/* TVDRMContext ============================================================= */
+
+static void
+tvh_drm_context_destroy(TVDRMContext *self)
+{
+    if (self) {
+        if (self->hw_device_ref) {
+            av_buffer_unref(&self->hw_device_ref);
+        }
+        free(self);
+        self = NULL;
+    }
+}
+
+/* internal ================================================================= */
+
+
+/* decoding ================================================================= */
+
+int
+v4l2m2m_get_download(TVHContext *self, char *filter, size_t filter_len)
+{
+    if (str_snprintf(filter, filter_len, "format=pix_fmts=%s",
+                    av_get_pix_fmt_name(self->iavctx->sw_pix_fmt))) {
+        return -1;
+    }
+    return 0;
+}
+
+/* encoding ================================================================= */
+
+int
+v4l2m2m_get_filters(TVHContext *self, char *filter, size_t filter_len)    
+{
+    return 0;
+}
+
+int
+v4l2m2m_encode_setup_context(AVCodecContext *avctx)
+{
+    TVHContext *ctx = avctx->opaque;
+    int ret = 0;
+
+    // Use the DRM device (render node)
+    ret = av_hwdevice_ctx_create(&ctx->hw_device_octx, AV_HWDEVICE_TYPE_DRM, "/dev/dri/renderD128", NULL, 0);
+    if (ret < 0) {
+        // Fallback to /dev/dri/card0 if renderD128 isn't available
+        ret = av_hwdevice_ctx_create(&ctx->hw_device_octx, AV_HWDEVICE_TYPE_DRM, "/dev/dri/card0", NULL, 0);
+    }
+
+    avctx->pix_fmt = AV_PIX_FMT_DRM_PRIME;
+    avctx->sw_pix_fmt = AV_PIX_FMT_NV12;
+    ctx->use_pkt_data_new_extradata = 1;
+    return ret;
+}
+
+int
+v4l2m2m_get_upload(TVHContext *self, char *filter, size_t filter_len) {
+    if (str_snprintf(filter, filter_len, "format=nv12,pad=width=ceil(iw/32)*32:height=ceil(ih/32)*32:x=(ow-iw)/2:y=(oh-ih)/2:color=black")) {
+        return -1;
+    }
+    return 0;
+}
+
+/* module =================================================================== */
+
+void
+v4l2m2m_decode_destroy(TVHContext *ctx)
+{
+    if (!ctx)
+        return;
+    tvh_drm_context_destroy(ctx->hw_accel_ictx);
+    ctx->hw_accel_ictx = NULL;
+}
+
+void
+v4l2m2m_done()
+{
+    /* nothing to do */
+}

--- a/src/transcoding/transcode/hwaccels/v4l2-m2m.h
+++ b/src/transcoding/transcode/hwaccels/v4l2-m2m.h
@@ -1,7 +1,7 @@
 /*
  *  tvheadend - Transcoding
  *
- *  Copyright (C) 2016 Tvheadend
+ *  Copyright (C) 2026 Tvheadend
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -18,8 +18,8 @@
  */
 
 
-#ifndef TVH_TRANSCODING_TRANSCODE_HWACCELS_VAAPI_H__
-#define TVH_TRANSCODING_TRANSCODE_HWACCELS_VAAPI_H__
+#ifndef TVH_TRANSCODING_TRANSCODE_HWACCELS_V4L2M2M_H__
+#define TVH_TRANSCODING_TRANSCODE_HWACCELS_V4L2M2M_H__
 
 
 #include "tvheadend.h"
@@ -30,26 +30,25 @@
 /* decoding ================================================================= */
 
 int
-vaapi_decode_setup_context(AVCodecContext *avctx);
+v4l2m2m_get_filters(TVHContext *self, char *filter, size_t filter_len);
 
 int
-vaapi_get_filters(TVHContext *self, char *filter, size_t filter_len);
-
-int
-vaapi_get_download(TVHContext *self, int skip_format, char *filter, size_t filter_len);
+v4l2m2m_get_download(TVHContext *self, char *filter, size_t filter_len);
 
 /* encoding ================================================================= */
 
 int
-vaapi_encode_setup_context(AVCodecContext *avctx);
+v4l2m2m_encode_setup_context(AVCodecContext *avctx);
+
+int
+v4l2m2m_get_upload(TVHContext *self, char *filter, size_t filter_len);
 
 /* module =================================================================== */
 
 void
-vaapi_decode_destroy(TVHContext *ctx);
+v4l2m2m_decode_destroy(TVHContext *ctx);
 
 void
-vaapi_done(void);
+v4l2m2m_done(void);
 
-
-#endif // TVH_TRANSCODING_TRANSCODE_HWACCELS_VAAPI_H__
+#endif // TVH_TRANSCODING_TRANSCODE_HWACCELS_V4L2M2M_H__

--- a/src/transcoding/transcode/hwaccels/vaapi.c
+++ b/src/transcoding/transcode/hwaccels/vaapi.c
@@ -17,35 +17,26 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "../../codec/internals.h"
+#include "transcoding/codec/internals.h"
 #include "../internals.h"
 #include "vaapi.h"
 
 #include <libavutil/hwcontext.h>
 #include <libavutil/hwcontext_vaapi.h>
 #include <libavutil/pixdesc.h>
-
 #include <va/va.h>
 
+#define ver2
 
 typedef struct tvh_vaapi_context_t {
-    int width;
-    int height;
     AVBufferRef *hw_device_ref;
 } TVHVAContext;
-
-
-static void
-tvhva_done()
-{
-    /* nothing to do */
-}
 
 
 /* TVHVAContext ============================================================= */
 
 static void
-tvhva_context_destroy(TVHVAContext *self)
+tvh_va_context_destroy(TVHVAContext *self)
 {
     if (self) {
         if (self->hw_device_ref) {
@@ -57,84 +48,52 @@ tvhva_context_destroy(TVHVAContext *self)
 }
 
 
-/* decoding ================================================================= */
-
-static int
-vaapi_get_buffer2(AVCodecContext *avctx, AVFrame *avframe, int flags)
+/* internal ================================================================= */
+#ifdef ver2
+#else
+// lifted from ffmpeg-6.1.1/doc/examples/vaapi_encode.c line 41
+static int set_hwframe_ctx(AVCodecContext *ctx, AVBufferRef *hw_device_ctx)
 {
-    if (!(avctx->codec->capabilities & AV_CODEC_CAP_DR1)) {
-        return avcodec_default_get_buffer2(avctx, avframe, flags);
+    AVBufferRef *hw_frames_ref;
+    AVHWFramesContext *frames_ctx = NULL;
+    int err = 0;
+
+    if (!(hw_frames_ref = av_hwframe_ctx_alloc(hw_device_ctx))) {
+        tvherror_transcode(LST_VAAPI, "Decode: Failed to create VAAPI frame context.");
+        return AVERROR(ENOMEM);
     }
-    return av_hwframe_get_buffer(avctx->hw_frames_ctx, avframe, 0);
+    frames_ctx = (AVHWFramesContext *)(hw_frames_ref->data);
+    frames_ctx->format    = AV_PIX_FMT_VAAPI;
+    frames_ctx->sw_format = AV_PIX_FMT_NV12;
+    frames_ctx->width     = ctx->width;
+    frames_ctx->height    = ctx->height;
+    frames_ctx->initial_pool_size = 20;
+    if ((err = av_hwframe_ctx_init(hw_frames_ref)) < 0) {
+        tvherror_transcode(LST_VAAPI, "Decode: Failed to initialize VAAPI frame context."
+                "Error code: %s",av_err2str(err));
+        av_buffer_unref(&hw_frames_ref);
+        return err;
+    }
+    ctx->hw_frames_ctx = av_buffer_ref(hw_frames_ref);
+    if (!ctx->hw_frames_ctx) {
+        err = AVERROR(ENOMEM);
+        tvherror_transcode(LST_VAAPI, "Decode: Failed to create a hardware frame context."
+                "Error code: %s",av_err2str(err));
+    }
+    av_buffer_unref(&hw_frames_ref);
+    return err;
 }
+#endif
 
-
-int
-vaapi_decode_setup_context(AVCodecContext *avctx)
+static int vaapi_get_scale_filter(AVCodecContext *iavctx, int height, char *filter, size_t filter_len)
 {
-    TVHContext *ctx = avctx->opaque;
-
-    TVHVAContext *self = NULL;
-    int ret = -1;
-
-    if (!(self = calloc(1, sizeof(TVHVAContext)))) {
-        tvherror_transcode(LST_VAAPI, "Decode: Failed to allocate VAAPI context (TVHVAContext)");
-        return AVERROR(ENOMEM);
+    if (str_snprintf(filter, filter_len, "scale_vaapi=w=-2:h=%d", height)){
+        return -1;
     }
-    // lifted from ffmpeg-6.1.1/doc/examples/vaapi_transcode.c line 237
-    /* Open VAAPI device and create an AVHWDeviceContext for it*/
-    if ((ret = av_hwdevice_ctx_create(&self->hw_device_ref, AV_HWDEVICE_TYPE_VAAPI, ctx->hw_accel_device, NULL, 0)) < 0) {
-        tvherror_transcode(LST_VAAPI, "Decode: Failed to Open VAAPI device and create an AVHWDeviceContext for device: "
-                            "%s with error code: %s", 
-                            ctx->hw_accel_device, av_err2str(ret));
-        free(self);
-        self = NULL;
-        return ret;
-    }
-    // lifted from ffmpeg-6.1.1/doc/examples/vaapi_transcode.c line 95
-    /* set hw_frames_ctx for decoder's AVCodecContext */
-    avctx->hw_device_ctx = av_buffer_ref(self->hw_device_ref);
-    if (!avctx->hw_device_ctx) {
-        tvherror_transcode(LST_VAAPI, "Decode: Failed to create a hardware device reference for device: %s.", 
-                        ctx->hw_accel_device);
-        // unref hw_device_ref
-        av_buffer_unref(&self->hw_device_ref);
-        self->hw_device_ref = NULL;
-        free(self);
-        self = NULL;
-        return AVERROR(ENOMEM);
-    }
-    ctx->hw_accel_ictx = self;
-    avctx->get_buffer2 = vaapi_get_buffer2;
-    avctx->pix_fmt = AV_PIX_FMT_VAAPI;
     return 0;
 }
 
-
-void
-vaapi_decode_close_context(AVCodecContext *avctx)
-{
-    TVHContext *ctx = avctx->opaque;
-
-
-    if (avctx->hw_device_ctx) {
-        av_buffer_unref(&avctx->hw_device_ctx);
-    }
-    tvhva_context_destroy(ctx->hw_accel_ictx);
-}
-
-
-int
-vaapi_get_scale_filter(AVCodecContext *iavctx, AVCodecContext *oavctx,
-                       char *filter, size_t filter_len)
-{
-    snprintf(filter, filter_len, "scale_vaapi=w=%d:h=%d", oavctx->width, oavctx->height);
-    return 0;
-}
-
-
-int
-vaapi_get_deint_filter(AVCodecContext *avctx, char *filter, size_t filter_len)
+static int vaapi_get_deint_filter(AVCodecContext *avctx, char *filter, size_t filter_len)
 {
     const TVHContext *ctx = avctx->opaque;
 
@@ -148,61 +107,233 @@ vaapi_get_deint_filter(AVCodecContext *avctx, char *filter, size_t filter_len)
                                          mode, rate, enable_auto)) {
         return -1;
     }
+    return 0;
+}
 
+static int vaapi_get_denoise_filter(AVCodecContext *avctx, int value, char *filter, size_t filter_len)
+{
+    if (str_snprintf(filter, filter_len, "denoise_vaapi=%d", value)){
+        return -1;
+    }
+    return 0;
+}
+
+static int vaapi_get_sharpness_filter(AVCodecContext *avctx, int value, char *filter, size_t filter_len)
+{
+    if (str_snprintf(filter, filter_len, "sharpness_vaapi=%d", value)){
+        return -1;
+    }
     return 0;
 }
 
 
+/* decoding ================================================================= */
+
 int
-vaapi_get_denoise_filter(AVCodecContext *avctx, int value, char *filter, size_t filter_len)
+vaapi_decode_setup_context(AVCodecContext *avctx)
 {
-    snprintf(filter, filter_len, "denoise_vaapi=%d", value);
+    TVHContext *ctx = avctx->opaque;
+    TVHVAContext *self = NULL;
+    int ret = -1;
+
+    // clean up required if you call decode twice
+    if (ctx->hw_accel_ictx) {
+        av_buffer_unref(&avctx->hw_device_ctx);
+        av_buffer_unref(&avctx->hw_frames_ctx);
+        vaapi_decode_destroy(ctx);
+    }
+
+    if (!(self = calloc(1, sizeof(TVHVAContext)))) {
+        tvherror_transcode(LST_VAAPI, "Decode: Failed to allocate VAAPI context (TVHVAContext)");
+        return AVERROR(ENOMEM);
+    }
+    // lifted from ffmpeg-6.1.1/doc/examples/vaapi_transcode.c line 237
+    // Open VAAPI device and create an AVHWDeviceContext for it
+    if ((ret = av_hwdevice_ctx_create(&self->hw_device_ref, AV_HWDEVICE_TYPE_VAAPI, ctx->hw_accel_device, NULL, 0)) < 0) {
+        tvherror_transcode(LST_VAAPI, "Decode: Failed to Open VAAPI device and create an AVHWDeviceContext for device: "
+                            "%s with error code: %s", 
+                            ctx->hw_accel_device, av_err2str(ret));
+        tvh_va_context_destroy(self);
+        return ret;
+    }
+
+    // lifted from ffmpeg-6.1.1/doc/examples/vaapi_transcode.c line 95
+    // set hw_device_ctx for decoder's AVCodecContext
+    avctx->hw_device_ctx = av_buffer_ref(self->hw_device_ref);
+    if (!avctx->hw_device_ctx) {
+        tvherror_transcode(LST_VAAPI, "Decode: Failed to create a hardware device reference for device: %s.", 
+                        ctx->hw_accel_device);
+        tvh_va_context_destroy(self);
+        return AVERROR(ENOMEM);
+    }
+
+#ifdef ver2
+    // 2. CRITICAL: Create the Frames Context
+    if (!avctx->hw_frames_ctx) {
+        AVBufferRef *frames_ref = av_hwframe_ctx_alloc(self->hw_device_ref);
+        if (!frames_ref) {
+            ret = AVERROR(ENOMEM);
+            tvherror_transcode(LST_VAAPI, "Decode: Failed to initialize HW Frames "
+                            "with error code: %s", av_err2str(ret));
+            av_buffer_unref(&avctx->hw_device_ctx);
+            tvh_va_context_destroy(self);
+            return ret;
+        }
+        int width = avctx->coded_width;
+        int height = avctx->coded_height;
+        // check if coded dimensions is populated
+        if (width == 0 || height == 0){
+            width = avctx->width;
+            height = avctx->height;
+        }
+
+        AVHWFramesContext *frames_ctx = (AVHWFramesContext *)frames_ref->data;
+        frames_ctx->format    = AV_PIX_FMT_VAAPI;
+        frames_ctx->sw_format = AV_PIX_FMT_NV12;
+        // Hardware dimensions MUST be aligned (usually 32 for VAAPI)
+        // TODO: we should make this adjustable for Intel Gen12+ (Xe) sometime is required 128 or 256
+        frames_ctx->width     = FFALIGN(width,  32);
+        frames_ctx->height    = FFALIGN(height, 32);
+        frames_ctx->initial_pool_size = 32; // Pre-allocate 32 surfaces
+
+        ret = av_hwframe_ctx_init(frames_ref);
+        if (ret < 0) {
+            tvherror_transcode(LST_VAAPI, "Decode: Failed to initialize HW Frames "
+                            "with error code: %s", av_err2str(ret));
+            av_buffer_unref(&avctx->hw_device_ctx);
+            av_buffer_unref(&frames_ref);
+            tvh_va_context_destroy(self);
+            return ret;
+        }
+
+        // Attach the pool to the decoder
+        avctx->hw_frames_ctx = frames_ref;
+    }
+
+    
+#else
+    // lifted from ffmpeg-6.1.1/doc/examples/vaapi_encode.c line 152
+    /* set hw_frames_ctx for decoder's AVCodecContext */
+    if ((ret = set_hwframe_ctx(avctx, avctx->hw_device_ctx)) < 0) {
+        tvherror_transcode(LST_VAAPI, "Decode: Failed to set hwframe context."
+                                      " Error code: %s", av_err2str(ret));
+        av_buffer_unref(&avctx->hw_device_ctx);
+        tvh_va_context_destroy(self);
+        return ret;
+    }
+#endif
+    
+    ctx->hw_accel_ictx = self;
+    avctx->pix_fmt = AV_PIX_FMT_VAAPI;
+    avctx->sw_pix_fmt = AV_PIX_FMT_NV12;
     return 0;
 }
 
 
+/**
+ * @brief Constructs a VAAPI hardware video filter chain string.
+ *
+ * This function evaluates the current transcoding profile and input/output
+ * contexts to determine which hardware filters (deinterlacing, scaling, 
+ * denoising, and sharpness) are required. It then fetches the individual 
+ * filter strings and concatenates them into a single, comma-separated 
+ * filter string safe for use with FFmpeg/libavcodec.
+ *
+ * @param self       Pointer to the TVHContext containing the transcoding state,
+ * input/output AV contexts, and profile configuration.
+ * @param filter     Pointer to the destination buffer where the final comma-separated
+ * filter string will be written.
+ * @param filter_len The maximum size (in bytes) of the destination filter buffer.
+ *
+ * @return 0 on success, or -1 if an error occurred while retrieving any of the 
+ * individual hardware filter strings.
+ */
 int
-vaapi_get_sharpness_filter(AVCodecContext *avctx, int value, char *filter, size_t filter_len)
+vaapi_get_filters(TVHContext *self, char *filter, size_t filter_len)    
 {
-    snprintf(filter, filter_len, "sharpness_vaapi=%d", value);
+    // NOTE: filter_len > sum of all string --> previously used strcat()
+    // Now using snprintf for guaranteed buffer safety
+    char hw_deint[64];
+    char hw_scale[64];
+    char hw_denoise[64];
+    char hw_sharpness[64];
+    size_t len=0;
+
+    int height = ((TVHVideoCodecProfile *)self->profile)->size.den;
+
+    int filter_scale = (self->iavctx->height != height);
+    int filter_deint = ((TVHVideoCodecProfile *)self->profile)->deinterlace;
+    int filter_denoise = ((TVHVideoCodecProfile *)self->profile)->filter_hw_denoise;
+    int filter_sharpness = ((TVHVideoCodecProfile *)self->profile)->filter_hw_sharpness;
+
+    memset(hw_deint, 0, sizeof(hw_deint));
+    if (filter_deint){
+        if (vaapi_get_deint_filter(self->iavctx, hw_deint, sizeof(hw_deint))){
+            tvherror_transcode(LST_VAAPI, "Filter: vaapi_get_deint_filter() returned with error.");
+            return -1;
+        }
+        else {
+            len = strnlen(filter, filter_len);
+            snprintf(filter + len, filter_len - len, "%s%s", (len > 0) ? "," : "", hw_deint);
+        }
+    }
+    
+    memset(hw_scale, 0, sizeof(hw_scale));
+    if (filter_scale){ 
+        if(vaapi_get_scale_filter(self->iavctx, height, hw_scale, sizeof(hw_scale))){
+            tvherror_transcode(LST_VAAPI, "Filter: vaapi_get_scale_filter() returned with error.");
+            return -1;
+        }
+        else {
+            len = strnlen(filter, filter_len);
+            snprintf(filter + len, filter_len - len, "%s%s", (len > 0) ? "," : "", hw_scale);
+        }
+    }
+    
+    memset(hw_denoise, 0, sizeof(hw_denoise));
+    if (filter_denoise) { 
+        if (vaapi_get_denoise_filter(self->iavctx, filter_denoise, hw_denoise, sizeof(hw_denoise))){
+            tvherror_transcode(LST_VAAPI, "Filter: vaapi_get_denoise_filter() returned with error.");
+            return -1;
+        }
+        else {
+            len = strnlen(filter, filter_len);
+            snprintf(filter + len, filter_len - len, "%s%s", (len > 0) ? "," : "", hw_denoise);
+        }
+    }
+
+    memset(hw_sharpness, 0, sizeof(hw_sharpness));
+    if (filter_sharpness){
+        if (vaapi_get_sharpness_filter(self->iavctx, filter_sharpness, hw_sharpness, sizeof(hw_sharpness))){
+            tvherror_transcode(LST_VAAPI, "Filter: vaapi_get_sharpness_filter() returned with error.");
+            return -1;
+        }
+        else {
+            len = strnlen(filter, filter_len);
+            snprintf(filter + len, filter_len - len, "%s%s", (len > 0) ? "," : "", hw_sharpness);
+        }
+    }
+    return 0;
+}
+
+int
+vaapi_get_download(TVHContext *self, int skip_format, char *filter, size_t filter_len)
+{
+    if (skip_format) {
+        if (str_snprintf(filter, filter_len, "hwdownload")) {
+            return -1;
+        }
+    }
+    else {
+        if (str_snprintf(filter, filter_len, "hwdownload,format=pix_fmts=%s",
+                        av_get_pix_fmt_name(self->oavctx->sw_pix_fmt))) {
+            return -1;
+        }
+    }
     return 0;
 }
 
 /* encoding ================================================================= */
-
-// lifted from ffmpeg-6.1.1/doc/examples/vaapi_encode.c line 41
-static int set_hwframe_ctx(AVCodecContext *ctx, AVBufferRef *hw_device_ctx)
-{
-    AVBufferRef *hw_frames_ref;
-    AVHWFramesContext *frames_ctx = NULL;
-    int err = 0;
-
-    if (!(hw_frames_ref = av_hwframe_ctx_alloc(hw_device_ctx))) {
-        tvherror_transcode(LST_VAAPI, "Encode: Failed to create VAAPI frame context.");
-        return AVERROR(ENOMEM);
-    }
-    frames_ctx = (AVHWFramesContext *)(hw_frames_ref->data);
-    frames_ctx->format    = AV_PIX_FMT_VAAPI;
-    frames_ctx->sw_format = AV_PIX_FMT_NV12;
-    frames_ctx->width     = ctx->width;
-    frames_ctx->height    = ctx->height;
-    frames_ctx->initial_pool_size = 20;
-    if ((err = av_hwframe_ctx_init(hw_frames_ref)) < 0) {
-        tvherror_transcode(LST_VAAPI, "Encode: Failed to initialize VAAPI frame context."
-                "Error code: %s",av_err2str(err));
-        av_buffer_unref(&hw_frames_ref);
-        return err;
-    }
-    ctx->hw_frames_ctx = av_buffer_ref(hw_frames_ref);
-    if (!ctx->hw_frames_ctx) {
-        err = AVERROR(ENOMEM);
-        tvherror_transcode(LST_VAAPI, "Encode: Failed to create a hardware device reference."
-                "Error code: %s",av_err2str(err));
-    }
-    av_buffer_unref(&hw_frames_ref);
-    return err;
-}
-
 
 int
 vaapi_encode_setup_context(AVCodecContext *avctx)
@@ -210,46 +341,47 @@ vaapi_encode_setup_context(AVCodecContext *avctx)
     TVHContext *ctx = avctx->opaque;
     int ret = 0;
 
-    // lifted from ffmpeg-6.1.1/doc/examples/vaapi_encode.c line 127
-    /* Open VAAPI device and create an AVHWDeviceContext for it*/
+    // this is required in case encode is called twice
+    if (ctx->hw_device_octx)
+        av_buffer_unref(&ctx->hw_device_octx);
+    // 1. Create Device Context
+    // Open VAAPI device and create an AVHWDeviceContext for it
     if ((ret = av_hwdevice_ctx_create(&ctx->hw_device_octx, AV_HWDEVICE_TYPE_VAAPI, NULL, NULL, 0)) < 0) {
         tvherror_transcode(LST_VAAPI, "Encode: Failed to open VAAPI device and create an AVHWDeviceContext for it."
-                "Error code: %s",av_err2str(ret));
+                " Error code: %s",av_err2str(ret));
         return ret;
     }
-    // lifted from ffmpeg-6.1.1/doc/examples/vaapi_encode.c line 152
-    /* set hw_frames_ctx for encoder's AVCodecContext */
-    if ((ret = set_hwframe_ctx(avctx, ctx->hw_device_octx)) < 0) {
-        tvherror_transcode(LST_VAAPI, "Encode: Failed to set hwframe context."
-                "Error code: %s",av_err2str(ret));
+    avctx->hw_device_ctx = av_buffer_ref(ctx->hw_device_octx);
+    if (!avctx->hw_device_ctx) {
         av_buffer_unref(&ctx->hw_device_octx);
+        ctx->hw_device_octx = NULL;
+        ret = AVERROR(ENOMEM);
+        tvherror_transcode(LST_VAAPI, "Encode: Failed to create a hardware device context."
+                " Error code: %s",av_err2str(ret));
+        return ret;
     }
+    
+    // 2. CRITICAL: Frames Context are created in tvh_context_open_filters2()
+
+    avctx->pix_fmt = AV_PIX_FMT_VAAPI;
+    avctx->sw_pix_fmt = AV_PIX_FMT_NV12;
     return ret;
-}
-
-
-void
-vaapi_encode_close_context(AVCodecContext *avctx)
-{
-    TVHContext *ctx = avctx->opaque;
-    // hw_device_octx is initialized for software decoding (line 764)
-    if (ctx->hw_device_octx) {
-        av_buffer_unref(&ctx->hw_device_octx);
-    }
-    // avctx->hw_device_ctx is cleaned up only if ffmpeg exit with error and didn't perform the clean up
-    if (avctx->hw_device_ctx) {
-        av_buffer_unref(&avctx->hw_device_ctx);
-    }
-    if (avctx->hw_frames_ctx) {
-        av_buffer_unref(&avctx->hw_frames_ctx);
-    }
 }
 
 
 /* module =================================================================== */
 
 void
+vaapi_decode_destroy(TVHContext *ctx)
+{
+    if (!ctx)
+        return;
+    tvh_va_context_destroy(ctx->hw_accel_ictx);
+    ctx->hw_accel_ictx = NULL;
+}
+
+void
 vaapi_done()
 {
-    tvhva_done();
+    /* nothing to do */
 }

--- a/src/transcoding/transcode/internals.h
+++ b/src/transcoding/transcode/internals.h
@@ -48,12 +48,13 @@ typedef struct tvh_context_type TVHContextType;
 typedef struct tvh_context TVHContext;
 typedef struct tvh_context_helper TVHContextHelper;
 
-// post phase _MUST_ be == phase + 1
 typedef enum {
+    PREPARE_DECODER,
     OPEN_DECODER,
-    OPEN_DECODER_POST,
-    OPEN_ENCODER,
-    OPEN_ENCODER_POST
+    NOTIFY_GLOBALHEADER,
+    PREPARE_ENCODER,
+    OPEN_FILTERS,
+    OPEN_ENCODER
 } TVHOpenPhase;
 
 #if LIBAVCODEC_VERSION_MAJOR > 59
@@ -154,6 +155,9 @@ struct tvh_context {
     TVHContextType *type;
     AVCodecContext *iavctx;
     AVCodecContext *oavctx;
+    // this is used to parse the data before is delivered for decoding
+    AVCodecParserContext *parser;
+    AVPacket *out_pkt;
     AVFrame *iavframe;
     AVFrame *oavframe;
     pktbuf_t *input_gh;
@@ -165,14 +169,39 @@ struct tvh_context {
     int require_meta;
     int64_t pts;
     // only for audio
+    // for decode/packet timeline only
     int64_t duration;
-    int64_t delta;
     uint8_t sri;
+    // for encode/filter only
+    // last filter PTS, input timebase
+    int64_t last_flt_pts;
     // hardware acceleration
+    // store the AVHWDeviceType to be used in decide the filters and hwaccels functions calls
+    enum AVHWDeviceType iavhwdevtype;
+    enum AVHWDeviceType oavhwdevtype;
+    // used to transport the sample aspect ratio from packets to filter
+    AVRational sample_aspect_ratio;
+    // snapshot of elementary_info_t from streaming_start at transcode setup
+    elementary_info_t es_info;
     char *hw_accel_device;
     AVBufferRef *hw_device_ref;
     void *hw_accel_ictx;
     AVBufferRef *hw_device_octx;
+    // used as 'temporary storage' to pass dict from one state machine to other
+    // (PREPARE_DECODER --> OPEN_DECODER or PREPARE_ENCODER --> OPEN_ENCODER)
+    AVDictionary *temp_opts;
+    // V4L2 is using AV_PKT_DATA_NEW_EXTRADATA so we need to change the conditions used for extradata
+    // to signal that we set this variable to 1
+    uint8_t use_pkt_data_new_extradata;
+#if ENABLE_V4L2M2M
+    // V4L2 driver on raspberry pi is not able to initialize if width and hieght is defined in avctx
+    // when this variable is set to 1 we bypass all width and height initialization from upstream
+    // and we let the driver initialize it from first few frames
+    uint8_t skip_width_and_height_initialization;
+#endif
+    // consecutive encode-failure counter; once it reaches TVH_MAX_ENCODE_ERRORS
+    // the stream is torn down cleanly instead of looping forever (or crashing).
+    int encode_errors;
 };
 
 int
@@ -182,8 +211,48 @@ int
 tvh_context_get_str_opt(AVDictionary **opts, const char *key, char **value);
 
 void
+tvh_context_setup_parser(TVHContext *self);
+
+void
 tvh_context_close(TVHContext *self, int flush);
 
+#if LIBAVCODEC_VERSION_MAJOR > 59
+/**
+ * @brief Initializes and configures an FFmpeg AVFilterGraph for audio or video processing.
+ *
+ * This function acts as the bridge between the decoder and the encoder. It constructs
+ * a filter graph, configures the input source using parameters from the input codec 
+ * context (`iavctx`), applies a user-specified filter chain, and extracts the negotiated 
+ * output parameters from the sink to configure the output codec context (`oavctx`).
+ *
+ * It handles format extraction, Sample Aspect Ratio (SAR) fallbacks, hardware frame 
+ * contexts (e.g., VAAPI/CUDA), and color space metadata synchronization for modern 
+ * FFmpeg APIs (FFmpeg 6.0/7.0+).
+ *
+ * @param self        Pointer to the main TVH transcoding context.
+ * @param source_name The name of the FFmpeg source filter to use (e.g., "buffer" for video, 
+ * "abuffer" for audio).
+ * @param filters     A string describing the linear filter chain to insert between source 
+ * and sink (e.g., "yadif=1,scale=1920:1080"). If NULL or empty, the 
+ * source is linked directly to the sink.
+ * @param sink_name   The name of the FFmpeg sink filter to use (e.g., "buffersink" for video, 
+ * "abuffersink" for audio).
+ *
+ * @return 0 on successful graph configuration, or a negative FFmpeg AVERROR code on failure.
+ *
+ * @note 
+ * - If the filter graph alters the stream's properties (e.g., changing resolution, pixel 
+ * format, or sample rate), this function automatically updates `self->oavctx` to match 
+ * the new negotiated parameters.
+ * - Hardware frame contexts are properly referenced and mapped if hardware decoding/filtering 
+ * is active.
+ */
+int
+tvh_context_open_filters2(TVHContext *self,
+                         const char *source_name,
+                         const char *filters, 
+                         const char *sink_name);
+#endif
 /* __VA_ARGS__ = NULL terminated list of sink options
    sink option = (const char *name, av_opt_set_type opt_set_type, int size, const uint8_t *value) */
 int

--- a/src/transcoding/transcode/stream.c
+++ b/src/transcoding/transcode/stream.c
@@ -63,18 +63,19 @@ tvh_stream_setup(TVHStream *self, TVHCodecProfile *profile, tvh_ssc_t *ssc)
                        streaming_component_type2txt(ssc->es_type));
         return -1;
     }
-#if ENABLE_MMAL | ENABLE_NVENC | ENABLE_VAAPI
-    int hwaccel = -1;
-    int hwaccel_details = -1;
+#if ENABLE_MMAL | ENABLE_V4L2M2M | ENABLE_NVENC | ENABLE_VAAPI | ENABLE_QSV
+    int decoder_hwaccel_type = -1;
+    enum AVHWDeviceType avhwdevtype = AV_HWDEVICE_TYPE_NONE;
     if (SCT_ISVIDEO(ssc->es_type)) {
-        if (((hwaccel         = tvh_codec_profile_video_get_hwaccel(profile)) < 0) ||
-            ((hwaccel_details = tvh_codec_profile_video_get_hwaccel_details(profile)) < 0)) {
+        // -1 is when user will force software decoding so is a valid value
+        // -2 will be ERROR
+        if ((decoder_hwaccel_type = tvh_codec_profile_video_get_decoder_hwaccel_type(profile)) < -1){
             return -1;
         }
 #if ENABLE_MMAL
         if (idnode_is_instance(&profile->idnode, (idclass_t *)&codec_profile_video_class) &&
-            hwaccel &&
-            ((hwaccel_details == HWACCEL_AUTO && strstr(profile->codec_name, "mmal")) || hwaccel_details == HWACCEL_PRIORITIZE_MMAL)) {
+            // AV_HWDEVICE_TYPE_MMAL does not really exist as a type, but we use it to select the MMAL hardware
+            ((decoder_hwaccel_type == AV_AUTO_DEVICE_TYPE && strstr(profile->codec_name, "mmal")) || decoder_hwaccel_type == AV_HWDEVICE_TYPE_MMAL)) {
             if (icodec_id == AV_CODEC_ID_H264) {
                 icodec = avcodec_find_decoder_by_name("h264_mmal");
             } else if (icodec_id == AV_CODEC_ID_MPEG2VIDEO) {
@@ -82,11 +83,21 @@ tvh_stream_setup(TVHStream *self, TVHCodecProfile *profile, tvh_ssc_t *ssc)
             }
         }
 #endif
+#if ENABLE_V4L2M2M
+        if (!icodec && 
+            idnode_is_instance(&profile->idnode, (idclass_t *)&codec_profile_video_class) &&
+            // v4l2 is using AV_HWDEVICE_TYPE_DRM
+            ((decoder_hwaccel_type == AV_AUTO_DEVICE_TYPE && strstr(profile->codec_name, "v4l2")) || decoder_hwaccel_type == AV_HWDEVICE_TYPE_DRM)) {
+            if (icodec_id == AV_CODEC_ID_H264) {
+                icodec = avcodec_find_decoder_by_name("h264_v4l2m2m");
+            }
+            if (icodec) avhwdevtype = AV_HWDEVICE_TYPE_DRM;
+        }
+#endif
 #if ENABLE_NVENC
         if (!icodec && 
             idnode_is_instance(&profile->idnode, (idclass_t *)&codec_profile_video_class) &&
-            hwaccel &&
-            ((hwaccel_details == HWACCEL_AUTO && strstr(profile->codec_name, "nvenc")) || hwaccel_details == HWACCEL_PRIORITIZE_NVDEC)) {
+            ((decoder_hwaccel_type == AV_AUTO_DEVICE_TYPE && strstr(profile->codec_name, "nvenc")) || decoder_hwaccel_type == AV_HWDEVICE_TYPE_CUDA)) {
             // https://developer.nvidia.com/video-codec-sdk
             if (icodec_id == AV_CODEC_ID_MPEG2VIDEO) {
                 icodec = avcodec_find_decoder_by_name("mpeg2_cuvid");
@@ -99,28 +110,46 @@ tvh_stream_setup(TVHStream *self, TVHCodecProfile *profile, tvh_ssc_t *ssc)
             } else if (icodec_id == AV_CODEC_ID_VP8) {
                 icodec = avcodec_find_decoder_by_name("vp8_cuvid");
             }
+            if (icodec) avhwdevtype = AV_HWDEVICE_TYPE_CUDA;
         }
 #endif
+#if ENABLE_QSV
+        if (!icodec && 
+            idnode_is_instance(&profile->idnode, (idclass_t *)&codec_profile_video_class) &&
+            ((decoder_hwaccel_type == AV_AUTO_DEVICE_TYPE && strstr(profile->codec_name, "qsv")) || decoder_hwaccel_type == AV_HWDEVICE_TYPE_QSV)) {
+            // 
+            if (icodec_id == AV_CODEC_ID_H264) {
+                icodec = avcodec_find_decoder_by_name("h264_qsv");
+            } else if (icodec_id == AV_CODEC_ID_HEVC) {
+                icodec = avcodec_find_decoder_by_name("hevc_qsv");
+            } else if (icodec_id == AV_CODEC_ID_MPEG2VIDEO) {
+                icodec = avcodec_find_decoder_by_name("mpeg2_qsv");
+            }
+            if (icodec) avhwdevtype = AV_HWDEVICE_TYPE_QSV;
+        }
+#endif
+// NOTE: VAAPI should always be left the last
 #if ENABLE_VAAPI
         if (!icodec && 
             idnode_is_instance(&profile->idnode, (idclass_t *)&codec_profile_video_class) &&
-            hwaccel &&
-            (hwaccel_details == HWACCEL_PRIORITIZE_VAAPI)) {
-            if (icodec_id == AV_CODEC_ID_MPEG2VIDEO) {
-                icodec = avcodec_find_decoder_by_name("mpeg2_vaapi");
-            } else if (icodec_id == AV_CODEC_ID_H264) {
-                icodec = avcodec_find_decoder_by_name("h264_vaapi");
-            } else if (icodec_id == AV_CODEC_ID_HEVC) {
-                icodec = avcodec_find_decoder_by_name("hevc_vaapi");
-            } else if (icodec_id == AV_CODEC_ID_VP9) {
-                icodec = avcodec_find_decoder_by_name("vp9_vaapi");
-            } else if (icodec_id == AV_CODEC_ID_VP8) {
-                icodec = avcodec_find_decoder_by_name("vp8_vaapi");
+            // VAAPI is used also for software encoders
+            (decoder_hwaccel_type == AV_AUTO_DEVICE_TYPE || decoder_hwaccel_type == AV_HWDEVICE_TYPE_VAAPI)) {
+                // VAAPI does not have a standalone decoder named mpeg2_vaapi h264_vaapi hevc_vaapi vp9_vaapi
+                // Instead, VAAPI uses the standard software decoder (e.g., mpeg2video) and "accelerates" it by attaching a hardware device context to it.
+            icodec = avcodec_find_decoder(icodec_id);
+            // implement a rudimentary NULL check for icodec
+            for (int i = 0; icodec; i++) {
+                const AVCodecHWConfig *config = avcodec_get_hw_config(icodec, i);
+                if (!config) break;
+                if (config->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX &&
+                    config->device_type == AV_HWDEVICE_TYPE_VAAPI) {
+                    avhwdevtype =  AV_HWDEVICE_TYPE_VAAPI;
+                }
             }
         }
 #endif
     }
-#endif // from ENABLE_MMAL | ENABLE_NVENC | ENABLE_VAAPI
+#endif // from ENABLE_MMAL | ENABLE_V4L2M2M | ENABLE_NVENC | ENABLE_VAAPI | ENABLE_QSV
     if (!icodec && !(icodec = avcodec_find_decoder(icodec_id))) {
         tvh_stream_log(self, LOG_ERR, "failed to find decoder for '%s'",
                        streaming_component_type2txt(ssc->es_type));
@@ -141,10 +170,49 @@ tvh_stream_setup(TVHStream *self, TVHCodecProfile *profile, tvh_ssc_t *ssc)
                                              icodec, ocodec, ssc->ssc_gh))) {
         return -1;
     }
+#if ENABLE_V4L2M2M
+    // initialize with 0 all codecs
+    self->context->skip_width_and_height_initialization = 0;
+#endif
+    // video stream HW / SAR setup
+    if (SCT_ISVIDEO(ssc->es_type)) {
+        // snapshot the elementary stream info: the decoder context needs the
+        // geometry/aspect/frame duration the parser already resolved, and it
+        // is not available from the AVCodecContext before the first frames.
+        // Deliberately outside the hwaccel guard below -- a software-only
+        // build needs this just as much.
+        memcpy(&self->context->es_info, ssc, sizeof(elementary_info_t));
+#if ENABLE_MMAL | ENABLE_V4L2M2M | ENABLE_NVENC | ENABLE_VAAPI | ENABLE_QSV
+        // record decoder hw accel (to be used later on, for filter selection)
+        self->context->iavhwdevtype = avhwdevtype;
+        // copy sample_aspect_ratio (if available)
+        if( ssc->es_sample_aspect_ratio.num > 0 &&
+            ssc->es_sample_aspect_ratio.den > 0) {
+            self->context->sample_aspect_ratio = ssc->es_sample_aspect_ratio;
+            self->context->iavctx->sample_aspect_ratio = ssc->es_sample_aspect_ratio;
+        }
+#if ENABLE_V4L2M2M
+        if (avhwdevtype == AV_HWDEVICE_TYPE_DRM)
+            // this workaround is required for V4L2 running on raspberry pi 4
+            self->context->skip_width_and_height_initialization = 1;
+#endif
+#endif
+    }
+
     self->type = ssc->es_type = codec_id2streaming_component_type(ocodec->id);
     if (ssc->es_type == SCT_UNKNOWN) {
         tvh_stream_log(self, LOG_ERR, "unable to translate AV type %s [%d] to SCT!", ocodec->name, ocodec->id);
     }
+    // compute frame rate from es_frame_duration
+    int fdur = (ssc->es_frame_duration > INT_MAX) ? INT_MAX : (int)ssc->es_frame_duration;
+    if (fdur > 0) {
+        AVRational fr = av_make_q(90000, fdur);
+        av_reduce(&fr.num, &fr.den, fr.num, fr.den, INT_MAX);
+        self->context->iavctx->framerate = fr;
+    }
+    // setup parser
+    tvh_context_setup_parser(self->context);
+
     ssc->ssc_gh = NULL;
     return 0;
 }

--- a/src/transcoding/transcode/transcoder.c
+++ b/src/transcoding/transcode/transcoder.c
@@ -93,6 +93,27 @@ tvh_transcoder_handle(TVHTranscoder *self, th_pkt_t *pkt)
 
     SLIST_FOREACH(stream, &self->streams, link) {
         if (pkt->pkt_componentindex == stream->index) {
+#if ENABLE_LIBAV
+            // update SAR when is changing midstream
+            if (SCT_ISVIDEO(pkt->pkt_type) && stream->context) {
+                AVRational sar = { pkt->v.pkt_sample_aspect_ratio.num, pkt->v.pkt_sample_aspect_ratio.den };
+                if (sar.num > 0 && sar.den > 0) {
+                    stream->context->sample_aspect_ratio = sar;
+                    if (stream->context->iavctx &&
+                        avcodec_is_open(stream->context->iavctx))
+                        stream->context->iavctx->sample_aspect_ratio = sar;
+                }
+                if (stream->context->iavctx &&
+                    (!stream->context->iavctx->framerate.num || !stream->context->iavctx->framerate.den) && (pkt->pkt_duration > 1)) {
+                    int fdur = (pkt->pkt_duration > INT_MAX) ? INT_MAX : (int)pkt->pkt_duration;
+                    if (fdur > 0) {
+                        AVRational fr = av_make_q(90000, fdur);
+                        av_reduce(&fr.num, &fr.den, fr.num, fr.den, INT_MAX);
+                        stream->context->iavctx->framerate = fr;
+                    }
+                }
+            }
+#endif
             err = tvh_stream_handle(stream, pkt);
             if (err) {
                 tvh_stream_stop(stream, 0);

--- a/src/transcoding/transcode/video.c
+++ b/src/transcoding/transcode/video.c
@@ -25,18 +25,82 @@
 #endif
 
 
-static int
-_video_filters_hw_pix_fmt(enum AVPixelFormat pix_fmt)
+#if ENABLE_HWACCELS
+/**
+ * @brief Identifies the hardware acceleration type for an encoder.
+ *
+ * This function determines the appropriate hardware device type by inspecting 
+ * the encoder's codec name. It is specifically tailored for encoder contexts 
+ * where hardware-specific codec names are explicitly used.
+ *
+ * Logic flow:
+ * 1. **NVIDIA NVENC**: If `ENABLE_NVENC` is defined, it checks for NVIDIA-specific 
+ *    encoder names, returning `AV_HWDEVICE_TYPE_CUDA`.
+ * 2. **VAAPI**: If `ENABLE_VAAPI` is defined, it checks for VAAPI-specific 
+ *    encoder names, returning `AV_HWDEVICE_TYPE_VAAPI`.
+ * 3. **Intel QSV**: If `ENABLE_QSV` is defined, it checks for Quick Sync Video 
+ *    encoder names, returning `AV_HWDEVICE_TYPE_QSV`.
+ * 4. **V4L2M2M**: If `ENABLE_V4L2M2M` is defined, it checks for the V4L2 
+ *    hardware encoder and verifies its hardware capability flag, returning 
+ *    `AV_HWDEVICE_TYPE_DRM`.
+ *
+ * @param avctx Pointer to the AVCodecContext of the encoder.
+ *
+ * @return The detected AVHWDeviceType (CUDA, VAAPI, QSV, or DRM), 
+ *         or AV_HWDEVICE_TYPE_NONE if no hardware acceleration is identified.
+ */
+static enum AVHWDeviceType
+get_encoder_hw_device_type(AVCodecContext *avctx)
 {
-    const AVPixFmtDescriptor *desc;
-
-    if ((desc = av_pix_fmt_desc_get(pix_fmt)) &&
-        (desc->flags & AV_PIX_FMT_FLAG_HWACCEL)) {
-        return 1;
+    // first we try to detect the hadrware pix_fmt using codec name
+#if ENABLE_NVENC
+    // check NVDEC/NVENC encoder
+    if (avctx->codec && 
+        (strstr(avctx->codec->name, "h264_nvenc") || strstr(avctx->codec->name, "hevc_nvenc"))) {
+            return AV_HWDEVICE_TYPE_CUDA;
     }
-    return 0;
+#endif
+#if ENABLE_VAAPI
+    // check VAAPI encoder
+    if (avctx->codec &&
+        (strstr(avctx->codec->name, "mpeg2_vaapi") || strstr(avctx->codec->name, "h264_vaapi") || strstr(avctx->codec->name, "hevc_vaapi") ||
+        strstr(avctx->codec->name, "vp9_vaapi") || strstr(avctx->codec->name, "vp8_vaapi"))) {
+            return AV_HWDEVICE_TYPE_VAAPI;
+    }
+#endif
+#if ENABLE_QSV
+    // check QSV decoder/encoder
+    if (avctx->codec && 
+        (strstr(avctx->codec->name, "mpeg2_qsv") || strstr(avctx->codec->name, "h264_qsv") || strstr(avctx->codec->name, "hevc_qsv"))) {
+            return AV_HWDEVICE_TYPE_QSV;
+    }
+#endif
+#if ENABLE_V4L2M2M
+    // check v4l2 encoder
+    if (avctx->codec && strstr(avctx->codec->name, "h264_v4l2m2m") && (avctx->codec->capabilities & AV_CODEC_CAP_HARDWARE)) {
+            return AV_HWDEVICE_TYPE_DRM;
+    }
+#endif
+    return AV_HWDEVICE_TYPE_NONE;
 }
+#endif
 
+/**
+ * @brief Constructs a software-based deinterlacing filter string.
+ *
+ * This function generates a filter string based on the 'yadif' (Yet Another 
+ * Deinterlacing Filter) algorithm. It retrieves deinterlacing parameters 
+ * from the user's video codec profile, specifically the field rate mode 
+ * and the auto-enable logic.
+ *
+ * @param self      Pointer to the TVHContext containing the transcoding profile.
+ * @param deint     Pointer to the destination buffer where the yadif filter 
+ * string will be written (e.g., "yadif=mode=0:deint=0").
+ * @param deint_len The maximum size of the destination buffer.
+ *
+ * @return 0 on success, or -1 if the filter string could not be formatted 
+ * within the provided buffer length.
+ */
 static int
 _video_get_sw_deint_filter(TVHContext *self, char *deint, size_t deint_len)
 {
@@ -48,118 +112,115 @@ _video_get_sw_deint_filter(TVHContext *self, char *deint, size_t deint_len)
     return 0;
 }
 
+
+/**
+ * @brief Generates the complete video filter chain string for a transcoding session.
+ *
+ * This function constructs the final FFmpeg/libavcodec video filter string by evaluating 
+ * the required software filters (scaling, deinterlacing) and the hardware acceleration 
+ * capabilities of the input (decoder) and output (encoder) contexts.
+ *
+ * When hardware acceleration is enabled, it uses the following logic matrix to 
+ * determine if frames must be downloaded from the GPU to main memory, or uploaded 
+ * from main memory to the GPU:
+ *
+ * Input -> Output | Download | Upload | Notes
+ * ----------------|----------|--------|---------------------------------------
+ * HW    -> HW     |    0     |   0    | Stays in VRAM (unless HW types differ)
+ * SW    -> HW     |    0     |   1    | Requires CPU to GPU upload
+ * HW    -> SW     |    1     |   0    | Requires GPU to CPU download
+ * SW    -> SW     |    0     |   0    | Entirely in main memory
+ *
+ * If hardware acceleration is disabled, it falls back to standard software-based 
+ * format formatting for `hwdownload` and `hwupload`. The resulting filter pieces 
+ * are concatenated into a single, dynamically allocated, comma-separated string.
+ *
+ * @param self    Pointer to the TVHContext containing the current transcoding state,
+ * including input/output AV contexts and codec profiles.
+ * @param filters Pointer to a char pointer. On success, this will be updated to point 
+ * to a newly allocated string containing the comma-separated filter graph. 
+ * The caller is responsible for freeing this string.
+ *
+ * @return 0 on success, or -1 if an error occurs during filter string generation or memory allocation.
+ */
 static int
 _video_filters_get_filters(TVHContext *self, char **filters)
 {
-    char download[48];
+    char download[64];
     char deint[64];
-    char hw_deint[64];
     char scale[24];
-    char hw_scale[64];
-    char upload[48];
-    char hw_denoise[64];
-    char hw_sharpness[64];
-    int ihw = _video_filters_hw_pix_fmt(self->iavctx->pix_fmt);
-    int ohw = _video_filters_hw_pix_fmt(self->oavctx->pix_fmt);
-    int filter_scale = (self->iavctx->height != self->oavctx->height);
+    char upload[128];
+#if ENABLE_HWACCELS
+    char hw_filters[512];
+    int skip_download_format = 0;
+#endif
+    int height = ((TVHVideoCodecProfile *)self->profile)->size.den;
+    // width and height are set based on size in function tvh_codec_profile_video_setup()
+    // should be used for scalling
+    int filter_scale = (self->iavctx->height != height);
     int filter_deint = ((TVHVideoCodecProfile *)self->profile)->deinterlace;
     int filter_download = 0;
     int filter_upload = 0;
+
 #if ENABLE_HWACCELS
-    int filter_denoise = ((TVHVideoCodecProfile *)self->profile)->filter_hw_denoise;
-    int filter_sharpness = ((TVHVideoCodecProfile *)self->profile)->filter_hw_sharpness;
-#endif
+    // get encoder hardware acceleration type 
+    self->oavhwdevtype = get_encoder_hw_device_type(self->oavctx);
+
     //  in --> out  |  download   |   upload 
     // -------------|-------------|------------
     //  hw --> hw   |     0       |     0
     //  sw --> hw   |     0       |     1
     //  hw --> sw   |     1       |     0
     //  sw --> sw   |     0       |     0
-    filter_download = (ihw && (!ohw)) ? 1 : 0;
-    filter_upload = ((!ihw) && ohw) ? 1 : 0;
+    filter_download = (self->iavhwdevtype && (!self->oavhwdevtype)) ? 1 : 0;
+    filter_upload = ((!self->iavhwdevtype) && self->oavhwdevtype) ? 1 : 0;
+    // special case is when we use hw --> hw but the hw device types are different
+    if (self->iavhwdevtype && self->oavhwdevtype && 
+        (self->iavhwdevtype != self->oavhwdevtype)){
+        filter_download = 1;
+        filter_upload = 1;
+        skip_download_format = 1;   // to avoid two identical format strings
+    }
+#endif
 
     memset(deint, 0, sizeof(deint));
-    memset(hw_deint, 0, sizeof(hw_deint));
-#if ENABLE_HWACCELS
-    if (filter_deint) {
-        // when hwaccel is enabled we have two options:
-        if (ihw) {
-            // hw deint
-            if (hwaccels_get_deint_filter(self->iavctx, hw_deint, sizeof(hw_deint))) {
-                return -1;
-            }
-        }
-        else {
-            // sw deint
-            if (_video_get_sw_deint_filter(self, deint, sizeof(deint))) {
-                return -1;
-            }
-        }
-    }
-#else
-    if (filter_deint) {
-        if (_video_get_sw_deint_filter(self, deint, sizeof(deint))) {
+    if (filter_deint &&
+        _video_get_sw_deint_filter(self, deint, sizeof(deint))){
             return -1;
-        }
     }
-#endif
 
     memset(scale, 0, sizeof(scale));
-    memset(hw_scale, 0, sizeof(hw_scale));
-#if ENABLE_HWACCELS
-    if (filter_scale) {
-        // when hwaccel is enabled we have two options:
-        if (ihw) {
-            // hw scale
-            hwaccels_get_scale_filter(self->iavctx, self->oavctx, hw_scale, sizeof(hw_scale));
-        }
-        else {
-            // sw scale
-            if (str_snprintf(scale, sizeof(scale), "scale=w=-2:h=%d",
-                         self->oavctx->height)) {
-                return -1;
-            }
-        }
-    }
-#else
-    if (filter_scale) {
-        if (str_snprintf(scale, sizeof(scale), "scale=w=-2:h=%d",
-                         self->oavctx->height)) {
+    if (filter_scale &&
+        str_snprintf(scale, sizeof(scale), "scale=w=-2:h=%d", height)) {
             return -1;
-        }
     }
-#endif
-
-    memset(hw_denoise, 0, sizeof(hw_denoise));
-#if ENABLE_HWACCELS
-    if (filter_denoise) {
-        // used only when hwaccel is enabled
-        if (ihw) {
-            // hw scale
-            hwaccels_get_denoise_filter(self->iavctx, filter_denoise, hw_denoise, sizeof(hw_denoise));
-        }
-    }
-#endif
-
-    memset(hw_sharpness, 0, sizeof(hw_sharpness));
-#if ENABLE_HWACCELS
-    if (filter_sharpness) {
-        // used only when hwaccel is enabled
-        if (ihw) {
-            // hw scale
-            hwaccels_get_sharpness_filter(self->iavctx, filter_sharpness, hw_sharpness, sizeof(hw_sharpness));
-        }
-    }
-#endif
 
 #if ENABLE_HWACCELS
-    // no filter required.
+    memset(hw_filters, 0, sizeof(hw_filters));
+    if (self->iavhwdevtype &&
+        // setup the hardware filter on each hwaccel
+        hwaccels_decode_get_filters(self, hw_filters, sizeof(hw_filters))){
+            tvherror(LS_TRANSCODE, "filters: video: function hwaccels_get_filter() returned with error.");
+            return -1;
+    }
+    memset(download, 0, sizeof(download));
+    if (filter_download &&
+        // setup the download filter
+        hwaccels_download(self, download, sizeof(download), skip_download_format)){
+            tvherror(LS_TRANSCODE, "filters: video: function hwaccels_download() returned with error.");
+            return -1;
+    }
+    memset(upload, 0, sizeof(upload));
+    if (filter_upload &&
+        // setup the upload filter
+        hwaccels_upload(self, upload, sizeof(upload))){
+            tvherror(LS_TRANSCODE, "filters: video: function hwaccels_upload() returned with error.");
+            return -1;
+    }
 #else
     if (deint[0] == '\0' && scale[0] == '\0') {
         filter_download = filter_upload = 0;
     }
-#endif
-
     memset(download, 0, sizeof(download));
     if (filter_download &&
         str_snprintf(download, sizeof(download), "hwdownload,format=pix_fmts=%s",
@@ -174,12 +235,81 @@ _video_filters_get_filters(TVHContext *self, char **filters)
                      av_get_pix_fmt_name(self->oavctx->pix_fmt))) {
         return -1;
     }
+#endif
 
-    if (!(*filters = str_join(",", hw_deint, hw_scale, hw_denoise, hw_sharpness, download, deint, scale, upload, NULL))) {
+#if ENABLE_HWACCELS
+    if (self->iavhwdevtype) {
+        if (!(*filters = str_join(",", hw_filters, download, upload, NULL))) {
+            return -1;
+        }
+    }
+    else {
+        if (!(*filters = str_join(",", deint, scale, upload, NULL))) {
+            return -1;
+        }
+    }
+#else
+    if (!(*filters = str_join(",", download, deint, scale, upload, NULL))) {
         return -1;
     }
+#endif
 
     return 0;
+}
+
+
+/* Push what the parser already knows about the elementary stream into the
+   decoder context: geometry, sample aspect ratio and frame rate.  stream.c
+   copies es_sample_aspect_ratio only -- and only in hwaccel builds -- so
+   width, height and frame rate reach the decoder unset, and the buffer
+   filter source is then configured from zeroes: libav reports 'Invalid
+   frame dimensions 0x0' and a pixel_aspect of 0/0.  Hardware paths mostly
+   negotiate geometry from the frames context instead, so it is the software
+   path that ends up running on the unset values. */
+static void
+tvh_video_apply_stream_params(TVHContext *self)
+{
+    const elementary_info_t *es = &self->es_info;
+#if ENABLE_V4L2M2M
+    // V4L2 on RPI is not working if we populate the width and height before we feed a frame -->
+    // we have to let the driver allocate properly width and height (with proper guardings) by the driver
+    if (!self->skip_width_and_height_initialization && es->es_width > 0 && es->es_height > 0)
+#else
+    if (es->es_width > 0 && es->es_height > 0)
+#endif
+    {
+        // we only update the fields that are not initialized
+        if (self->iavctx->width <= 0)
+            self->iavctx->width = es->es_width;
+        if (self->iavctx->height <= 0)
+            self->iavctx->height = es->es_height;
+    }
+    // update only if sar is not initialized
+    if (self->iavctx->sample_aspect_ratio.den <= 0 || self->iavctx->sample_aspect_ratio.num <= 0){
+        if (self->sample_aspect_ratio.num > 0 && self->sample_aspect_ratio.den > 0)
+            self->iavctx->sample_aspect_ratio = self->sample_aspect_ratio;
+#if ENABLE_LIBAV
+        else if (es->es_sample_aspect_ratio.num > 0 && es->es_sample_aspect_ratio.den > 0)
+            self->iavctx->sample_aspect_ratio = es->es_sample_aspect_ratio;
+#endif
+        else if (es->es_aspect_num && es->es_aspect_den &&
+                es->es_width > 0 && es->es_height > 0) {
+            /* display aspect -> sample aspect */
+            AVRational sar;
+            av_reduce(&sar.num, &sar.den,
+                    (int64_t)es->es_aspect_num * es->es_height,
+                    (int64_t)es->es_aspect_den * es->es_width,
+                    INT_MAX);
+            if (sar.num > 0 && sar.den > 0)
+                self->iavctx->sample_aspect_ratio = sar;
+        }
+    }
+    // update only if framerate is not initialized
+    if ((!self->iavctx->framerate.num || !self->iavctx->framerate.den) &&
+        es->es_frame_duration > 1) {
+        int fdur = (es->es_frame_duration > INT_MAX) ? INT_MAX : (int)es->es_frame_duration;
+        self->iavctx->framerate = av_make_q(90000, fdur);
+    }
 }
 
 
@@ -187,16 +317,30 @@ static int
 tvh_video_context_open_decoder(TVHContext *self, AVDictionary **opts)
 {
 #if ENABLE_HWACCELS
-    int hwaccel = -1;
-    if ((hwaccel = tvh_codec_profile_video_get_hwaccel(self->profile)) < 0) {
-        return -1;
-    }
-    if (hwaccel) {
+    /* 1) HW decoder hooks (get_format, V4L2 pix_fmt, device…) */
+    if (self->iavhwdevtype != AV_HWDEVICE_TYPE_NONE) {
+#if ENABLE_V4L2M2M
+        // NOTE: V4L2 will not call hwaccels_decode_get_format() so v4l2m2m_decode_setup_context() can't be implemented
+        // sw --> *: bypass
+        // hw --> *: we force NV12/YUV420P
+        self->use_pkt_data_new_extradata = 0;
+        if (self->iavctx->codec && strstr(self->iavctx->codec->name, "h264_v4l2m2m") && self->iavhwdevtype == AV_HWDEVICE_TYPE_DRM) {
+            // We have to force NV12 for decoder and YUV420P for hwdownload
+            // for full hardware transcoding, 6by9 recommended in https://github.com/tvheadend/tvheadend/pull/1916#issuecomment-3298916606 
+            // to avoid YUV420P and force NV12 due to a misalignment between YUV420P decode (32) and encode (64)
+            self->iavctx->sw_pix_fmt = AV_PIX_FMT_YUV420P;
+            self->iavctx->pix_fmt = AV_PIX_FMT_NV12;
+        }
+#endif
         self->iavctx->get_format = hwaccels_decode_get_format;
     }
     mystrset(&self->hw_accel_device, self->profile->device);
 #endif
+    /* 2) TVHeadend timing convention (fixed) */
     self->iavctx->time_base = av_make_q(1, 90000); // MPEG-TS uses a fixed timebase of 90kHz
+    self->iavctx->pkt_timebase = self->iavctx->time_base; // to fix the warning: libav: AVCodecContext: Invalid pkt_timebase, passing timestamps as-is.
+    /* 3) Stream metadata from the parser/service snapshot */
+    tvh_video_apply_stream_params(self);
     return 0;
 }
 
@@ -222,76 +366,82 @@ tvh_video_context_notify_gh(TVHContext *self)
 static int
 tvh_video_context_open_encoder(TVHContext *self, AVDictionary **opts)
 {
-    AVRational ticks_per_frame;
-    int deinterlace  = ((TVHVideoCodecProfile *)self->profile)->deinterlace;
-    int field_rate = (deinterlace && ((TVHVideoCodecProfile *)self->profile)->deinterlace_field_rate) ? 2 : 1;
     int gop_size = ((TVHVideoCodecProfile *)self->profile)->gop_size;
 
-    if (tvh_context_get_int_opt(opts, "pix_fmt", &self->oavctx->pix_fmt) ||
-        tvh_context_get_int_opt(opts, "width", &self->oavctx->width) ||
-        tvh_context_get_int_opt(opts, "height", &self->oavctx->height)) {
+    if (tvh_context_get_int_opt(opts, "pix_fmt", &self->oavctx->pix_fmt)) {
         return -1;
     }
 
 #if ENABLE_HWACCELS
-    // hwaccel is the user input for Hardware acceleration from Codec parameteres
-    int hwaccel = -1;
-    if ((hwaccel = tvh_codec_profile_video_get_hwaccel(self->profile)) < 0) {
+    // get encoder hardware acceleration type 
+    self->oavhwdevtype = get_encoder_hw_device_type(self->oavctx);
+    // initialize encoder
+    if (hwaccels_encode_setup_context(self)) {
         return -1;
-    }
-    if (_video_filters_hw_pix_fmt(self->oavctx->pix_fmt)){
-        // encoder is hw accelerated
-        if (hwaccel) {
-            // decoder is hw accelerated 
-            // --> we initialize encoder from decoder as recomanded in: 
-            // ffmpeg-6.1.1/doc/examples/vaapi_transcode.c line 169
-            if (hwaccels_initialize_encoder_from_decoder(self->iavctx, self->oavctx)) {
-                return -1;
-            }
-        }
-        else {
-            // decoder is sw
-            // --> we initialize as recommended in:
-            // ffmpeg-6.1.1/doc/examples/vaapi_encode.c line 145
-            if (hwaccels_encode_setup_context(self->oavctx)) {
-                return -1;
-            }
-        }
     }
 #endif // from ENABLE_HWACCELS
 
-    // XXX: is this a safe assumption?
-    if (!self->iavctx->framerate.num) {
-        self->iavctx->framerate = av_make_q(30, 1);
+    // check frame rate
+    if (!self->iavctx->framerate.num || !self->iavctx->framerate.den) {
+        // compute frame rate from pkt_duration (probably es_frame_duration was 0)
+        int fdur = 0;
+        if (self->src_pkt)
+            fdur = (self->src_pkt->pkt_duration > INT_MAX) ? INT_MAX : (int)self->src_pkt->pkt_duration;
+        if (fdur > 0) {
+            AVRational fr = av_make_q(90000, fdur);
+            av_reduce(&fr.num, &fr.den, fr.num, fr.den, INT_MAX);
+            self->iavctx->framerate = fr;
+        }
     }
-    self->oavctx->framerate = av_mul_q(self->iavctx->framerate, (AVRational) { field_rate, 1 }); //take into account double rate i.e. field-based deinterlacers
-    int ticks_per_frame_tmp = (90000 * self->oavctx->framerate.den) / self->oavctx->framerate.num; // We assume 90kHz as timebase which is mandatory for MPEG-TS
-    ticks_per_frame = av_make_q(ticks_per_frame_tmp, 1);
-    self->oavctx->time_base = av_inv_q(av_mul_q(self->oavctx->framerate, ticks_per_frame));
+    
+#if LIBAVCODEC_VERSION_MAJOR <= 59
+    /* Legacy path: tvh_context_open_filters2() does not exist, so the encoder
+       geometry and timing cannot be taken from the negotiated buffersink and
+       must be configured here, as before the filter2 rework. */
+    {
+        TVHVideoCodecProfile *vprofile = (TVHVideoCodecProfile *)self->profile;
+        int field_rate = (vprofile->deinterlace &&
+                          vprofile->deinterlace_field_rate) ? 2 : 1;
+        AVRational ticks_per_frame;
+        int ticks_per_frame_tmp;
+
+        if (!self->oavctx->width) {
+            if (vprofile->size.num > 0 && vprofile->size.den > 0) {
+                self->oavctx->width  = vprofile->size.num;
+                self->oavctx->height = vprofile->size.den;
+            } else {
+                self->oavctx->width  = self->iavctx->width;
+                self->oavctx->height = self->iavctx->height;
+            }
+        }
+        // XXX: is this a safe assumption?
+        if (!self->iavctx->framerate.num) {
+            self->iavctx->framerate = av_make_q(30, 1);
+        }
+        // take into account double rate i.e. field-based deinterlacers
+        self->oavctx->framerate =
+            av_mul_q(self->iavctx->framerate, (AVRational) { field_rate, 1 });
+        // We assume 90kHz as timebase which is mandatory for MPEG-TS
+        ticks_per_frame_tmp =
+            (90000 * self->oavctx->framerate.den) / self->oavctx->framerate.num;
+        ticks_per_frame = av_make_q(ticks_per_frame_tmp, 1);
+        self->oavctx->time_base =
+            av_inv_q(av_mul_q(self->oavctx->framerate, ticks_per_frame));
+        self->oavctx->sample_aspect_ratio = self->iavctx->sample_aspect_ratio;
+    }
+#endif
+
     if (gop_size) {
         // gop was set by the user
         self->oavctx->gop_size = gop_size;
     }
     else {
         // gop = 0 --> we use default of 3 sec.
-        self->oavctx->gop_size = ceil(av_q2d(av_inv_q(av_mul_q(self->oavctx->time_base, ticks_per_frame))));
+        if (self->iavctx->framerate.den != 0) {
+            self->oavctx->gop_size = (self->iavctx->framerate.num + self->iavctx->framerate.den / 2) / self->iavctx->framerate.den;
+        }
         self->oavctx->gop_size *= 3;
     }
-
-    self->oavctx->sample_aspect_ratio = self->iavctx->sample_aspect_ratio;
-
-    tvh_context_log(self, LOG_DEBUG,
-        "Encoder configuration: "
-        "framerate: %d/%d (%.3f fps),time_base: %.0fHz,"
-        "frame duration: %" PRId64 " ticks (%.6f sec),"
-        "gop_size: %d,sample_aspect_ratio: %d/%d",
-        self->oavctx->framerate.num, self->oavctx->framerate.den, av_q2d(self->oavctx->framerate),
-        av_q2d(av_inv_q(self->oavctx->time_base)),
-        av_rescale_q(1, av_inv_q(self->oavctx->framerate), self->oavctx->time_base),
-        av_q2d(av_inv_q(self->oavctx->framerate)),
-        self->oavctx->gop_size,
-        self->oavctx->sample_aspect_ratio.num, self->oavctx->sample_aspect_ratio.den);
-
     return 0;
 }
 
@@ -301,6 +451,10 @@ tvh_video_context_open_filters(TVHContext *self)
 {
     char source_args[128];
     char *filters = NULL;
+
+    // re-apply: the decoder may have learned the real geometry since, and the
+    // buffer source below is configured straight from these fields
+    tvh_video_apply_stream_params(self);
 
     // source args
     memset(source_args, 0, sizeof(source_args));
@@ -318,17 +472,19 @@ tvh_video_context_open_filters(TVHContext *self)
 
     // filters
     if (_video_filters_get_filters(self, &filters)) {
+        tvherror(LS_TRANSCODE, "filters: video: function _video_filters_get_filters() returned with error.");
+        str_clear(filters);
         return -1;
     }
+    
+    tvhinfo(LS_TRANSCODE, "filters: video: '%s'", filters);
 
 #if LIBAVCODEC_VERSION_MAJOR > 59
-    int ret = tvh_context_open_filters(self,
-        "buffer", source_args,                                  // source
-        strlen(filters) ? filters : "null",                     // filters
-        "buffersink",                                           // sink
-        "pix_fmts", AV_OPT_SET_BIN,                             // sink option: pix_fmt
-        sizeof(self->oavctx->pix_fmt), &self->oavctx->pix_fmt,
-        NULL);                                                  // _IMPORTANT!_
+    int ret = tvh_context_open_filters2(self,
+        "buffer",                                               // source
+        (filters && filters[0] != '\0') ? filters : "null",     // filters
+        "buffersink"                                            // sink
+    );
 #else
     int ret = tvh_context_open_filters(self,
         "buffer", source_args,              // source
@@ -342,18 +498,35 @@ tvh_video_context_open_filters(TVHContext *self)
     return ret;
 }
 
-
+/**
+ * Video half of the transcoder open state machine: dispatches @p phase to the
+ * appropriate setup routine.
+ *
+ * Handled phases:
+ * - PREPARE_DECODER — allocate/configure decoder-side @c AVCodecContext (and HW paths).
+ * - NOTIFY_GLOBALHEADER — propagate global headers / extradata as needed.
+ * - PREPARE_ENCODER — choose output size, pixel format, time base, GOP, HW encode hooks, etc.
+ * - OPEN_FILTERS — build the libavfilter graph (@c buffer → filters → @c buffersink).
+ *
+ * Phases such as OPEN_DECODER and OPEN_ENCODER are opened in @c context.c
+ * (@c tvh_context_open); this callback returns 0 for any unhandled @p phase.
+ *
+ * @param self  Transcode context (decoder + encoder + filter graph owner).
+ * @param phase Which open step @ref tvh_context_open is executing.
+ * @param opts  Codec/profile options dictionary (used by decoder/encoder prep paths).
+ * @return      0 on success or no-op; a negative @c AVERROR code on failure from the callee.
+ */
 static int
 tvh_video_context_open(TVHContext *self, TVHOpenPhase phase, AVDictionary **opts)
 {
     switch (phase) {
-        case OPEN_DECODER:
+        case PREPARE_DECODER:
             return tvh_video_context_open_decoder(self, opts);
-        case OPEN_DECODER_POST:
+        case NOTIFY_GLOBALHEADER:
             return tvh_video_context_notify_gh(self);
-        case OPEN_ENCODER:
+        case PREPARE_ENCODER:
             return tvh_video_context_open_encoder(self, opts);
-        case OPEN_ENCODER_POST:
+        case OPEN_FILTERS:
             return tvh_video_context_open_filters(self);
         default:
             break;
@@ -366,6 +539,7 @@ static int
 tvh_video_context_encode(TVHContext *self, AVFrame *avframe)
 {
     if (!self || !self->oavctx) {
+        tvherror(LS_TRANSCODE, "tvh_video_context_encode: oavctx is not initialized");
         return -1;
     }
 
@@ -373,16 +547,13 @@ tvh_video_context_encode(TVHContext *self, AVFrame *avframe)
 #if LIBAVUTIL_VERSION_MAJOR >= 58
     // FFmpeg 6.x+ — proper duration field and reliable time_base attached to deint filter
     int64_t *frame_duration = &avframe->duration;
-    if (self->oavfltctx && self->oavfltctx->nb_inputs > 0) {
-        src_time_base = self->oavfltctx->inputs[0]->time_base;
-    } else {
-        // Fallback if filter graph input not available (e.g. early pipeline)
-        int rate_factor = ((TVHVideoCodecProfile *)self->profile)->deinterlace_field_rate == 1 ? 2 : 1;
-        src_time_base = av_mul_q(self->oavctx->time_base, (AVRational){1, rate_factor});
-        tvh_context_log(self, LOG_TRACE,
-            "No valid input link found, falling back to scaled encoder time_base {%d/%d}",
-            src_time_base.num, src_time_base.den);
+    // we protect against null pointers
+    if (!self->oavfltctx || self->oavfltctx->nb_inputs == 0 || !self->oavfltctx->inputs || !self->oavfltctx->inputs[0]) {
+        tvherror(LS_TRANSCODE, "tvh_video_context_encode: oavfltctx is not initialized or is not initialized properly");
+        return -1;
     }
+    // we use timebase from oavfltctx
+    src_time_base = self->oavfltctx->inputs[0]->time_base;
 #else
     // FFmpeg 4.x–5.x — older API, VAAPI filter time_base not API exposed
     int64_t *frame_duration = &avframe->pkt_duration;
@@ -425,6 +596,19 @@ tvh_video_context_encode(TVHContext *self, AVFrame *avframe)
             src_time_base.num, src_time_base.den,
             self->oavctx->time_base.num, self->oavctx->time_base.den,
             avframe->pts, avframe->pkt_dts, *frame_duration);
+    }
+    /* av_parser_parse2() emits the first frame of a stream with no timestamps
+       at all -- both pts and dts come back unset even though the packet fed to
+       it carried them -- so the decoder hands us a frame whose pts is
+       AV_NOPTS_VALUE while its dts still holds the right value. Since
+       AV_NOPTS_VALUE is INT64_MIN, the monotonicity test below reads such a
+       frame as older than everything and discards it. Take the dts instead:
+       measured on a 30000/1001 source the recovered value was 77718 and the
+       next frame arrived at 80721, exactly one frame later. */
+    if (avframe->pts == AV_NOPTS_VALUE && avframe->pkt_dts != AV_NOPTS_VALUE) {
+        tvh_context_log(self, LOG_DEBUG,
+                        "frame has no pts, using dts (%"PRId64")", avframe->pkt_dts);
+        avframe->pts = avframe->pkt_dts;
     }
 
     if (avframe->pts <= self->pts) {
@@ -515,9 +699,12 @@ tvh_video_context_wrap(TVHContext *self, AVPacket *avpkt, th_pkt_t *pkt)
                             pict_type);
             break;
     }
-    pkt->pkt_duration   = avpkt->duration;
     pkt->pkt_commercial = self->src_pkt->pkt_commercial;
     pkt->v.pkt_field      = (self->oavctx->field_order > AV_FIELD_PROGRESSIVE);
+#if ENABLE_LIBAV
+    pkt->v.pkt_sample_aspect_ratio.num = self->src_pkt->v.pkt_sample_aspect_ratio.num;
+    pkt->v.pkt_sample_aspect_ratio.den = self->src_pkt->v.pkt_sample_aspect_ratio.den;
+#endif
     pkt->v.pkt_aspect_num = self->src_pkt->v.pkt_aspect_num;
     pkt->v.pkt_aspect_den = self->src_pkt->v.pkt_aspect_den;
     return 0;
@@ -527,10 +714,7 @@ tvh_video_context_wrap(TVHContext *self, AVPacket *avpkt, th_pkt_t *pkt)
 static void
 tvh_video_context_close(TVHContext *self)
 {
-#if ENABLE_HWACCELS
-    hwaccels_encode_close_context(self->oavctx);
-    hwaccels_decode_close_context(self->iavctx);
-#endif
+
 }
 
 

--- a/src/tvhlog.c
+++ b/src/tvhlog.c
@@ -210,7 +210,9 @@ tvhlog_subsys_t tvhlog_transcode_subsystems[] = {
     [LST_LIBX26X]       = { "libx26x",       N_("LIB x264_x265") },
     [LST_NVENC]         = { "nvenc",         N_("NVENC") },
     [LST_OMX]           = { "omx",           N_("OMX") },
+    [LST_V4l2M2M]       = { "v4l2",          N_("V4L2-API") },
     [LST_VAAPI]         = { "vaapi",         N_("VA-API") },
+    [LST_QSV]           = { "qsv",           N_("QSV-API") },
     [LST_VAINFO]        = { "vainfo",        N_("VAINFO") },
 };
 

--- a/src/tvhlog.h
+++ b/src/tvhlog.h
@@ -225,7 +225,9 @@ enum {
     LST_LIBX26X,
     LST_NVENC,
     LST_OMX,
+    LST_V4l2M2M,
     LST_VAAPI,
+    LST_QSV,
     LST_VAINFO,
     LST_LAST     /* keep this last */
 };

--- a/src/webui/static/app/codec.js
+++ b/src/webui/static/app/codec.js
@@ -26,61 +26,85 @@ function genericCBRvsVBR(form) {
 
 // functions used for Video Codec profiles
 
-function update_hwaccel_details(form) {
-    form.findField('hwaccel_details').setDisabled(!form.findField('hwaccel').getValue());
-    update_deinterlace_vaapi_mode(form);
-}
-
-function update_deinterlace_vaapi_mode(form) {
-    if (form.findField('deinterlace_vaapi_mode')) {
-        const hwaccel = form.findField('hwaccel').getValue();
+function update_deinterlace_mode(form) {
+    if (form.findField('decoder_hwaccel_type') && form.findField('encoder_hwaccel_type') && form.findField('deinterlace')){
         const deinterlace = form.findField('deinterlace').getValue();
-        const hwaccelDetails = form.findField('hwaccel_details').getValue(); // 0=AUTO, 1=VAAPI, 2=NVDEC, 3=MMAL
-
-        const disableDeintVaapiMode = !hwaccel || !deinterlace || (hwaccelDetails !== 0 && hwaccelDetails !== 1);
-        form.findField('deinterlace_vaapi_mode').setDisabled(disableDeintVaapiMode);
+        const decoder_hwaccel_type = Number(form.findField('decoder_hwaccel_type').getValue()); // -1=AUTO, 0=SW, 3=VAAPI, 5=QSV, 2=NVDEC, 100=MMAL, 8=V4L2
+        const encoder_hwaccel_type = Number(form.findField('encoder_hwaccel_type').getValue()); // 0=SW, 3=VAAPI, 5=QSV, 2=NVDEC, 100=MMAL, 8=V4L2
+        // for VAAPI
+        if (form.findField('deinterlace_vaapi_mode')) {
+            const vaapi_or_auto = ((decoder_hwaccel_type === -1) && (encoder_hwaccel_type === 3)) || decoder_hwaccel_type === 3;
+            const disable_deint_vaapi_mode = !deinterlace || !vaapi_or_auto;
+            form.findField('deinterlace_vaapi_mode').setDisabled(disable_deint_vaapi_mode);
+        }
+        // for QSV
+        if (form.findField('deinterlace_qsv_mode')) {
+            const qsv_or_auto = ((decoder_hwaccel_type === -1) && (encoder_hwaccel_type === 5)) || decoder_hwaccel_type === 5;
+            const disable_deint_qsv_mode = !deinterlace || !qsv_or_auto;
+            form.findField('deinterlace_qsv_mode').setDisabled(disable_deint_qsv_mode);
+        }
+        // for NVDEC
+        if (form.findField('deinterlace_nvdec_mode')) {
+            const nvdec_or_auto = ((decoder_hwaccel_type === -1) && (encoder_hwaccel_type === 2)) || decoder_hwaccel_type === 2;
+            const disable_deint_nvdec_mode = !deinterlace || !nvdec_or_auto;
+            form.findField('deinterlace_nvdec_mode').setDisabled(disable_deint_nvdec_mode);
+        }
     }
-}
-
-function update_deinterlace_details(form) {
-    if (form.findField('deinterlace_field_rate') && form.findField('deinterlace_enable_auto')) {
-        form.findField('deinterlace_field_rate').setDisabled(!form.findField('deinterlace').getValue());
-        form.findField('deinterlace_enable_auto').setDisabled(!form.findField('deinterlace').getValue());
-    }
-    update_deinterlace_vaapi_mode(form);
+    
 }
 
 function enable_hwaccels_details(form) {
-    if (form.findField('hwaccel_details') && form.findField('hwaccel')) {
-        update_hwaccel_details(form);
-        // on hwaccel change
-        form.findField('hwaccel').on('check', function(checkbox, value) {
-            update_hwaccel_details(form);
-        });
-        // on hwaccel_details change
-        form.findField('hwaccel_details').on('select', function(combo, record, index) {
-            update_deinterlace_vaapi_mode(form);
-        });
-    }
-    if (form.findField('deinterlace')) {
-        // on deinterlace change
-        form.findField('deinterlace').on('check', function(checkbox, value) {
-            update_deinterlace_details(form);
-        });
+
+    if (form.findField('decoder_hwaccel_type') && form.findField('encoder_hwaccel_type') && form.findField('deinterlace')){
+        const deinterlace = Number(form.findField('deinterlace').getValue());
+        const decoder_hwaccel_type = Number(form.findField('decoder_hwaccel_type').getValue()); // -1=AUTO, 0=SW, 3=VAAPI, 5=QSV, 2=NVDEC, 100=MMAL, 8=V4L2
+        const encoder_hwaccel_type = Number(form.findField('encoder_hwaccel_type').getValue()); // 0=SW, 3=VAAPI, 5=QSV, 2=NVDEC, 100=MMAL, 8=V4L2
+        // for VAAPI
+        const vaapi_or_auto = ((decoder_hwaccel_type === -1) && (encoder_hwaccel_type === 3)) || decoder_hwaccel_type === 3;
+        const disable_deint_vaapi_mode = !deinterlace || !vaapi_or_auto;
+        if (form.findField('deinterlace_vaapi_mode')) {
+            form.findField('deinterlace_vaapi_mode').setDisabled(disable_deint_vaapi_mode);
+        }
+        // for QSV
+        if (form.findField('deinterlace_qsv_mode')) {
+            const qsv_or_auto = ((decoder_hwaccel_type === -1) && (encoder_hwaccel_type === 5)) || decoder_hwaccel_type === 5;
+            const disable_deint_qsv_mode = !deinterlace || !qsv_or_auto;
+            form.findField('deinterlace_qsv_mode').setDisabled(disable_deint_qsv_mode);
+        }
+        // for NVDEC
+        const nvdec_or_auto = ((decoder_hwaccel_type === -1) && (encoder_hwaccel_type === 2)) || decoder_hwaccel_type === 2;
+        const disable_deint_nvdec_mode = !deinterlace || !nvdec_or_auto;
+        if (form.findField('deinterlace_nvdec_mode')) {
+            form.findField('deinterlace_nvdec_mode').setDisabled(disable_deint_nvdec_mode);
+        }
+        // Field Rate and Enable are only enabled for SW, VAAPI and NVDEC
+        const sw_vaapi_or_nvdec = (decoder_hwaccel_type === 0) || vaapi_or_auto || nvdec_or_auto
+        const disable_field_rate = !deinterlace || !sw_vaapi_or_nvdec;
+        if (form.findField('deinterlace_field_rate')) {
+            form.findField('deinterlace_field_rate').setDisabled(disable_field_rate);
+        }
+        if (form.findField('deinterlace_enable_auto')) {
+            form.findField('deinterlace_enable_auto').setDisabled(disable_field_rate);
+        }
     }
 }
 
 // functions used for VAAPI Video Codec profiles
 
 function updateHWFilters(form) {
-    if (form.findField('hw_denoise') && form.findField('hw_sharpness') && 
-        form.findField('hwaccel_details') && form.findField('hwaccel')) 
-    {
-        form.findField('hw_denoise').setDisabled(!form.findField('hwaccel').getValue());
-        form.findField('hw_sharpness').setDisabled(!form.findField('hwaccel').getValue());
-        form.findField('hwaccel_details').setDisabled(!form.findField('hwaccel').getValue());
+    if (form.findField('decoder_hwaccel_type') && form.findField('encoder_hwaccel_type')) {
+        const decoder_hwaccel_type = Number(form.findField('decoder_hwaccel_type').getValue()); // -1=AUTO, 0=SW, 3=VAAPI, 5=QSV, 2=NVDEC, 100=MMAL, 8=V4L2
+        const encoder_hwaccel_type = Number(form.findField('encoder_hwaccel_type').getValue()); // 0=SW, 3=VAAPI, 5=QSV, 2=NVDEC, 100=MMAL, 8=V4L2
+        // for VAAPI and QSV we show hw filters
+        if (form.findField('hw_denoise') && form.findField('hw_sharpness')) {
+            const vaapi_or_auto = ((decoder_hwaccel_type === -1) && (encoder_hwaccel_type === 3)) || decoder_hwaccel_type === 3;
+            const qsv_or_auto = ((decoder_hwaccel_type === -1) && (encoder_hwaccel_type === 5)) || decoder_hwaccel_type === 5;
+            const vaapi_or_qsv = vaapi_or_auto || qsv_or_auto;
+            form.findField('hw_denoise').setDisabled(!vaapi_or_qsv);
+            form.findField('hw_sharpness').setDisabled(!vaapi_or_qsv);
+        }
     }
-    update_deinterlace_details(form);
+    enable_hwaccels_details(form);
 }
 
 function checkBFrameQuality(low_power_field, desired_b_depth_field, b_reference_field, quality_field, ui_value, uilp_value) {
@@ -239,6 +263,71 @@ function updateFilters(form) {
     }
 }
 
+function update_rc_settings_nvenc(form, bit_rate_value, max_bit_rate_value, cq_value, bit_rate_scale_factor_value, qp_value) {
+    if (form.findField('bit_rate') && form.findField('max_bit_rate') && form.findField('cq') && 
+        form.findField('bit_rate_scale_factor') && form.findField('qp')) {
+        form.findField('bit_rate').setDisabled(bit_rate_value);
+        form.findField('max_bit_rate').setDisabled(max_bit_rate_value);
+        form.findField('cq').setDisabled(cq_value);
+        form.findField('bit_rate_scale_factor').setDisabled(bit_rate_scale_factor_value);
+        form.findField('qp').setDisabled(qp_value);
+    }
+}
+
+function filter_based_on_rc_nvenc(form) {
+    if (form.findField('rc_mode')) {
+        switch (form.findField('rc_mode').getValue()) {
+            case 0:
+                // for auto --> let the driver decide as requested by documentation
+                update_rc_settings_nvenc(form, false, false, false, false, false);
+                break;
+            case 1:
+                // for constant quality: CQP we use qp
+                update_rc_settings_nvenc(form, true, true, true, true, false);
+                break;
+            case 2:
+            case 4:
+            case 32:
+                // for variable bitrate: VBR we use bitrate
+                update_rc_settings_nvenc(form, false, false, false, false, true);
+                break;
+            case 3:
+            case 8:
+            case 16:
+                // for constant bitrate: CBR we use bitrate
+                update_rc_settings_nvenc(form, false, true, true, false, true);
+                break;
+        }
+    }
+}
+
+function update_nvenc_ui(form) {
+    // first time we have to call this manually
+    filter_based_on_rc_nvenc(form);
+
+    // on rc_mode change
+    if (form.findField('rc_mode'))
+        form.findField('rc_mode').on('select', function(combo, record, index) {
+            // filter based in rc_mode
+            filter_based_on_rc_nvenc(form);
+        });
+
+    // on hwaccel_details change
+    if (form.findField('decoder_hwaccel_type')) {
+        enable_hwaccels_details(form);
+        form.findField('decoder_hwaccel_type').on('select', function(combo, record, index) {
+            enable_hwaccels_details(form);
+        });
+    }
+
+    // on deinterlace change
+    if (form.findField('deinterlace')) {
+        enable_hwaccels_details(form);
+        form.findField('deinterlace').on('check', function(checkbox, value) {
+            enable_hwaccels_details(form);
+        });
+    }
+}
 
 function update_vaapi_ui(form) {
     // first time we have to call this manually
@@ -263,22 +352,22 @@ function update_vaapi_ui(form) {
             updateLowPower(form);
         });
 
-    // on hwaccel change
-    if (form.findField('hwaccel'))
-        form.findField('hwaccel').on('check', function(checkbox, value) {
+    // on hwaccel_details change
+    if (form.findField('decoder_hwaccel_type')) {
+        enable_hwaccels_details(form);
+        form.findField('decoder_hwaccel_type').on('select', function(combo, record, index) {
+            enable_hwaccels_details(form);
             updateHWFilters(form);
         });
-
-    // on hwaccel_details change
-    form.findField('hwaccel_details').on('select', function(combo, record, index) {
-        update_deinterlace_vaapi_mode(form);
-    });
+    }
 
     // on deinterlace change
-    if (form.findField('deinterlace'))
+    if (form.findField('deinterlace')) {
+        enable_hwaccels_details(form);
         form.findField('deinterlace').on('check', function(checkbox, value) {
-            update_deinterlace_details(form);
+            enable_hwaccels_details(form);
         });
+    }
 
     // on desired_b_depth change
     if (form.findField('desired_b_depth'))
@@ -293,6 +382,69 @@ function update_vaapi_ui(form) {
         });
 }
 
+// this function is used for all software encoders
+function update_sw_ui(form) {
+
+    // on hwaccel_details change
+    if (form.findField('decoder_hwaccel_type')) {
+        enable_hwaccels_details(form);
+        form.findField('decoder_hwaccel_type').on('select', function(combo, record, index) {
+            enable_hwaccels_details(form);
+        });
+    }
+
+    // on deinterlace change
+    if (form.findField('deinterlace')) {
+        enable_hwaccels_details(form);
+        form.findField('deinterlace').on('check', function(checkbox, value) {
+            enable_hwaccels_details(form);
+        });
+    }
+}
+
+// 
+function update_qsv_ui(form) {
+    // first time we have to call this manually
+    updateHWFilters(form);
+
+    // on hwaccel_details change
+    if (form.findField('decoder_hwaccel_type')) {
+        enable_hwaccels_details(form);
+        form.findField('decoder_hwaccel_type').on('select', function(combo, record, index) {
+            enable_hwaccels_details(form);
+            updateHWFilters(form);
+        });
+    }
+
+    // on deinterlace change
+    if (form.findField('deinterlace')) {
+        enable_hwaccels_details(form);
+        form.findField('deinterlace').on('check', function(checkbox, value) {
+            enable_hwaccels_details(form);
+        });
+    }
+}
+
+// 
+function update_v4l2_ui(form) {
+
+    // TODO update
+    // on hwaccel_details change
+    if (form.findField('decoder_hwaccel_type')) {
+        enable_hwaccels_details(form);
+        form.findField('decoder_hwaccel_type').on('select', function(combo, record, index) {
+            enable_hwaccels_details(form);
+        });
+    }
+
+    // we disable deinterlace (because is not available)
+    if (form.findField('deinterlace')) {
+        form.findField('deinterlace').setValue(false);
+        form.findField('deinterlace').setDisabled(true);
+    }
+    
+}
+
 var codec_profile_forms = {
     'default': function(form) {
         var name_field = form.findField('name');
@@ -301,7 +453,7 @@ var codec_profile_forms = {
 
     'codec_profile_mpeg2video': function(form) {
         genericCBRvsVBR(form);
-        enable_hwaccels_details(form);
+        update_sw_ui(form);
     },
 
     'codec_profile_mp2': function(form) {
@@ -410,12 +562,12 @@ var codec_profile_forms = {
 
     'codec_profile_libx264': function(form) {
         genericCBRvsVBR(form);
-        enable_hwaccels_details(form);
+        update_sw_ui(form);
     },
 
     'codec_profile_libx265': function(form) {
         genericCBRvsVBR(form);
-        enable_hwaccels_details(form);
+        update_sw_ui(form);
     },
 
     'codec_profile_libvpx': function(form) {
@@ -429,7 +581,7 @@ var codec_profile_forms = {
         }
 
         genericCBRvsVBR(form);
-        enable_hwaccels_details(form);
+        update_sw_ui(form);
         var quality_field = form.findField('deadline');
         var speed_field = form.findField('cpu-used');
         updateSpeed(quality_field, speed_field);
@@ -442,7 +594,10 @@ var codec_profile_forms = {
         });
     },
 
-    'codec_profile_libtheora': genericCBRvsVBR,
+    'codec_profile_libtheora':  function(form) {
+        genericCBRvsVBR(form);
+        update_sw_ui(form);
+    },
 
     'codec_profile_libvorbis': genericCBRvsVBR,
 
@@ -538,12 +693,24 @@ var codec_profile_forms = {
     },
 
     'codec_profile_nvenc_h264': function(form) { 
-        enable_hwaccels_details(form);
+        update_nvenc_ui(form);
     },
 
     'codec_profile_nvenc_hevc': function(form) { 
-        enable_hwaccels_details(form);
-    }
+        update_nvenc_ui(form);
+    },
+
+    'codec_profile_qsv_h264': function(form) { 
+        update_qsv_ui(form);
+    },
+
+    'codec_profile_qsv_hevc': function(form) { 
+        update_qsv_ui(form);
+    },
+
+    'codec_profile_v4l2m2m': function(form) { 
+        update_v4l2_ui(form);
+    },
 };
 
 

--- a/src/webui/static/tv.js
+++ b/src/webui/static/tv.js
@@ -59,27 +59,27 @@ tv.ui.VideoPlayer = Ext.extend(Ext.Panel, (function() {
             mimetype:  'video/MP2T'
         },
         webm: {
-            profile:   'webtv-vp8-vorbis-webm',
+            profile:   'webtv-vp8-software-vorbis-webm',
             playlist:  false,
             mimetype:  'video/webm; codecs="vp8.0, vorbis"'
         },
         hls: {
-            profile:   'webtv-h264-aac-mpegts',
+            profile:   'webtv-h264-software-aac-mpegts',
             playlist:  true,
             mimetype:  'application/x-mpegURL; codecs="avc1.42E01E, mp4a.40.2"'
         },
         apple: {
-            profile:   'webtv-h264-aac-mpegts',
+            profile:   'webtv-h264-software-aac-mpegts',
             playlist:  true,
             mimetype:  'application/vnd.apple.mpegURL; codecs="avc1.42E01E, mp4a.40.2"'
         },
         ts: {
-            profile:   'webtv-h264-aac-mpegts',
+            profile:   'webtv-h264-software-aac-mpegts',
             playlist:  false,
             mimetype:  'video/MP2T; codecs="avc1.42E01E, mp4a.40.2"'
         },
         mkv: {
-            profile:   'webtv-h264-aac-matroska',
+            profile:   'webtv-h264-software-aac-mkv',
             playlist:  false,
             mimetype:  'video/x-matroska; codecs="avc1.42E01E, mp4a.40.2"'
         }

--- a/support/patches/ffmpeg.vaapi.diff
+++ b/support/patches/ffmpeg.vaapi.diff
@@ -1,0 +1,13 @@
+# Patch is fixing: https://github.com/tvheadend/tvheadend/issues/1833
+diff -urN ../ffmpeg-7.1.3.orig/libavcodec/hw_base_encode.c ./libavcodec/hw_base_encode.c
+--- ../ffmpeg-7.1.3.orig/libavcodec/hw_base_encode.c    2023-04-03 00:53:26.000000000 +0200
++++ ./libavcodec/hw_base_encode.c    2023-04-03 07:46:36.641867975 +0200
+@@ -504,7 +504,7 @@ static int hw_base_encode_send_frame(AVCodecContext *avctx, FFHWBaseEncodeContex
+ 
+         // Fix timestamps if we hit end-of-stream before the initial decode
+         // delay has elapsed.
+-        if (ctx->input_order <= ctx->decode_delay)
++        if (ctx->input_order <= ctx->decode_delay && ctx->pic_end)
+             ctx->dts_pts_diff = ctx->pic_end->pts - ctx->first_pts;
+     }
+ 

--- a/support/patches/ffmpeg.vaapi2.diff
+++ b/support/patches/ffmpeg.vaapi2.diff
@@ -1,0 +1,34 @@
+# Patch is fixing: https://github.com/tvheadend/tvheadend/issues/1869
+# is combining two commits:
+#
+# Commit 1:
+# From: David Rosca <nowrep@gmail.com>
+# Date: Tue, 15 Oct 2024 16:49:41 +0200
+# Subject: hw_base_encode: Free pictures on close
+#
+# Fixes leaking recon surfaces with VAAPI.
+#
+# Commit 2:
+# From: Marvin Scholz <epirat07@gmail.com>
+# Date: Thu, 17 Oct 2024 20:23:40 +0200
+# Subject: avcodec/hw_base_encode: fix use after free on close
+#
+# The way the linked list of images was freed caused a
+# use after free, by accessing pic->next after pic was
+# already freed.
+#
+diff --urN ../ffmpeg-7.1.1/libavcodec/hw_base_encode.c ./libavcodec/hw_base_encode.c
+--- ../ffmpeg-7.1.1/libavcodec/hw_base_encode.c
++++ ./libavcodec/hw_base_encode.c
+@@ -804,6 +804,11 @@ int ff_hw_base_encode_init(AVCodecContext *avctx, FFHWBaseEncodeContext *ctx)
+
+ int ff_hw_base_encode_close(FFHWBaseEncodeContext *ctx)
+ {
++    for (FFHWBaseEncodePicture *pic = ctx->pic_start, *next_pic = pic; pic; pic = next_pic) {
++        next_pic = pic->next;
++        base_encode_pic_free(pic);
++    }
++
+     av_fifo_freep2(&ctx->encode_fifo);
+
+     av_frame_free(&ctx->frame);


### PR DESCRIPTION
- send mpegts_flags=nit starting ffmpeg 5.0
- fixes [1997](https://github.com/tvheadend/tvheadend/issues/1997)
- #1997
- leverage ffnvcodec/nvEncodeAPI.h constants
- update the presets with new introduced values (P1-P7)
- update presets deprecated with proper values
- bring nvenc closer to vaapi format: qp, maxrate, bit_rate_scale_factor
- defined new set of variables for new settings (with docstrincs)
- update the avDictionary set from string to integer
- updated the order of the settings to match the vaapi order
- consolidated common settings for h264 and hevc
- applied filters from vaapi to nvenc for rc_mode setting
- removed profile from nvenc.c because is handled by profile_class.c: tvh_codec_profile_base_open(TVHCodecProfile *self, AVDictionary **opts)
- replaced quality with cq (because nvenc doesn't have quality)
- this PR is implementing the changes from: #1869 and #1833
- fixed MPEG-PS (DVD)/av-lib and a hardcoded time_base
- added a worst case fallback to (90000,1)
- update the filter initialization from avfilter_graph_create_filter() to avfilter_graph_alloc_filter() +  avfilter_init_str(()
- transition audio filter to aformat for audio conversions.
- used avfilter_graph_alloc_filter() and avfilter_init_str to allow attach of hw_device_ctx to upload filter
- use codec_type to separate audio from video processing
- updated with a more robust implementation how get_format() is selecting pixel format
- cleaned up vaapi
- added parsing for height and width from Sequence Header and Extension Header
- transfer of sample_aspect_ratio from h264 and hevc and compute that form DAR for mpeg2
- add sample_aspect_ratio to to elementary_info (esstream) and th_pkt
- fixed bug for not searching if beginning or end was found during search in src/plumbing/globalheaders.c
- fixing PTS_MASK + 1 for wrapping around in src/plumbing/globalheaders.c
- workaround for time stamp discontinuity V4L2 decoder
- fixed a bug in src/muxer/muxer_libav.c where DAR was pushed into SAR
- separated states ENCODE and DECODE in 6 in order to get granularity to build filter before encoder is opened.
- added asetpts filter in audio path
- removed initialize encoder from decoder because filter has to override the encoder buffers.
- moved the string concatenation from video.c to vaapi.c. This will allow different separation strings and will allow separations of settings between hardware accels
- move also download and upload to hwaccel.c (to be forwarded to hwaccels if needed)
- changed the dispatch from hwaccell to other accels, to AVHWDeviceType because is more robust with many decoders/encoders implemented
- VAAPI does not have a standalone decoder named mpeg2_vaapi h264_vaapi hevc_vaapi vp9_vaapi
- if filter will change the frame rate we have to rescale PTS/DTS/duration
- if frame rate is not set we compute it from pkt_duration (instead of default to 30)
- we only use avpkt->duration if is set
- update tvh_pkt_t->pkt_duration and parser_es_r->es_frame_duration to int64_t to match AVPacket->duration
- load input framerate from esstream, as backup use src_pkt
- added QSV and V4L2 (for raspberry pi 4)
- added encoder_hwaccel_type that will help with enablement of features in UI based on what encoder is used
- combined two controls (hwaccel and hwaccel_details) into one (decoder_hwaccel_type)
- introduced "asetpts=N/SR/TB" to normalize PTS (on/off/auto)
- after ssc is copied continue to update the parameters from pkt
- add also a elementary_info_t to tvh_context to update more parameters from iavctx in decode phase
- limit consecutive encode failures to 50
- limit valid level above 0 for vaapi
- don't drop the whole hvcC when an optional SEI fails
- set the B-frame count unconditionally for qsv
- transcoding/qsv: derive and cache the QSV hw device (decode+encode)
- muxer/libav: don't report a muxer error on normal client disconnect
- fixed webm container and added oga, ogg and opus containers (all with av-lib)
- introduced a more robust muxer finder
- added nvdec hardware filters: scale_cuda and yadif_cuda
- fixed flac encoder
- removed --enable-nvenc and --enable-qsv from Containrfile.debian (due to unavailability in ARM systems)
- frag_duration for mp4 increased to 1000000us (1 sec).
- enable VP9 and opus for webm mkv container 
- enable avcodec_get_supported_config for future ffmpeg
- update to ffmpeg 7.1.3 (with patch for vaapi)
- update to ffmpeg 8.1.2
- updated default codecs and profiles
- copied information from es_stream to decoder (except for V4L2 width and height)
- add parsers from ffmpeg to generate a more robust decoding path (especially for hardware transcoding)- unfortunately disabled for V4L2 because HDTV is not working if avctx is initialized with width and height before driver is receiving frames  
- cleaned up and documented tsfix.c
- removed openssl
- add --ffmpeg=N (where N = {5,6,7 or [8]} with default set to 8
- limit trusty (for CI and cloudsmith) to ffmpeg 6 due to GCC compiler depedency
- limit fedora37 to fedora43 to ffmpeg 6 because is missing native support (so will require build from sources for system level packages for ffmpeg 7/8).
- improved the synchronization between audio and video (skipping samples with pts before video pts start)