### PR TITLE
epggrab: per-service EIT processing policy with global default

### DIFF
--- a/docs/property/eit_processing.md
+++ b/docs/property/eit_processing.md
@@ -1,0 +1,51 @@
+
+
+This setting controls which Event Information Table (EIT) sub-tables
+are accepted when building the EPG for this service.
+
+DVB EIT is broadcast in two forms, distinguished by `table_id`:
+
+- **Actual transport stream EIT** (`0x4e` / `0x50–0x5f`) — broadcast
+  by the service's *own* multiplex. Describes the service itself.
+- **Other transport stream EIT** (`0x4f` / `0x60–0x6f`) — broadcast
+  by *another* multiplex describing this one. Often coarser; mostly
+  used so a receiver tuned to one multiplex can still show some EPG
+  for services on neighbouring multiplexes.
+
+Without a precedence rule, the two sources can overwrite each other
+on every grab cycle, making the EPG flip between a detailed
+schedule (from actual-TS) and a coarser placeholder (from other-TS).
+
+| Value | Behaviour |
+| --- | --- |
+| **Default** | Defer to the global *EIT processing (default)* setting under EPG Grabber → OTA. Use this for most services. |
+| **None** | Ignore all EIT for this service. Equivalent to the legacy *Ignore EPG (EIT)* toggle. |
+| **Actual transport stream only** | Accept only actual-TS sub-tables (`0x4e`, `0x50–0x5f`). |
+| **Other transport stream only** | Accept only other-TS sub-tables (`0x4f`, `0x60–0x6f`). |
+| **Either** | Accept both, no precedence. Today's default behaviour — what tvheadend has always done. |
+| **Adaptive** | Accept both, but once this service's own actual-TS schedule has been seen this session, drop further other-TS for it. A neighbour's coarse description cannot overwrite the service's detailed schedule, while services whose actual-TS is never received keep using other-TS (so a dedicated EPG multiplex still works). |
+
+The Adaptive policy is self-correcting per service: it suppresses
+other-TS only once detailed actual-TS data has actually been
+received. Inspired by VDR's adaptive EIT handling.
+
+**One operational caveat for Adaptive.** The "actual-TS observed"
+state is per session and resets when tvheadend restarts. For a
+short window at startup, other-TS may briefly overwrite the
+detailed EPG until the service's own actual-TS schedule is re-
+observed in the new session. DVR entries whose link to an EPG
+event was made before the restart are reconnected by the existing
+fuzzy-match fallback in `dvr_entry_fuzzy_match` once actual-TS
+data returns. The one remaining edge is a recording already in
+progress at restart that happens to receive a stop-time-extension
+update during this swap window — the extension lands on the
+placeholder rather than the resumed entry, so the recording stops
+at its originally-scheduled time. Across normal operation (no
+restart), Adaptive self-heals after the first actual-TS arrival
+and the placeholder is then permanently filtered for that service.
+
+Most installations should leave this at *Default* and pick the
+policy globally. Per-service overrides are useful for diagnosing or
+working around broadcaster-specific quirks — a service whose own
+actual-TS EIT is intermittent, or one where you trust the
+neighbour's other-TS more than the service's own.

--- a/docs/property/eit_processing_default.md
+++ b/docs/property/eit_processing_default.md
@@ -1,0 +1,46 @@
+
+
+This setting is the default EIT (Event Information Table)
+processing policy applied to every DVB service whose own *EIT
+processing* is left at *Default*.
+
+DVB EIT is broadcast in two forms, distinguished by `table_id`:
+
+- **Actual transport stream EIT** (`0x4e` / `0x50–0x5f`) — broadcast
+  by the service's *own* multiplex. Describes the service itself.
+- **Other transport stream EIT** (`0x4f` / `0x60–0x6f`) — broadcast
+  by *another* multiplex describing this one. Often coarser.
+
+Without a precedence rule, the two sources can overwrite each other
+on every grab cycle, making the EPG flip between a detailed
+schedule (from actual-TS) and a coarser placeholder (from other-TS).
+
+| Value | Behaviour |
+| --- | --- |
+| **None** | Ignore all EIT for services set to Default. |
+| **Actual transport stream only** | Accept only actual-TS sub-tables (`0x4e`, `0x50–0x5f`). |
+| **Other transport stream only** | Accept only other-TS sub-tables (`0x4f`, `0x60–0x6f`). |
+| **Either** | Accept both, no precedence. Today's default behaviour — what tvheadend has always done. |
+| **Adaptive** | Accept both, but once a service's own actual-TS schedule has been seen this session, drop further other-TS for it. A neighbouring multiplex's coarse description cannot overwrite the service's detailed schedule. Services whose actual-TS is never received keep using other-TS, so a dedicated EPG multiplex still works. |
+
+Fresh installations default to **Either**, which preserves the
+historical behaviour. Switch to **Adaptive** to opt into the
+actual-TS-precedence heuristic without configuring services
+individually.
+
+**One operational caveat for Adaptive.** The "actual-TS observed"
+state is per session and resets when tvheadend restarts. For a
+short window at startup, other-TS may briefly overwrite the
+detailed EPG until each service's own actual-TS schedule is re-
+observed in the new session. DVR entries whose link to an EPG
+event was made before the restart are reconnected by the existing
+fuzzy-match fallback in `dvr_entry_fuzzy_match` once actual-TS
+data returns. The one remaining edge is a recording already in
+progress at restart that happens to receive a stop-time-extension
+update during this swap window — the extension lands on the
+placeholder rather than the resumed entry, so the recording stops
+at its originally-scheduled time. Across normal operation (no
+restart), Adaptive self-heals after the first actual-TS arrival.
+
+Any service can override this global default via its own *EIT
+processing* setting.

--- a/src/epggrab.c
+++ b/src/epggrab.c
@@ -333,9 +333,25 @@ epggrab_class_ota_genre_translation_notify(void *self, const char *lang)
   epggrab_ota_set_genre_translation();
 }
 
+static htsmsg_t *
+epggrab_class_eit_processing_default_list(void *o, const char *lang)
+{
+  /* Per-service EIT_PROCESSING_DEFAULT defers here, so the global
+   * choice list omits Default itself. */
+  static const struct strtab tab[] = {
+    { N_("None"),                         EIT_PROCESSING_NONE        },
+    { N_("Actual transport stream only"), EIT_PROCESSING_ACTUAL_ONLY },
+    { N_("Other transport stream only"),  EIT_PROCESSING_OTHER_ONLY  },
+    { N_("Either"),                       EIT_PROCESSING_EITHER      },
+    { N_("Adaptive"),                     EIT_PROCESSING_ADAPTIVE    },
+  };
+  return strtab2htsmsg(tab, 1, lang);
+}
+
 CLASS_DOC(epgconf)
 PROP_DOC(cron)
 PROP_DOC(ota_genre_translation)
+PROP_DOC(eit_processing_default)
 
 const idclass_t epggrab_class = {
   .ic_snode      = &epggrab_conf.idnode,
@@ -467,6 +483,20 @@ const idclass_t epggrab_class = {
       .group  = 3,
     },
     {
+      .type   = PT_INT,
+      .id     = "eit_processing_default",
+      .name   = N_("EIT processing (default)"),
+      .desc   = N_("Default EIT processing policy applied to "
+                   "services whose own \"EIT processing\" is set "
+                   "to Default. See Help for the full policy "
+                   "descriptions."),
+      .doc    = prop_doc_eit_processing_default,
+      .off    = offsetof(epggrab_conf_t, eit_processing_default),
+      .opts   = PO_ADVANCED | PO_DOC_NLIST,
+      .list   = epggrab_class_eit_processing_default_list,
+      .group  = 3,
+    },
+    {
       .type   = PT_STR,
       .id     = "ota_cron",
       .name   = N_("Over-the-air Cron multi-line"),
@@ -587,6 +617,7 @@ void epggrab_init ( void )
   epggrab_conf.epgdb_periodicsave = 0;
   epggrab_conf.epgdb_saveafterimport = 0;
   epggrab_conf.epgdb_processparentallabels = 0;
+  epggrab_conf.eit_processing_default = EIT_PROCESSING_EITHER;
 
   epggrab_cron_multi              = NULL;
 

--- a/src/epggrab.h
+++ b/src/epggrab.h
@@ -317,6 +317,22 @@ struct epggrab_module_ota_scraper
 /*
  *
  */
+/*
+ * EIT processing policy. Per-service value selects which EIT sub-tables
+ * are accepted for that service; the per-service Default value defers
+ * to the global default (which therefore omits Default from its choice
+ * list). Adaptive accepts both actual- and other-TS but, once the
+ * service's own actual-TS schedule has been received, drops further
+ * other-TS for it so a neighbouring multiplex's coarse description
+ * cannot overwrite the service's detailed schedule.
+ */
+#define EIT_PROCESSING_DEFAULT       0   /* per-service only: use global */
+#define EIT_PROCESSING_NONE          1
+#define EIT_PROCESSING_ACTUAL_ONLY   2
+#define EIT_PROCESSING_OTHER_ONLY    3
+#define EIT_PROCESSING_EITHER        4
+#define EIT_PROCESSING_ADAPTIVE      5
+
 typedef struct epggrab_conf {
   idnode_t              idnode;
   char                 *cron;
@@ -330,6 +346,7 @@ typedef struct epggrab_conf {
   char                 *ota_genre_translation;
   uint32_t              ota_timeout;
   uint32_t              ota_initial;
+  uint32_t              eit_processing_default;
   uint32_t              int_initial;
 } epggrab_conf_t;
 

--- a/src/epggrab/module/eit.c
+++ b/src/epggrab/module/eit.c
@@ -1285,8 +1285,54 @@ svc_ok:
   if (!LIST_FIRST(&svc->s_channels))
     goto done;
 
-  if (svc->s_dvb_ignore_eit)
+  /* Apply the effective EIT processing policy for this service:
+   * the per-service value, falling back to the global default when
+   * the service is set to Default. Tableid ranges in this callback
+   * (see the bounds check earlier in this function) are
+   *   0x4e               actual-TS present/following
+   *   0x50-0x5f          actual-TS schedule
+   *   0x4f, 0x60-0x6f    other-TS present/following + schedule. */
+  int processing = svc->s_dvb_eit_processing;
+  if (processing == EIT_PROCESSING_DEFAULT)
+    processing = epggrab_conf.eit_processing_default;
+
+  switch (processing) {
+  case EIT_PROCESSING_NONE:
     goto done;
+  case EIT_PROCESSING_ACTUAL_ONLY:
+    if (tableid == 0x4f || tableid >= 0x60)
+      goto done;
+    break;
+  case EIT_PROCESSING_OTHER_ONLY:
+    if (tableid == 0x4e || (tableid >= 0x50 && tableid < 0x60))
+      goto done;
+    break;
+  case EIT_PROCESSING_ADAPTIVE:
+    /* Track actual-TS schedule arrival per service. Once seen,
+     * drop further other-TS for it so a neighbouring multiplex's
+     * coarse description cannot overwrite the service's own
+     * detailed schedule. Services whose actual-TS is never
+     * received keep using other-TS, so a dedicated EPG multiplex
+     * still works. P/F (0x4e / 0x4f) is only two events per
+     * service and is not used as the "actual-TS seen" trigger. */
+    if (tableid >= 0x50 && tableid < 0x60) {
+      if (!svc->s_dvb_eit_actual_seen) {
+        svc->s_dvb_eit_actual_seen = 1;
+        tvhtrace(LS_TBL_EIT, "%s: %s actual-TS schedule seen",
+                 mt->mt_name, svc->s_nicename);
+      }
+    } else if ((tableid == 0x4f || tableid >= 0x60) &&
+               svc->s_dvb_eit_actual_seen) {
+      tvhtrace(LS_TBL_EIT,
+               "%s: skip other-TS tid 0x%02X for %s, actual-TS seen",
+               mt->mt_name, tableid, svc->s_nicename);
+      goto done;
+    }
+    break;
+  case EIT_PROCESSING_EITHER:
+  default:
+    break;
+  }
 
   /* Queue events */
   len -= 11;

--- a/src/input/mpegts.h
+++ b/src/input/mpegts.h
@@ -578,7 +578,7 @@ struct mpegts_service
   char    *s_dvb_provider;
   char    *s_dvb_cridauth;
   uint16_t s_dvb_servicetype;
-  int      s_dvb_ignore_eit;
+  int      s_dvb_eit_processing;            //EIT processing policy (EIT_PROCESSING_* in epggrab.h); Default defers to the global setting
   int      s_dvb_subtitle_processing;       //Various options for replacing/augmenting the desc from the sub-title
   int      s_dvb_ignore_matching_subtitle;  //Ignore the sub-title if same as title
   char    *s_dvb_charset;
@@ -593,6 +593,11 @@ struct mpegts_service
    */
 
   int      s_dvb_eit_enable;
+  /* Runtime flag: this service's own actual-TS schedule EIT
+   * (table_id 0x50-0x5f) has been received this session. Used by
+   * the EIT_PROCESSING_ADAPTIVE policy to start dropping other-TS
+   * once detailed actual-TS data is available. Not persisted. */
+  int      s_dvb_eit_actual_seen;
   uint64_t s_dvb_opentv_chnum;
   uint16_t s_dvb_opentv_id;
   uint16_t s_atsc_source_id;

--- a/src/input/mpegts/mpegts_service.c
+++ b/src/input/mpegts/mpegts_service.c
@@ -94,7 +94,42 @@ mpegts_service_subtitle_procesing ( void *o, const char *lang )
    return strtab2htsmsg(tab, 1, lang);
 }
 
+static htsmsg_t *
+mpegts_service_eit_processing_list ( void *o, const char *lang )
+{
+  static const struct strtab tab[] = {
+    { N_("Default (use global setting)"), EIT_PROCESSING_DEFAULT     },
+    { N_("None"),                         EIT_PROCESSING_NONE        }, //Ignore EIT for this service.
+    { N_("Actual transport stream only"), EIT_PROCESSING_ACTUAL_ONLY },
+    { N_("Other transport stream only"),  EIT_PROCESSING_OTHER_ONLY  },
+    { N_("Either"),                       EIT_PROCESSING_EITHER      },
+    { N_("Adaptive"),                     EIT_PROCESSING_ADAPTIVE    }, //Drop other-TS once actual-TS schedule has been seen.
+  };
+  return strtab2htsmsg(tab, 1, lang);
+}
+
+/* Translate the legacy dvb_ignore_eit bool into dvb_eit_processing on
+ * first load of an existing config. true → None (ignore EIT for this
+ * service), false → Default (defer to the global setting). Only run
+ * when the new key is absent, so already-migrated configs are
+ * untouched; the old key naturally disappears on next save (no
+ * matching prop on the class). */
+static void
+mpegts_service_class_load(struct idnode *self, htsmsg_t *c)
+{
+  mpegts_service_t *s = (mpegts_service_t *)self;
+  int b;
+
+  service_load((service_t *)self, c);
+
+  if (!htsmsg_field_find(c, "dvb_eit_processing") &&
+      !htsmsg_get_bool(c, "dvb_ignore_eit", &b))
+    s->s_dvb_eit_processing = b ? EIT_PROCESSING_NONE
+                                : EIT_PROCESSING_DEFAULT;
+}
+
 CLASS_DOC(mpegts_service)
+PROP_DOC(eit_processing)
 
 const idclass_t mpegts_service_class =
 {
@@ -103,6 +138,7 @@ const idclass_t mpegts_service_class =
   .ic_caption    = N_("DVB Inputs - Services"),
   .ic_doc        = tvh_doc_mpegts_service_class,
   .ic_order      = "enabled,channel,svcname",
+  .ic_load       = mpegts_service_class_load,
   .ic_properties = (const property_t[]){
     {
       .type     = PT_STR,
@@ -203,13 +239,16 @@ const idclass_t mpegts_service_class =
       .off      = offsetof(mpegts_service_t, s_dvb_servicetype),
     },
     {
-      .type     = PT_BOOL,
-      .id       = "dvb_ignore_eit",
-      .name     = N_("Ignore EPG (EIT)"),
-      .desc     = N_("Enable or disable ignoring of Event Information "
-                     "Table (EIT) data for this service."),
-      .off      = offsetof(mpegts_service_t, s_dvb_ignore_eit),
-      .opts     = PO_EXPERT,
+      .type     = PT_INT,
+      .id       = "dvb_eit_processing",
+      .name     = N_("EIT processing"),
+      .desc     = N_("Which EIT sub-tables are accepted for this "
+                     "service. Default defers to the global setting. "
+                     "See Help for the full policy descriptions."),
+      .doc      = prop_doc_eit_processing,
+      .off      = offsetof(mpegts_service_t, s_dvb_eit_processing),
+      .opts     = PO_EXPERT | PO_DOC_NLIST,
+      .list     = mpegts_service_eit_processing_list,
     },
     {
       .type     = PT_INT,


### PR DESCRIPTION
## Update (2026-05-23) — reworked to per-service enum + global default

Reworked per the discussion above. Two settings instead of one:

- **Per-service "EIT processing"** (replaces the legacy "Ignore EPG (EIT)" toggle on each DVB service)
- **Global "EIT processing (default)"** (under EPG Grabber → OTA settings)

Per-service values:

| Value | Behaviour |
|---|---|
| **Default** | Defer to the global default |
| **None** | Ignore EIT for this service (= old `Ignore EPG (EIT) = true`) |
| **Actual only** | Accept only actual-TS sub-tables (0x4e, 0x50–0x5f) |
| **Other only** | Accept only other-TS sub-tables (0x4f, 0x60–0x6f) |
| **Either** | Accept both, no precedence — today's behaviour |
| **Adaptive** | The original v1 behaviour: accept both, but once a service's own actual-TS schedule has been seen, drop further other-TS for it |

Global default exposes the same enum minus Default. New installs default to **Either** — no behaviour change from today, no surprise migrations.

Legacy migration on first load: `dvb_ignore_eit=true` → **None** (same observable behaviour), `dvb_ignore_eit=false` (the vast majority) → **Default** (defers to the global, also same observable behaviour while the global stays Either). The old key disappears from the config on next save.

The motivation, validation, prior report, peer-project comparison, and standards basis sections below are unchanged. The "Opt-in / compatibility", "The change", and "Testing" sections below are updated to reflect this shape.

---

## The problem

DVB EIT (Event Information Table) is broadcast in two forms, distinguished by `table_id`:

- **actual-TS** — `0x4E` (present/following) and `0x50–0x5F` (schedule): the EPG of the transport stream that carries the table. A service describing *itself*.
- **other-TS** — `0x4F` (present/following) and `0x60–0x6F` (schedule): EPG for services on a *different* transport stream — a second-hand description, carried so a receiver tuned to one mux can show EPG for others.

tvheadend's OTA grabber tunes every multiplex, so on a typical installation it ingests both the actual-TS EIT (from a service's own transponder) and any other-TS EIT for that same service (from neighbouring transponders). `_eit_callback()` resolves both to the same service and stores whatever was parsed last — **last-writer-wins, with no precedence between the two sub-tables.**

When the two disagree, the EPG **intermittently flips** between the service's correct, detailed, show-by-show schedule and whatever coarse description a neighbouring transponder happens to carry. A common failure mode: a service's own transponder carries a full schedule, while an unrelated platform sharing the same orbital position carries a single multi-hour channel-level placeholder for that service via other-TS — and the two overwrite each other on every grab cycle.

## Validation

This was reproduced and traced on a **live European DVB-S2 installation receiving Astra 19.2°E**:

- A free-to-air channel's EPG was observed flipping between its detailed schedule and a single **24-hour placeholder event**.
- Instrumenting the EIT handler showed the placeholder arriving as an **other-TS present/following event (`table_id 0x4F`)**, 24 hours long, with descriptors tagged language `spa` and rating country `ESP` — broadcast by a Spanish-language DTH platform that shares the 19.2°E position.
- The placeholder is **cross-carried by several transponders of that platform** — not a single rogue mux. The affected channel's own transponder, meanwhile, carries a correct detailed actual-TS schedule for it.
- With the option in this PR enabled, the other-TS placeholder is dropped as soon as the channel's own actual-TS schedule has been seen, and the detailed EPG stops being overwritten.

## Prior report

This exact situation was reported previously on the tvheadend issue tracker — **Bug #6249**, full URL:

> https://old.tvheadend.org/issues/6249

(EIT recorded off a Spanish pay-TV platform's transponders carrying another network's free-to-air channel, with a coarse Spanish-language placeholder.) That report was closed as *Invalid*, on the basis that tvheadend correctly follows the DVB specification for service identification (services keyed on original_network_id / transport_stream_id / service_id).

This PR does **not** dispute that. Service identification is unchanged. The change here is narrower and separate: an *optional* precedence between two spec-distinct EIT sub-tables describing the *same* service — a question the specification leaves to the receiver (see "Standards basis" below) — and it is opt-in, so it changes nothing unless an operator chooses to enable it.

## How other DVB projects handle this

Every comparable open-source DVB project already treats other-TS EIT as a distinct, lower-trust category rather than as interchangeable with actual-TS:

- **VDR** — drops EIT `0x4F` (present/following other-TS) entirely, and for schedule tables suppresses an incoming `0x60–0x6F` section once actual-TS schedule data has been seen for that schedule (`cSchedule::OnActualTp()` in [`eit.c`](https://github.com/vdr-projects/vdr/blob/master/eit.c)).
- **Enigma2** — tags every cached event with its source and ranks actual-TS sources above their other-TS counterparts; a lower-priority other-TS write is rejected when a higher-priority actual-TS event is already stored (`eEPGCache::sectionRead()` in [`epgcache.cpp`](https://github.com/openatv/enigma2/blob/master/lib/dvb/epgcache.cpp)).
- **MythTV** — splits the two by `table_id`, anchoring actual-TS to the tuned multiplex while resolving other-TS via the full onid/tsid/sid triple (`EITHelper::AddEIT()` in [`eithelper.cpp`](https://github.com/MythTV/mythtv/blob/master/mythtv/libs/libmythtv/eithelper.cpp)).

tvheadend is currently the outlier: it resolves other-TS to any enabled mux's service and lets it overwrite unconditionally.

## Why this PR mirrors VDR's approach

Of the three models, this PR adopts **VDR's** — an adaptive, per-service rule that keys on *data actually received*:

- **VDR's model is adaptive, not configuration-based.** It suppresses other-TS for a service only once that service's *own* actual-TS schedule has genuinely been observed. A service that never broadcasts its own schedule — e.g. one whose EPG is legitimately distributed by a dedicated EPG multiplex via other-TS — is never affected. The rule is self-correcting and safe for every network topology, with no per-network configuration to get wrong.
- **Enigma2's model** — a source-priority tag persisted on every cached event — would, in tvheadend, require a new field on the core `epg_broadcast_t`, a change to the on-disk EPG database format, and a project-wide priority ordering across *all* grabbers (EIT, OpenTV, XMLTV, …). That is a far larger and more invasive change than the problem requires, and is deliberately out of scope.
- **MythTV's model** is the weakest precedent (no per-event arbitration) but confirms the principle.

This PR implements the VDR model, contained entirely within the EIT grabber:

- a runtime, per-service flag (`mpegts_service_t::s_dvb_eit_actual_seen`) is set the first time that service's actual-TS *schedule* EIT (`0x50–0x5F`) is parsed;
- once set, other-TS EIT (`0x4F` and `0x60–0x6F`) for that service is dropped in `_eit_callback()` before it can be stored.

No change to the EPG core and no change to the on-disk EPG database format. The flag is runtime-only and relearned each session.

## Opt-in / compatibility

Existing behaviour is preserved by default:

- **Fresh installs**: global default = **Either**. Identical to today — both EIT sub-tables accepted, no precedence between them.
- **Existing installs with services on `Ignore EPG (EIT) = true`**: migrate to per-service **None** on first load. Same observable behaviour as before (EIT remains ignored for those services).
- **Existing installs with services on `Ignore EPG (EIT) = false`** (the vast majority): migrate to per-service **Default**. With the global at Either, behaviour is unchanged. Operators can then opt into Adaptive (or any other policy) via a single global change without touching individual services.

The legacy `dvb_ignore_eit` key is read on first load and silently dropped from the config on next save (no matching prop on the class).

## Standards basis — why this is not a specification violation

The relevant DVB documents — **ETSI EN 300 468** (Specification for Service Information) and **ETSI TS 101 211** (Guidelines on implementation and usage of SI) — are *transmission* specifications: they define how broadcasters encode SI and how a receiver decodes the bitstream.

1. **The standard itself treats actual-TS and other-TS EIT as distinct.** EN 300 468 allocates them *separate `table_id` values* (`0x4E`/`0x50–0x5F` vs `0x4F`/`0x60–0x6F`). They form independent sub-tables, versioned independently. The distinction — "this transport stream describing itself" vs "describing another" — is encoded in the standard by design.
2. **No clause governs receiver conflict-resolution between them.** Neither EN 300 468 nor TS 101 211 contains a normative requirement specifying how a receiver must build its EPG when an actual-TS sub-table and an other-TS sub-table describe the same event differently. EPG-merge / conflict-resolution policy is outside the scope of these documents — it is receiver implementation behaviour. TS 101 211 makes EIT present/following *actual* mandatory while EIT schedule and EIT other-TS are optional, tiering the two by guaranteed availability, but it still mandates no precedence.

Consequently there is **no clause for this change to violate.** Preferring a service's own actual-TS description over a second-hand other-TS one, for a service the receiver demonstrably receives directly, is a permitted implementation choice in an area the specification deliberately leaves open. If anything, tvheadend's *current* last-writer-wins behaviour is the one that discards a distinction the standard explicitly encodes (the separate `table_id` allocation); this change makes tvheadend honour that distinction rather than flatten it — and only when the operator opts in.

## The change

A single commit:

- `src/epggrab.h` — adds the `EIT_PROCESSING_*` enum values (Default, None, Actual only, Other only, Either, Adaptive) and renames the global config field to `eit_processing_default`.
- `src/epggrab.c` — replaces the global `eit_actual_priority` boolean with the `eit_processing_default` PT_INT enum (5 values, no Default) and its `.list` callback. Fresh-install default is `EIT_PROCESSING_EITHER`.
- `src/input/mpegts.h` — renames the per-service field `s_dvb_ignore_eit` to `s_dvb_eit_processing` (now an int enum). Keeps the runtime `s_dvb_eit_actual_seen` flag, used by the Adaptive policy.
- `src/input/mpegts/mpegts_service.c` — replaces the per-service "Ignore EPG (EIT)" boolean prop with the "EIT processing" PT_INT enum (6 values, includes Default). Adds an `ic_load` hook that migrates the legacy `dvb_ignore_eit` key once on first load.
- `src/epggrab/module/eit.c` — resolves the effective policy per call (per-service unless Default, in which case the global default applies) and switches on it: drop everything for None; drop other-TS for Actual only; drop actual-TS for Other only; the original adaptive logic for Adaptive; no filter for Either.

~150 lines (incl. comments + property tables); no EPG-core or database-format changes.

## Testing

There is no automated test suite for this area; verification is by build and runtime observation.

- Builds cleanly under `-Werror -Wmissing-prototypes`.
- Verified on the same DVB-S2 / 19.2°E installation that motivated the original PR. The **Adaptive** policy reproduces v1's observed behaviour: the 24-hour other-TS placeholder is dropped once the affected channel's own actual-TS schedule is seen, and the channel retains its detailed schedule. The **Other only** policy, applied to a single service, was used as the inverse test — that service's EPG converges to the placeholder while every other service (on Default → global Either) remains on its detailed schedule, confirming the per-service override path.
- A reviewer can verify by setting **EIT processing (default)** to Adaptive (under EPG Grabber → OTA settings), running an OTA EPG grab with `--trace tbl-eit --stderr`, and observing `actual-TS schedule seen` lines for each service as their own schedule arrives, followed by `skip other-TS tid 0x... actual-TS seen` lines when a neighbour's other-TS for them is dropped.
