### PR TITLE
dvr: make data error threshold configurable

### DIFF
--- a/src/dvr/dvr.h
+++ b/src/dvr/dvr.h
@@ -78,6 +78,7 @@ typedef struct dvr_config {
   int dvr_clone;
   int dvr_complex_scheduling;
   uint32_t dvr_rerecord_errors;
+  uint32_t dvr_max_data_errors;
   uint32_t dvr_retention_days;
   uint32_t dvr_removal_days;
   uint32_t dvr_removal_after_playback;
@@ -556,6 +557,13 @@ uint32_t dvr_entry_get_retention_days( dvr_entry_t *de );
 uint32_t dvr_entry_get_removal_days( dvr_entry_t *de );
 
 uint32_t dvr_entry_get_rerecord_errors( dvr_entry_t *de );
+
+static inline uint32_t dvr_entry_get_max_data_errors( dvr_entry_t *de )
+  { return de->de_config ? de->de_config->dvr_max_data_errors : DVR_MAX_DATA_ERRORS; }
+
+static inline int dvr_entry_data_error_limit_reached( dvr_entry_t *de )
+  { uint32_t max_data_errors = dvr_entry_get_max_data_errors(de);
+    return max_data_errors && de->de_data_errors >= max_data_errors; }
 
 int dvr_entry_get_epg_running( dvr_entry_t *de );
 

--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -178,6 +178,7 @@ dvr_config_create(const char *name, const char *uuid, htsmsg_t *conf)
   cfg->dvr_config_name = strdup(name);
   cfg->dvr_retention_days = DVR_RET_ONREMOVE;
   cfg->dvr_removal_days = DVR_RET_REM_FOREVER;
+  cfg->dvr_max_data_errors = DVR_MAX_DATA_ERRORS;
   cfg->dvr_clone = 1;
   cfg->dvr_tag_files = 1;
   cfg->dvr_create_scene_markers = 1;
@@ -1093,6 +1094,18 @@ const idclass_t dvr_config_class = {
                      "schedule a re-record (if possible)."),
       .off      = offsetof(dvr_config_t, dvr_rerecord_errors),
       .opts     = PO_ADVANCED,
+      .group    = 1,
+    },
+    {
+      .type     = PT_U32,
+      .id       = "data-error-threshold",
+      .name     = N_("Data error threshold for failed recordings (0=off)"),
+      .desc     = N_("If a completed recording has this many or more data "
+                     "errors, mark it as failed. Set to 0 to disable this "
+                     "check."),
+      .off      = offsetof(dvr_config_t, dvr_max_data_errors),
+      .opts     = PO_ADVANCED,
+      .def.u32  = DVR_MAX_DATA_ERRORS,
       .group    = 1,
     },
     {

--- a/src/dvr/dvr_db.c
+++ b/src/dvr/dvr_db.c
@@ -161,7 +161,7 @@ int dvr_entry_is_finished(dvr_entry_t *entry, int flags)
 
   if (success) {
     if (entry->de_last_error == SM_CODE_OK)
-      success = entry->de_data_errors < DVR_MAX_DATA_ERRORS;
+      success = !dvr_entry_data_error_limit_reached(entry);
     else
       success = dvr_entry_is_completed_ok(entry);
   }
@@ -679,7 +679,7 @@ dvr_entry_status(dvr_entry_t *de)
     if (dvr_get_filesize(de, 0) < 0 && !de->de_file_removed)
       return N_("File missing");
     if(de->de_last_error != SM_CODE_FORCE_OK &&
-       de->de_data_errors >= DVR_MAX_DATA_ERRORS) /* user configurable threshold? */
+       dvr_entry_data_error_limit_reached(de))
       return N_("Too many data errors");
     if(de->de_last_error)
       return streaming_code2txt(de->de_last_error);


### PR DESCRIPTION
## Summary

Make the DVR data-error failure threshold configurable per DVR profile.

The default remains `10000`, preserving current behavior. Setting the value to `0` disables failing completed recordings based only on the data-error count.

## Changes

- add `data-error-threshold` DVR profile property
- store the value in `dvr_config_t`
- use the profile value when classifying completed recordings as finished/failed

## Verification

Built locally:

```sh
./configure --disable-pcre2 --disable-pcre --disable-uriparser --disable-avahi --disable-libav --disable-ffmpeg_static --disable-hdhomerun_static --disable-tvhcsa
make -j2
```

Started a temporary local instance and verified:

- `/api/dvr/config/class` exposes `data-error-threshold`
- `/api/dvr/config/grid` reports default value `10000` for the default DVR profile