### PR TITLE
satip: expose DVB-S frequency override and fix matching priority

### DIFF
--- a/src/input/mpegts/mpegts_mux_dvb.c
+++ b/src/input/mpegts/mpegts_mux_dvb.c
@@ -554,6 +554,19 @@ const idclass_t dvb_mux_dvbs_class =
       .desc     = N_("For example: 312000000. This frequency is 312Mhz."),
       .opts     = PO_ADVANCED
     },
+    {
+      .type     = PT_U32,
+      .id       = "dvb_satip_dvbs_freq",
+      .name     = N_("SAT>IP DVB-S frequency (kHz)"),
+      .off      = offsetof(dvb_mux_t, mm_dvb_satip_dvbs_freq),
+      .desc     = N_("Virtual DVB-S frequency in kHz for SAT>IP clients. "
+                     "When set, SAT>IP clients tune to this mux using "
+                     "this frequency instead of the real transponder frequency. "
+                     "Required for DVB-S2X MIS muxes sharing the same "
+                     "physical frequency with different ISI values. "
+                     "Example: 10701000 (= 10701 MHz)."),
+      .opts     = PO_ADVANCED
+    },
     {}
   }
 };

--- a/src/satip/rtsp.c
+++ b/src/satip/rtsp.c
@@ -613,24 +613,50 @@ rtsp_start
   if (newmux) {
     mux = NULL;
     mn2 = NULL;
+    /* SAT>IP frequency override matching (highest priority) */
     LIST_FOREACH(mn, &mpegts_network_all, mn_global_link) {
       if (idnode_is_instance(&mn->mn_id, &dvb_network_class)) {
-        ln = (dvb_network_t *)mn;
-        if (ln->ln_type == rs->dmc.dmc_fe_type &&
-            mn->mn_satip_source == rs->src) {
-          if (!mn2) mn2 = mn;
-          mux = (mpegts_mux_t *)
-                dvb_network_find_mux((dvb_network_t *)mn, &rs->dmc,
-                                     MPEGTS_ONID_NONE, MPEGTS_TSID_NONE, 1, rtsp_muxcnf == MUXCNF_REJECT_EXACT_MATCH );
-          if (mux) {
-            dmc = ((dvb_mux_t *)mux)->lm_tuning;
-            rs->perm_lock = 0;
-            break;
+        LIST_FOREACH(mux, &mn->mn_muxes, mm_network_link) {
+          const dvb_mux_t *dm = (const dvb_mux_t *)mux;
+          uint32_t override_freq = 0;
+          switch (rs->dmc.dmc_fe_type) {
+            case DVB_TYPE_T: override_freq = dm->mm_dvb_satip_dvbt_freq; break;
+            case DVB_TYPE_C: override_freq = dm->mm_dvb_satip_dvbc_freq; break;
+            case DVB_TYPE_S: override_freq = dm->mm_dvb_satip_dvbs_freq; break;
+            default: break;
           }
+          if (override_freq != 0 &&
+              deltaU32(rs->dmc.dmc_fe_freq, override_freq) < 2000)
+            break;
+        }
+        if (mux) {
+          dmc = rs->dmc;
+          rs->perm_lock = 1;
+          break;
         }
       }
+    }
+    /* Normal mux matching */
+    LIST_FOREACH(mn, &mpegts_network_all, mn_global_link) {
+      if (mux != NULL)
+        break;
+      if (idnode_is_instance(&mn->mn_id, &dvb_network_class)) {
+        ln = (dvb_network_t *)mn;
+        if (ln->ln_type != rs->dmc.dmc_fe_type ||
+            mn->mn_satip_source != rs->src)
+          continue;
+        if (!mn2) mn2 = mn;
+        mux = (mpegts_mux_t *)
+              dvb_network_find_mux((dvb_network_t *)mn, &rs->dmc,
+                                   MPEGTS_ONID_NONE, MPEGTS_TSID_NONE, 1, rtsp_muxcnf == MUXCNF_REJECT_EXACT_MATCH );
+        if (!mux)
+          continue;
+        dmc = ((dvb_mux_t *)mux)->lm_tuning;
+        rs->perm_lock = 0;
+        break;
+      }
 #if ENABLE_IPTV
-      if (idnode_is_instance(&mn->mn_id, &iptv_network_class)) {
+      else if (idnode_is_instance(&mn->mn_id, &iptv_network_class)) {
         LIST_FOREACH(mux, &mn->mn_muxes, mm_network_link) {
           if (rs->dmc.dmc_fe_type == DVB_TYPE_T &&
               deltaU32(rs->dmc.dmc_fe_freq, ((iptv_mux_t *)mux)->mm_iptv_satip_dvbt_freq) < 2000)
@@ -641,32 +667,14 @@ rtsp_start
           if (rs->dmc.dmc_fe_type == DVB_TYPE_S &&
               deltaU32(rs->dmc.dmc_fe_freq, ((iptv_mux_t *)mux)->mm_iptv_satip_dvbs_freq) < 2000)
             break;
-          }
-        if (mux) {
-          dmc = rs->dmc;
-          rs->perm_lock = 1;
-          break;
         }
+        if (!mux)
+          continue;
+        dmc = rs->dmc;
+        rs->perm_lock = 1;
+        break;
       }
 #endif
-      if (idnode_is_instance(&mn->mn_id, &dvb_network_class)) {
-        LIST_FOREACH(mux, &mn->mn_muxes, mm_network_link) {
-          if (rs->dmc.dmc_fe_type == DVB_TYPE_T &&
-              deltaU32(rs->dmc.dmc_fe_freq, ((dvb_mux_t *)mux)->mm_dvb_satip_dvbt_freq) < 2000)
-            break;
-          if (rs->dmc.dmc_fe_type == DVB_TYPE_C &&
-              deltaU32(rs->dmc.dmc_fe_freq, ((dvb_mux_t *)mux)->mm_dvb_satip_dvbc_freq) < 2000)
-            break;
-          if (rs->dmc.dmc_fe_type == DVB_TYPE_S &&
-              deltaU32(rs->dmc.dmc_fe_freq, ((dvb_mux_t *)mux)->mm_dvb_satip_dvbs_freq) < 2000)
-            break;
-          }
-        if (mux) {
-          dmc = rs->dmc;
-          rs->perm_lock = 1;
-          break;
-        }
-      }
     }
     if (mux == NULL && mn2 &&
         (rtsp_muxcnf == MUXCNF_AUTO || rtsp_muxcnf == MUXCNF_KEEP)) {


### PR DESCRIPTION
## Summary

* Expose the existing but hidden `mm_dvb_satip_dvbs_freq` field in the DVB-S mux editor UI by adding a property entry to `dvb_mux_dvbs_class` in `mpegts_mux_dvb.c`. This allows operators to assign virtual SAT>IP frequencies to individual DVB-S muxes.
* Move the SAT>IP frequency override matching in `rtsp_start()` to run before the normal `dvb_network_find_mux()` lookup, ensuring that explicitly configured virtual frequencies always take precedence.
* Guard the override match against unconfigured (zero) values so `deltaU32(freq, 0)` cannot produce false matches.

## Motivation

DVB-S2X MIS (Multiple Input Streams) muxes share the same physical transponder frequency but have different ISI (Input Stream Identifier) values. The SAT>IP protocol has no native ISI parameter, and `dvb_network_find_mux()` checks `dmc_fe_stream_id` which SAT>IP clients never set for DVB-S. This means MIS muxes are unreachable via SAT>IP without this change.

By assigning a unique virtual frequency to each MIS mux (via the new UI field), SAT>IP clients can address individual streams. TVHeadend matches the virtual frequency and tunes to the real transponder with the correct ISI.

**Note:** The DVB-S field uses kHz (not Hz like DVB-C/T) because DVB-S frequencies internally use kHz after RTSP parsing (`freq_mhz * 1000`), and satellite frequencies in Hz would overflow `uint32_t`.

## Changes

* `src/input/mpegts/mpegts_mux_dvb.c`: Add `dvb_satip_dvbs_freq` property to `dvb_mux_dvbs_class` (PT_U32, PO_ADVANCED)
* `src/satip/rtsp.c`: Move SAT>IP frequency override loop before the normal mux matching loop in `rtsp_start()`, guarded by `if (mux == NULL)`

## Test plan

Tested on aarch64 with a Panasonic TV as SAT>IP client:

* Configured a DVB-S2X MIS mux (12466 MHz V, ISI 13) with virtual frequency 10700000 kHz (10700 MHz)
* Panasonic TV manual scan on 10700 MHz successfully received ISI 13 channels
* Existing non-MIS muxes continue to work via normal frequency matching
* Switching back to the official image (without this change) works -- the field is silently ignored in mux configs

Supersedes #2084 (squashed to a single commit as requested).