### PR TITLE
debian: write superuser file to the daemon's actual config directory

### DIFF
--- a/debian/tvheadend.postinst
+++ b/debian/tvheadend.postinst
@@ -34,18 +34,48 @@ configure)
     fi
 
     HTS_HOMEDIR="$(getent passwd "$HTS_USER" | cut -d':' -f6)"
+    HTS_UID="$(getent passwd "$HTS_USER" | cut -d':' -f3)"
 
-    # Handle previous configuration directory: If the HTS_USER home directory
-    # starts with /home/, append "/.hts/tvheadend" so the superuser
-    # configuration will go in the right place.
-    if [ -z "${HTS_HOMEDIR##/home/*}" ]; then
-        HTS_CONFDIR="$HTS_HOMEDIR/.hts/tvheadend"
-        echo >&2 "Legacy configuration directory $HTS_CONFDIR is in use."
-        install -d -g "$HTS_USER" -o "$HTS_USER" "$HTS_CONFDIR"
-    else
-        HTS_CONFDIR="$HTS_HOMEDIR"
+    # Write the superuser file to the SAME directory the daemon loads its
+    # configuration from. This must mirror config_get_dir() in src/config.c,
+    # otherwise the file is silently ignored and the initial login returns
+    # "403 Forbidden".
+    #
+    # config_get_dir() uses /var/lib/tvheadend (then /etc/tvheadend) only when
+    # that directory is owned by the user Tvheadend runs as; otherwise it falls
+    # back to a pre-existing legacy ~/.hts/tvheadend and finally to the XDG
+    # default ~/.config/hts.
+    #
+    # Use "stat -L" so symlinked locations are dereferenced like the daemon's
+    # stat() call does.
+    owned_by_hts() {
+        [ -d "$1" ] && [ "$(stat -L -c '%u' "$1" 2>/dev/null)" = "$HTS_UID" ]
+    }
+
+    # adduser does not change ownership of a pre-existing home directory, so
+    # /var/lib/tvheadend can be left owned by root - which makes config_get_dir()
+    # skip it and fall back to ~/.config/hts. Take ownership so it is used as the
+    # canonical configuration directory, but not if an earlier install already
+    # has configuration under a fallback location (we must not strand it).
+    if [ -d /var/lib/tvheadend ] && ! owned_by_hts /var/lib/tvheadend; then
+        if [ ! -e "$HTS_HOMEDIR/.config/hts/config" ] && \
+           [ ! -e "$HTS_HOMEDIR/.hts/tvheadend/config" ]; then
+            chown "$HTS_USER":"$HTS_USER" /var/lib/tvheadend
+        fi
     fi
 
+    if owned_by_hts /var/lib/tvheadend; then
+        HTS_CONFDIR="/var/lib/tvheadend"
+    elif owned_by_hts /etc/tvheadend; then
+        HTS_CONFDIR="/etc/tvheadend"
+    elif [ -d "$HTS_HOMEDIR/.hts/tvheadend" ]; then
+        HTS_CONFDIR="$HTS_HOMEDIR/.hts/tvheadend"
+        echo >&2 "Legacy configuration directory $HTS_CONFDIR is in use."
+    else
+        HTS_CONFDIR="$HTS_HOMEDIR/.config/hts"
+    fi
+
+    install -d -g "$HTS_USER" -o "$HTS_USER" "$HTS_CONFDIR"
     install -d -g "$HTS_USER" -o "$HTS_USER" "$HTS_HOMEDIR/recordings"
 
     HTS_SUPERUSERCONF="${HTS_CONFDIR}/superuser"

--- a/src/config.c
+++ b/src/config.c
@@ -1709,6 +1709,12 @@ static char *config_get_dir ( uid_t uid )
   if (uid == -1)
     uid = getuid();
 
+  /* Prefer the well-known system locations, but only when they are owned by
+   * the user we run as. If the ownership does not match (e.g. a packaged
+   * /var/lib/tvheadend left owned by root), fall through to the HOME-based
+   * locations below. Distribution packaging must keep this directory owned
+   * by the service user, otherwise the config silently moves to ~/.config/hts
+   * and any file pre-seeded here (e.g. debian's superuser) is never read. */
   snprintf(hts_home, sizeof(hts_home), "/var/lib/tvheadend");
   if ((stat(hts_home, &st) == 0) && (st.st_uid == uid))
     return strndup(hts_home, sizeof(hts_home));


### PR DESCRIPTION
  ## debian: write the superuser file to the daemon's actual config directory

  ### Problem

  On a stock Debian/Ubuntu/RaspiOS package install, the administrator (superuser)
  account created during `dpkg` configuration cannot log in — the first login
  returns **403 Forbidden**. This is a long-standing, intermittent report
  (e.g. https://tvheadend.org/d/8480).

  ### Root cause

  The postinst writes the `superuser` file into the service user's home directory
  (`/var/lib/tvheadend/superuser`), but the daemon looks for it somewhere else.

  `config_get_dir()` (`src/config.c`) resolves the configuration directory as:

  1. `/var/lib/tvheadend` — **only if owned by the user tvheadend runs as**
  2. `/etc/tvheadend` — same ownership condition
  3. a pre-existing legacy `~/.hts/tvheadend`
  4. otherwise the XDG default `~/.config/hts`

  On a stock install `/var/lib/tvheadend` is owned by **root** (it pre-exists when
  `adduser` runs, and `adduser` does not chown a home directory it didn't create),
  so step 1 is skipped and the daemon uses `~hts/.config/hts`. The postinst,
  however, wrote the file to the parent `/var/lib/tvheadend`, so
  `hts_settings_load("superuser")` finds nothing, `superuser_username` /
  `superuser_password` stay `NULL`, and the superuser credential never matches.

  ### Reproduction (Debian Bookworm / Raspberry Pi, `4.3-2680~g6253057de`)

  ```
  $ sudo journalctl -u tvheadend | grep "Using configuration"
  ... Using configuration from '/var/lib/tvheadend/.config/hts'

  $ sudo ls -l /var/lib/tvheadend/.config/hts/superuser   # where the daemon reads
  ls: cannot access ...: No such file or directory
  $ sudo ls -l /var/lib/tvheadend/superuser               # where postinst wrote it
  -rw------- 1 hts hts 45 ... /var/lib/tvheadend/superuser

  $ sudo ls -ld /var/lib/tvheadend
  drwxr-xr-x 4 root root ... /var/lib/tvheadend
  ```

  ### Fix

  Resolve the configuration directory in the postinst using the same precedence as
  `config_get_dir()`, and write the `superuser` file there. On a stock install that
  is `~hts/.config/hts/superuser`; where `/var/lib/tvheadend` *is* owned by the
  service user, the daemon and the postinst both use it directly.

  The patch deliberately does **not** change any ownership — it simply follows the
  daemon to wherever it already looks. A pre-existing `~/.hts/tvheadend` or
  `~/.config/hts` is honoured, so existing installations keep their settings (no
  config is stranded). A comment is also added to `config_get_dir()` documenting
  the ownership requirement of the `/var/lib/tvheadend` shortcut so packaging can't
  silently reintroduce this mismatch.

  ### Scope

  Debian-family packaging only. The RPM packaging is unaffected (it launches with an
  explicit `-c /var/lib/tvheadend/config` and does not pre-seed a superuser), and the
  Docker images don't write a superuser file either — this is the only packaging that
  both pre-seeds the superuser via debconf *and* relies on implicit directory
  resolution.

  ### Testing

  - `dash -n` on the postinst.
  - Verified the new resolution against each scenario (root-owned `/var/lib/tvheadend`
    → `~/.config/hts`; service-user-owned → `/var/lib/tvheadend`; legacy
    `~/.hts/tvheadend` present → that dir), matching `config_get_dir()`.
