### PR TITLE
access: store the superuser password obfuscated like normal accounts

### DIFF
--- a/debian/tvheadend.postinst
+++ b/debian/tvheadend.postinst
@@ -63,9 +63,24 @@ configure)
     fi
 
     if db_get tvheadend/admin_password; then
-        JSONPASS="$(escape_json_string "$RET")"
-        echo >>"$HTS_SUPERUSERCONF" "\"password\": $JSONPASS"
-        JSONPASS=""
+        # Store the password using the same reversible obfuscation Tvheadend
+        # uses for normal user accounts: base64 of "TVHeadend-Hide-<password>".
+        # NOTE: this is obfuscation, not encryption (HTTP Digest auth needs a
+        # recoverable password, so a one-way hash is not possible) - the file
+        # is still created mode 0600 above.
+        #
+        # If base64/tr are unavailable (e.g. a stripped-down busybox system),
+        # fall back to the cleartext "password" field that Tvheadend also
+        # accepts, so the superuser file is always valid and login works.
+        if command -v base64 >/dev/null 2>&1 && command -v tr >/dev/null 2>&1; then
+            PASS2="$(printf 'TVHeadend-Hide-%s' "$RET" | base64 | tr -d '\n')"
+            echo >>"$HTS_SUPERUSERCONF" "\"password2\": \"$PASS2\""
+            PASS2=""
+        else
+            JSONPASS="$(escape_json_string "$RET")"
+            echo >>"$HTS_SUPERUSERCONF" "\"password\": $JSONPASS"
+            JSONPASS=""
+        fi
     fi
 
     echo >>"$HTS_SUPERUSERCONF" "}"

--- a/src/access.c
+++ b/src/access.c
@@ -2583,8 +2583,23 @@ access_init(int createdefault, int noacl)
   if((m = hts_settings_load("superuser")) != NULL) {
     s = htsmsg_get_str(m, "username");
     superuser_username = s ? strdup(s) : NULL;
-    s = htsmsg_get_str(m, "password");
-    superuser_password = s ? strdup(s) : NULL;
+    /* Prefer the obfuscated form (password2, the same reversible "TVHeadend-
+     * Hide-" base64 scheme used for normal user accounts); fall back to a
+     * plaintext password so existing superuser files keep working. */
+    s = htsmsg_get_str(m, "password2");
+    if (s && s[0]) {
+      char buf[300];
+      int l = base64_decode((uint8_t *)buf, s, sizeof(buf) - 1);
+      if (l >= 15) {
+        buf[l] = '\0';
+        if (!strncmp(buf, "TVHeadend-Hide-", 15))
+          superuser_password = strdup(buf + 15);
+      }
+    }
+    if (superuser_password == NULL) {
+      s = htsmsg_get_str(m, "password");
+      superuser_password = s ? strdup(s) : NULL;
+    }
     htsmsg_destroy(m);
   }
 }


### PR DESCRIPTION
  ## access: store the superuser password obfuscated like normal user accounts

  ### Motivation

  The debian postinst writes the superuser password into the `superuser` file as
  **cleartext JSON**:

  ```json
  { "username": "admin", "password": "hunter2" }
  ```

  Normal user accounts (`passwd/*`) don't store cleartext — they use Tvheadend's
  reversible `TVHeadend-Hide-` base64 scheme in a `password2` field
  (`passwd_entry_class_password_set()`). This change makes the superuser file
  consistent with that, so a cleartext password no longer sits on disk in a
  different format from every other account.

  ### What this is **not**

  This is **obfuscation, not encryption or hashing**. `password2` is trivially
  reversible (base64-decode, strip the 15-byte prefix) and lives in the same
  `0600` file, so it is not a security boundary — it only avoids a literal
  password showing up in a `cat`/screen-share/grep.

  A one-way salted hash is **not** an option here: HTTP Digest auth (the default,
  `HTTP_AUTH_DIGEST`) requires the server to hold a recoverable password (or the
  realm-bound HA1) to compute the challenge response. The existing user accounts
  store recoverable passwords for exactly this reason; the superuser now matches.

  ### Changes

  - **`debian/tvheadend.postinst`** — write `"password2": "<base64 of
    TVHeadend-Hide-<password>>"` instead of `"password": "<cleartext>"`.
  - **`src/access.c`** — `access_init()` now prefers `password2` (decode + strip
    prefix) and **falls back to the plaintext `password` field**, so existing
    `superuser` files written by older packages keep working unchanged.

  ### Compatibility

  - Old `superuser` files (plaintext `password`) → still read via the fallback.
  - New `superuser` files (`password2`) → require this `access.c` change, which
    ships in the same package, so there is no version skew on a normal
    install/upgrade. (A *downgrade* to a pre-`password2` binary would not read a
    `password2`-only file — same caveat as any forward-format change.)

  ### Testing

  - Round-tripped the postinst encoder against the `access.c` decoder for plain,
    special-character, and UTF-8 passwords — all match.
  - Confirmed the emitted JSON is valid and `base64_decode` is declared in
    `tvheadend.h`.
  - `dash -n` on the postinst.

  ### Notes

  Independent of the superuser **placement** fix (#2134); it touches a different
  region of the postinst, so the two can be reviewed/merged in any order. This one
  is purely a consistency cleanup — happy to drop it if you'd prefer cleartext stay
  as-is.
