### PR TITLE
Fix GCC 16 -Werror build failures (satip, ratinglabels)

### DIFF
--- a/src/input/mpegts/satip/satip_rtsp.c
+++ b/src/input/mpegts/satip/satip_rtsp.c
@@ -340,11 +340,12 @@ satip_rtsp_play( http_client_t *hc, const char *pids,
                  int max_pids_len, int weight )
 {
   char *stream = NULL;
-  char _stream[32], _w[16];
+  char _stream[32], _w[24];
   const char *p[8], *add[8], *del[8];
   int pcnt, addcnt, delcnt;
   int i, r = 0, index = 0;
-  char buf[max_pids_len + 32];
+  /* room for "delpids=%s&addpids=%s%s": del+add up to max_pids_len, plus _w */
+  char buf[(max_pids_len < 32 ? 32 : max_pids_len) + 64];
 
   if (max_pids_len < 32)
     max_pids_len = 32;

--- a/src/ratinglabels.c
+++ b/src/ratinglabels.c
@@ -612,6 +612,8 @@ ratinglabel_class_get_icon ( void *obj )
 static void
 ratinglabel_class_enabled_notify ( void *obj, const char *lang )
 {
+  /* Intentionally empty: toggling "enabled" needs no side effect; the
+     property write is sufficient. Kept as a registered no-op hook point. */
 }
 
 CLASS_DOC(ratinglabel)

--- a/src/ratinglabels.c
+++ b/src/ratinglabels.c
@@ -612,11 +612,6 @@ ratinglabel_class_get_icon ( void *obj )
 static void
 ratinglabel_class_enabled_notify ( void *obj, const char *lang )
 {
-  int a=1;
-  ratinglabel_t *rl = obj;
-
-  if (rl->rl_enabled)
-    a++;
 }
 
 CLASS_DOC(ratinglabel)


### PR DESCRIPTION
Current master fails to build on Fedora 44 / GCC 16.1.1 because of two
diagnostics that GCC 16 newly treats as errors under the default `-Werror`.

**satip_rtsp.c** — the fixed 16-byte `_w` buffer cannot hold `"&tvhweight=%d"`
for the full range of `int weight` (worst case 23 bytes incl. NUL), tripping
`-Werror=format-truncation`. Enlarged to 24 bytes.

**ratinglabels.c** — `ratinglabel_class_enabled_notify()` only incremented a
local variable that was never read; it had no observable effect. Removed the
dead body (`-Werror=unused-but-set-variable`), leaving the registered notify
callback as a no-op — no behavior change.

Both are old, dormant lines, not regressions.

Fixes #2137
