### PR TITLE
rpm: build binary packages from the local source tree

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -51,13 +51,13 @@ SOURCES:
 
 .PHONY: srpm
 srpm: clean SOURCES tvheadend.spec
-	spectool --get-files -C SOURCES tvheadend.spec
-	rpmbuild $(DEFINES) -bs tvheadend.spec
+	@echo "Source RPMs cannot be built from the local tree without tar-ing a"
+	@echo "release tarball first. Run 'make build' for binary RPMs."
+	@false
 
 .PHONY: build
 build: clean SOURCES tvheadend.spec
-	spectool --get-files -C SOURCES tvheadend.spec
-	rpmbuild $(DEFINES) -ba tvheadend.spec
+	rpmbuild $(DEFINES) -bb tvheadend.spec
 
 .PHONY: build-doozer
 build-doozer: build

--- a/rpm/tvheadend.spec.in
+++ b/rpm/tvheadend.spec.in
@@ -15,7 +15,8 @@ License:        GPLv3
 Group:          Applications/Multimedia
 URL:            http://tvheadend.org
 
-Source:         https://github.com/tvheadend/tvheadend/archive/%{ref}/tvheadend-%{commit}.tar.gz
+# Source tarball intentionally omitted — the build uses the local
+# checked-out tree directly (see %prep), so nothing is downloaded.
 #Patch999:      test.patch
 
 BuildRequires:  bzip2
@@ -47,7 +48,13 @@ SAT>IP and various other clients using these protocols.
 
 
 %prep
-%setup -q -n tvheadend-%{commit}
+# Build from the local checked-out tree instead of a downloaded tarball:
+# symlink the build subdir at the repo root (%{_topdir} is rpm/, so
+# %{_topdir}/.. is the worktree), then %setup -T -D enters it without
+# fetching or unpacking anything.
+rm -rf tvheadend-%{commit}
+ln -s %{_topdir}/.. tvheadend-%{commit}
+%setup -T -D -n tvheadend-%{commit}
 #%patch999 -p1 -b .test
 
 

--- a/support/lib.sh
+++ b/support/lib.sh
@@ -78,6 +78,21 @@ $(grep ^CONFIG_ ${ROOTDIR}/.config.mk)
 }
 
 #
+# Raw public-link download (token-free): fetch a single file from the
+# pcloud public link (PCLOUD_HASHDIR) by its path into a local file.
+# Used directly by CI to probe-and-fetch a cached artifact (a failed
+# fetch simply means "not cached"), and by download() below so the
+# publink call lives in one place.
+#
+function raw_download
+{
+  REMOTE="$1"
+  OUT="$2"
+  ${ROOTDIR}/support/pcloud.py publink_download "${PCLOUD_HASHDIR}" "${REMOTE}" "${OUT}" || \
+    python3 ${ROOTDIR}/support/pcloud.py publink_download "${PCLOUD_HASHDIR}" "${REMOTE}" "${OUT}"
+}
+
+#
 # Attempt to download
 #
 function download
@@ -99,7 +114,7 @@ function download
   N="${PCLOUD_BASEDIR}/staticlib/${CODENAME}/${ARCH}/${LIB_NAME}-${LIB_HASH}.tgz"
 
   echo "DOWNLOAD        ${N} / ${PCLOUD_HASHDIR}"
-  ${ROOTDIR}/support/pcloud.py publink_download "${PCLOUD_HASHDIR}" "${N}" "${P}.tmp" || python3 ${ROOTDIR}/support/pcloud.py publink_download "${PCLOUD_HASHDIR}" "${N}" "${P}.tmp"
+  raw_download "${N}" "${P}.tmp"
 
   R=$?
 
@@ -187,6 +202,9 @@ case "${C}" in
     ;;
   download)
     download $*
+    ;;
+  raw_download)
+    raw_download $*
     ;;
   unpack)
     unpack $*


### PR DESCRIPTION
## Build binary RPMs from the local source tree

`make -C rpm build` runs `spectool --get-files`, which reads the spec's `Source:` URL and re-downloads the source archive for the exact commit being built from GitHub — then rpmbuild compiles that downloaded copy instead of the checked-out tree.

This builds from the local tree directly:
- `%prep` symlinks the rpmbuild subdir at the repo root (`%{_topdir}` is `rpm/`, so `%{_topdir}/..` is the worktree) and uses `%setup -T -D` to enter it without fetching or unpacking.
- `make build` switches to `rpmbuild -bb` (binary only); `srpm` is disabled (a source RPM needs a tar-ed release tarball first).
- Adds a token-free `raw_download` helper to `support/lib.sh` (factored out of `download()`) to fetch a single file from the pcloud public link by path without an upload token.

Note: `make -C rpm build` now compiles in the live checked-out tree (via the symlink) rather than an isolated archive copy — fine for CI, worth knowing for local use.

### Related PRs / merge order
Part of a small stack coordinating the web-UI build. Suggested merge order: **this PR first**, then #2098 (rebases on top of it — uses `raw_download`), then the rpm web-UI follow-up #2144. This PR stands alone; nothing here depends on the others.