### PR TITLE
webui: keep the EPG viewport following "now" over long sessions

### DIFF
--- a/src/webui/static-vue/src/composables/__tests__/useEpgInitialScrollToNow.test.ts
+++ b/src/webui/static-vue/src/composables/__tests__/useEpgInitialScrollToNow.test.ts
@@ -147,4 +147,96 @@ describe('useEpgInitialScrollToNow — restore vs scroll-to-now routing', () => 
     expect(scrollToNow).toHaveBeenCalledTimes(1)
     expect(scrollToTime).not.toHaveBeenCalled()
   })
+
+  it('starts following on the default scroll-to-now path via onFollowNow', async () => {
+    /* When the view provides onFollowNow (the follow-now wiring), the
+     * scroll-to-now path routes through it instead of scrollToNow, so
+     * the viewport starts pinned to the live edge. */
+    stubRAF()
+    const state = makeState({ restoredPosition: ref(null) })
+    const el = document.createElement('div')
+    const scrollEl = computed(() => el as HTMLElement | null)
+    const scrollToNow = vi.fn()
+    const onFollowNow = vi.fn()
+
+    useEpgInitialScrollToNow({
+      state: state as unknown as Parameters<typeof useEpgInitialScrollToNow>[0]['state'],
+      scrollEl,
+      scrollToNow,
+      align: 'leftThird',
+      onFollowNow,
+    })
+    state.events.value = [{ eventId: 1 }, { eventId: 2 }]
+    await flushPromises()
+    await flushPromises()
+
+    expect(onFollowNow).toHaveBeenCalledTimes(1)
+    expect(onFollowNow).toHaveBeenCalledWith('instant')
+    expect(scrollToNow).not.toHaveBeenCalled()
+  })
+
+  it('starts following on the wasClamped restore path via onFollowNow', async () => {
+    /* A clamped restore is a "show me now" intent, so it should follow
+     * too. */
+    stubRAF()
+    const state = makeState({
+      restoredPosition: ref({
+        dayStart: 1_700_000_000,
+        scrollTime: 1_700_050_000,
+        topChannelUuid: 'a',
+        wasClamped: true,
+      }),
+    })
+    const el = document.createElement('div')
+    const scrollEl = computed(() => el as HTMLElement | null)
+    const scrollToNow = vi.fn()
+    const onFollowNow = vi.fn()
+
+    useEpgInitialScrollToNow({
+      state: state as unknown as Parameters<typeof useEpgInitialScrollToNow>[0]['state'],
+      scrollEl,
+      scrollToNow,
+      restoreTopChannel: vi.fn(),
+      align: 'leftThird',
+      onFollowNow,
+    })
+    state.events.value = [{ eventId: 1 }, { eventId: 2 }]
+    await flushPromises()
+    await flushPromises()
+
+    expect(onFollowNow).toHaveBeenCalledTimes(1)
+    expect(scrollToNow).not.toHaveBeenCalled()
+  })
+
+  it('does NOT start following on a normal restore (user had a saved position)', async () => {
+    /* A non-clamped restore lands the user where they saved (possibly a
+     * future day) — the live-edge follow must stay off. */
+    stubRAF()
+    const state = makeState({
+      restoredPosition: ref({
+        dayStart: 1_700_000_000,
+        scrollTime: 1_700_080_000,
+        topChannelUuid: 'a',
+      }),
+    })
+    const el = document.createElement('div')
+    const scrollEl = computed(() => el as HTMLElement | null)
+    const scrollToTime = vi.fn()
+    const onFollowNow = vi.fn()
+
+    useEpgInitialScrollToNow({
+      state: state as unknown as Parameters<typeof useEpgInitialScrollToNow>[0]['state'],
+      scrollEl,
+      scrollToNow: vi.fn(),
+      scrollToTime,
+      align: 'leftThird',
+      onFollowNow,
+    })
+    state.events.value = [{ eventId: 1 }, { eventId: 2 }]
+    await flushPromises()
+    await flushPromises()
+
+    expect(onFollowNow).not.toHaveBeenCalled()
+    expect(scrollToTime).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/webui/static-vue/src/composables/__tests__/useEpgScrollDaySync.test.ts
+++ b/src/webui/static-vue/src/composables/__tests__/useEpgScrollDaySync.test.ts
@@ -82,14 +82,20 @@ function makeScrollEl(state: ScrollState): {
 /* Minimal useEpgViewState surface — only the slice
  * useEpgScrollDaySync touches. dayStart is a real ref so the
  * composable's watch fires on writes. */
-function makeState(initialDayStart: number, trackStart: number) {
+function makeState(initialDayStart: number, trackStart: number, now: number = initialDayStart) {
   const dayStart = ref(initialDayStart)
+  /* Wall-clock minute ticker the follow-now watch keys off; a real ref
+   * so tests can advance it to fire the watch. isToday mirrors the real
+   * composable (dayStart === start-of-day of now). */
+  const nowEpoch = ref(now)
   /* Mirror the real useEpgViewState: setDayStart honours a `silent`
    * opt that marks a highlight-only change, and the scroll-sync
    * watch consumes it to decide whether to scroll. One-shot. */
   let dayStartScrollSuppressed = false
   return {
     dayStart,
+    nowEpoch,
+    isToday: computed(() => dayStart.value === startOfLocalDay(nowEpoch.value)),
     trackStart: ref(trackStart),
     trackEnd: ref(trackStart + 14 * ONE_DAY),
     setDayStart: (epoch: number, opts?: { silent?: boolean }) => {
@@ -168,6 +174,7 @@ describe('useEpgScrollDaySync', () => {
       scrollEl,
       pxPerMinute: computed(() => 4),
       state,
+      scrollToNow: vi.fn(),
     })
     /* Simulate the Today button: state.setDayStart(today) →
      * dayStart watch fires. */
@@ -199,6 +206,7 @@ describe('useEpgScrollDaySync', () => {
       scrollEl,
       pxPerMinute: computed(() => 4),
       state,
+      scrollToNow: vi.fn(),
     })
     state.setDayStart(TOMORROW)
     await flushPromises()
@@ -234,6 +242,7 @@ describe('useEpgScrollDaySync', () => {
       scrollEl,
       pxPerMinute: computed(() => 4),
       state,
+      scrollToNow: vi.fn(),
     })
 
     /* Dropdown pick of the day whose preroll is currently visible. */
@@ -265,6 +274,7 @@ describe('useEpgScrollDaySync', () => {
       scrollEl,
       pxPerMinute: computed(() => 4),
       state,
+      scrollToNow: vi.fn(),
     })
 
     jumpToNow()
@@ -297,6 +307,7 @@ describe('useEpgScrollDaySync', () => {
       scrollEl,
       pxPerMinute: computed(() => 4),
       state,
+      scrollToNow: vi.fn(),
     })
 
     jumpToNow()
@@ -346,6 +357,7 @@ describe('useEpgScrollDaySync', () => {
       scrollEl,
       pxPerMinute: computed(() => 4),
       state,
+      scrollToNow: vi.fn(),
     })
 
     state.setDayStart(DAY_PLUS_4)
@@ -396,6 +408,7 @@ describe('useEpgScrollDaySync', () => {
       scrollEl,
       pxPerMinute: computed(() => 4),
       state,
+      scrollToNow: vi.fn(),
     })
 
     state.setDayStart(DAY_PLUS_2)
@@ -445,6 +458,7 @@ describe('useEpgScrollDaySync', () => {
       scrollEl,
       pxPerMinute: computed(() => 4),
       state,
+      scrollToNow: vi.fn(),
     })
     state.setDayStart(TOMORROW)
     await flushPromises()
@@ -473,6 +487,7 @@ describe('useEpgScrollDaySync', () => {
       scrollEl,
       pxPerMinute: computed(() => 4),
       state,
+      scrollToNow: vi.fn(),
     })
     onViewportRangeChanged({ start: TODAY + 22 * 3600, end: TOMORROW + 2 * 3600 })
     const stateAny = state as unknown as { ensureDaysLoaded: ReturnType<typeof vi.fn> }
@@ -505,6 +520,7 @@ describe('useEpgScrollDaySync', () => {
       scrollEl,
       pxPerMinute: computed(() => 4),
       state,
+      scrollToNow: vi.fn(),
     })
     onViewportRangeChanged({
       start: Math.floor(new Date(2026, 9, 24, 12).getTime() / 1000),
@@ -516,5 +532,127 @@ describe('useEpgScrollDaySync', () => {
       expect(new Date(d * 1000).getHours()).toBe(0)
     }
     expect(days).toContain(Math.floor(new Date(2026, 9, 26).getTime() / 1000))
+  })
+
+  /* ---- follow-now: keep the viewport pinned to the live edge ---- */
+
+  function makeFollowSetup(axis: 'horizontal' | 'vertical' = 'horizontal') {
+    const state = makeState(TODAY, TODAY, NOW_SEC)
+    const made = makeScrollEl({
+      scrollLeft: axis === 'horizontal' ? NOW_SNAP_PX : 0,
+      scrollTop: axis === 'vertical' ? NOW_SNAP_PX : 0,
+      clientWidth: 1200,
+      clientHeight: 800,
+    })
+    const scrollEl = computed(() => made.el as HTMLElement | null)
+    const scrollToNow = vi.fn()
+    const sync = useEpgScrollDaySync({
+      axis,
+      scrollEl,
+      pxPerMinute: computed(() => 4),
+      state,
+      scrollToNow,
+    })
+    return { state, made, scrollToNow, sync }
+  }
+
+  /* Advance the wall clock AND the state's nowEpoch to `sec` together
+   * (they represent the same instant) and flush the follow watch. */
+  async function tickTo(
+    state: ReturnType<typeof makeFollowSetup>['state'],
+    sec: number,
+  ): Promise<void> {
+    vi.setSystemTime(new Date(sec * 1000))
+    state.nowEpoch.value = sec
+    await flushPromises()
+  }
+
+  it('re-pins to now when the :30 snap boundary advances while following', async () => {
+    const { state, scrollToNow, sync } = makeFollowSetup()
+    sync.followNow('instant') // simulate the initial scroll-to-now
+    scrollToNow.mockClear()
+
+    /* Same half-hour window (22:45 → 22:50) — snapped-now target is
+     * unchanged, so the drift check makes it a no-op. */
+    await tickTo(state, TODAY + 22 * 3600 + 50 * 60)
+    expect(scrollToNow).not.toHaveBeenCalled()
+
+    /* Cross the 23:00 boundary — snapped-now advances 30 min, so the
+     * viewport offset drifts from the target and we re-pin. */
+    await tickTo(state, TODAY + 23 * 3600)
+    expect(scrollToNow).toHaveBeenCalledTimes(1)
+    expect(scrollToNow).toHaveBeenCalledWith({ behavior: 'smooth' })
+  })
+
+  it('does not follow when following is disabled', async () => {
+    const { state, scrollToNow } = makeFollowSetup()
+    await tickTo(state, TODAY + 23 * 3600)
+    expect(scrollToNow).not.toHaveBeenCalled()
+  })
+
+  it('does not follow when the active day is not today', async () => {
+    const { state, scrollToNow, sync } = makeFollowSetup()
+    sync.followNow('instant')
+    scrollToNow.mockClear()
+    state.setDayStart(TOMORROW) // viewing a future day → isToday false
+    await flushPromises()
+    await tickTo(state, TODAY + 23 * 3600)
+    expect(scrollToNow).not.toHaveBeenCalled()
+  })
+
+  it('stops following after a genuine user scroll', async () => {
+    const { state, made, scrollToNow, sync } = makeFollowSetup()
+    sync.followNow('instant')
+    /* Lift the intent latch the followNow armed (scrollend + deferred
+     * rAF) so the next onActiveDayChanged reads as a user scroll. */
+    made.fireScrollend()
+    drainRAF()
+    expect(sync.following.value).toBe(true)
+
+    sync.onActiveDayChanged(TODAY) // user free-scroll, unlatched
+    expect(sync.following.value).toBe(false)
+
+    scrollToNow.mockClear()
+    await tickTo(state, TODAY + 23 * 3600)
+    expect(scrollToNow).not.toHaveBeenCalled()
+  })
+
+  it('jumpToNow re-enables following', async () => {
+    const { state, made, scrollToNow, sync } = makeFollowSetup()
+    sync.followNow('instant')
+    made.fireScrollend()
+    drainRAF()
+    sync.onActiveDayChanged(TODAY) // user scroll disables follow
+    expect(sync.following.value).toBe(false)
+
+    sync.jumpToNow()
+    expect(sync.following.value).toBe(true)
+
+    scrollToNow.mockClear()
+    await tickTo(state, TODAY + 23 * 3600)
+    expect(scrollToNow).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps following across a midnight rollover', async () => {
+    const { state, scrollToNow, sync } = makeFollowSetup()
+    sync.followNow('instant')
+    scrollToNow.mockClear()
+
+    /* Simulate the real midnight handler: nowEpoch crosses into the
+     * next day and dayStart is silently advanced to match, so isToday
+     * stays true and following continues. */
+    const afterMidnight = TOMORROW + 15 * 60 // 00:15 next day
+    state.setDayStart(TOMORROW, { silent: true })
+    await flushPromises()
+    await tickTo(state, afterMidnight)
+    expect(scrollToNow).toHaveBeenCalledTimes(1)
+  })
+
+  it('follows on the vertical axis too (Magazine)', async () => {
+    const { state, scrollToNow, sync } = makeFollowSetup('vertical')
+    sync.followNow('instant')
+    scrollToNow.mockClear()
+    await tickTo(state, TODAY + 23 * 3600)
+    expect(scrollToNow).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/webui/static-vue/src/composables/useEpgInitialScrollToNow.ts
+++ b/src/webui/static-vue/src/composables/useEpgInitialScrollToNow.ts
@@ -44,6 +44,12 @@ export function useEpgInitialScrollToNow<Align extends string>(opts: {
   state: ReturnType<typeof useEpgViewState>
   scrollEl: ComputedRef<HTMLElement | null>
   scrollToNow: (o?: { behavior?: ScrollBehavior; align?: Align }) => void
+  /* When provided, the scroll-to-now paths (default + wasClamped) route
+   * through this instead of `scrollToNow`, so the viewport starts
+   * "following" now (see useEpgScrollDaySync.followNow). The normal
+   * restore path deliberately does NOT call it — a user with a saved
+   * scroll position isn't following the live edge. */
+  onFollowNow?: (behavior: ScrollBehavior) => void
   /* B2 — sticky position. Optional so callers without restore
    * support (e.g. a future flat-list view) still work. When both
    * `restoreToPosition` AND `scrollToTime` are absent the restore
@@ -126,7 +132,9 @@ export function useEpgInitialScrollToNow<Align extends string>(opts: {
          *   LEADING-edge target, putting the user exactly where the
          *   save snapshot was taken. */
         if (restored.wasClamped) {
-          opts.scrollToNow({ behavior: 'instant' as ScrollBehavior, align: opts.align })
+          /* "Show me now" intent → start following (see onFollowNow). */
+          if (opts.onFollowNow) opts.onFollowNow('instant')
+          else opts.scrollToNow({ behavior: 'instant' as ScrollBehavior, align: opts.align })
         } else if (opts.restoreToPosition) {
           opts.restoreToPosition(restored)
         } else if (opts.scrollToTime) {
@@ -139,10 +147,11 @@ export function useEpgInitialScrollToNow<Align extends string>(opts: {
         return
       }
 
-      /* Default path: scroll to now. `instant` keeps the initial
-       * position from feeling like an animation; later user-triggered
-       * "Now" clicks animate. */
-      opts.scrollToNow({ behavior: 'instant' as ScrollBehavior, align: opts.align })
+      /* Default path: scroll to now AND start following the live edge.
+       * `instant` keeps the initial position from feeling like an
+       * animation; later user-triggered "Now" clicks animate. */
+      if (opts.onFollowNow) opts.onFollowNow('instant')
+      else opts.scrollToNow({ behavior: 'instant' as ScrollBehavior, align: opts.align })
     },
     { flush: 'post' },
   )

--- a/src/webui/static-vue/src/composables/useEpgScrollDaySync.ts
+++ b/src/webui/static-vue/src/composables/useEpgScrollDaySync.ts
@@ -61,12 +61,24 @@ const NOW_SNAP_SECONDS = 30 * 60
  * highlights the clicked day because the intent latch overrides
  * the leading-edge writeback for the duration of the scroll. */
 const PREROLL_SECONDS = 30 * 60
+/* Follow-now re-pin threshold. While following, the viewport is pinned
+ * to the half-hour-snapped now position, so its scroll offset equals
+ * that target between snaps; only when the :30 boundary advances (or the
+ * tab regains focus after being hidden) does the target move, at which
+ * point the offset differs by far more than this epsilon and the follow
+ * watch re-pins. Small enough that any real user scroll exceeds it. */
+const FOLLOW_EPSILON_PX = 4
 
 export function useEpgScrollDaySync(opts: {
   axis: 'horizontal' | 'vertical'
   scrollEl: ComputedRef<HTMLElement | null>
   pxPerMinute: ComputedRef<number>
   state: ReturnType<typeof useEpgViewState>
+  /* The view's own scrollToNow primitive (useTimelineScroll /
+   * useMagazineScroll): snaps to the last :30 and pins it to the leading
+   * edge (left for Timeline, top for Magazine). The follow-now path
+   * routes through it so every "scroll to now" goes through one place. */
+  scrollToNow: (o?: { behavior?: ScrollBehavior }) => void
 }) {
   const { axis, scrollEl, pxPerMinute, state } = opts
   const isHorizontal = axis === 'horizontal'
@@ -87,8 +99,20 @@ export function useEpgScrollDaySync(opts: {
   let activeSettleHandler: (() => void) | null = null
   let activeSettleEl: HTMLElement | null = null
 
+  /* Follow-now: while true, each wall-clock tick re-pins the viewport to
+   * "now" (see the nowEpoch watch below). Enabled by the initial
+   * scroll-to-now, the Now button, and each re-pin; disabled the moment
+   * the user free-scrolls away. Every programmatic now-scroll arms the
+   * intent latch, so onActiveDayChanged only turns it off for genuine
+   * user scrolls. */
+  const following = ref(false)
+
   function onActiveDayChanged(epoch: number) {
     if (expectingButtonScroll.value) return
+    /* Past the intent latch → a genuine user free-scroll. Stop
+     * following so we don't yank the user back to now while they browse;
+     * only the Now button / followNow re-enable it. */
+    following.value = false
     /* Highlight-only writeback from the scroll listener — mark it
      * silent so the dayStart watch doesn't bounce it back into a
      * counter-scroll against the user's own free scroll. */
@@ -232,16 +256,32 @@ export function useEpgScrollDaySync(opts: {
     el.scrollTo(scrollOpts)
   }
 
+  /* Scroll to now-snap and (re-)enable following. Routed through the
+   * intent latch so the resulting scroll emit isn't mistaken for a user
+   * free-scroll (which onActiveDayChanged would read as "stop
+   * following"). Shared by the initial scroll-to-now and the periodic
+   * re-pin; the view's own `scrollToNow` does the snap + edge-align. */
+  function followNow(behavior: ScrollBehavior = 'smooth'): void {
+    const el = scrollEl.value
+    if (!el) return
+    armIntentScroll(el, startOfLocalDay(Math.floor(Date.now() / 1000)))
+    opts.scrollToNow({ behavior })
+    following.value = true
+  }
+
   /* Now button entry point. Always sets dayStart=today so the
    * picker highlight matches what the user just asked for, then
    * force-scrolls regardless of whether dayStart changed (a
    * Now-click while already on today would otherwise short-
    * circuit and leave the user looking at the morning or
-   * wherever they'd previously panned). */
+   * wherever they'd previously panned). Re-enables following: the
+   * scrollToDay(today) already arms the intent latch, so the flag is
+   * set after it without the scroll emit clearing it. */
   function jumpToNow(): void {
     const today = startOfLocalDay(Math.floor(Date.now() / 1000))
     if (state.dayStart.value !== today) state.setDayStart(today)
     scrollToDay(today, true)
+    following.value = true
   }
 
   /* Restore from a sticky position (B2 path). Called from
@@ -316,10 +356,36 @@ export function useEpgScrollDaySync(opts: {
     },
   )
 
+  /* Follow-now: on each wall-clock tick (visibility-aware ~60s
+   * `nowEpoch`), if the user is parked at the live edge and viewing
+   * today, re-pin the viewport to now. The drift check makes it a no-op
+   * between :30 snap boundaries (the snapped-now target only moves every
+   * 30 min) — it issues a real scroll only when the boundary advances or
+   * the tab regains focus after being hidden (nowEpoch jumps forward),
+   * which is the reported "left it open for hours" case. */
+  watch(
+    () => state.nowEpoch.value,
+    () => {
+      if (!following.value || !state.isToday.value) return
+      const el = scrollEl.value
+      if (!el) return
+      /* The isToday gate guarantees dayStart is start-of-today, so use it
+       * directly rather than recomputing startOfLocalDay(now) each tick. */
+      const current = isHorizontal ? el.scrollLeft : el.scrollTop
+      if (Math.abs(current - targetPxForDay(state.dayStart.value)) <= FOLLOW_EPSILON_PX) return
+      followNow('smooth')
+    },
+  )
+
   return {
     onActiveDayChanged,
     onViewportRangeChanged,
     jumpToNow,
     restoreToPosition,
+    /* Enable following + scroll to now; the views wire this into
+     * useEpgInitialScrollToNow's scroll-to-now path. */
+    followNow,
+    /* Read-only for tests / potential UI affordance ("following" badge). */
+    following,
   }
 }

--- a/src/webui/static-vue/src/composables/useEpgViewState.ts
+++ b/src/webui/static-vue/src/composables/useEpgViewState.ts
@@ -285,6 +285,11 @@ export interface UseEpgViewState {
   dayStart: Ref<number>
   dayEnd: ComputedRef<number>
   isToday: ComputedRef<boolean>
+  /* Wall-clock minute ticker (epoch seconds). Ticks every 60s and
+   * pauses while the tab is hidden; also drives `isToday`. Exposed so
+   * the scroll-sync's follow-now watch has a visibility-aware tick to
+   * re-pin the viewport on. */
+  nowEpoch: Ref<number>
   goToToday: () => void
   goToTomorrow: () => void
   setDayStart: (epoch: number, opts?: { silent?: boolean }) => void
@@ -2003,6 +2008,7 @@ export function useEpgViewState(opts: UseEpgViewStateOpts = {}): UseEpgViewState
     dayStart,
     dayEnd,
     isToday,
+    nowEpoch,
     goToToday,
     goToTomorrow,
     setDayStart,

--- a/src/webui/static-vue/src/views/epg/MagazineView.vue
+++ b/src/webui/static-vue/src/views/epg/MagazineView.vue
@@ -123,12 +123,13 @@ function restoreMagazineTopChannel(uuid: string) {
  * the latter can take this composable's `restoreToPosition` as an
  * opt — the restore path needs the day-sync latch in place before
  * its scroll fires. */
-const { onActiveDayChanged, onViewportRangeChanged, jumpToNow, restoreToPosition } =
+const { onActiveDayChanged, onViewportRangeChanged, jumpToNow, restoreToPosition, followNow } =
   useEpgScrollDaySync({
     axis: 'vertical',
     scrollEl,
     pxPerMinute,
     state,
+    scrollToNow,
   })
 
 useEpgInitialScrollToNow({
@@ -139,6 +140,7 @@ useEpgInitialScrollToNow({
   restoreToPosition,
   restoreTopChannel: restoreMagazineTopChannel,
   align: 'topThird',
+  onFollowNow: followNow,
 })
 
 /* ---- B2 — debounced position save on scroll -----------------

--- a/src/webui/static-vue/src/views/epg/TimelineView.vue
+++ b/src/webui/static-vue/src/views/epg/TimelineView.vue
@@ -174,12 +174,13 @@ function restoreTimelineTopChannel(uuid: string) {
  * `restoreToPosition` as an opt; the restore path needs the day-
  * sync latch in place before its scroll fires, otherwise the
  * dayStart watch races a competing scrollToDay. */
-const { onActiveDayChanged, onViewportRangeChanged, jumpToNow, restoreToPosition } =
+const { onActiveDayChanged, onViewportRangeChanged, jumpToNow, restoreToPosition, followNow } =
   useEpgScrollDaySync({
     axis: 'horizontal',
     scrollEl,
     pxPerMinute,
     state,
+    scrollToNow,
   })
 
 useEpgInitialScrollToNow({
@@ -190,6 +191,7 @@ useEpgInitialScrollToNow({
   restoreToPosition,
   restoreTopChannel: restoreTimelineTopChannel,
   align: 'leftThird',
+  onFollowNow: followNow,
 })
 
 /* ---- B2 — debounced position save on scroll -----------------

--- a/src/webui/static-vue/src/views/epg/__tests__/MagazineView.test.ts
+++ b/src/webui/static-vue/src/views/epg/__tests__/MagazineView.test.ts
@@ -65,6 +65,7 @@ function makeFakeState(): ReturnType<typeof useEpgViewState> {
     dayStart,
     dayEnd: computed(() => dayStart.value + ONE_DAY),
     isToday: computed(() => true),
+    nowEpoch: ref(Math.floor(Date.now() / 1000)),
     goToToday: vi.fn(),
     goToTomorrow: vi.fn(),
     setDayStart: (epoch: number) => {


### PR DESCRIPTION
Fixes the stale-EPG behaviour reported by @th0ma7 on #2098 ([comment](https://github.com/tvheadend/tvheadend/pull/2098#issuecomment-4878187208)): leaving the EPG open for a few hours makes it go stale — the red "now" cursor drifts across a frozen viewport, already-aired programmes disappear (the server expires them and pushes `'epg'` delete notifications), and you're left with a large empty gap on the left with current/upcoming shows bunched near the drifted cursor. Both **Timeline** and **Magazine** were affected.

### Cause
The viewport scrolled to "now" only **once**, at mount. Nothing re-scrolled as wall-clock time advanced — the now-cursor moved but the viewport stayed put.

### Fix — auto-follow "now"
While the user is parked at the live edge, a wall-clock tick re-pins the viewport so "now" stays at the leading edge (left for Timeline, top for Magazine — matching what the "Now" button already does). Following:
- **starts** on the initial scroll-to-now,
- **stops** the moment the user scrolls away to browse ahead (so it never hijacks scrolling),
- **re-engages** via the existing **Now** button.

It lives in `useEpgScrollDaySync`, which already owns the scroll listener, the Now button, and the intent-scroll suppression latch — the re-pin routes through that latch so its own scroll emit isn't mistaken for a user scroll, and any unlatched scroll disables following. The re-pin is driven by the visibility-aware minute tick and drift-gated against the half-hour-snapped target, so it's a no-op between :30 boundaries and fires only when the boundary advances or the tab regains focus after being hidden (the reported "left it open for hours" case). `trackStart` stays frozen — only the scroll offset moves.

Verified in the browser on both views; new unit tests cover the follow/disable/re-enable/drift/midnight/vertical-axis paths.
