### PR TITLE
webui: honour webroot (--http_root) in the Vue UI

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1072,10 +1072,14 @@ main(int argc, char **argv)
     }
     if (tmp[strlen(tmp)-1] == '/')
       tmp[strlen(tmp)-1] = '\0';
-    if (tmp[0])
+    if (tmp[0]) {
       tvheadend_webroot = tmp;
-    else
+    } else {
+      /* "/" or "" normalise to no webroot at all — leaving the raw
+       * value would prefix every registered route with it. */
       free(tmp);
+      tvheadend_webroot = NULL;
+    }
   }
   tvheadend_webui_debug = opt_uidebug;
 

--- a/src/webui/static-vue/index.html
+++ b/src/webui/static-vue/index.html
@@ -6,6 +6,13 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
+    <!--
+      Webroot anchor: vue.c rewrites this href to {webroot}/gui/static/
+      at serve time. The production build uses a relative Vite base, so
+      the hashed assets resolve through this tag, and utils/base.ts
+      derives the router base + server root from document.baseURI.
+    -->
+    <base href="/gui/static/">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tvheadend</title>
   </head>

--- a/src/webui/static-vue/src/api/client.ts
+++ b/src/webui/static-vue/src/api/client.ts
@@ -11,6 +11,7 @@
  */
 
 import { ApiError } from './errors'
+import { serverUrl } from '@/utils/base'
 
 export async function apiCall<T = unknown>(
   endpoint: string,
@@ -37,7 +38,7 @@ export async function apiCall<T = unknown>(
     body.append(k, typeof v === 'string' ? v : JSON.stringify(v))
   }
 
-  const res = await fetch(`/api/${endpoint}`, {
+  const res = await fetch(serverUrl(`api/${endpoint}`), {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body,

--- a/src/webui/static-vue/src/api/comet.ts
+++ b/src/webui/static-vue/src/api/comet.ts
@@ -23,6 +23,7 @@
  */
 
 import type { CometEnvelope, ConnectionState, NotificationMessage } from '@/types/comet'
+import { serverUrl } from '@/utils/base'
 
 type Listener = (msg: NotificationMessage) => void
 type StateListener = (state: ConnectionState) => void
@@ -142,7 +143,7 @@ class CometClient {
         if (this.boxid) body.append('boxid', this.boxid)
         body.append('immediate', '0')
 
-        const res = await fetch('/comet/poll', {
+        const res = await fetch(serverUrl('comet/poll'), {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
           body,

--- a/src/webui/static-vue/src/commands/actionHandlers.ts
+++ b/src/webui/static-vue/src/commands/actionHandlers.ts
@@ -25,6 +25,7 @@
  */
 import type { Router } from 'vue-router'
 import { apiCall } from '@/api/client'
+import { serverUrl } from '@/utils/base'
 import { t } from '@/composables/useI18n'
 import type { useConfirmDialog } from '@/composables/useConfirmDialog'
 import type { useToastNotify } from '@/composables/useToastNotify'
@@ -132,7 +133,7 @@ export async function startSetupWizard(
  * to duplicate the URL or the cross-UI rationale.
  */
 export function openLogout(): void {
-  globalThis.window.location.href = '/logout'
+  globalThis.window.location.href = serverUrl('logout')
 }
 
 /*

--- a/src/webui/static-vue/src/commands/channelSource.ts
+++ b/src/webui/static-vue/src/commands/channelSource.ts
@@ -49,6 +49,7 @@ import { ref, type Ref } from 'vue'
 import { Tv } from 'lucide-vue-next'
 import type { Router } from 'vue-router'
 import { apiCall } from '@/api/client'
+import { serverUrl } from '@/utils/base'
 import type { useAccessStore } from '@/stores/access'
 import type { useEntityEditor } from '@/composables/useEntityEditor'
 import type { Command } from './commandRegistry'
@@ -174,7 +175,7 @@ function buildChannelCommand(entry: ChannelListEntry, deps: ChannelSourceDeps): 
  * readable channel name; some players read it as the playlist
  * title. */
 function openExternalPlayer(uuid: string, name: string): void {
-  const url = `/play/ticket/stream/channel/${encodeURIComponent(uuid)}?title=${encodeURIComponent(name)}`
+  const url = serverUrl(`play/ticket/stream/channel/${encodeURIComponent(uuid)}?title=${encodeURIComponent(name)}`)
   /* `_blank` so the user keeps the Vue UI open in the original
    * tab. `noopener` denies the new context access to
    * `window.opener` — defensive against any future hostile

--- a/src/webui/static-vue/src/commands/recordingSource.ts
+++ b/src/webui/static-vue/src/commands/recordingSource.ts
@@ -34,6 +34,7 @@ import { ref, type Ref } from 'vue'
 import { Video } from 'lucide-vue-next'
 import type { Router } from 'vue-router'
 import { apiCall } from '@/api/client'
+import { serverUrl } from '@/utils/base'
 import { t } from '@/composables/useI18n'
 import type { useAccessStore } from '@/stores/access'
 import type { useConfirmDialog } from '@/composables/useConfirmDialog'
@@ -166,7 +167,7 @@ function formatEntryContext(channelName?: string, startEpoch?: number): string {
 }
 
 function openExternalPlayer(uuid: string, title: string): void {
-  const url = `/play/ticket/dvrfile/${encodeURIComponent(uuid)}?title=${encodeURIComponent(title)}`
+  const url = serverUrl(`play/ticket/dvrfile/${encodeURIComponent(uuid)}?title=${encodeURIComponent(title)}`)
   globalThis.window.open(url, '_blank', 'noopener')
 }
 

--- a/src/webui/static-vue/src/components/NavRail.vue
+++ b/src/webui/static-vue/src/components/NavRail.vue
@@ -25,6 +25,7 @@ import { useRailPreference } from '@/composables/useRailPreference'
 import { useI18n } from '@/composables/useI18n'
 import { useIsPhone } from '@/composables/useIsPhone'
 import { useStickyBottom } from '@/composables/useStickyBottom'
+import { serverUrl } from '@/utils/base'
 import RailInfoArea from './RailInfoArea.vue'
 import CommandPaletteTrigger from './CommandPaletteTrigger.vue'
 
@@ -39,7 +40,7 @@ const { t } = useI18n()
  * ExtJS UI retires, copy the asset into `static-vue/src/assets/`
  * and replace this with a Vite-imported reference.
  */
-const logoUrl = '/static/img/logo.png'
+const logoUrl = serverUrl('static/img/logo.png')
 
 const props = defineProps<{
   open: boolean
@@ -135,7 +136,7 @@ const NAV_SECTIONS: NavSection[] = [
  * interface, available while both UIs ship side by side. */
 const NAV_UNGROUPED: Blueprint[] = [
   { routeName: 'about', label: t('About'), icon: Info },
-  { href: '/extjs.html', label: t('Classic UI'), icon: ExternalLink },
+  { href: serverUrl('extjs.html'), label: t('Classic UI'), icon: ExternalLink },
 ]
 
 /*
@@ -313,11 +314,11 @@ const showLogin = computed(
     !access.data?.admin,
 )
 function onLogoutClick() {
-  globalThis.window.location.href = '/logout'
+  globalThis.window.location.href = serverUrl('logout')
 }
 async function onLoginClick() {
   try {
-    const res = await fetch('/login', {
+    const res = await fetch(serverUrl('login'), {
       method: 'GET',
       credentials: 'include',
       cache: 'no-store',

--- a/src/webui/static-vue/src/components/SubviewPlaceholder.vue
+++ b/src/webui/static-vue/src/components/SubviewPlaceholder.vue
@@ -13,11 +13,9 @@
  * Lives as a component (not duplicated copy in each placeholder view)
  * so consistency stays automatic; each view's body can be swapped
  * for a real implementation without touching this scaffolding.
- *
- * Note: `href="/"` doesn't honour `tvheadend_webroot` prefixes — the
- * v2 UI as a whole doesn't yet (Vite `base` is hardcoded). Will be
- * addressed when `base` becomes runtime-configurable.
  */
+import { serverBase } from '@/utils/base'
+
 defineProps<{
   /* User-facing label of the absent view, e.g. "Users", "Networks". */
   label: string
@@ -32,7 +30,7 @@ defineProps<{
     <p class="subview-placeholder__action">
       <a
         class="subview-placeholder__link"
-        href="/"
+        :href="serverBase"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/src/webui/static-vue/src/components/TopBar.vue
+++ b/src/webui/static-vue/src/components/TopBar.vue
@@ -37,12 +37,13 @@ import { Menu } from 'lucide-vue-next'
 import RailInfoArea from './RailInfoArea.vue'
 import CommandPaletteTrigger from './CommandPaletteTrigger.vue'
 import { useI18n } from '@/composables/useI18n'
+import { serverUrl } from '@/utils/base'
 
 const { t } = useI18n()
 
 defineEmits<{ toggleRail: [] }>()
 
-const logoUrl = '/static/img/logo.png'
+const logoUrl = serverUrl('static/img/logo.png')
 
 const barRef = ref<HTMLElement | null>(null)
 const infoRef = ref<HTMLElement | null>(null)

--- a/src/webui/static-vue/src/composables/useHelp.ts
+++ b/src/webui/static-vue/src/composables/useHelp.ts
@@ -44,6 +44,7 @@ import {
   renderMarkdown,
   rewriteStaticUrls,
 } from '@/utils/markdown'
+import { serverUrl } from '@/utils/base'
 
 export interface HelpHistoryEntry {
   /* Page id, e.g. `firstconfig` or `class/mpegts_service`. The
@@ -93,7 +94,7 @@ function encodePagePath(page: string): string {
 }
 
 async function fetchAndRender(page: string): Promise<HelpHistoryEntry> {
-  const res = await fetch(`/markdown/${encodePagePath(page)}`)
+  const res = await fetch(serverUrl(`markdown/${encodePagePath(page)}`))
   if (!res.ok) {
     throw new Error(`HTTP ${res.status}`)
   }

--- a/src/webui/static-vue/src/composables/useI18n.ts
+++ b/src/webui/static-vue/src/composables/useI18n.ts
@@ -37,6 +37,7 @@
  * `/* i18n: new string *\/` so a future audit finds them.
  */
 import { ref } from 'vue'
+import { serverUrl } from '@/utils/base'
 
 /*
  * Reactivity hook. Bumped every time `loadLocale()` swaps the
@@ -162,7 +163,7 @@ export function loadLocale(): Promise<void> {
     /* Cache bust by timestamp — the server may reasonably set
      * caching headers and we must always pick up the current
      * user's language file. */
-    s.src = `/redir/locale.js?_=${Date.now()}`
+    s.src = serverUrl(`redir/locale.js?_=${Date.now()}`)
     s.onload = () => {
       /* Bump the reactive ref so any reactive consumer of `t()`
        * re-evaluates against the new dict. */

--- a/src/webui/static-vue/src/layouts/AppShell.vue
+++ b/src/webui/static-vue/src/layouts/AppShell.vue
@@ -187,10 +187,25 @@ onBeforeUnmount(() => {
   unregisterCmdK = null
   unregisterSlash = null
 })
+
+/* Skip-link target jump in JS: the document carries a <base> tag
+ * (webroot support), so a bare href="#main-content" would resolve
+ * against the base URL and navigate away instead of jumping
+ * in-page. Focus the landmark directly (tabindex=-1 makes <main>
+ * focusable), which is also the more robust skip-link behaviour. */
+function skipToMain(): void {
+  const el = document.getElementById('main-content')
+  if (!el) return
+  el.setAttribute('tabindex', '-1')
+  el.focus()
+  el.scrollIntoView()
+}
 </script>
 
 <template>
-  <a class="skip-link" href="#main-content">{{ t('Skip to main content') }}</a>
+  <a class="skip-link" href="#main-content" @click.prevent="skipToMain">{{
+    t('Skip to main content')
+  }}</a>
   <div class="app-shell">
     <TopBar @toggle-rail="toggleRail" />
     <div class="app-shell__body">

--- a/src/webui/static-vue/src/router/index.ts
+++ b/src/webui/static-vue/src/router/index.ts
@@ -8,6 +8,7 @@ import {
   type RouteRecordRaw,
 } from 'vue-router'
 import { watch } from 'vue'
+import { appBase } from '@/utils/base'
 import type { PermissionKey } from '@/types/access'
 import { useAccessStore } from '@/stores/access'
 import { useCapabilitiesStore } from '@/stores/capabilities'
@@ -728,7 +729,9 @@ if (import.meta.env.DEV) {
 }
 
 const router = createRouter({
-  history: createWebHistory('/gui/'),
+  /* Base derived at runtime from the served <base> tag so the app
+   * works behind a webroot (`--http_root`) — see utils/base.ts. */
+  history: createWebHistory(appBase),
   routes,
 })
 

--- a/src/webui/static-vue/src/stores/log.ts
+++ b/src/webui/static-vue/src/stores/log.ts
@@ -47,6 +47,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { cometClient } from '@/api/comet'
+import { serverUrl } from '@/utils/base'
 
 /* Ring buffer cap. 5000 lines × ~200 bytes per LogLine ≈ 1 MB
  * resident; comfortable for any session length. Drop-oldest on
@@ -234,7 +235,7 @@ export const useLogStore = defineStore('log', () => {
     try {
       const body = new URLSearchParams()
       body.append('boxid', boxid)
-      const res = await fetch('/comet/debug', {
+      const res = await fetch(serverUrl('comet/debug'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body,

--- a/src/webui/static-vue/src/utils/__tests__/base.test.ts
+++ b/src/webui/static-vue/src/utils/__tests__/base.test.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/*
+ * URL-base derivation for webroot support. The served <base> tag is
+ * `{webroot}/gui/static/` (rewritten by vue.c when --http_root is
+ * set); computeBases must derive the router base and server root
+ * from any such value and fall back to root-mounted defaults for
+ * everything else — the fallback is what keeps the whole vitest
+ * suite (happy-dom, no <base> tag) running against unprefixed URLs.
+ */
+import { describe, expect, it } from 'vitest'
+import { computeBases, serverUrl } from '../base'
+
+const ROOT_BASES = { assetBase: '/gui/static/', appBase: '/gui/', serverBase: '/' }
+
+describe('computeBases', () => {
+  it.each([
+    [
+      'root-mounted default <base> href',
+      'http://localhost:9981/gui/static/',
+      ROOT_BASES,
+    ],
+    [
+      'webroot prefix (--http_root /tvheadend)',
+      'https://example.org/tvheadend/gui/static/',
+      { assetBase: '/tvheadend/gui/static/', appBase: '/tvheadend/gui/', serverBase: '/tvheadend/' },
+    ],
+    [
+      'nested multi-segment webroot',
+      'https://h/a/b/gui/static/',
+      { assetBase: '/a/b/gui/static/', appBase: '/a/b/gui/', serverBase: '/a/b/' },
+    ],
+    ['fallback: vitest page URL with pathname /', 'http://localhost/', ROOT_BASES],
+    ['fallback: unrelated path', 'http://localhost/some/other/path/', ROOT_BASES],
+    ['fallback: empty base URI', '', ROOT_BASES],
+    ['fallback: unparseable base URI', 'not a url', ROOT_BASES],
+  ])('%s', (_name, baseUri, expected) => {
+    expect(computeBases(baseUri)).toEqual(expected)
+  })
+})
+
+describe('serverUrl', () => {
+  /* Module-level serverBase is '/' under vitest (fallback), so these
+   * assert the join semantics; the prefixed form is covered by the
+   * computeBases cases above (serverUrl is serverBase + stripped path). */
+  it('joins a bare path onto the server base', () => {
+    expect(serverUrl('api/epg/events/grid')).toBe('/api/epg/events/grid')
+  })
+
+  it('strips leading slashes so no double slash is produced', () => {
+    expect(serverUrl('/imagecache/42')).toBe('/imagecache/42')
+    expect(serverUrl('//imagecache/42')).toBe('/imagecache/42')
+  })
+
+  it('leaves query strings untouched', () => {
+    expect(serverUrl('redir/locale.js?_=123')).toBe('/redir/locale.js?_=123')
+  })
+})

--- a/src/webui/static-vue/src/utils/__tests__/noHardcodedServerPaths.test.ts
+++ b/src/webui/static-vue/src/utils/__tests__/noHardcodedServerPaths.test.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/*
+ * Webroot regression fence. Every URL the app sends to the server
+ * must go through `serverUrl()` / `appBase` (utils/base.ts) so it
+ * carries the tvheadend_webroot prefix. A hardcoded root-absolute
+ * literal like fetch('/api/...') works on a root-mounted server but
+ * silently breaks behind --http_root (the server's catch-all only
+ * rescues it via a 302 that downgrades POSTs to GETs).
+ *
+ * This test scans the source tree for root-absolute server-route
+ * literals in string quotes and in call/assignment-position template
+ * literals. Doc comments use backtick code spans and don't match the
+ * patterns. If it flags your new code: route the URL through
+ * `serverUrl()` instead of widening the allowlist.
+ */
+import { describe, expect, it } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+
+const SRC_ROOT = resolve(process.cwd(), 'src')
+
+/* Server routes registered under the webroot (http_path_add). Router
+ * paths like '/dvr/upcoming' are internal and deliberately absent. */
+const ROUTES = String.raw`(api|comet|play|dvrfile|stream|imagecache|markdown|redir|static|extjs\.html|login|logout|gui)`
+
+/* Root-absolute server route inside ' or " quotes. Comments quote
+ * paths with backticks, so plain prose doesn't trip this. */
+const QUOTED = new RegExp(`['"]/${ROUTES}(/|['"?])`)
+/* Template literal starting with a server route, in call or
+ * assignment position — catches fetch(\`/api/...\`) etc. without
+ * matching backtick code spans inside doc comments. */
+const TEMPLATE = new RegExp(String.raw`[(=]\s*` + '`' + `/${ROUTES}/`)
+
+/* Files allowed to hold root-absolute literals. */
+const ALLOWED = new Set([
+  'utils/base.ts', // the fallback constants live here by design
+])
+
+function collect(dir: string, out: string[]): string[] {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name)
+    if (statSync(p).isDirectory()) {
+      if (name === '__tests__' || name === 'node_modules') continue
+      collect(p, out)
+    } else if (/\.(ts|vue)$/.test(name)) {
+      out.push(p)
+    }
+  }
+  return out
+}
+
+describe('no hardcoded root-absolute server URLs', () => {
+  it('every server URL goes through serverUrl()/appBase', () => {
+    const violations: string[] = []
+    for (const file of collect(SRC_ROOT, [])) {
+      const rel = relative(SRC_ROOT, file)
+      if (ALLOWED.has(rel)) continue
+      const lines = readFileSync(file, 'utf8').split('\n')
+      lines.forEach((line, i) => {
+        /* Comment lines quote paths as backtick code spans (often
+         * parenthesised, which mimics call position) — skip them. */
+        const trimmed = line.trim()
+        if (trimmed.startsWith('*') || trimmed.startsWith('//') || trimmed.startsWith('/*'))
+          return
+        if (QUOTED.test(line) || TEMPLATE.test(line)) {
+          violations.push(`${rel}:${i + 1}: ${trimmed}`)
+        }
+      })
+    }
+    expect(violations, violations.join('\n')).toEqual([])
+  })
+})

--- a/src/webui/static-vue/src/utils/__tests__/webrootContract.test.ts
+++ b/src/webui/static-vue/src/utils/__tests__/webrootContract.test.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/*
+ * Build-config contract for webroot support. Three pieces must stay
+ * in agreement or the app breaks behind --http_root:
+ *
+ *   - index.html carries `<base href="/gui/static/">` — the token
+ *     vue.c rewrites to `{webroot}/gui/static/` at serve time and
+ *     the anchor utils/base.ts derives every URL from.
+ *   - the production Vite base is relative ('./') so hashed assets
+ *     resolve through that tag and lazy chunks via import.meta.url.
+ *   - the dev base stays '/gui/' (no <base>-rewrite in dev).
+ *
+ * vite.config.ts is asserted as text (importing it would execute its
+ * file-URL alias resolution, which the happy-dom transform breaks).
+ */
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const viteConfig = readFileSync(resolve(process.cwd(), 'vite.config.ts'), 'utf8')
+const indexHtml = readFileSync(resolve(process.cwd(), 'index.html'), 'utf8')
+
+describe('webroot build contract', () => {
+  it('production build uses a relative Vite base, dev keeps /gui/', () => {
+    expect(viteConfig).toContain("base: command === 'build' ? './' : '/gui/'")
+  })
+
+  it('index.html carries the injectable <base> tag', () => {
+    expect(indexHtml).toContain('<base href="/gui/static/">')
+  })
+})

--- a/src/webui/static-vue/src/utils/base.ts
+++ b/src/webui/static-vue/src/utils/base.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/*
+ * URL bases for serving the app behind a webroot (`--http_root`).
+ *
+ * The server registers every route under `tvheadend_webroot`
+ * (http_path_add prepends it, src/http.c), so the app must prefix
+ * every server URL it builds. The prefix is discovered at runtime
+ * from the document's <base> tag: index.html carries
+ * `<base href="/gui/static/">` and vue.c rewrites it to
+ * `<base href="{webroot}/gui/static/">` at serve time. Vite builds
+ * with a relative base (`base: './'`), so the hashed assets resolve
+ * through the same tag and lazy chunks resolve via import.meta.url —
+ * nothing else in the bundle needs the prefix baked in.
+ *
+ * Derivation: assetBase is the <base> pathname; appBase (the Vue
+ * Router base) strips the trailing `static/`; serverBase (the prefix
+ * for /api, /comet, /static, … — always slash-terminated) strips the
+ * trailing `gui/`. When no <base> tag matches the expected shape
+ * (vitest's happy-dom, unexpected hosting) everything falls back to
+ * the root-mounted defaults, which are byte-identical to the
+ * pre-webroot behaviour.
+ */
+
+export interface Bases {
+  /** Where the dist assets are served from, e.g. `/tvheadend/gui/static/`. */
+  assetBase: string
+  /** Vue Router base, e.g. `/tvheadend/gui/`. */
+  appBase: string
+  /** Server root for API/static routes, e.g. `/tvheadend/`. */
+  serverBase: string
+}
+
+const ASSET_SUFFIX = 'gui/static/'
+
+export function computeBases(baseUri: string): Bases {
+  let pathname: string | null = null
+  try {
+    pathname = new URL(baseUri).pathname
+  } catch {
+    pathname = null
+  }
+  if (pathname?.endsWith(`/${ASSET_SUFFIX}`)) {
+    const appBase = pathname.slice(0, -'static/'.length)
+    return {
+      assetBase: pathname,
+      appBase,
+      serverBase: appBase.slice(0, -'gui/'.length),
+    }
+  }
+  return { assetBase: '/gui/static/', appBase: '/gui/', serverBase: '/' }
+}
+
+const bases = computeBases(typeof document !== 'undefined' ? document.baseURI : '')
+
+export const assetBase = bases.assetBase
+export const appBase = bases.appBase
+export const serverBase = bases.serverBase
+
+/**
+ * Absolute URL for a server route, honouring the webroot. Input is
+ * the server-root-relative path with or without a leading slash:
+ * `serverUrl('api/epg/events/grid')` → `/tvheadend/api/epg/events/grid`.
+ */
+export function serverUrl(path: string): string {
+  return serverBase + path.replace(/^\/+/, '')
+}

--- a/src/webui/static-vue/src/utils/markdown.ts
+++ b/src/webui/static-vue/src/utils/markdown.ts
@@ -22,6 +22,8 @@
  * legibly (without `**` artifacts becoming HTML).
  */
 
+import { serverUrl } from '@/utils/base'
+
 interface MarkedGlobal {
   marked?: (src: string, opts?: Record<string, unknown>) => string
 }
@@ -34,9 +36,9 @@ export function loadMarkedScript(): Promise<void> {
     }
     const s = document.createElement('script')
     s.id = 'tvh-marked-script'
-    s.src = '/static/app/marked.js'
+    s.src = serverUrl('static/app/marked.js')
     s.onload = () => resolve()
-    s.onerror = () => reject(new Error('Failed to load /static/app/marked.js'))
+    s.onerror = () => reject(new Error('Failed to load static/app/marked.js'))
     document.head.appendChild(s)
   })
 }
@@ -152,14 +154,14 @@ export function extractFirstHeading(html: string, fallback: string): string {
 
 /*
  * Rewrite root-relative `static/…` attribute values to absolute
- * `/static/…`. The compiled-in markdown (wizard step
+ * webroot-aware `/static/…`. The compiled-in markdown (wizard step
  * descriptions + `/markdown/firstconfig` help page) uses paths
  * like `static/img/doc/firstconfig/wizard.png` that work
  * verbatim under ExtJS's `/` root but resolve against the
  * current route under Vue (`/gui/wizard/login` →
- * `/gui/wizard/static/...` → 404). Prepending `/` anchors them
- * at the server root so the existing /static handler serves
- * the asset.
+ * `/gui/wizard/static/...` → 404). Anchoring them at the
+ * webroot-aware server root lets the existing /static handler
+ * serve the asset.
  *
  * Only touches `src=` and `href=` whose value starts with
  * exactly `static/` (no leading slash, no scheme) — external
@@ -169,6 +171,6 @@ export function extractFirstHeading(html: string, fallback: string): string {
 export function rewriteStaticUrls(html: string): string {
   return html.replace(
     /(\s(?:src|href))="(static\/[^"]*)"/g,
-    (_match, attr: string, path: string) => `${attr}="/${path}"`,
+    (_match, attr: string, path: string) => `${attr}="${serverUrl(path)}"`,
   )
 }

--- a/src/webui/static-vue/src/utils/playUrl.ts
+++ b/src/webui/static-vue/src/utils/playUrl.ts
@@ -10,6 +10,8 @@
  * the negotiation that applies it is in the `streamProfiles` store.
  */
 
+import { serverUrl } from '@/utils/base'
+
 /*
  * External-player handoff.
  *
@@ -42,7 +44,7 @@
  * `stream/mux/<uuid>`, or `dvrfile/<uuid>` — and may carry a query
  * string (`?profile=…`, `?title=…`). */
 export function openPlay(path: string): void {
-  globalThis.open(`/play/ticket/${path}`, '_blank', 'noopener,noreferrer')
+  globalThis.open(serverUrl(`play/ticket/${path}`), '_blank', 'noopener,noreferrer')
 }
 
 /*
@@ -58,5 +60,5 @@ export function openPlay(path: string): void {
  * is live-channel only; recordings keep the external-player path.
  */
 export function channelStreamUrl(channelUuid: string, profile: string): string {
-  return `/stream/channel/${channelUuid}?profile=${encodeURIComponent(profile)}`
+  return serverUrl(`stream/channel/${channelUuid}?profile=${encodeURIComponent(profile)}`)
 }

--- a/src/webui/static-vue/src/views/AboutView.vue
+++ b/src/webui/static-vue/src/views/AboutView.vue
@@ -30,6 +30,7 @@
 import { onMounted, ref } from 'vue'
 import { apiCall } from '@/api/client'
 import { useI18n } from '@/composables/useI18n'
+import { serverUrl } from '@/utils/base'
 
 const { t } = useI18n()
 
@@ -68,7 +69,7 @@ const currentYear = new Date().getFullYear()
     </header>
 
     <section class="about__hero">
-      <img class="about__logo" :src="'/static/img/logobig.png'" alt="" />
+      <img class="about__logo" :src="serverUrl('static/img/logobig.png')" alt="" />
       <h2 class="about__title">
         HTS Tvheadend
         <span v-if="info?.sw_version" class="about__version">{{ info.sw_version }}</span>
@@ -172,10 +173,10 @@ const currentYear = new Date().getFullYear()
       <p>
         {{ t('It is not endorsed or certified by') }}
         <a href="https://www.themoviedb.org" target="_blank" rel="noopener noreferrer">TMDb</a>
-        <img class="about__inline-logo" :src="'/static/img/tmdb.png'" alt="" />
+        <img class="about__inline-logo" :src="serverUrl('static/img/tmdb.png')" alt="" />
         {{ t('or by') }}
         <a href="https://thetvdb.com" target="_blank" rel="noopener noreferrer">TheTVDB.com</a>
-        <img class="about__inline-logo" :src="'/static/img/tvdb.png'" alt="" />.
+        <img class="about__inline-logo" :src="serverUrl('static/img/tvdb.png')" alt="" />.
       </p>
     </section>
 
@@ -189,7 +190,7 @@ const currentYear = new Date().getFullYear()
         target="_blank"
         rel="noopener noreferrer"
       >
-        <img :src="'/static/img/opencollective.png'" :alt="t('Donate via OpenCollective')" />
+        <img :src="serverUrl('static/img/opencollective.png')" :alt="t('Donate via OpenCollective')" />
       </a>
     </section>
   </article>

--- a/src/webui/static-vue/src/views/dvr/FailedView.vue
+++ b/src/webui/static-vue/src/views/dvr/FailedView.vue
@@ -36,6 +36,7 @@ import IdnodeGrid from '@/components/IdnodeGrid.vue'
 import ActionMenu from '@/components/ActionMenu.vue'
 import IdnodeEditor from '@/components/IdnodeEditor.vue'
 import type { BaseRow } from '@/types/grid'
+import { serverUrl } from '@/utils/base'
 import { useAccessStore } from '@/stores/access'
 import { useBulkAction } from '@/composables/useBulkAction'
 import { useDvrListView } from '@/composables/useDvrListView'
@@ -115,7 +116,7 @@ function downloadSelection(selected: BaseRow[]) {
   if (selected.length === 0) return
   const uuid = selected[0].uuid
   if (typeof uuid !== 'string' || !uuid) return
-  globalThis.open(`/dvrfile/${uuid}`, '_blank')
+  globalThis.open(serverUrl(`dvrfile/${uuid}`), '_blank')
 }
 </script>
 

--- a/src/webui/static-vue/src/views/dvr/FinishedView.vue
+++ b/src/webui/static-vue/src/views/dvr/FinishedView.vue
@@ -32,6 +32,7 @@ import IdnodeGrid from '@/components/IdnodeGrid.vue'
 import ActionMenu from '@/components/ActionMenu.vue'
 import IdnodeEditor from '@/components/IdnodeEditor.vue'
 import type { BaseRow } from '@/types/grid'
+import { serverUrl } from '@/utils/base'
 import { useAccessStore } from '@/stores/access'
 import { useBulkAction } from '@/composables/useBulkAction'
 import { useDvrListView } from '@/composables/useDvrListView'
@@ -140,7 +141,7 @@ function downloadSelection(selected: BaseRow[]) {
   if (selected.length === 0) return
   const uuid = selected[0].uuid
   if (typeof uuid !== 'string' || !uuid) return
-  globalThis.open(`/dvrfile/${uuid}`, '_blank')
+  globalThis.open(serverUrl(`dvrfile/${uuid}`), '_blank')
 }
 
 /* Play moved from a toolbar `ActionDef` to a per-row icon in

--- a/src/webui/static-vue/src/views/epg/epgGridShared.ts
+++ b/src/webui/static-vue/src/views/epg/epgGridShared.ts
@@ -17,6 +17,7 @@
 
 import type { TooltipMode } from './epgViewOptions'
 import { flattenKodiText } from './kodiText'
+import { serverUrl } from '@/utils/base'
 
 const ONE_HOUR = 3600
 
@@ -118,7 +119,7 @@ function fmtTimeRange(start: number | undefined, stop: number | undefined): stri
 export function iconUrl(icon: string | undefined): string | null {
   if (!icon) return null
   if (icon.startsWith('http://') || icon.startsWith('https://')) return icon
-  return '/' + icon.replace(/^\/+/, '')
+  return serverUrl(icon)
 }
 
 export function channelNumber(ch: GridChannel): string {

--- a/src/webui/static-vue/src/views/home/HomeView.vue
+++ b/src/webui/static-vue/src/views/home/HomeView.vue
@@ -22,6 +22,7 @@ import { useHomeState } from '@/composables/useHomeState'
 import { consumeSetupGreeting } from '@/utils/setupGreeting'
 import { useAccessStore } from '@/stores/access'
 import { cometClient } from '@/api/comet'
+import { serverUrl } from '@/utils/base'
 import { useWizardStore } from '@/stores/wizard'
 import {
   refreshEpg as refreshEpgAction,
@@ -171,7 +172,7 @@ async function onCardAction(actionId: string): Promise<void> {
      * server has one pending. See `NavRail.vue` for the long
      * rationale. */
     try {
-      const res = await fetch('/login', {
+      const res = await fetch(serverUrl('login'), {
         method: 'GET',
         credentials: 'include',
         cache: 'no-store',

--- a/src/webui/static-vue/src/views/wizard/WizardLayout.vue
+++ b/src/webui/static-vue/src/views/wizard/WizardLayout.vue
@@ -32,6 +32,7 @@ import { useRoute } from 'vue-router'
 import ConfirmDialog from 'primevue/confirmdialog'
 import { HelpCircle } from 'lucide-vue-next'
 import { useI18n } from '@/composables/useI18n'
+import { serverUrl } from '@/utils/base'
 import WizardProgress from './WizardProgress.vue'
 import WizardHelpDock from './WizardHelpDock.vue'
 
@@ -56,7 +57,7 @@ const routeKey = computed(() => route.fullPath ?? '')
  * the URL is served at runtime by tvheadend's existing /static
  * handler from the ExtJS bundle.
  */
-const logoUrl = '/static/img/logo.png'
+const logoUrl = serverUrl('static/img/logo.png')
 </script>
 
 <template>

--- a/src/webui/static-vue/src/views/wizard/WizardStepChannels.vue
+++ b/src/webui/static-vue/src/views/wizard/WizardStepChannels.vue
@@ -31,6 +31,7 @@ import WizardFooter from './WizardFooter.vue'
 import { useWizardStore } from '@/stores/wizard'
 import { apiCall } from '@/api/client'
 import { markSetupComplete } from '@/utils/setupGreeting'
+import { appBase } from '@/utils/base'
 import { addExternalLinkAttrs, renderMarkdown, rewriteStaticUrls } from '@/utils/markdown'
 import type { IdnodeProp } from '@/types/idnode'
 
@@ -108,7 +109,7 @@ async function handleFinish(): Promise<void> {
    * the reload — sessionStorage survives the full reload, in-memory
    * state does not. The Home reads + clears it once. */
   markSetupComplete()
-  globalThis.location.assign('/gui/')
+  globalThis.location.assign(appBase)
 }
 
 async function handlePrevious(): Promise<void> {

--- a/src/webui/static-vue/vite.config.ts
+++ b/src/webui/static-vue/vite.config.ts
@@ -9,11 +9,15 @@ import vue from '@vitejs/plugin-vue'
 /*
  * `base` differs between build and dev:
  *
- *   build: '/gui/static/'   — production assets are served by
- *                              tvheadend's C `/gui/static` route
- *                              (page_static_file handler) so the
- *                              hashed URLs in index.html must carry
- *                              that prefix.
+ *   build: './'             — relative base, so the bundle works at
+ *                              ANY mount point (tvheadend_webroot).
+ *                              index.html's asset refs resolve via its
+ *                              `<base href>` tag (rewritten to
+ *                              {webroot}/gui/static/ by vue.c at serve
+ *                              time) and lazy chunks resolve via
+ *                              import.meta.url. Vue Router's base +
+ *                              server-root URLs derive from the same
+ *                              tag — see src/utils/base.ts.
  *
  *   dev:   '/gui/'          — the Vite dev server has no `/static`
  *                              split; the SPA mounts at /gui/ to
@@ -23,7 +27,7 @@ import vue from '@vitejs/plugin-vue'
  *                              be serving at /gui/static/.
  */
 export default defineConfig(({ command }) => ({
-  base: command === 'build' ? '/gui/static/' : '/gui/',
+  base: command === 'build' ? './' : '/gui/',
   plugins: [vue()],
   resolve: {
     alias: {

--- a/src/webui/vue.c
+++ b/src/webui/vue.c
@@ -20,10 +20,61 @@
 #include "tvheadend.h"
 #include "http.h"
 #include "webui.h"
+#include "filebundle.h"
 
 #if ENABLE_VUE_UI
 
 #define VUE_DIST "src/webui/static-vue/dist"
+
+/* The <base href> token in dist/index.html; the webroot is injected
+ * right after `href="` so the SPA discovers its mount point. */
+#define VUE_BASE_TOKEN  "href=\"/gui/static/\""
+#define VUE_BASE_SKIP   6 /* strlen("href=\"") */
+
+/* Serve index.html with tvheadend_webroot injected into its
+ * <base href> so the app derives all URLs from the real mount. */
+static int
+page_vue_index_webroot(http_connection_t *hc)
+{
+  htsbuf_queue_t *hq = &hc->hc_reply;
+  fb_file *fp;
+  char *buf, *pos;
+  size_t size, off = 0;
+
+  fp = fb_open(VUE_DIST "/index.html", 1, 0);
+  if (!fp)
+    return HTTP_STATUS_INTERNAL;
+  size = fb_size(fp);
+  buf = malloc(size + 1);
+  if (!buf) {
+    fb_close(fp);
+    return HTTP_STATUS_INTERNAL;
+  }
+  while (off < size && !fb_eof(fp)) {
+    ssize_t c = fb_read(fp, buf + off, size - off);
+    if (c <= 0)
+      break;
+    off += c;
+  }
+  fb_close(fp);
+  if (off != size) {
+    free(buf);
+    return HTTP_STATUS_INTERNAL;
+  }
+  buf[size] = '\0';
+
+  pos = strstr(buf, VUE_BASE_TOKEN);
+  if (pos) {
+    htsbuf_append(hq, buf, (pos - buf) + VUE_BASE_SKIP);
+    htsbuf_append_str(hq, tvheadend_webroot);
+    htsbuf_append_str(hq, pos + VUE_BASE_SKIP);
+  } else {
+    htsbuf_append(hq, buf, size);
+  }
+  free(buf);
+  http_output_html(hc);
+  return 0;
+}
 
 static int
 page_vue_index(http_connection_t *hc, const char *remain, void *opaque)
@@ -37,7 +88,9 @@ page_vue_index(http_connection_t *hc, const char *remain, void *opaque)
    * + a fixed filename. */
   (void)remain;
   (void)opaque;
-  return page_static_file(hc, "index.html", (void *)VUE_DIST);
+  if (tvheadend_webroot == NULL)
+    return page_static_file(hc, "index.html", (void *)VUE_DIST);
+  return page_vue_index_webroot(hc);
 }
 
 #else /* !ENABLE_VUE_UI */
@@ -58,9 +111,11 @@ page_vue_index(http_connection_t *hc, const char *remain, void *opaque)
     "</head><body>"
     "<h1>Vue UI not available in this build</h1>"
     "<p>This binary was built without the Vue UI "
-    "(neither <code>vue_build</code> nor <code>vue_cache</code> enabled). "
-    "<a href=\"/extjs.html\">Use the ExtJS UI instead.</a></p>"
-    "</body></html>\n");
+    "(neither <code>vue_build</code> nor <code>vue_cache</code> enabled). ");
+  /* Honour the webroot in the escape link. */
+  htsbuf_qprintf(hq,
+    "<a href=\"%s/extjs.html\">Use the ExtJS UI instead.</a></p>"
+    "</body></html>\n", tvheadend_webroot ?: "");
   http_output_html(hc);
   return 0;
 }


### PR DESCRIPTION
Fixes #2167 — with `--http_root` set, the Vue UI flashed, blanked, and the URL accumulated `<webroot>/gui/<webroot>/gui/…` in a redirect loop.

### Cause
The bundle baked absolute asset URLs and a `/gui/` router base at build time, and every server URL the app constructs (`/api`, `/comet/poll`, play/stream/dvrfile links, channel icons, `/static` images, locale/marked loaders, `/markdown` help, login/logout, the Classic UI link) was hardcoded root-absolute. Behind a webroot each of them missed its route, and the server's `page_no_webroot` catch-all turned the misses into 302 cycles (downgrading POSTed API calls to GETs) instead of clean failures. The server side has always been webroot-ready — `http_path_add` registers every route under `tvheadend_webroot` and `http_redirect` prefixes absolute targets — so the gaps were purely client-side.

### Fix — one runtime anchor, everything derived
- `index.html` carries `<base href="/gui/static/">`; **`vue.c` rewrites the href to `{webroot}/gui/static/` at serve time** (no webroot → the file streams untouched, byte-identical to before).
- The production **Vite base is now relative (`'./'`)** — index.html assets resolve through the base tag and lazy chunks via `import.meta.url`, so the bundle works at any mount point (this is Vite's documented "relative base" mechanism for exactly this case).
- New `src/utils/base.ts` derives the **Vue Router base** (`{webroot}/gui/`) and the **server root** (`{webroot}/`) from `document.baseURI`, with root-mounted fallbacks for the dev server and tests.
- Every server URL goes through `serverUrl()` — the API client and comet poll are single choke points; the rest (play tickets, icons, images, auth, help, wizard redirect) were converted individually. The a11y skip-link now jumps via JS since a bare `#fragment` href would resolve against the base tag.

### Tests
- A **source-scan fence**: any new root-absolute server-URL literal outside `utils/base.ts` fails the suite, so the bug can't silently return.
- Unit tests for the base derivation (root, webroot, nested webroot, fallbacks) and a contract test pinning the Vite base + the `index.html` tag the `vue.c` rewrite depends on.
- Full suite: 2642 tests green; the fallback keeps every pre-existing test running unchanged.

### Verified
Both modes against the built binary: without webroot, serving is byte-identical to before. With `--http_root /tvheadend`: injected base tag, `/` → `/tvheadend/` → `/tvheadend/gui/` redirect chain, assets 200 with zero redirects, SPA deep-link reloads, API POSTs, and an old prefix-less URL recovers into the webroot with **no loop** — plus a browser walkthrough of both instances.
