### PR TITLE
fix applying avfilter options for ffmpeg >8

### DIFF
--- a/src/transcoding/transcode/audio.c
+++ b/src/transcoding/transcode/audio.c
@@ -295,15 +295,6 @@ tvh_audio_context_open_filters(TVHContext *self, AVDictionary **opts)
         "abuffer", source_args,                           // source
         filters,                                          // filters
         "abuffersink",                                    // sink
-        "ch_layouts",   AV_OPT_SET_STRING,                // sink option: channel_layout
-        sizeof(ch_layout),
-        ch_layout,
-        "sample_fmts",  AV_OPT_SET_BIN,                   // sink option: sample_fmt
-        sizeof(self->oavctx->sample_fmt),
-        &self->oavctx->sample_fmt,
-        "sample_rates", AV_OPT_SET_BIN,                   // sink option: sample_rate
-        sizeof(self->oavctx->sample_rate),
-        &self->oavctx->sample_rate,
         NULL);                                            // _IMPORTANT!_
 #else
     int ret = tvh_context_open_filters(self,

--- a/src/transcoding/transcode/context.c
+++ b/src/transcoding/transcode/context.c
@@ -102,53 +102,16 @@ _context_print_opts(TVHContext *self, AVDictionary *opts)
 }
 
 
+#if LIBAVCODEC_VERSION_MAJOR <= 59
 static int
 _context_filters_apply_sink_options(TVHContext *self, va_list ap)
 {
     const char *opt_name = NULL;
     const uint8_t *opt_val = NULL;
-#if LIBAVCODEC_VERSION_MAJOR > 59
-    const char *opt_val_char = NULL;
-    av_opt_set_type opt_type = AV_OPT_SET_UNKNOWN;
-    char err_desciption[32];
-#endif
     int opt_size = 0;
     int ret = -1;
 
     while ((opt_name = va_arg(ap, const char *))) {
-#if LIBAVCODEC_VERSION_MAJOR > 59
-        opt_type = (av_opt_set_type) va_arg(ap, int);
-        opt_size = va_arg(ap, int);
-        if (opt_type == AV_OPT_SET_BIN) {
-            opt_val = va_arg(ap, const uint8_t *);
-            ret = av_opt_set_bin(self->oavfltctx, opt_name, opt_val, opt_size, AV_OPT_SEARCH_CHILDREN);}
-        else {
-            if (opt_type == AV_OPT_SET_STRING) {
-                opt_val_char = va_arg(ap, const char *);
-                ret = av_opt_set(self->oavfltctx, opt_name, opt_val_char, AV_OPT_SEARCH_CHILDREN);} 
-            else {
-                tvh_context_log(self, LOG_ERR, "filters: failed to set option: '%s' with error: 'AV_OPT_SET_UNKNOWN'", opt_name);
-                return ret;
-            }
-        }
-        if (ret) {
-            switch (ret) {
-                case AVERROR_OPTION_NOT_FOUND:
-                    str_snprintf(err_desciption, sizeof(err_desciption), "AVERROR_OPTION_NOT_FOUND");
-                    break;
-                case AVERROR(EINVAL):
-                    str_snprintf(err_desciption, sizeof(err_desciption), "AVERROR(EINVAL)");
-                    break;
-                case AVERROR(ENOMEM):
-                    str_snprintf(err_desciption, sizeof(err_desciption), "AVERROR(ENOMEM)");
-                    break;
-                default:
-                    str_snprintf(err_desciption, sizeof(err_desciption), "UNKNOWN ERROR");
-                    break;
-            }
-            tvh_context_log(self, LOG_ERR, "filters: failed to set option: '%s' with error: '%s'", opt_name, err_desciption);
-        }
-#else
         opt_val = va_arg(ap, const uint8_t *);
         opt_size = va_arg(ap, int);
         if ((ret = av_opt_set_bin(self->oavfltctx, opt_name, opt_val, opt_size,
@@ -157,10 +120,10 @@ _context_filters_apply_sink_options(TVHContext *self, va_list ap)
                             opt_name);
             break;
         }
-#endif
     }
     return ret;
 }
+#endif
 
 
 static int
@@ -599,6 +562,37 @@ tvh_context_open_filters(TVHContext *self,
         ret = AVERROR_FILTER_NOT_FOUND;
         goto finish;
     }
+#if LIBAVCODEC_VERSION_MAJOR > 59
+    self->oavfltctx = avfilter_graph_alloc_filter(self->avfltgraph, oavflt, "out");
+    if (!self->oavfltctx) {
+        ret = AVERROR(ENOMEM);
+        goto finish;
+    }
+
+    AVDictionary *opts = NULL;
+    if (self->oavctx) {
+        char ch_layout_str[64];
+        av_channel_layout_describe(&self->oavctx->ch_layout, ch_layout_str, sizeof(ch_layout_str));
+
+        av_dict_set(&opts, "channel_layouts", ch_layout_str, 0);
+
+        char sample_fmt_str[16];
+        snprintf(sample_fmt_str, sizeof(sample_fmt_str), "%s", av_get_sample_fmt_name(self->oavctx->sample_fmt));
+        av_dict_set(&opts, "sample_formats", sample_fmt_str, 0);
+
+        char sample_rate_str[16];
+        snprintf(sample_rate_str, sizeof(sample_rate_str), "%d", self->oavctx->sample_rate);
+        av_dict_set(&opts, "samplerates", sample_rate_str, 0);
+    }
+
+    ret = avfilter_init_dict(self->oavfltctx, &opts);
+    av_dict_free(&opts);
+
+    if (ret < 0) {
+        tvh_context_log(self, LOG_ERR, "filters: failed to initialize sink filter '%s' (Error: %d)", sink_name, ret);
+        goto finish;
+    }
+#else
     ret = avfilter_graph_create_filter(&self->oavfltctx, oavflt, "out",
                                        NULL, NULL, self->avfltgraph);
     if (ret < 0) {
@@ -614,6 +608,7 @@ tvh_context_open_filters(TVHContext *self,
     if (ret) {
         goto finish;
     }
+#endif
 
     // Endpoints for the filter graph.
     iavfltio->name       = av_strdup("out");

--- a/src/transcoding/transcode/context.c
+++ b/src/transcoding/transcode/context.c
@@ -572,13 +572,18 @@ tvh_context_open_filters(TVHContext *self,
     AVDictionary *opts = NULL;
     if (self->oavctx) {
         char ch_layout_str[64];
-        av_channel_layout_describe(&self->oavctx->ch_layout, ch_layout_str, sizeof(ch_layout_str));
+        if (av_channel_layout_describe(&self->oavctx->ch_layout, ch_layout_str, sizeof(ch_layout_str)) >= 0) {
+            av_dict_set(&opts, "channel_layouts", ch_layout_str, 0);
+        } else {
+            tvh_context_log(self, LOG_ERR, "filters: failed to describe channel layout");
+        }
 
-        av_dict_set(&opts, "channel_layouts", ch_layout_str, 0);
-
-        char sample_fmt_str[16];
-        snprintf(sample_fmt_str, sizeof(sample_fmt_str), "%s", av_get_sample_fmt_name(self->oavctx->sample_fmt));
-        av_dict_set(&opts, "sample_formats", sample_fmt_str, 0);
+        const char *fmt_name = av_get_sample_fmt_name(self->oavctx->sample_fmt);
+        if (fmt_name) {
+            av_dict_set(&opts, "sample_formats", fmt_name, 0);
+        } else {
+            tvh_context_log(self, LOG_ERR, "filters: invalid sample format");
+        }
 
         char sample_rate_str[16];
         snprintf(sample_rate_str, sizeof(sample_rate_str), "%d", self->oavctx->sample_rate);


### PR DESCRIPTION
With a current master build and ffmpeg >8 transcoding for using the web player does not work for audio and I see the following in the log:
```
Jul 12 09:21:46 dkrpitv tvheadend[749996]: subscription: 01C7: "HTTP" subscribing on channel "arte HD", weight: 100, adapter: "Sundtek DVB-S/S2 (VIII) #1 : DVB-S #0", network: "Astra_19.2_E", mux: "11493.75H", provider: "ARD", service: "arte HD", profile="webtv-h264-aac-matroska", hostname="192.168.1.12", client="Mozilla/5.0 (Android 16; Mobile; rv:152.0) Gecko/152.0 Firefox/152.0"
Jul 12 09:21:46 dkrpitv tvheadend[749996]: transcode: 0001: 01:H264: ==> Copy
Jul 12 09:21:46 dkrpitv tvheadend[749996]: transcode: 0001: 02:MPEG2AUDIO: ==> Using profile webtv-aac
Jul 12 09:21:46 dkrpitv tvheadend[749996]: transcode: 0001: 03:MPEG2AUDIO: ==> Filtered out
Jul 12 09:21:46 dkrpitv tvheadend[749996]: transcode: 0001: 05:DVBSUB: ==> Filtered out
Jul 12 09:21:46 dkrpitv tvheadend[749996]: transcode: 0001: 06:MPEG2AUDIO: ==> Filtered out
Jul 12 09:21:46 dkrpitv tvheadend[749996]: transcode: 0001: 07:MPEG2AUDIO: ==> Filtered out
Jul 12 09:21:46 dkrpitv tvheadend[749996]: transcode: 0001: 08:DVBSUB: ==> Filtered out
Jul 12 09:21:46 dkrpitv tvheadend[749996]: transcode: 0001: 09:DVBSUB: ==> Filtered out
Jul 12 09:21:46 dkrpitv tvheadend[749996]: transcode: 0001: 11:DVBSUB: ==> Filtered out
Jul 12 09:21:46 dkrpitv tvheadend[749996]: spawn:     Last message repeated 31 times
Jul 12 09:21:46 dkrpitv tvheadend[749996]: spawn: [h264 @ 0xaaaae2f56660] Decoding VUI
Jul 12 09:21:46 dkrpitv tvheadend[749996]: spawn: [h264 @ 0xaaaae2f56660] ct_type:0 pic_struct:0
Jul 12 09:21:47 dkrpitv tvheadend[749996]: libav: AVFilter: Option 'ch_layouts' is not a runtime option and so cannot be set after the object has been initialized
Jul 12 09:21:47 dkrpitv tvheadend[749996]: transcode: 0001: 02:AAC-LATM: [mp2 => aac]: filters: failed to set option: 'ch_layouts' with error: 'AVERROR(EINVAL)'
Jul 12 09:21:47 dkrpitv tvheadend[749996]: libav: AVFilter: Option 'sample_fmts' is not a runtime option and so cannot be set after the object has been initialized
Jul 12 09:21:47 dkrpitv tvheadend[749996]: transcode: 0001: 02:AAC-LATM: [mp2 => aac]: filters: failed to set option: 'sample_fmts' with error: 'AVERROR(EINVAL)'
Jul 12 09:21:47 dkrpitv tvheadend[749996]: libav: AVFilter: Option 'sample_rates' is not a runtime option and so cannot be set after the object has been initialized
Jul 12 09:21:47 dkrpitv tvheadend[749996]: transcode: 0001: 02:AAC-LATM: [mp2 => aac]: filters: failed to set option: 'sample_rates' with error: 'AVERROR(EINVAL)'
Jul 12 09:21:50 dkrpitv systemd-coredump[924684]: Process 749996 (tvheadend) of user 971 dumped core.
                                                  
                                                  Stack trace of thread 924678:
                                                  #0  0x0000ffffab912b08 av_buffersrc_add_frame_flags (libavfilter.so.11 + 0x172b08)
                                                  #1  0x0000aaaac83dd2fc tvh_context_push_frame (tvheadend + 0x30d2fc)
                                                  #2  0x0000aaaac83de408 tvh_context_decode (tvheadend + 0x30e408)
                                                  #3  0x0000aaaac83e0314 tvh_transcoder_handle (tvheadend + 0x310314)
                                                  #4  0x0000aaaac833d7e0 normalize_ts (tvheadend + 0x26d7e0)
                                                  #5  0x0000aaaac833e278 tsfix_backlog (tvheadend + 0x26e278)
                                                  #6  0x0000aaaac8315e84 profile_sharer_thread (tvheadend + 0x245e84)
                                                  #7  0x0000aaaac82b0c50 thread_wrapper (tvheadend + 0x1e0c50)
                                                  #8  0x0000ffffa9578978 n/a (libc.so.6 + 0x88978)
                                                  #9  0x0000ffffa95de75c n/a (libc.so.6 + 0xee75c)
                                                  
                                                  Stack trace of thread 924540:
                                                  #0  0x0000ffffa958f510 strchrnul (libc.so.6 + 0x9f510)
                                                  #1  0x0000ffffa95461d4 n/a (libc.so.6 + 0x561d4)
                                                  #2  0x0000ffffa956cda8 n/a (libc.so.6 + 0x7cda8)
                                                  #3  0x0000ffffa95eb810 __vsnprintf_chk (libc.so.6 + 0xfb810)
                                                  #4  0x0000aaaac82f558c vsnprintf (tvheadend + 0x22558c)
                                                  #5  0x0000aaaac82f5714 htsbuf_qprintf (tvheadend + 0x225714)
                                                  #6  0x0000aaaac82bcb30 http_send_header (tvheadend + 0x1ecb30)
                                                  #7  0x0000aaaac82bdcc8 http_send_reply (tvheadend + 0x1edcc8)
                                                  #8  0x0000aaaac835e8ec comet_mailbox_poll (tvheadend + 0x28e8ec)
                                                  #9  0x0000aaaac82beb9c http_exec (tvheadend + 0x1eeb9c)
                                                  #10 0x0000aaaac82c0270 http_cmd_post (tvheadend + 0x1f0270)
                                                  #11 0x0000aaaac82bf3a0 process_request (tvheadend + 0x1ef3a0)
                                                  #12 0x0000aaaac82c05f8 http_serve_requests (tvheadend + 0x1f05f8)
                                                  #13 0x0000aaaac82c092c http_serve (tvheadend + 0x1f092c)
                                                  #14 0x0000aaaac82b5e34 tcp_server_start (tvheadend + 0x1e5e34)
                                                  #15 0x0000aaaac82b0c50 thread_wrapper (tvheadend + 0x1e0c50)
                                                  #16 0x0000ffffa9578978 n/a (libc.so.6 + 0x88978)
                                                  #17 0x0000ffffa95de75c n/a (libc.so.6 + 0xee75c)
                                                  
                                                  Stack trace of thread 750129:
                                                  #0  0x0000ffffa9581c68 n/a (libc.so.6 + 0x91c68)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa9575424 n/a (libc.so.6 + 0x85424)
                                                  #3  0x0000ffffa9577fc4 pthread_cond_timedwait (libc.so.6 + 0x87fc4)
                                                  #4  0x0000aaaac82b18c8 tvh_cond_timedwait_ts (tvheadend + 0x1e18c8)
                                                  #5  0x0000aaaac82cd5ec _epggrab_internal_thread (tvheadend + 0x1fd5ec)
                                                  #6  0x0000aaaac82b0c50 thread_wrapper (tvheadend + 0x1e0c50)
                                                  #7  0x0000ffffa9578978 n/a (libc.so.6 + 0x88978)
                                                  #8  0x0000ffffa95de75c n/a (libc.so.6 + 0xee75c)
                                                  
                                                  Stack trace of thread 749996:
                                                  #0  0x0000ffffa9581c68 n/a (libc.so.6 + 0x91c68)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa9575424 n/a (libc.so.6 + 0x85424)
                                                  #3  0x0000ffffa9577fc4 pthread_cond_timedwait (libc.so.6 + 0x87fc4)
                                                  #4  0x0000aaaac82b18c8 tvh_cond_timedwait_ts (tvheadend + 0x1e18c8)
                                                  #5  0x0000aaaac829df6c mainloop (tvheadend + 0x1cdf6c)
                                                  #6  0x0000ffffa9512d94 n/a (libc.so.6 + 0x22d94)
                                                  #7  0x0000ffffa9512ef8 __libc_start_main (libc.so.6 + 0x22ef8)
                                                  #8  0x0000aaaac82a0b70 _start (tvheadend + 0x1d0b70)
                                                  
                                                  Stack trace of thread 924681:
                                                  #0  0x0000ffffa9581c68 n/a (libc.so.6 + 0x91c68)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa9575424 n/a (libc.so.6 + 0x85424)
                                                  #3  0x0000ffffa9577ddc pthread_cond_wait (libc.so.6 + 0x87ddc)
                                                  #4  0x0000ffffa9a7a13c n/a (libavutil.so.60 + 0x8a13c)
                                                  #5  0x0000ffffa9578978 n/a (libc.so.6 + 0x88978)
                                                  #6  0x0000ffffa95de75c n/a (libc.so.6 + 0xee75c)
                                                  
                                                  Stack trace of thread 749997:
                                                  #0  0x0000ffffa9581c68 n/a (libc.so.6 + 0x91c68)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa9575424 n/a (libc.so.6 + 0x85424)
                                                  #3  0x0000ffffa9577ddc pthread_cond_wait (libc.so.6 + 0x87ddc)
                                                  #4  0x0000aaaac82b1640 tvh_cond_wait (tvheadend + 0x1e1640)
                                                  #5  0x0000aaaac82a2fa0 tvhlog_thread (tvheadend + 0x1d2fa0)
                                                  #6  0x0000aaaac82b0c50 thread_wrapper (tvheadend + 0x1e0c50)
                                                  #7  0x0000ffffa9578978 n/a (libc.so.6 + 0x88978)
                                                  #8  0x0000ffffa95de75c n/a (libc.so.6 + 0xee75c)
                                                  
                                                  Stack trace of thread 749998:
                                                  #0  0x0000ffffa9581c68 n/a (libc.so.6 + 0x91c68)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa9575424 n/a (libc.so.6 + 0x85424)
                                                  #3  0x0000ffffa9577ddc pthread_cond_wait (libc.so.6 + 0x87ddc)
                                                  #4  0x0000aaaac82b1640 tvh_cond_wait (tvheadend + 0x1e1640)
                                                  #5  0x0000aaaac82c136c notify_thread (tvheadend + 0x1f136c)
                                                  #6  0x0000aaaac82b0c50 thread_wrapper (tvheadend + 0x1e0c50)
                                                  #7  0x0000ffffa9578978 n/a (libc.so.6 + 0x88978)
                                                  #8  0x0000ffffa95de75c n/a (libc.so.6 + 0xee75c)
                                                  
                                                  Stack trace of thread 749999:
                                                  #0  0x0000ffffa9581c6c n/a (libc.so.6 + 0x91c6c)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa95750b8 n/a (libc.so.6 + 0x850b8)
                                                  #3  0x0000ffffa95dea20 epoll_pwait (libc.so.6 + 0xeea20)
                                                  #4  0x0000aaaac82f7304 tvhpoll_wait (tvheadend + 0x227304)
                                                  #5  0x0000aaaac82cef5c spawn_pipe_thread (tvheadend + 0x1fef5c)
                                                  #6  0x0000ffffa9578978 n/a (libc.so.6 + 0x88978)
                                                  #7  0x0000ffffa95de75c n/a (libc.so.6 + 0xee75c)
                                                  
                                                  Stack trace of thread 750116:
                                                  #0  0x0000ffffa9581c68 n/a (libc.so.6 + 0x91c68)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa95af234 clock_nanosleep (libc.so.6 + 0xbf234)
                                                  #3  0x0000aaaac82af9cc tvh_usleep (tvheadend + 0x1df9cc)
                                                  #4  0x0000aaaac82b00c0 tvh_usleep (tvheadend + 0x1e00c0)
                                                  #5  0x0000aaaac82a1608 mtimer_tick_thread (tvheadend + 0x1d1608)
                                                  #6  0x0000aaaac82b0c50 thread_wrapper (tvheadend + 0x1e0c50)
                                                  #7  0x0000ffffa9578978 n/a (libc.so.6 + 0x88978)
                                                  #8  0x0000ffffa95de75c n/a (libc.so.6 + 0xee75c)
                                                  
                                                  Stack trace of thread 750117:
                                                  #0  0x0000ffffa9581c68 n/a (libc.so.6 + 0x91c68)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa9575424 n/a (libc.so.6 + 0x85424)
                                                  #3  0x0000ffffa9577fc4 pthread_cond_timedwait (libc.so.6 + 0x87fc4)
                                                  #4  0x0000aaaac82b17a8 tvh_cond_timedwait (tvheadend + 0x1e17a8)
                                                  #5  0x0000aaaac82a1a14 mtimer_thread (tvheadend + 0x1d1a14)
                                                  #6  0x0000aaaac82b0c50 thread_wrapper (tvheadend + 0x1e0c50)
                                                  #7  0x0000ffffa9578978 n/a (libc.so.6 + 0x88978)
                                                  #8  0x0000ffffa95de75c n/a (libc.so.6 + 0xee75c)
                                                  
                                                  Stack trace of thread 750119:
                                                  #0  0x0000ffffa9581c68 n/a (libc.so.6 + 0x91c68)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa95750b8 n/a (libc.so.6 + 0x850b8)
                                                  #3  0x0000ffffac6e2350 n/a (libmediaclient.so + 0x2350)
                                                  #4  0x0000ffffac6e2350 n/a (libmediaclient.so + 0x2350)
                                                  #5  0x0000ffffac6e2be0 read (libmediaclient.so + 0x2be0)
                                                  #6  0x0000aaaac830e7f0 read (tvheadend + 0x23e7f0)
                                                  
                                                  Stack trace of thread 750120:
                                                  #0  0x0000ffffa9581c68 n/a (libc.so.6 + 0x91c68)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa9575424 n/a (libc.so.6 + 0x85424)
                                                  #3  0x0000ffffa9577fc4 pthread_cond_timedwait (libc.so.6 + 0x87fc4)
                                                  #4  0x0000aaaac82b17a8 tvh_cond_timedwait (tvheadend + 0x1e17a8)
                                                  #5  0x0000aaaac8305b54 imagecache_thread (tvheadend + 0x235b54)
                                                  #6  0x0000aaaac82b0c50 thread_wrapper (tvheadend + 0x1e0c50)
                                                  #7  0x0000ffffa9578978 n/a (libc.so.6 + 0x88978)
                                                  #8  0x0000ffffa95de75c n/a (libc.so.6 + 0xee75c)
                                                  
                                                  Stack trace of thread 750121:
                                                  #0  0x0000ffffa9581c6c n/a (libc.so.6 + 0x91c6c)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa95750b8 n/a (libc.so.6 + 0x850b8)
                                                  #3  0x0000ffffa95dea20 epoll_pwait (libc.so.6 + 0xeea20)
                                                  #4  0x0000aaaac82f7304 tvhpoll_wait (tvheadend + 0x227304)
                                                  #5  0x0000aaaac830c384 http_client_thread (tvheadend + 0x23c384)
                                                  #6  0x0000aaaac82b0c50 thread_wrapper (tvheadend + 0x1e0c50)
                                                  #7  0x0000ffffa9578978 n/a (libc.so.6 + 0x88978)
                                                  #8  0x0000ffffa95de75c n/a (libc.so.6 + 0xee75c)
                                                  
                                                  Stack trace of thread 750122:
                                                  #0  0x0000ffffa9581c68 n/a (libc.so.6 + 0x91c68)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa9575424 n/a (libc.so.6 + 0x85424)
                                                  #3  0x0000ffffa9577ddc pthread_cond_wait (libc.so.6 + 0x87ddc)
                                                  #4  0x0000aaaac82b1640 tvh_cond_wait (tvheadend + 0x1e1640)
                                                  #5  0x0000aaaac82dbedc service_saver (tvheadend + 0x20bedc)
                                                  #6  0x0000aaaac82b0c50 thread_wrapper (tvheadend + 0x1e0c50)
                                                  #7  0x0000ffffa9578978 n/a (libc.so.6 + 0x88978)
                                                  #8  0x0000ffffa95de75c n/a (libc.so.6 + 0xee75c)
                                                  
                                                  Stack trace of thread 750123:
                                                  #0  0x0000ffffa9581c6c n/a (libc.so.6 + 0x91c6c)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa95750b8 n/a (libc.so.6 + 0x850b8)
                                                  #3  0x0000ffffa95dea20 epoll_pwait (libc.so.6 + 0xeea20)
                                                  #4  0x0000aaaac82f7304 tvhpoll_wait (tvheadend + 0x227304)
                                                  #5  0x0000aaaac83c9d04 iptv_input_thread (tvheadend + 0x2f9d04)
                                                  #6  0x0000aaaac82b0c50 thread_wrapper (tvheadend + 0x1e0c50)
                                                  #7  0x0000ffffa9578978 n/a (libc.so.6 + 0x88978)
                                                  #8  0x0000ffffa95de75c n/a (libc.so.6 + 0xee75c)
                                                  
                                                  Stack trace of thread 750124:
                                                  #0  0x0000ffffa9581c6c n/a (libc.so.6 + 0x91c6c)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa95750b8 n/a (libc.so.6 + 0x850b8)
                                                  #3  0x0000ffffa95dea20 epoll_pwait (libc.so.6 + 0xeea20)
                                                  #4  0x0000aaaac82f7304 tvhpoll_wait (tvheadend + 0x227304)
                                                  #5  0x0000aaaac83c9d04 iptv_input_thread (tvheadend + 0x2f9d04)
                                                  #6  0x0000aaaac82b0c50 thread_wrapper (tvheadend + 0x1e0c50)
                                                  #7  0x0000ffffa9578978 n/a (libc.so.6 + 0x88978)
                                                  #8  0x0000ffffa95de75c n/a (libc.so.6 + 0xee75c)
                                                  
                                                  Stack trace of thread 750125:
                                                  #0  0x0000ffffa9581c68 n/a (libc.so.6 + 0x91c68)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa9575424 n/a (libc.so.6 + 0x85424)
                                                  #3  0x0000ffffa9577ddc pthread_cond_wait (libc.so.6 + 0x87ddc)
                                                  #4  0x0000aaaac82b1640 tvh_cond_wait (tvheadend + 0x1e1640)
                                                  #5  0x0000aaaac83d2274 timeshift_reaper_callback (tvheadend + 0x302274)
                                                  #6  0x0000aaaac82b0c50 thread_wrapper (tvheadend + 0x1e0c50)
                                                  #7  0x0000ffffa9578978 n/a (libc.so.6 + 0x88978)
                                                  #8  0x0000ffffa95de75c n/a (libc.so.6 + 0xee75c)
                                                  
                                                  Stack trace of thread 750126:
                                                  #0  0x0000ffffa9581c6c n/a (libc.so.6 + 0x91c6c)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa95750b8 n/a (libc.so.6 + 0x850b8)
                                                  #3  0x0000ffffa95dea20 epoll_pwait (libc.so.6 + 0xeea20)
                                                  #4  0x0000aaaac82f7304 tvhpoll_wait (tvheadend + 0x227304)
                                                  #5  0x0000aaaac82b5fa4 tcp_server_loop (tvheadend + 0x1e5fa4)
                                                  #6  0x0000aaaac82b0c50 thread_wrapper (tvheadend + 0x1e0c50)
                                                  #7  0x0000ffffa9578978 n/a (libc.so.6 + 0x88978)
                                                  #8  0x0000ffffa95de75c n/a (libc.so.6 + 0xee75c)
                                                  
                                                  Stack trace of thread 750127:
                                                  #0  0x0000ffffa9581c6c n/a (libc.so.6 + 0x91c6c)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa95750b8 n/a (libc.so.6 + 0x850b8)
                                                  #3  0x0000ffffa95dea20 epoll_pwait (libc.so.6 + 0xeea20)
                                                  #4  0x0000aaaac82f7304 tvhpoll_wait (tvheadend + 0x227304)
                                                  #5  0x0000aaaac836b224 upnp_thread (tvheadend + 0x29b224)
                                                  #6  0x0000aaaac82b0c50 thread_wrapper (tvheadend + 0x1e0c50)
                                                  #7  0x0000ffffa9578978 n/a (libc.so.6 + 0x88978)
                                                  #8  0x0000ffffa95de75c n/a (libc.so.6 + 0xee75c)
                                                  
                                                  Stack trace of thread 750128:
                                                  #0  0x0000ffffa9581c68 n/a (libc.so.6 + 0x91c68)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa9575424 n/a (libc.so.6 + 0x85424)
                                                  #3  0x0000ffffa9577ddc pthread_cond_wait (libc.so.6 + 0x87ddc)
                                                  #4  0x0000aaaac82b1640 tvh_cond_wait (tvheadend + 0x1e1640)
                                                  #5  0x0000aaaac8307b30 service_mapper_thread (tvheadend + 0x237b30)
                                                  #6  0x0000aaaac82b0c50 thread_wrapper (tvheadend + 0x1e0c50)
                                                  #7  0x0000ffffa9578978 n/a (libc.so.6 + 0x88978)
                                                  #8  0x0000ffffa95de75c n/a (libc.so.6 + 0xee75c)
                                                  
                                                  Stack trace of thread 750130:
                                                  #0  0x0000ffffa9581c68 n/a (libc.so.6 + 0x91c68)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa9575424 n/a (libc.so.6 + 0x85424)
                                                  #3  0x0000ffffa9577ddc pthread_cond_wait (libc.so.6 + 0x87ddc)
                                                  #4  0x0000aaaac82b1640 tvh_cond_wait (tvheadend + 0x1e1640)
                                                  #5  0x0000aaaac82cd8e4 _epggrab_data_thread (tvheadend + 0x1fd8e4)
                                                  #6  0x0000aaaac82b0c50 thread_wrapper (tvheadend + 0x1e0c50)
                                                  #7  0x0000ffffa9578978 n/a (libc.so.6 + 0x88978)
                                                  #8  0x0000ffffa95de75c n/a (libc.so.6 + 0xee75c)
                                                  
                                                  Stack trace of thread 750131:
                                                  #0  0x0000ffffa9581c68 n/a (libc.so.6 + 0x91c68)
                                                  #1  0x0000ffffa9575074 n/a (libc.so.6 + 0x85074)
                                                  #2  0x0000ffffa95750b8 n/a (libc.so.6 + 0x850b8)
                                                  #3  0x0000ffffac6e2350 n/a (libmediaclient.so + 0x2350)
                                                  #4  0x0000ffffac6e2350 n/a (libmediaclient.so + 0x2350)
                                                  #5  0x0000ffffac6e2be0 read (libmediaclient.so + 0x2be0)
                                                  #6  0x0000aaaac83d7da8 read (tvheadend + 0x307da8)
                                                  #7  0x203a6362696c6720 n/a (n/a + 0x0)
                                                  #8  0x203a6362696c6720 n/a (n/a + 0x0)
                                                  ELF object binary architecture: AARCH64
Jul 12 09:21:50 dkrpitv systemd[1]: tvheadend.service: Main process exited, code=dumped, status=11/SEGV
Jul 12 09:21:50 dkrpitv systemd[1]: tvheadend.service: Failed with result 'core-dump'.
Jul 12 09:21:50 dkrpitv systemd[1]: tvheadend.service: Consumed 10min 45.719s CPU time over 1d 15h 41min 21.850s wall clock time.
Jul 12 09:21:51 dkrpitv systemd[1]: tvheadend.service: Scheduled restart job, restart counter is at 1.
```

With the help of Gemini, I was able to produce the following, minimal invasive patch. With this, the web player and transcoding work again.

The pull request fixes applying avfilter options like channel layout, sample format and sample rate for ffmpeg >8

If you need further info, please ask.