### PR TITLE
webui: sort channel numbers numerically in the EPG grids

### DIFF
--- a/src/webui/static-vue/src/components/DataGrid.vue
+++ b/src/webui/static-vue/src/components/DataGrid.vue
@@ -966,11 +966,20 @@ const entriesForTable = computed(() => {
   const userField = props.sortField
   const userOrderMul = props.sortOrder === -1 ? -1 : 1
   const useSecondary = !!userField && userField !== def.field
+  /* Honour the sorted column's custom comparator (e.g.
+   * channelNumber's numeric "major.minor" ordering) for the
+   * within-cluster secondary sort; fall back to the generic
+   * value comparison otherwise. */
+  const userComparator = userField
+    ? props.columns.find((c) => c.field === userField)?.sortComparator
+    : undefined
   projected.sort((a, b) => {
     const primary = compareValues(clusterKeys.get(a), clusterKeys.get(b))
     if (primary !== 0) return primary * groupOrderMul
     if (!useSecondary) return 0
-    return compareValues(a[userField!], b[userField!]) * userOrderMul
+    const av = a[userField!]
+    const bv = b[userField!]
+    return (userComparator ? userComparator(av, bv) : compareValues(av, bv)) * userOrderMul
   })
   return projected
 })

--- a/src/webui/static-vue/src/components/__tests__/DataGrid.test.ts
+++ b/src/webui/static-vue/src/components/__tests__/DataGrid.test.ts
@@ -37,6 +37,7 @@ vi.mock('@/composables/useIsPhone', async () => {
 
 import DataGrid from '../DataGrid.vue'
 import type { ColumnDef } from '@/types/column'
+import { channelNumberCompare } from '@/utils/channelNumberSort'
 
 interface Row extends Record<string, unknown> {
   uuid: string
@@ -570,6 +571,75 @@ describe('DataGrid', () => {
         .props('value') as Array<{ uuid: string }>
       /* Within-cluster ties stay in arrival order (stable sort). */
       expect(value.map((r) => r.uuid)).toEqual(['e2', 'e4', 'e1', 'e3'])
+    })
+
+    it('lazy mode renders entries in the given order without re-sorting', () => {
+      /* The EPG Table owns its sort and hands DataGrid pre-sorted
+       * rows in :lazy mode. Prove the grid renders them as-is — so
+       * applyInMemorySort's output is exactly what reaches the DOM,
+       * and nothing here clobbers the numeric channel order. */
+      const wrapper = mountGrid({
+        lazy: true,
+        sortField: 'bytes',
+        sortOrder: 1,
+        entries: [
+          { uuid: 'a', title: 'A', bytes: 30 },
+          { uuid: 'b', title: 'B', bytes: 10 },
+          { uuid: 'c', title: 'C', bytes: 20 },
+        ],
+      })
+      const value = wrapper
+        .findComponent({ name: 'DataTable' })
+        .props('value') as Array<{ uuid: string }>
+      /* bytes ASC would reorder to b,c,a if the grid re-sorted —
+       * lazy must not: arrival order preserved. */
+      expect(value.map((r) => r.uuid)).toEqual(['a', 'b', 'c'])
+    })
+
+    it('forwards the DataTable sort event so the owner can re-sort', async () => {
+      /* Header click -> PrimeVue emits sort -> DataGrid forwards it
+       * -> the Table view's onSort sets sortField. Prove the relay. */
+      const wrapper = mountGrid({
+        lazy: true,
+        entries: [{ uuid: 'a', title: 'A', bytes: 1 }],
+      })
+      await wrapper
+        .findComponent({ name: 'DataTable' })
+        .vm.$emit('sort', { sortField: 'channelNumber', sortOrder: 1 })
+      expect(wrapper.emitted('sort')).toEqual([
+        [{ sortField: 'channelNumber', sortOrder: 1 }],
+      ])
+    })
+
+    it('uses a column sortComparator for the within-cluster secondary sort', () => {
+      /* channelNumber's "major.minor" string must order numerically
+       * within each cluster, not lexically (10 before 2). */
+      const wrapper = mountGrid({
+        columns: [
+          { field: 'title', label: 'Title', sortable: true },
+          {
+            field: 'channelNumber',
+            label: '#',
+            sortable: true,
+            sortComparator: channelNumberCompare,
+          },
+        ],
+        entries: [
+          { uuid: 'e1', channelNumber: '10', channel: 'ch-uuid-1', channelname: 'Alpha' },
+          { uuid: 'e2', channelNumber: '2', channel: 'ch-uuid-1', channelname: 'Alpha' },
+          { uuid: 'e3', channelNumber: '10.9', channel: 'ch-uuid-1', channelname: 'Alpha' },
+          { uuid: 'e4', channelNumber: '10.10', channel: 'ch-uuid-1', channelname: 'Alpha' },
+        ],
+        groupField: 'channel',
+        groupableFields,
+        sortField: 'channelNumber',
+        sortOrder: 1,
+      })
+      const value = wrapper
+        .findComponent({ name: 'DataTable' })
+        .props('value') as Array<{ uuid: string }>
+      /* 2 < 10 < 10.9 < 10.10 — numeric, not lexical. */
+      expect(value.map((r) => r.uuid)).toEqual(['e2', 'e1', 'e3', 'e4'])
     })
   })
 

--- a/src/webui/static-vue/src/types/column.ts
+++ b/src/webui/static-vue/src/types/column.ts
@@ -111,6 +111,18 @@ export interface ColumnDef {
    * caller).
    */
   computeValue?: (row: BaseRow) => unknown
+  /*
+   * Optional custom comparator for client-side sorting of this
+   * column. Direction-agnostic ascending: return <0 when a sorts
+   * before b; the grid applies the sort direction. Set it when the
+   * column's wire value doesn't sort correctly by default — e.g.
+   * channelNumber's "major.minor" string, which neither
+   * String.localeCompare nor a decimal parse orders right.
+   * Consumed by DataGrid's grouped within-cluster secondary sort
+   * and by callers that own a client-side sort (the EPG Table
+   * view). Ignored in server-side (lazy) sort — the server owns it.
+   */
+  sortComparator?: (a: unknown, b: unknown) => number
   /* Whether the column starts hidden (user can re-enable from the column-toggle menu). */
   hiddenByDefault?: boolean
   /* Initial width in pixels; user can resize and the value is persisted. */

--- a/src/webui/static-vue/src/utils/__tests__/channelNumberSort.test.ts
+++ b/src/webui/static-vue/src/utils/__tests__/channelNumberSort.test.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/*
+ * Unit tests for the channel-number comparator. Covers the
+ * lexical trap (10 before 2) and the decimal trap (10.9 vs 10.10),
+ * since channel numbers are "major.minor" strings on the wire.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { channelNumberCompare } from '../channelNumberSort'
+
+const sorted = (list: readonly (string | null)[]) => [...list].sort(channelNumberCompare)
+
+describe('channelNumberCompare', () => {
+  it('orders whole numbers numerically, not lexically', () => {
+    expect(sorted(['1', '10', '101', '11', '2', '20'])).toEqual([
+      '1',
+      '2',
+      '10',
+      '11',
+      '20',
+      '101',
+    ])
+  })
+
+  it('orders minor parts as integers, not decimals (10.9 before 10.10)', () => {
+    expect(sorted(['10.10', '10.2', '10.100', '10', '10.9', '10.1'])).toEqual([
+      '10',
+      '10.1',
+      '10.2',
+      '10.9',
+      '10.10',
+      '10.100',
+    ])
+  })
+
+  it('treats a bare major as major.0', () => {
+    expect(channelNumberCompare('10', '10.1')).toBeLessThan(0)
+    expect(channelNumberCompare('10', '10')).toBe(0)
+  })
+
+  it('sorts null/undefined first', () => {
+    expect(channelNumberCompare(null, '5')).toBeLessThan(0)
+    expect(channelNumberCompare('5', null)).toBeGreaterThan(0)
+    expect(channelNumberCompare(null, null)).toBe(0)
+    expect(channelNumberCompare(undefined, '5')).toBeLessThan(0)
+  })
+
+  it('accepts numbers as well as strings', () => {
+    expect(channelNumberCompare(2, 10)).toBeLessThan(0)
+    expect(channelNumberCompare(10, 2)).toBeGreaterThan(0)
+  })
+})

--- a/src/webui/static-vue/src/utils/channelNumberSort.ts
+++ b/src/webui/static-vue/src/utils/channelNumberSort.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/*
+ * Comparator for tvheadend channel numbers, which the server
+ * emits as a "major.minor" STRING ("1", "10", "10.1") — see
+ * api_epg_add_channel in src/api/api_epg.c. Neither
+ * String.localeCompare (orders "10" before "2") nor a decimal
+ * parse (as decimals 10.9 > 10.10, but as channel numbers 10.9
+ * precedes 10.10 — the minor is a sub-index up to
+ * CHANNEL_SPLIT-1, not a fraction) sorts these correctly.
+ *
+ * Shared between the EPG Table's in-memory sort and DataGrid's
+ * grouped within-cluster secondary sort via ColumnDef.sortComparator.
+ */
+
+/* Split "major.minor" into two integer parts. Missing/non-numeric
+ * majors sink to the end (Infinity); a missing minor is 0 (bare
+ * "10" == "10.0"). */
+function channelNumberParts(v: unknown): [number, number] {
+  const s = String(v)
+  const dot = s.indexOf('.')
+  const maj = Number(dot < 0 ? s : s.slice(0, dot))
+  const min = dot < 0 ? 0 : Number(s.slice(dot + 1))
+  return [
+    Number.isFinite(maj) ? maj : Number.POSITIVE_INFINITY,
+    Number.isFinite(min) ? min : 0,
+  ]
+}
+
+/* Direction-agnostic ascending comparator: negative when a sorts
+ * before b. Callers apply the sort direction. null/undefined sort
+ * first (matching the grid's generic comparators). */
+export function channelNumberCompare(a: unknown, b: unknown): number {
+  if (a == null && b == null) return 0
+  if (a == null) return -1
+  if (b == null) return 1
+  const [amaj, amin] = channelNumberParts(a)
+  const [bmaj, bmin] = channelNumberParts(b)
+  return amaj !== bmaj ? amaj - bmaj : amin - bmin
+}

--- a/src/webui/static-vue/src/views/epg/TableView.vue
+++ b/src/webui/static-vue/src/views/epg/TableView.vue
@@ -99,6 +99,8 @@ import {
   type EpgGroupField,
   serverParamsFromFilters as serverParamsFromFiltersPure,
 } from './epgTableFilters'
+import { applyInMemorySort } from './epgTableSort'
+import { channelNumberCompare } from '@/utils/channelNumberSort'
 import {
   applyError,
   applyResponse,
@@ -246,6 +248,8 @@ const baseCols: ColumnDef[] = [
     field: 'channelNumber',
     label: '#',
     sortable: true,
+    /* "major.minor" string wire shape — sort numerically. */
+    sortComparator: channelNumberCompare,
     minVisible: 'desktop',
     width: 60,
   },
@@ -1589,38 +1593,6 @@ function applyPerColumnFilters(
   return { rows: out, mutated }
 }
 
-/* Three-way comparator for the in-memory sort. Splits the
- * value-shape branching out of the comparator hot path so the
- * outer pipeline stays simple. Stable: callers `sort` on a
- * fresh array spread; equal-key rows preserve the composable's
- * start-ASC order. */
-function compareSortValues(av: unknown, bv: unknown, dir: number): number {
-  if (av == null && bv == null) return 0
-  if (av == null) return -dir
-  if (bv == null) return dir
-  if (typeof av === 'number' && typeof bv === 'number') return (av - bv) * dir
-  return String(av).localeCompare(String(bv)) * dir
-}
-
-/* Apply the user's current in-memory sort. Skip the
- * spread+sort when the data is already start-ASC (the
- * composable's own ordering) — saves an N-element copy +
- * sort during the initial-load reactive cascade. */
-function applyInMemorySort(
-  rows: readonly EpgRow[],
-  key: string | null,
-  order: number,
-): { rows: readonly EpgRow[]; mutated: boolean } {
-  if (!key) return { rows, mutated: false }
-  if (key === 'start' && order === 1) return { rows, mutated: false }
-  const sorted = [...rows].sort((a, b) => {
-    const av = (a as unknown as Record<string, unknown>)[key]
-    const bv = (b as unknown as Record<string, unknown>)[key]
-    return compareSortValues(av, bv, order)
-  })
-  return { rows: sorted, mutated: true }
-}
-
 const visibleEvents = computed<EpgRow[]>(() => {
   const inQueryMode = queryResults.value !== null
   const grouped = state.viewOptions.value.groupField !== null
@@ -1640,7 +1612,13 @@ const visibleEvents = computed<EpgRow[]>(() => {
   const source = pickVisibleSource(realEvents, inQueryMode, grouped)
 
   const filtered = applyPerColumnFilters(source, filters.value.perColumn, inQueryMode)
-  const sorted = applyInMemorySort(filtered.rows, sortField.value, sortOrder.value)
+  const sortComparator = baseCols.find((c) => c.field === sortField.value)?.sortComparator
+  const sorted = applyInMemorySort(
+    filtered.rows,
+    sortField.value,
+    sortOrder.value,
+    sortComparator,
+  )
 
   /* Return the original source reference when nothing
    * narrowed or re-ordered — lets downstream computeds skip

--- a/src/webui/static-vue/src/views/epg/__tests__/epgTableSort.test.ts
+++ b/src/webui/static-vue/src/views/epg/__tests__/epgTableSort.test.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/*
+ * Unit tests for the EPG Table in-memory sort helpers extracted
+ * from TableView.vue. The channelNumber numeric ordering itself
+ * lives in utils/channelNumberSort (tested there); here we verify
+ * the generic comparator and that applyInMemorySort defers to a
+ * supplied column comparator.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { applyInMemorySort, compareSortValues } from '../epgTableSort'
+import { channelNumberCompare } from '@/utils/channelNumberSort'
+
+const numbers = (rows: readonly { channelNumber?: string | null }[]) =>
+  rows.map((r) => r.channelNumber)
+
+describe('compareSortValues (generic columns)', () => {
+  it('compares numbers numerically', () => {
+    expect(compareSortValues(2, 10, 1)).toBeLessThan(0)
+  })
+  it('compares text with localeCompare', () => {
+    expect(compareSortValues('ARD', 'ZDF', 1)).toBeLessThan(0)
+  })
+  it('would order numeric strings lexically (why channelNumber needs a comparator)', () => {
+    expect(compareSortValues('10', '2', 1)).toBeLessThan(0)
+  })
+  it('respects direction and null-first contract', () => {
+    expect(compareSortValues('a', 'b', -1)).toBeGreaterThan(0)
+    expect(compareSortValues(null, 'x', 1)).toBeLessThan(0)
+  })
+})
+
+describe('applyInMemorySort', () => {
+  it('uses the supplied comparator for channelNumber (ascending)', () => {
+    const rows = [
+      { channelNumber: '1' },
+      { channelNumber: '10' },
+      { channelNumber: '101' },
+      { channelNumber: '11' },
+      { channelNumber: '2' },
+      { channelNumber: '20' },
+    ]
+    const out = applyInMemorySort(rows, 'channelNumber', 1, channelNumberCompare)
+    expect(out.mutated).toBe(true)
+    expect(numbers(out.rows)).toEqual(['1', '2', '10', '11', '20', '101'])
+  })
+
+  it('orders major.minor via the comparator, descending', () => {
+    const rows = [
+      { channelNumber: '10.10' },
+      { channelNumber: '10.2' },
+      { channelNumber: '10.9' },
+    ]
+    const out = applyInMemorySort(rows, 'channelNumber', -1, channelNumberCompare)
+    expect(numbers(out.rows)).toEqual(['10.10', '10.9', '10.2'])
+  })
+
+  it('falls back to the generic comparator when none is supplied', () => {
+    const rows = [{ channelName: 'ZDF' }, { channelName: 'ARD' }]
+    const out = applyInMemorySort(rows, 'channelName', 1)
+    expect(out.rows.map((r) => r.channelName)).toEqual(['ARD', 'ZDF'])
+  })
+
+  it('skips the copy+sort for the default start-ASC ordering', () => {
+    const rows = [{ start: 3 }, { start: 1 }, { start: 2 }]
+    const out = applyInMemorySort(rows, 'start', 1)
+    expect(out.mutated).toBe(false)
+    expect(out.rows).toBe(rows)
+  })
+
+  it('is a no-op when no sort key is set', () => {
+    const rows = [{ channelNumber: '2' }]
+    const out = applyInMemorySort(rows, null, 1)
+    expect(out.mutated).toBe(false)
+    expect(out.rows).toBe(rows)
+  })
+})

--- a/src/webui/static-vue/src/views/epg/epgTableSort.ts
+++ b/src/webui/static-vue/src/views/epg/epgTableSort.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/*
+ * In-memory sort for the EPG Table view, extracted from
+ * TableView.vue so the wire-shape handling is unit-testable.
+ *
+ * The Table view owns its sort (DataTable runs in :lazy mode).
+ * Most columns use the generic three-way comparator below; a
+ * column can override it with a direction-agnostic
+ * ColumnDef.sortComparator (e.g. channelNumber, whose
+ * "major.minor" string wire shape needs numeric ordering).
+ */
+
+/* Three-way comparator for the in-memory sort. Splits the
+ * value-shape branching out of the comparator hot path so the
+ * outer pipeline stays simple. Stable: callers `sort` on a
+ * fresh array spread; equal-key rows preserve the composable's
+ * start-ASC order. */
+export function compareSortValues(av: unknown, bv: unknown, dir: number): number {
+  if (av == null && bv == null) return 0
+  if (av == null) return -dir
+  if (bv == null) return dir
+  if (typeof av === 'number' && typeof bv === 'number') return (av - bv) * dir
+  return String(av).localeCompare(String(bv)) * dir
+}
+
+/* Apply the user's current in-memory sort. Skip the spread+sort
+ * when the data is already start-ASC (the composable's own
+ * ordering) — saves an N-element copy + sort during the
+ * initial-load reactive cascade. `comparator` is the active
+ * column's direction-agnostic ColumnDef.sortComparator, when set. */
+export function applyInMemorySort<T>(
+  rows: readonly T[],
+  key: string | null,
+  order: number,
+  comparator?: (a: unknown, b: unknown) => number,
+): { rows: readonly T[]; mutated: boolean } {
+  if (!key) return { rows, mutated: false }
+  if (key === 'start' && order === 1) return { rows, mutated: false }
+  const sorted = [...rows].sort((a, b) => {
+    const av = (a as unknown as Record<string, unknown>)[key]
+    const bv = (b as unknown as Record<string, unknown>)[key]
+    return comparator ? comparator(av, bv) * order : compareSortValues(av, bv, order)
+  })
+  return { rows: sorted, mutated: true }
+}


### PR DESCRIPTION
### What

In the Vue Web GUI's EPG Table view (`/gui/epg/table`), clicking the Channel Number column header (`#`) sorted channels as text — `1, 10, 101, 11, 2, 20…` — instead of numerically `1, 2, 3…`. Reported in #2172.

The same lexical fallback also affected `DataGrid`'s grouped within-cluster secondary sort, so both paths are fixed here.

### Why

The EPG Table owns its own sort (the DataTable runs in `:lazy` mode). Its client-side comparators only compared numerically when both values were JS numbers, otherwise falling back to `String.localeCompare`. The channel number arrives from `epg/events/grid` as a `"major.minor"` **string** (`api_epg_add_channel` in `src/api/api_epg.c`), so it took the lexical path.

### Fix

Add a shared `channelNumberCompare` (`utils/channelNumberSort`) that splits the value into **major and minor integer parts** and compares major first, then minor. The minor is a sub-index up to `CHANNEL_SPLIT - 1` (`channels.h`), not a fraction — so a plain decimal parse would also be wrong: as decimals `10.9 > 10.10`, but as channel numbers `10.9` must precede `10.10`.

Expose it generically through a new optional `ColumnDef.sortComparator` (direction-agnostic) so no grid needs to know about channel numbers:
- the EPG Table's `#` column sets it, and `applyInMemorySort` (extracted to `epgTableSort.ts`) uses the active column's comparator;
- `DataGrid`'s grouped secondary sort uses the sorted column's comparator, falling back to the generic value comparison.

### Testing

- New/updated unit tests: the comparator (lexical + `10.9`/`10.10` decimal traps), `applyInMemorySort` deferring to the column comparator, `DataGrid`'s within-cluster secondary sort honouring it, plus lazy-mode order-preservation and `sort`-event forwarding.
- Full Vue suite green (183 files, 2661 tests); `vue-tsc` type-check, ESLint, SPDX header check clean; `npm run build` succeeds.

Fixes #2172