### PR TITLE
webui: fix status bandwidth reporting (subscriptions + streams)

### DIFF
--- a/src/webui/static-vue/src/stores/__tests__/status.test.ts
+++ b/src/webui/static-vue/src/stores/__tests__/status.test.ts
@@ -30,11 +30,18 @@ vi.mock('@/api/client', () => ({
   apiCall: (...args: unknown[]) => apiMock(...args),
 }))
 
-/* Comet's `on` is invoked at store creation; stub so it doesn't try
- * to register against the real client. We don't drive Comet events
- * in these tests — store-level fetch / merge is what we're after. */
+/* Capture the handler each store registers so tests can drive Comet
+ * events. Keyed by notification class; last registration wins (each
+ * test uses a unique endpoint, so its store's handler is the latest). */
+const cometMock = vi.hoisted(() => {
+  const handlers = new Map<string, (msg: unknown) => void>()
+  return {
+    handlers,
+    on: (cls: string, fn: (msg: unknown) => void) => handlers.set(cls, fn),
+  }
+})
 vi.mock('@/api/comet', () => ({
-  cometClient: { on: vi.fn() },
+  cometClient: { on: cometMock.on },
 }))
 
 interface Row extends Record<string, unknown> {
@@ -168,5 +175,70 @@ describe('useStatusStore', () => {
     resolveFn({ entries: [] })
     await inflight
     expect(store.loading).toBe(false)
+  })
+
+  /*
+   * input_status regression: the bps counter is reset on every read
+   * (api/status/inputs resets it), so a refetch triggered by the
+   * notification would return a fraction of a second's data. The
+   * store must apply the pushed payload in place and NOT re-poll.
+   */
+  describe('input_status applies the notification in place (no refetch)', () => {
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
+    it('updates the row from the payload without calling apiCall again', async () => {
+      apiMock.mockResolvedValueOnce({
+        entries: [{ uuid: 'i1', name: 'Tuner', bps: 8_000_000 }],
+      })
+      const store = useStatusStore<Row>('status/inputs-a', 'input_status', 'uuid')
+      const handler = cometMock.handlers.get('input_status')!
+      await store.fetch()
+      expect(apiMock).toHaveBeenCalledTimes(1) /* the initial load */
+
+      /* Server's 1-second tick pushes the full-second value — the
+       * real message carries the `notificationClass` envelope
+       * discriminator alongside the data fields. */
+      handler({
+        notificationClass: 'input_status',
+        uuid: 'i1',
+        bps: 6_000_000,
+        signal: 900,
+        update: 1,
+      })
+      vi.advanceTimersByTime(500) /* well past the refetch debounce */
+
+      const row = store.entries.find((r) => r.uuid === 'i1')!
+      expect(row.bps).toBe(6_000_000) /* applied from the payload */
+      expect(row.signal).toBe(900)
+      expect(row.update).toBeUndefined() /* control flag stripped */
+      expect(row.notificationClass).toBeUndefined() /* envelope stripped */
+      expect(apiMock).toHaveBeenCalledTimes(1) /* NO counter-resetting refetch */
+    })
+
+    it('falls back to a refetch on a reload notification', async () => {
+      apiMock.mockResolvedValueOnce({ entries: [{ uuid: 'i1', name: 'Tuner' }] })
+      const store = useStatusStore<Row>('status/inputs-b', 'input_status', 'uuid')
+      const handler = cometMock.handlers.get('input_status')!
+      await store.fetch()
+      expect(apiMock).toHaveBeenCalledTimes(1)
+
+      apiMock.mockResolvedValueOnce({ entries: [{ uuid: 'i2', name: 'Tuner 2' }] })
+      handler({ reload: 1 })
+      await vi.advanceTimersByTimeAsync(200) /* debounce elapses */
+      expect(apiMock).toHaveBeenCalledTimes(2) /* structural change refetches */
+    })
+
+    it('falls back to a refetch when the pushed row is unknown', async () => {
+      apiMock.mockResolvedValueOnce({ entries: [{ uuid: 'i1', name: 'Tuner' }] })
+      const store = useStatusStore<Row>('status/inputs-c', 'input_status', 'uuid')
+      const handler = cometMock.handlers.get('input_status')!
+      await store.fetch()
+
+      apiMock.mockResolvedValueOnce({ entries: [{ uuid: 'i1' }, { uuid: 'i9' }] })
+      handler({ uuid: 'i9', bps: 1000, update: 1 }) /* i9 not loaded yet */
+      await vi.advanceTimersByTimeAsync(200)
+      expect(apiMock).toHaveBeenCalledTimes(2)
+    })
   })
 })

--- a/src/webui/static-vue/src/stores/status.ts
+++ b/src/webui/static-vue/src/stores/status.ts
@@ -58,6 +58,20 @@ import { cometClient } from '@/api/comet'
 
 const COMET_REFETCH_DEBOUNCE_MS = 100
 
+/* Comet envelope fields — stripped before a notification payload is
+ * merged onto a row so they don't pollute the row's data fields:
+ * the structural / update flags plus `notificationClass`, the
+ * dispatch discriminator every Comet message carries. */
+const CONTROL_KEYS = new Set([
+  'reload',
+  'update',
+  'updateEntry',
+  'create',
+  'change',
+  'delete',
+  'notificationClass',
+])
+
 /*
  * Row alias — Status entries are loosely typed records; the grid's
  * `keyField` prop tells consumers which field is the identifier
@@ -166,14 +180,46 @@ export function useStatusStore<Row extends StatusEntry = StatusEntry>(
       }
 
       /*
-       * Comet listener — refetch silently on any notification
-       * carrying `reload`, an `update*` field, or a `delete` array.
-       * Silent mode skips the loading flag, avoiding the
-       * loading-overlay flash on every 2-second bandwidth update.
-       * The status notification shapes vary per class (input_status
-       * uses `update`, subscriptions uses `updateEntry` + `id`, etc.)
-       * so this is a permissive check rather than tight type
-       * narrowing.
+       * `input_status` carries a reset-on-read bandwidth counter: the
+       * server's 1-second timer reads-and-resets `bps` and pushes the
+       * full-second value in the notification. The generic refetch
+       * path below would then re-poll api/status/inputs, which resets
+       * the counter AGAIN mid-window, so the poll returns only a
+       * fraction of a second's data — bandwidth reads ~8-10x too low
+       * and the refresh cadence is erratic. For this class we apply
+       * the pushed payload in place instead (matching the Classic UI's
+       * update handler), so no counter-resetting poll fires.
+       * subscriptions / connections read their counters without
+       * resetting, so they keep the simpler full-refetch path.
+       */
+      const mergeFromNotification = notificationClass === 'input_status'
+
+      /*
+       * Merge a per-row notification payload onto the matching
+       * existing row, in place (same object identity, reactive fields
+       * update one-by-one — same mechanism mergeByKey relies on).
+       * Returns false when the row is unknown (a newly-started stream
+       * the caller must refetch to pick up).
+       */
+      function applyNotification(msg: Record<string, unknown>): boolean {
+        const key = msg[keyField]
+        if (key == null) return false
+        const existing = (entries.value as Row[]).find((r) => r[keyField] === key)
+        if (!existing) return false
+        const row = existing as Record<string, unknown>
+        for (const [k, v] of Object.entries(msg)) {
+          if (!CONTROL_KEYS.has(k)) row[k] = v
+        }
+        return true
+      }
+
+      /*
+       * Comet listener — refetch silently on any notification carrying
+       * `reload`, an `update*` field, a `change`, `create` or `delete`.
+       * Silent mode skips the loading flag, avoiding the loading-
+       * overlay flash on every bandwidth update. The notification
+       * shapes vary per class (input_status uses `update`, subscriptions
+       * uses `updateEntry` + `id`, etc.) so this is a permissive check.
        */
       cometClient.on(notificationClass, (msg) => {
         const note = msg as IdnodeNotification & {
@@ -181,16 +227,25 @@ export function useStatusStore<Row extends StatusEntry = StatusEntry>(
           updateEntry?: unknown
           update?: unknown
         }
+        const structural =
+          !!note.reload ||
+          (note.create?.length ?? 0) > 0 ||
+          (note.delete?.length ?? 0) > 0
+        const fieldUpdate =
+          !!note.update || !!note.updateEntry || (note.change?.length ?? 0) > 0
+        if (!structural && !fieldUpdate) return
+
+        /* Apply the pushed row in place for reset-on-read endpoints so
+         * no counter-resetting poll fires; unknown rows fall through
+         * to the refetch below. */
         if (
-          !note.reload &&
-          !note.updateEntry &&
-          !note.update &&
-          (note.create?.length ?? 0) === 0 &&
-          (note.change?.length ?? 0) === 0 &&
-          (note.delete?.length ?? 0) === 0
+          !structural &&
+          mergeFromNotification &&
+          applyNotification(msg as Record<string, unknown>)
         ) {
           return
         }
+
         clearTimeout(refetchTimer)
         refetchTimer = globalThis.setTimeout(() => {
           void fetch({ silent: true })

--- a/src/webui/static-vue/src/views/status/SubscriptionsView.vue
+++ b/src/webui/static-vue/src/views/status/SubscriptionsView.vue
@@ -35,8 +35,14 @@ const fmtHexId = (v: unknown) => {
   return ('0000000' + v.toString(16).toUpperCase()).slice(-8)
 }
 
+/* `in` / `out` are BYTES per second (the 1-second byte delta;
+ * subscriptions.c). The column header is kb/s (kilobits), so
+ * convert bytes/s -> kbit/s = *8 / 1000. Matches Classic's
+ * subscriptions renderer (status.js: value / 125), which the
+ * previous /1024 diverged from by a factor of ~8. The Number.isFinite
+ * guard keeps malformed data from rendering as "NaN" / "Infinity". */
 const fmtKbps = (v: unknown) =>
-  typeof v === 'number' ? Math.round(v / 1024).toString() : ''
+  typeof v === 'number' && Number.isFinite(v) ? Math.round((v * 8) / 1000).toString() : ''
 
 const fmtPids = (v: unknown) => {
   if (!Array.isArray(v) || v.length === 0) return ''

--- a/src/webui/static-vue/src/views/status/__tests__/SubscriptionsView.test.ts
+++ b/src/webui/static-vue/src/views/status/__tests__/SubscriptionsView.test.ts
@@ -44,4 +44,19 @@ describe('SubscriptionsView — column formatting', () => {
     const id = gridColumns().find((c) => c.field === 'id')
     expect(id?.format?.(0x1a2b, {})).toBe('00001A2B')
   })
+
+  it('converts Input/Output from bytes/s to kb/s (kilobits), matching Classic', () => {
+    const cols = gridColumns()
+    const input = cols.find((c) => c.field === 'in')
+    const output = cols.find((c) => c.field === 'out')
+    /* 1,500,000 bytes/s = 12 Mbit/s -> 12000 kb/s (bytes*8/1000),
+     * NOT 1465 (the old bytes/1024). */
+    expect(input?.format?.(1_500_000, {})).toBe('12000')
+    expect(output?.format?.(1_500_000, {})).toBe('12000')
+    expect(input?.format?.(0, {})).toBe('0')
+    expect(input?.format?.('n/a', {})).toBe('')
+    /* malformed data must not render as "NaN" / "Infinity". */
+    expect(input?.format?.(NaN, {})).toBe('')
+    expect(input?.format?.(Infinity, {})).toBe('')
+  })
 })


### PR DESCRIPTION
### What

Two bandwidth bugs on the Status page, both reported in #2175.

**Subscriptions tab** — the Input/Output columns showed values ~8× too small compared to the classic UI.

**Streams tab** — input bandwidth read ~8–10× too low, with an erratic refresh cadence (raised in [this comment](https://github.com/tvheadend/tvheadend/issues/2175#issuecomment-4970844044)).

### Why

**Subscriptions:** `in` / `out` are the 1-second byte delta — **bytes/sec** (`ths_bytes_in_avg` in `subscriptions.c`). The header is **kb/s (kilobits)**, so the value must be `bytes/s × 8 ÷ 1000`. The Vue formatter divided by 1024, dropping the ×8 and under-reporting by ~8.2×.

**Streams:** the input `bps` counter is **reset on every read** (`atomic_exchange` in `mpegts_input.c`). The server's 1-second timer reads-and-resets it and pushes the full-second value in the `input_status` Comet notification. The Vue status store discarded that payload and re-polled `api/status/inputs` ~100 ms later, which reset the counter *again* mid-window — returning only a fraction of a second's data. Because each mux fires its own notification (each triggering a debounced refetch that resets all counters), the values were both too low and erratic. Subscriptions are immune because their counters are read with `atomic_get` (no reset) — which is why that tab wasn't affected by the erratic refresh.

### Fix

- **Subscriptions:** convert `bytes/s → kbit/s` (`× 8 ÷ 1000`), matching the classic renderer (`status.js`: `value / 125`) and the subscription bandwidth chart (which already scales by 8).
- **Streams:** for the `input_status` class, apply the pushed Comet payload in place instead of re-polling — matching the classic UI's update handler (`r.data.bps = m.bps`). No counter-resetting poll fires, so values are the correct full-second rate and the cadence is the steady 1 Hz tick. subscriptions / connections keep the refetch path (their counters don't reset on read).

### Testing

- Subscriptions: column-format test asserts `1,500,000 bytes/s → "12000"` (12 Mbit/s), not the old `1465`.
- Streams: status-store tests assert an `input_status` notification updates the row in place **without** an extra `apiCall`, and that `reload` / unknown-row notifications still fall back to a refetch.
- Full Vue suite green; `vue-tsc`, ESLint, SPDX header check clean; `npm run build` succeeds.

Fixes #2175