### PR TITLE
mpegts: per-network default for automatic EPG source mapping on new channels

### DIFF
--- a/src/input/mpegts.h
+++ b/src/input/mpegts.h
@@ -374,6 +374,7 @@ struct mpegts_network
   int      mn_autodiscovery;
   int      mn_skipinitscan;
   int      mn_bouquet;
+  int      mn_epgauto_default;
   char    *mn_charset;
   int      mn_idlescan;
   int      mn_ignore_chnum;

--- a/src/input/mpegts/mpegts_network.c
+++ b/src/input/mpegts/mpegts_network.c
@@ -237,6 +237,18 @@ const idclass_t mpegts_network_class =
       .off      = offsetof(mpegts_network_t, mn_bouquet),
       .notify   = mpegts_network_class_notify_bouquet,
     },
+    {
+      .type     = PT_BOOL,
+      .id       = "epgauto_default",
+      .name     = N_("Auto-map EPG source on new channels"),
+      .desc     = N_("Initial value of the channel option \"Automatically "
+                     "map EPG source\" for channels created from this "
+                     "network. Changing this setting does not affect "
+                     "existing channels."),
+      .off      = offsetof(mpegts_network_t, mn_epgauto_default),
+      .opts     = PO_ADVANCED,
+      .def.i    = 1,
+    },
 
     {
       .type     = PT_BOOL,
@@ -567,6 +579,7 @@ mpegts_network_create0
   mn->mn_satpos = INT_MAX;
   mn->mn_skipinitscan = 1;
   mn->mn_autodiscovery = MN_DISCOVERY_NEW;
+  mn->mn_epgauto_default = 1;
 
   /* Load config */
   if (conf)

--- a/src/service_mapper.c
+++ b/src/service_mapper.c
@@ -27,6 +27,7 @@
 #include "profile.h"
 #include "bouquet.h"
 #include "api.h"
+#include "input.h"
 
 typedef struct service_mapper_item {
   TAILQ_ENTRY(service_mapper_item) link;
@@ -272,6 +273,16 @@ service_mapper_process
   if (!chn || (bq && chn->ch_bouquet != bq)) {
     chn = channel_create(NULL, NULL, NULL);
     chn->ch_bouquet = bq;
+
+#if ENABLE_MPEGTS
+    /* Take the initial "Automatically map EPG source" value from the
+     * network of the service the channel is created for */
+    if (idnode_is_instance(&s->s_id, &mpegts_service_class)) {
+      mpegts_service_t *ms = (mpegts_service_t *)s;
+      if (ms->s_dvb_mux && ms->s_dvb_mux->mm_network)
+        chn->ch_epgauto = ms->s_dvb_mux->mm_network->mn_epgauto_default;
+    }
+#endif
   }
     
   /* Map */


### PR DESCRIPTION
Channels created by the service mapper or bouquet mapping always start with "Automatically map EPG source" enabled, hardcoded in channel_create0(). Whether that is desirable depends on the network the channel comes from: on DVB networks the OTA EIT grabber follows the service mapping regardless, while the flag lets any enabled grabber channel with a matching name attach itself. On IPTV networks name matching is usually exactly what is wanted.

Add a per-network option "Auto-map EPG source on new channels" (default enabled, so behaviour is unchanged) that supplies the initial value of the per-channel option at channel creation time. The per-channel option remains authoritative for the grabbers and changing the network option does not modify existing channels. Channels merged into an existing channel keep that channel's setting; the network of the service that first created the channel determines the initial value.

No UI changes are required or included; both the ExtJS and Vue interfaces render the new option through the generic idnode forms.

Implements #2177.
