### PR TITLE
build: add nodejs and npm to dockerfile

### DIFF
--- a/Containerfile.alpine
+++ b/Containerfile.alpine
@@ -34,6 +34,8 @@ RUN apk add --no-cache \
         'uriparser-dev' \
         'wget' \
         'zlib-dev' \
+        'nodejs' \
+        'npm' \
     && \
     git config --global --add safe.directory '/src/data/dvb-scan' && \
     ./configure \

--- a/Containerfile.debian
+++ b/Containerfile.debian
@@ -41,6 +41,8 @@ RUN apt-get update --yes && apt-get install --yes \
         'python3-requests' \
         'wget' \
         'zlib1g-dev' \
+        'nodejs' \
+        'npm' \
     && \
     git config --global --add safe.directory '/src/data/dvb-scan' && \
     ./configure \


### PR DESCRIPTION
Installs Node.js and npm to support the Vue.js build process. Previously, the Vue.js assets were not being included in the image because the JavaScript runtime was missing.