### PR TITLE
tvhdhomerun: rework tvhdhomerun frontend

### DIFF
--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun.c
@@ -202,6 +202,33 @@ const idclass_t tvhdhomerun_device_class =
     },
     {
       .type     = PT_STR,
+      .id       = "fe_override",
+      .name     = N_("Network type"),
+      .opts     = PO_SORTKEY,
+      .set      = tvhdhomerun_device_class_override_set,
+      .notify   = tvhdhomerun_device_class_override_notify,
+      .list     = tvhdhomerun_device_class_override_enum,
+      .off      = offsetof(tvhdhomerun_device_t, hd_type),
+    },
+    {
+      .type     = PT_BOOL,
+      .id       = "fullmux_ok",
+      .name     = N_("Full mux RX mode supported"),
+      .desc     = N_("Enable or disable full mux mode."),
+      .opts     = PO_ADVANCED,
+      .off      = offsetof(tvhdhomerun_device_t, hd_fullmux_ok),
+    },
+    {
+      .type     = PT_INT,
+      .id       = "pids_max",
+      .name     = N_("Maximum PIDs"),
+      .desc     = N_("Set the maxiumum packet identifiers your HDHomeRun "
+                     "server supports."),
+      .opts     = PO_ADVANCED,
+      .off      = offsetof(tvhdhomerun_device_t, hd_pids_max),
+    },
+    {
+      .type     = PT_STR,
       .id       = "networkType",
       .name     = N_("Network"),
       .opts     = PO_RDONLY | PO_NOSAVE,
@@ -234,16 +261,6 @@ const idclass_t tvhdhomerun_device_class =
       .name     = N_("Device model"),
       .opts     = PO_RDONLY | PO_NOSAVE,
       .off      = offsetof(tvhdhomerun_device_t, hd_info.deviceModel),
-    },
-    {
-      .type     = PT_STR,
-      .id       = "fe_override",
-      .name     = N_("Network type"),
-      .opts     = PO_ADVANCED,
-      .set      = tvhdhomerun_device_class_override_set,
-      .notify   = tvhdhomerun_device_class_override_notify,
-      .list     = tvhdhomerun_device_class_override_enum,
-      .off      = offsetof(tvhdhomerun_device_t, hd_type),
     },
     {}
   }
@@ -350,9 +367,7 @@ static void tvhdhomerun_device_create(struct hdhomerun_discover_device_t *dInfo)
 
   /* some sane defaults */
   hd->hd_fullmux_ok  = 1;
-  hd->hd_pids_len    = 127;
-  hd->hd_pids_max    = 32;
-  hd->hd_pids_deladd = 1;
+  hd->hd_pids_max    = 128;
 
   if (!tvh_hardware_create0((tvh_hardware_t*)hd, &tvhdhomerun_device_class,
                             uhex, conf))

--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c
@@ -23,7 +23,7 @@
 #include "tvheadend.h"
 #include "tvhpoll.h"
 #include "streaming.h"
-#include "tcp.h"
+#include "udp.h"
 #include "tvhdhomerun_private.h"
 
 #include <arpa/inet.h>
@@ -44,7 +44,8 @@ tvhdhomerun_frontend_get_priority ( mpegts_input_t *mi, mpegts_mux_t *mm, int fl
 static int
 tvhdhomerun_frontend_get_grace ( mpegts_input_t *mi, mpegts_mux_t *mm )
 {
-  return 15;
+  tvhdhomerun_frontend_t *hfe = (tvhdhomerun_frontend_t*)mi;
+  return hfe->hf_grace_period > 0 ? MINMAX(hfe->hf_grace_period, 1, 60) : 5;
 }
 
 static int
@@ -54,172 +55,17 @@ tvhdhomerun_frontend_is_enabled
   return mpegts_input_is_enabled(mi, mm, flags, weight);
 }
 
-static void *
-tvhdhomerun_frontend_input_thread ( void *aux )
+static void
+tvhdhomerun_frontend_stop_streaming(tvhdhomerun_frontend_t *hfe)
 {
-  tvhdhomerun_frontend_t *hfe = aux;
-  mpegts_mux_instance_t *mmi;
-  sbuf_t sb;
-  char buf[256];
-  char target[64];
-  uint32_t local_ip;
-  int sockfd, nfds;
-  int sock_opt = 1;
-  int r;
-  int rx_size = 1024 * 1024;
-  struct sockaddr_in sock_addr;
-  socklen_t sockaddr_len = sizeof(sock_addr);
-  tvhpoll_event_t ev[2];
-  tvhpoll_t *efd;
-
-  tvhdebug(LS_TVHDHOMERUN, "starting input thread");
-
-  /* Get MMI */
-  tvh_mutex_lock(&hfe->hf_input_thread_mutex);
-  hfe->mi_display_name((mpegts_input_t*)hfe, buf, sizeof(buf));
-  mmi = LIST_FIRST(&hfe->mi_mux_active);
-  tvh_cond_signal(&hfe->hf_input_thread_cond, 0);
-  tvh_mutex_unlock(&hfe->hf_input_thread_mutex);
-  if (mmi == NULL) return NULL;
-
-  tvhdebug(LS_TVHDHOMERUN, "opening client socket");
-
-  /* One would like to use libhdhomerun for the streaming details,
-   * but that library uses threads on its own and the socket is put
-   * into a ring buffer. That makes it less practical to use here,
-   * so we do the whole UPD recv() stuff ourselves. And we can assume
-   * POSIX here ;)
-   */
-
-  /* local IP */
-  /* TODO: this is nasty */
-  if (*config.local_ip == 0)
-    local_ip = hdhomerun_device_get_local_machine_addr(hfe->hf_hdhomerun_tuner);
-  else if (inet_pton(AF_INET, config.local_ip, &local_ip))
-    local_ip = ntohl(local_ip);
-  else
-    tvherror(LS_TVHDHOMERUN, "failed to parse local IP (%s)", config.local_ip);
-
-  /* first setup a local socket for the device to stream to */
-  sockfd = tvh_socket(AF_INET, SOCK_DGRAM, 0);
-  if(sockfd == -1) {
-    tvherror(LS_TVHDHOMERUN, "failed to open socket (%d)", errno);
-    return NULL;
-  }
-
-  if(fcntl(sockfd, F_SETFL, O_NONBLOCK) != 0) {
-    close(sockfd);
-    tvherror(LS_TVHDHOMERUN, "failed to set socket nonblocking (%d)", errno);
-    return NULL;
-  }
-
-  /* enable broadcast */
-  if(setsockopt(sockfd, SOL_SOCKET, SO_BROADCAST, (char *) &sock_opt, sizeof(sock_opt)) < 0) {
-    close(sockfd);
-    tvherror(LS_TVHDHOMERUN, "failed to enable broadcast on socket (%d)", errno);
-    return NULL;
-  }
-
-  if(setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, (char *) &sock_opt, sizeof(sock_opt)) < 0) {
-    close(sockfd);
-    tvherror(LS_TVHDHOMERUN, "failed to set address reuse on socket (%d)", errno);
-    return NULL;
-  }
-
-  /* important: we need large rx buffers to accommodate the large amount of traffic */
-  if(setsockopt(sockfd, SOL_SOCKET, SO_RCVBUF, (char *) &rx_size, sizeof(rx_size)) < 0) {
-    tvhwarn(LS_TVHDHOMERUN, "failed set socket rx buffer size, expect CC errors (%d)", errno);
-  }
-
-  memset(&sock_addr, 0, sizeof(sock_addr));
-  sock_addr.sin_family = AF_INET;
-  sock_addr.sin_addr.s_addr = htonl(INADDR_ANY);
-  sock_addr.sin_port = config.local_port==0?0:htons(config.local_port + hfe->hf_tunerNumber);
-  if(bind(sockfd, (struct sockaddr *) &sock_addr, sizeof(sock_addr)) != 0) {
-    tvherror(LS_TVHDHOMERUN, "failed bind socket: %d", errno);
-    close(sockfd);
-    return NULL;
-  }
-
-  memset(&sock_addr, 0, sizeof(sock_addr));
-  if(getsockname(sockfd, (struct sockaddr *) &sock_addr, &sockaddr_len) != 0) {
-    tvherror(LS_TVHDHOMERUN, "failed to getsockname: %d", errno);
-    close(sockfd);
-    return NULL;
-  }
-
-  /* pretend we are smart and set video_socket; doubt that this is required though */
-  //hfe->hf_hdhomerun_tuner->vs = sockfd;
-
-  /* and tell the device to stream to the local port */
-  memset(target, 0, sizeof(target));
-  snprintf(target, sizeof(target), "udp://%u.%u.%u.%u:%u",
-    (unsigned int)(local_ip >> 24) & 0xFF,
-    (unsigned int)(local_ip >> 16) & 0xFF,
-    (unsigned int)(local_ip >>  8) & 0xFF,
-    (unsigned int)(local_ip >>  0) & 0xFF,
-    ntohs(sock_addr.sin_port));
-  tvhdebug(LS_TVHDHOMERUN, "setting target to: %s", target);
   tvh_mutex_lock(&hfe->hf_hdhomerun_device_mutex);
-  r = hdhomerun_device_set_tuner_target(hfe->hf_hdhomerun_tuner, target);
-  tvh_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
-  if(r < 1) {
-    tvherror(LS_TVHDHOMERUN, "failed to set target: %d", r);
-    close(sockfd);
-    return NULL;
-  }
-
-  /* the poll set includes the sockfd and the pipe for IPC */
-  efd = tvhpoll_create(2);
-  tvhpoll_event(ev+0, sockfd, TVHPOLL_IN, hfe);
-  tvhpoll_event(ev+1, hfe->hf_input_thread_pipe.rd, TVHPOLL_IN,
-                &hfe->hf_input_thread_pipe);
-
-  r = tvhpoll_add(efd, ev, 2);
-  if(r < 0)
-    tvherror(LS_TVHDHOMERUN, "failed to setup poll");
-
-  sbuf_init_fixed(&sb, (20000000 / 8));
-
-  /* TODO: flush buffer? */
-
-  while(tvheadend_is_running()) {
-    nfds = tvhpoll_wait(efd, ev, 1, -1);
-
-    if (nfds < 1) continue;
-    if (ev[0].ptr != hfe) break;
-
-    if((r = sbuf_read(&sb, sockfd)) < 0) {
-      /* whoopsy */
-      if(ERRNO_AGAIN(errno))
-        continue;
-      if(errno == EOVERFLOW) {
-        tvhwarn(LS_TVHDHOMERUN, "%s - read() EOVERFLOW", buf);
-        continue;
-      }
-      tvherror(LS_TVHDHOMERUN, "%s - read() error %d (%s)",
-               buf, errno, strerror(errno));
-      break;
-    }
-
-    //if(r != (7*188))
-      //continue; /* dude; this is not a valid packet */
-
-    //tvhdebug(LS_TVHDHOMERUN, "got r=%d (thats %d)", r, (r == 7*188));
-
-    mpegts_input_recv_packets(mmi, &sb, 0, NULL);
-  }
-
-  tvhdebug(LS_TVHDHOMERUN, "setting target to none");
-  tvh_mutex_lock(&hfe->hf_hdhomerun_device_mutex);
-  hdhomerun_device_set_tuner_target(hfe->hf_hdhomerun_tuner, "none");
-  hdhomerun_device_tuner_lockkey_release(hfe->hf_hdhomerun_tuner);
+  hdhomerun_device_set_tuner_channel(hfe->hf_hdhomerun_tuner, "none");
   tvh_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
 
-  sbuf_free(&sb);
-  tvhpoll_destroy(efd);
-  close(sockfd);
-  return NULL;
+  hfe->hf_locked = 0;
+  hfe->hf_running  = 0;
+  hfe->hf_status = SIGNAL_NONE;
+  hfe->hf_last_tune = getfastmonoclock();
 }
 
 static void
@@ -231,27 +77,35 @@ tvhdhomerun_frontend_monitor_cb( void *aux )
   streaming_message_t      sm;
   signal_status_t          sigstat;
   service_t               *svc;
-  int                      res, e;
+  int                      res;
+  char                     buf[256];
 
   struct hdhomerun_tuner_status_t tuner_status;
-  char *tuner_status_str;
 
   /* Stop timer */
-  if (!mmi || !hfe->hf_ready) return;
+  if (!mmi) return;
 
-  /* re-arm */
-  mtimer_arm_rel(&hfe->hf_monitor_timer, tvhdhomerun_frontend_monitor_cb,
-                 hfe, sec2mono(1));
+  if (!hfe->hf_tables) {
+    psi_tables_install(mmi->mmi_input, mmi->mmi_mux,
+                       ((dvb_mux_t *)mmi->mmi_mux)->lm_tuning.dmc_fe_delsys);
+    hfe->hf_tables = 1;
+  }
+
+  hfe->mi_display_name((mpegts_input_t*)hfe, buf, sizeof(buf));
 
   /* Get current status */
   tvh_mutex_lock(&hfe->hf_hdhomerun_device_mutex);
-  res = hdhomerun_device_get_tuner_status(hfe->hf_hdhomerun_tuner, &tuner_status_str, &tuner_status);
+  res = hdhomerun_device_get_tuner_status(hfe->hf_hdhomerun_tuner, NULL, &tuner_status);
   tvh_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
-  if(res < 1)
-    tvhwarn(LS_TVHDHOMERUN, "tuner_status (%d)", res);
+  if(res < 0)
+    tvhdebug(LS_TVHDHOMERUN, "%s - tuner_status: device %s communication error", buf, hfe->hf_device->hd_info.friendlyname);
+  if(res == 0)
+    tvhdebug(LS_TVHDHOMERUN, "%s - tuner_status: device %s in use", buf, hfe->hf_device->hd_info.friendlyname);
 
   if(tuner_status.signal_present)
     hfe->hf_status = SIGNAL_GOOD;
+  else if (tuner_status.lock_supported || tuner_status.lock_unsupported)
+    hfe->hf_status = SIGNAL_UNKNOWN;
   else
     hfe->hf_status = SIGNAL_NONE;
 
@@ -261,41 +115,30 @@ tvhdhomerun_frontend_monitor_cb( void *aux )
   /* wait for a signal_present */
   if(!hfe->hf_locked) {
     if(tuner_status.signal_present) {
-      tvhdebug(LS_TVHDHOMERUN, "locked");
+      tvhdebug(LS_TVHDHOMERUN, "%s - tuner_status: signal locked", buf);
       hfe->hf_locked = 1;
 
       /* Get CableCARD variables */
       if (hfe->hf_type == DVB_TYPE_CABLECARD) {
         dvb_mux_t *lm = (dvb_mux_t *)mm;
         struct hdhomerun_tuner_vstatus_t tuner_vstatus;
-        char *tuner_vstatus_str;
         tvh_mutex_lock(&hfe->hf_hdhomerun_device_mutex);
         res = hdhomerun_device_get_tuner_vstatus(hfe->hf_hdhomerun_tuner,
-                                                 &tuner_vstatus_str, &tuner_vstatus);
+                                                 NULL, &tuner_vstatus);
         tvh_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
-        if (res < 1)
-          tvhwarn(LS_TVHDHOMERUN, "tuner_vstatus (%d)", res);
+        if(res < 0)
+          tvhdebug(LS_TVHDHOMERUN, "%s - tuner_vstatus: device %s communication error", buf, hfe->hf_device->hd_info.friendlyname);
+        if(res == 0)
+          tvhdebug(LS_TVHDHOMERUN, "%s - tuner_vstatus: device %s in use", buf, hfe->hf_device->hd_info.friendlyname);
+
+        free(lm->lm_tuning.u.dmc_fe_cablecard.name);
         lm->lm_tuning.u.dmc_fe_cablecard.name = strdup(tuner_vstatus.name);
-        sscanf(strstr(tuner_status.channel, ":"), ":%u", &lm->lm_tuning.dmc_fe_freq);
+
+        char *p = strchr(tuner_status.channel, ':');
+        if (p)
+          sscanf(p, ":%u", &lm->lm_tuning.dmc_fe_freq);
       }
 
-      /* start input thread */
-      tvh_pipe(O_NONBLOCK, &hfe->hf_input_thread_pipe);
-      tvh_mutex_lock(&hfe->hf_input_thread_mutex);
-      tvh_thread_create(&hfe->hf_input_thread, NULL, tvhdhomerun_frontend_input_thread, hfe, "hdhm-front");
-      do {
-        e = tvh_cond_wait(&hfe->hf_input_thread_cond, &hfe->hf_input_thread_mutex);
-        if (e == ETIMEDOUT)
-          break;
-      } while (ERRNO_AGAIN(e));
-      tvh_mutex_unlock(&hfe->hf_input_thread_mutex);
-
-      /* install table handlers */
-      psi_tables_install(mmi->mmi_input, mm,
-                         ((dvb_mux_t *)mm)->lm_tuning.dmc_fe_delsys);
-
-    } else { // quick re-arm the timer to wait for signal lock
-      mtimer_arm_rel(&hfe->hf_monitor_timer, tvhdhomerun_frontend_monitor_cb, hfe, ms2mono(50));
     }
   }
 
@@ -306,7 +149,8 @@ tvhdhomerun_frontend_monitor_cb( void *aux )
     mmi->tii_stats.snr = tuner_status.signal_to_noise_quality * 655.35;
     mmi->tii_stats.signal = tuner_status.signal_strength * 655.35;
   } else {
-    mmi->tii_stats.snr = 0;
+    mmi->tii_stats.snr = SIGNAL_NONE;
+    mmi->tii_stats.signal = SIGNAL_NONE;
   }
 
   sigstat.status_text  = signal2str(hfe->hf_status);
@@ -327,104 +171,230 @@ tvhdhomerun_frontend_monitor_cb( void *aux )
     streaming_service_deliver(svc, streaming_msg_clone(&sm));
     tvh_mutex_unlock(&svc->s_stream_mutex);
   }
+
+  /* re-arm */
+  mtimer_arm_rel(&hfe->hf_monitor_timer, tvhdhomerun_frontend_monitor_cb,
+                 hfe, sec2mono(1));
 }
 
-static int tvhdhomerun_frontend_tune(tvhdhomerun_frontend_t *hfe, mpegts_mux_instance_t *mmi)
+static uint32_t get_local_ip(struct hdhomerun_device_t *tuner)
 {
-  hfe->hf_status          = SIGNAL_NONE;
-  dvb_mux_t *lm = (dvb_mux_t*)mmi->mmi_mux;
-  dvb_mux_conf_t *dmc = &lm->lm_tuning;
-  char channel_buf[64];
+  uint32_t local_ip;
+  if (*config.local_ip == 0)
+    return hdhomerun_device_get_local_machine_addr(tuner);
+
+  if (inet_pton(AF_INET, config.local_ip, &local_ip) == 1)
+    return ntohl(local_ip);
+
+  return hdhomerun_device_get_local_machine_addr(tuner);
+}
+
+static int tvhdhomerun_frontend_lockkey_request(tvhdhomerun_frontend_t *hfe, const char *name)
+{
+  int res;
+  char *error = NULL;
+
+  /*
+   * Attempt to aquire lock.
+   */
+  tvh_mutex_lock(&hfe->hf_hdhomerun_device_mutex);
+  res = hdhomerun_device_tuner_lockkey_request(hfe->hf_hdhomerun_tuner, &error);
+  tvh_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
+  if (res > 0)  {
+    return res;
+  }
+  if (res < 0) {
+    tvherror(LS_TVHDHOMERUN, "%s - lockkey_request: device %s communication error", name, hfe->hf_device->hd_info.friendlyname);
+    return res;
+  }
+
+  /*
+   * In use - check target.
+   */
+  char *target;
+  tvh_mutex_lock(&hfe->hf_hdhomerun_device_mutex);
+	res = hdhomerun_device_get_tuner_target(hfe->hf_hdhomerun_tuner, &target);
+  tvh_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
+	if (res < 0) {
+		tvherror(LS_TVHDHOMERUN, "%s - lockkey_request_target: device %s communication error", name, hfe->hf_device->hd_info.friendlyname);
+		return -1;
+	}
+	if (res == 0) {
+    tvherror(LS_TVHDHOMERUN, "%s - lockkey_request_target: device %s in use, failed to read target", name, hfe->hf_device->hd_info.friendlyname);
+		return -1;
+	}
+
+	if (strcmp(target, "none") == 0) {
+    tvherror(LS_TVHDHOMERUN, "%s - lockkey_request: device %s in use, no target set", name, hfe->hf_device->hd_info.friendlyname);
+		return -1;
+	}
+
+	if ((strncmp(target, "udp://", 6) != 0) && (strncmp(target, "rtp://", 6) != 0)) {
+    tvherror(LS_TVHDHOMERUN, "%s - lockkey_request: device %s in use by %s", name, hfe->hf_device->hd_info.friendlyname, target);
+		return -1;
+	}
+
+	unsigned int a[4];
+	unsigned int target_port;
+	if (sscanf(target + 6, "%u.%u.%u.%u:%u", &a[0], &a[1], &a[2], &a[3], &target_port) != 5) {
+    tvherror(LS_TVHDHOMERUN, "%s - lockkey_request: device %s in use, unexpected target set (%s)", name, hfe->hf_device->hd_info.friendlyname, target);
+		return -1;
+	}
+
+	uint32_t target_ip = (uint32_t)((a[0] << 24) | (a[1] << 16) | (a[2] << 8) | (a[3] << 0));
+	uint32_t local_ip = get_local_ip(hfe->hf_hdhomerun_tuner);
+	if (target_ip != local_ip) {
+    tvherror(LS_TVHDHOMERUN, "%s - lockkey_request: device %s in use by %s", name, hfe->hf_device->hd_info.friendlyname, target);
+		return -1;
+	}
+
+	/*
+   * Dead local target, force clear lock.
+   */
+  tvh_mutex_lock(&hfe->hf_hdhomerun_device_mutex);
+	res = hdhomerun_device_tuner_lockkey_force(hfe->hf_hdhomerun_tuner);
+  tvh_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
+	if (res < 0) {
+    tvherror(LS_TVHDHOMERUN, "%s - lockkey_force: device %s communication error", name, hfe->hf_device->hd_info.friendlyname);
+		return -1;
+	}
+	if (res == 0) {
+    tvherror(LS_TVHDHOMERUN, "%s - lockkey_force: device %s in use by local machine, dead target, failed to force release lockkey", name, hfe->hf_device->hd_info.friendlyname);
+		return -1;
+	}
+
+  tvhinfo(LS_TVHDHOMERUN, "%s - lockkey_force: device %s in use by local machine, dead target, lockkey force successful", name, hfe->hf_device->hd_info.friendlyname);
+
+	/*
+   * Attempt to aquire lock.
+   */
+  tvh_mutex_lock(&hfe->hf_hdhomerun_device_mutex);
+	res = hdhomerun_device_tuner_lockkey_request(hfe->hf_hdhomerun_tuner, &error);
+  tvh_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
+	if (res > 0) {
+		return res;
+	}
+	if (res < 0) {
+		tvherror(LS_TVHDHOMERUN, "%s - lockkey_request: device %s communication error", name, hfe->hf_device->hd_info.friendlyname);
+		return res;
+	}
+
+  tvherror(LS_TVHDHOMERUN, "%s - lockkey_request: device %s still in use after lockkey force (%s)", name, hfe->hf_device->hd_info.friendlyname, error);
+	return -1;
+}
+
+static void
+tvhdhomerun_build_channel_buf(const dvb_mux_conf_t *dmc, char *channel_buf, size_t channel_len)
+{
   uint32_t symbol_rate = 0;
   uint8_t bandwidth = 0;
-  int res;
-  char *perror;
 
-  /* resolve the modulation type */
   switch (dmc->dmc_fe_type) {
+
     case DVB_TYPE_C:
-      /* the symbol rate */
       symbol_rate = dmc->u.dmc_fe_qam.symbol_rate / 1000;
-      switch(dmc->dmc_fe_modulation) {
+      switch (dmc->dmc_fe_modulation) {
         case DVB_MOD_QAM_64:
-          snprintf(channel_buf, sizeof(channel_buf), "a8qam64-%d:%u", symbol_rate, dmc->dmc_fe_freq);
+          snprintf(channel_buf, channel_len, "a8qam64-%u:%u",
+                   symbol_rate, dmc->dmc_fe_freq);
           break;
         case DVB_MOD_QAM_256:
-          snprintf(channel_buf, sizeof(channel_buf), "a8qam256-%d:%u", symbol_rate, dmc->dmc_fe_freq);
+          snprintf(channel_buf, channel_len, "a8qam256-%u:%u",
+                   symbol_rate, dmc->dmc_fe_freq);
           break;
         default:
-          snprintf(channel_buf, sizeof(channel_buf), "auto:%u", dmc->dmc_fe_freq);
+          snprintf(channel_buf, channel_len, "auto:%u", dmc->dmc_fe_freq);
           break;
       }
       break;
+
     case DVB_TYPE_T:
       bandwidth = dmc->u.dmc_fe_ofdm.bandwidth / 1000UL;
       switch (dmc->dmc_fe_modulation) {
         case DVB_MOD_AUTO:
-            if (dmc->u.dmc_fe_ofdm.bandwidth == DVB_BANDWIDTH_AUTO) {
-                snprintf(channel_buf, sizeof(channel_buf), "auto:%u", dmc->dmc_fe_freq);
-            } else {
-                snprintf(channel_buf, sizeof(channel_buf), "auto%dt:%u", bandwidth, dmc->dmc_fe_freq);
-            }
-            break;
+          if (dmc->u.dmc_fe_ofdm.bandwidth == DVB_BANDWIDTH_AUTO)
+            snprintf(channel_buf, channel_len, "auto:%u", dmc->dmc_fe_freq);
+          else
+            snprintf(channel_buf, channel_len, "auto%dt:%u",
+                     bandwidth, dmc->dmc_fe_freq);
+          break;
+
         case DVB_MOD_QAM_256:
-            if (dmc->dmc_fe_delsys == DVB_SYS_DVBT2) {
-                snprintf(channel_buf, sizeof(channel_buf), "tt%dqam256:%u", bandwidth, dmc->dmc_fe_freq);
-            } else {
-                snprintf(channel_buf, sizeof(channel_buf), "t%dqam256:%u", bandwidth, dmc->dmc_fe_freq);
-            }
-            break;
+          if (dmc->dmc_fe_delsys == DVB_SYS_DVBT2)
+            snprintf(channel_buf, channel_len, "tt%dqam256:%u",
+                     bandwidth, dmc->dmc_fe_freq);
+          else
+            snprintf(channel_buf, channel_len, "t%dqam256:%u",
+                     bandwidth, dmc->dmc_fe_freq);
+          break;
+
         case DVB_MOD_QAM_64:
-            if (dmc->dmc_fe_delsys == DVB_SYS_DVBT2) {
-                snprintf(channel_buf, sizeof(channel_buf), "tt%dqam64:%u", bandwidth, dmc->dmc_fe_freq);
-            } else {
-                snprintf(channel_buf, sizeof(channel_buf), "t%dqam64:%u", bandwidth, dmc->dmc_fe_freq);
-            }
-            break;
+          if (dmc->dmc_fe_delsys == DVB_SYS_DVBT2)
+            snprintf(channel_buf, channel_len, "tt%dqam64:%u",
+                     bandwidth, dmc->dmc_fe_freq);
+          else
+            snprintf(channel_buf, channel_len, "t%dqam64:%u",
+                     bandwidth, dmc->dmc_fe_freq);
+          break;
+
         default:
-            /* probably won't work but never mind */
-            snprintf(channel_buf, sizeof(channel_buf), "auto:%u", dmc->dmc_fe_freq);
-            break;
+          snprintf(channel_buf, channel_len, "auto:%u", dmc->dmc_fe_freq);
+          break;
       }
       break;
+
     case DVB_TYPE_CABLECARD:
-      snprintf(channel_buf, sizeof(channel_buf), "%u", dmc->u.dmc_fe_cablecard.vchannel);
+      snprintf(channel_buf, channel_len, "%u",
+               dmc->u.dmc_fe_cablecard.vchannel);
       break;
+
     case DVB_TYPE_ATSC_T:
-      switch(dmc->dmc_fe_modulation) {
+      switch (dmc->dmc_fe_modulation) {
         case DVB_MOD_VSB_8:
-          snprintf(channel_buf, sizeof(channel_buf), "auto6t:%u", dmc->dmc_fe_freq);
+          snprintf(channel_buf, channel_len, "auto6t:%u", dmc->dmc_fe_freq);
           break;
         default:
-          snprintf(channel_buf, sizeof(channel_buf), "auto:%u", dmc->dmc_fe_freq);
+          snprintf(channel_buf, channel_len, "auto:%u", dmc->dmc_fe_freq);
           break;
       }
       break;
+
     default:
-      snprintf(channel_buf, sizeof(channel_buf), "auto:%u", dmc->dmc_fe_freq);
+      snprintf(channel_buf, channel_len, "auto:%u", dmc->dmc_fe_freq);
       break;
   }
+}
 
-  tvhinfo(LS_TVHDHOMERUN, "tuning to %s", channel_buf);
+static int tvhdhomerun_frontend_tune(tvhdhomerun_frontend_t *hfe, mpegts_mux_instance_t *mmi)
+{
+  dvb_mux_t *lm = (dvb_mux_t*)mmi->mmi_mux;
+  dvb_mux_conf_t *dmc = &lm->lm_tuning;
+  char channel_buf[64];
+  char buf[256];
+  int res;
+
+  hfe->mi_display_name((mpegts_input_t*)hfe, buf, sizeof(buf));
+
+  /* resolve the modulation type */
+  tvhdhomerun_build_channel_buf(dmc, channel_buf, sizeof(channel_buf));
+
+  tvhdebug(LS_TVHDHOMERUN, "%s - tuning to %s", buf, channel_buf);
 
   tvh_mutex_lock(&hfe->hf_hdhomerun_device_mutex);
-  
-  res = hdhomerun_device_tuner_lockkey_request(hfe->hf_hdhomerun_tuner, &perror);
-  if(res < 1) {
-    tvh_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
-    tvherror(LS_TVHDHOMERUN, "failed to acquire lockkey: %s", perror);
-    return SM_CODE_TUNING_FAILED;
-  }
   
   if (hfe->hf_type == DVB_TYPE_CABLECARD)
     res = hdhomerun_device_set_tuner_vchannel(hfe->hf_hdhomerun_tuner, channel_buf);
   else
     res = hdhomerun_device_set_tuner_channel(hfe->hf_hdhomerun_tuner, channel_buf);
 
-  if(res < 1) {
-    hdhomerun_device_tuner_lockkey_release(hfe->hf_hdhomerun_tuner);
+  if(res < 0) {
     tvh_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
-    tvherror(LS_TVHDHOMERUN, "failed to tune to %s", channel_buf);
+    tvhdebug(LS_TVHDHOMERUN, "%s - tune error: device %s communication error", buf, hfe->hf_device->hd_info.friendlyname);
+    return SM_CODE_TUNING_FAILED;
+  }
+  if(res == 0) {
+    tvh_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
+    tvhdebug(LS_TVHDHOMERUN, "%s - tune error: device %s in use", buf, hfe->hf_device->hd_info.friendlyname);
     return SM_CODE_TUNING_FAILED;
   }
 
@@ -433,10 +403,22 @@ static int tvhdhomerun_frontend_tune(tvhdhomerun_frontend_t *hfe, mpegts_mux_ins
   hfe->hf_status = SIGNAL_NONE;
 
   /* start the monitoring */
-  mtimer_arm_rel(&hfe->hf_monitor_timer, tvhdhomerun_frontend_monitor_cb, hfe, ms2mono(50));
-  hfe->hf_ready = 1;
+  mtimer_arm_rel(&hfe->hf_monitor_timer, tvhdhomerun_frontend_monitor_cb, 
+                 hfe, ms2mono(50));
 
   return 0;
+}
+
+static void
+tvhdhomerun_frontend_request_cleanup
+  (tvhdhomerun_frontend_t *hfe, tvhdhomerun_tune_req_t *tr)
+{
+  if (tr && tr != hfe->hf_req) {
+    mpegts_pid_done(&tr->hf_pids);
+    free(tr);
+  }
+  if (tr == hfe->hf_req_thread)
+    hfe->hf_req_thread = NULL;
 }
 
 static int
@@ -444,26 +426,36 @@ tvhdhomerun_frontend_start_mux
   ( mpegts_input_t *mi, mpegts_mux_instance_t *mmi, int weight )
 {
   tvhdhomerun_frontend_t *hfe = (tvhdhomerun_frontend_t*)mi;
-  int res, r;
-  char buf1[256], buf2[256];
+  dvb_mux_t *lm = (dvb_mux_t *)mmi->mmi_mux;
+  tvhdhomerun_tune_req_t *tr;
+  char buf1[256];
 
-  mi->mi_display_name(mi, buf1, sizeof(buf1));
-  mpegts_mux_nice_name(mmi->mmi_mux, buf2, sizeof(buf2));
-  tvhdebug(LS_TVHDHOMERUN, "%s - starting %s", buf1, buf2);
+  hfe->mi_display_name((mpegts_input_t*)hfe, buf1, sizeof(buf1));
+  tvhdebug(LS_TVHDHOMERUN, "%s - starting %s", buf1, lm->mm_nicename);
 
-  /* tune to the right mux */
-  res = tvhdhomerun_frontend_tune(hfe, mmi);
+  tr = calloc(1, sizeof(*tr));
+  tr->hf_mmi = mmi;
 
-  /* reset the pfilters */
-  if (hfe->hf_type != DVB_TYPE_CABLECARD) {
-    tvh_mutex_lock(&hfe->hf_hdhomerun_device_mutex);
-    r = hdhomerun_device_set_tuner_filter(hfe->hf_hdhomerun_tuner, "0x0000");
-    tvh_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
-    if(r < 1)
-      tvherror(LS_TVHDHOMERUN, "failed to reset pfilter: %d", r);
-  }
+  mpegts_pid_init(&tr->hf_pids);
 
-  return res;
+  tvh_mutex_lock(&hfe->hf_dvr_lock);
+  hfe->hf_req     = tr;
+  hfe->hf_running = 1;
+  hfe->hf_tables  = 0;
+  tvh_mutex_unlock(&hfe->hf_dvr_lock);
+  tvh_mutex_lock(&mmi->tii_stats_mutex);
+  hfe->hf_status    = SIGNAL_NONE;
+  mmi->tii_stats.signal_scale = SIGNAL_STATUS_SCALE_UNKNOWN;
+  mmi->tii_stats.snr_scale = SIGNAL_STATUS_SCALE_UNKNOWN;
+  tvh_mutex_unlock(&mmi->tii_stats_mutex);
+
+  /* notify thread that we are ready */
+  tvh_write(hfe->hf_dvr_pipe.wr, "s", 1);
+
+  mtimer_arm_rel(&hfe->hf_monitor_timer, tvhdhomerun_frontend_monitor_cb, 
+                 hfe, ms2mono(50));
+
+  return 0;
 }
 
 static void
@@ -471,115 +463,146 @@ tvhdhomerun_frontend_stop_mux
   ( mpegts_input_t *mi, mpegts_mux_instance_t *mmi )
 {
   tvhdhomerun_frontend_t *hfe = (tvhdhomerun_frontend_t*)mi;
-  char buf1[256], buf2[256];
 
-  mi->mi_display_name(mi, buf1, sizeof(buf1));
-  mpegts_mux_nice_name(mmi->mmi_mux, buf2, sizeof(buf2));
-  tvhdebug(LS_TVHDHOMERUN, "%s - stopping %s", buf1, buf2);
+  tvh_mutex_lock(&hfe->hf_dvr_lock);
 
-  /* join input thread */
-  if(hfe->hf_input_thread_pipe.wr > 0) {
-    tvh_write(hfe->hf_input_thread_pipe.wr, "", 1); // wake input thread
-    tvhtrace(LS_TVHDHOMERUN, "%s - waiting for input thread", buf1);
-    pthread_join(hfe->hf_input_thread, NULL);
-    tvh_pipe_close(&hfe->hf_input_thread_pipe);
-    tvhtrace(LS_TVHDHOMERUN, "%s - input thread stopped", buf1);
+  tvhdhomerun_tune_req_t *old = hfe->hf_req;
+  hfe->hf_req = NULL;
+
+  if (old && old != hfe->hf_req_thread) {
+    mpegts_pid_done(&old->hf_pids);
+    free(old);
   }
 
-  tvh_mutex_lock(&hfe->hf_hdhomerun_device_mutex);
-  hdhomerun_device_set_tuner_target(hfe->hf_hdhomerun_tuner, "none");
-  hdhomerun_device_tuner_lockkey_release(hfe->hf_hdhomerun_tuner);
-  tvh_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
+  tvh_mutex_unlock(&hfe->hf_dvr_lock);
 
-  hfe->hf_locked = 0;
-  hfe->hf_status = 0;
-  hfe->hf_ready = 0;
-
-  mtimer_arm_rel(&hfe->hf_monitor_timer, tvhdhomerun_frontend_monitor_cb, hfe, sec2mono(2));
+  tvh_write(hfe->hf_dvr_pipe.wr, "x", 1); /* stop tune */
+  mtimer_disarm(&hfe->hf_monitor_timer);
 }
 
-static void tvhdhomerun_frontend_update_pids_appendPidRange(int a, int b, int *firstDelimiter, char **pBuffer, const char **endBuffer )
+static void
+tvhdhomerun_frontend_update_pids ( mpegts_input_t *mi, mpegts_mux_t *mm ) 
+{
+  tvhdhomerun_frontend_t *hfe = (tvhdhomerun_frontend_t*)mi;
+  tvhdhomerun_tune_req_t *tr;
+  mpegts_pid_t *mp;
+  mpegts_pid_sub_t *mps;
+
+  tvh_mutex_lock(&hfe->hf_dvr_lock);
+  if ((tr = hfe->hf_req) != NULL) {
+    mpegts_pid_done(&tr->hf_pids);
+    RB_FOREACH(mp, &mm->mm_pids, mp_link) {
+      if (mp->mp_pid == MPEGTS_FULLMUX_PID) {
+        if (hfe->hf_device->hd_fullmux_ok) {
+          tr->hf_pids.all = 1;
+        } else {
+          mpegts_service_t *s;
+          elementary_stream_t *st;
+          int w = 0;
+          RB_FOREACH(mps, &mp->mp_subs, mps_link)
+            w = MAX(w, mps->mps_weight);
+          LIST_FOREACH(s, &mm->mm_services, s_dvb_mux_link) {
+            mpegts_pid_add(&tr->hf_pids, s->s_components.set_pmt_pid, w);
+            mpegts_pid_add(&tr->hf_pids, s->s_components.set_pcr_pid, w);
+            TAILQ_FOREACH(st, &s->s_components.set_all, es_link)
+              if (st->es_pid < MPEGTS_FULLMUX_PID)
+                mpegts_pid_add(&tr->hf_pids, st->es_pid, w);
+          }
+        }
+      } else if (mp->mp_pid < MPEGTS_FULLMUX_PID) {
+        RB_FOREACH(mps, &mp->mp_subs, mps_link)
+          mpegts_pid_add(&tr->hf_pids, mp->mp_pid, mps->mps_weight);
+      }
+    }
+    mpegts_pid_add(&tr->hf_pids, 0, MPS_WEIGHT_PMT_SCAN);
+  }
+  tvh_mutex_unlock(&hfe->hf_dvr_lock);
+
+  tvh_write(hfe->hf_dvr_pipe.wr, "c", 1);
+}
+
+static void tvhdhomerun_frontend_update_pids_append_pid_range(int a, int b, int *firstDelimiter, char **pBuffer, const char *endBuffer )
  /* A helper function that writes a range of pids to the 'buffer'.  This function is called more than once from tvhdhomerun_frontend_update_pids. */
 {
   if(*firstDelimiter) /* Don't bother printing a space before the first range of pids. */
      *firstDelimiter = 0;  /* Set this to false the first time. */
   else {
-    if(*pBuffer < *endBuffer) /* Check if 'buffer' is full. */
-      *pBuffer += snprintf(*pBuffer, *endBuffer-*pBuffer, " "); /* After the first range, separate pid ranges by a space. */
+    if(*pBuffer < endBuffer) /* Check if 'buffer' is full. */
+      *pBuffer += snprintf(*pBuffer, endBuffer-*pBuffer, " "); /* After the first range, separate pid ranges by a space. */
   }
-  if(*pBuffer < *endBuffer) { /* Check if 'buffer' is full. */
+  if(*pBuffer < endBuffer) { /* Check if 'buffer' is full. */
     if(a == b)
-      *pBuffer += snprintf(*pBuffer, *endBuffer-*pBuffer, "0x%04x", a); /* First and last pid in a range are the same, then that one pid is appended. */
+      *pBuffer += snprintf(*pBuffer, endBuffer-*pBuffer, "0x%04x", a); /* First and last pid in a range are the same, then that one pid is appended. */
     else
-      *pBuffer += snprintf(*pBuffer, *endBuffer-*pBuffer, "0x%04x-0x%04x", a, b); /* Append a range of pids to 'buffer'. */
+      *pBuffer += snprintf(*pBuffer, endBuffer-*pBuffer, "0x%04x-0x%04x", a, b); /* Append a range of pids to 'buffer'. */
   }
 }
 
-static void tvhdhomerun_frontend_update_pids( mpegts_input_t *mi, mpegts_mux_t *mm )
+static void tvhdhomerun_frontend_pid_changed( tvhdhomerun_frontend_t *hfe, const char *name )
 {
-  tvhdhomerun_frontend_t *hfe = (tvhdhomerun_frontend_t*)mi;
-  mpegts_apids_t pids, wpids;
-  mpegts_pid_t *mp;
-  mpegts_pid_sub_t *mps;
-  int i;
-  int res;
-
-  /* The length of the buffer for list of hdhomerun formatted list of pids. MUST BE GREATER THAN 14! */
+  tvhdhomerun_tune_req_t *tr;
+  tvhdhomerun_device_t *hd = hfe->hf_device;
+  mpegts_apids_t wpid;
+  int max_pids_count = hd->hd_pids_max;
+  int res, overlimit;
   const unsigned int bufferSize = 1024;
-
-  /* Temporary storage for preparing the list of pid ranges to send to the hdhomerun device by the set filter command.
-   * (hdhomerun's filter format example: "0x0000-0x0001 0x0030-0x0031 0x0034-0x0036 0x00a0-0x00a1 0x00a4-0x00a5 0x1ffb") */
   char buffer[bufferSize];
 
-  mpegts_pid_init(&pids);
-  RB_FOREACH(mp, &mm->mm_pids, mp_link) {
-    if (mp->mp_pid == MPEGTS_FULLMUX_PID)
-      pids.all = 1;
-    else if (mp->mp_pid < MPEGTS_FULLMUX_PID) {
-      RB_FOREACH(mps, &mp->mp_subs, mps_link)
-        mpegts_pid_add(&pids, mp->mp_pid, mps->mps_weight);
-    }
+  tvh_mutex_lock(&hfe->hf_dvr_lock);
+
+  tr = hfe->hf_req_thread;
+
+  if (!hfe->hf_running || !hfe->hf_req || !tr) {
+    tvh_mutex_unlock(&hfe->hf_dvr_lock);
+    return;
   }
 
-  mpegts_pid_weighted(&wpids, &pids, 128 /* max? */, MPS_WEIGHT_ALLLIMIT);
-  if (hfe->hf_type == DVB_TYPE_CABLECARD)
+  if (hfe->hf_type == DVB_TYPE_CABLECARD) {
+    tvh_mutex_unlock(&hfe->hf_dvr_lock);
     return;
+  }
 
   buffer[0] = '\0'; /* Initialize buffer to handle the case where no pids are requested. */
 
-  /* Check if the turn-on-all-pids flag is set.  If so, ask the hdhomerun to send all pids ("0x0000-0x1fff").  */
-  if(wpids.all) {
-      tvhdebug(LS_TVHDHOMERUN, "setting PID filter full mux");
-      snprintf(buffer, bufferSize, "0x0000-0x1fff");
-  }
-  /* Otherwise, if we have any pids, proceed to find consecutive runs of pids to group them into a list of ranges. */
-  else {
-    if(wpids.count > 0) {
+  if(tr->hf_pids.all) {
 
-      /* 'begin' is the first pid in a consecutive run of pids.
-       * 'prev' is the previous pid while walking the list of pids and
-       * 'curr' is the current pid. */
+all:
+    tvhdebug(LS_TVHDHOMERUN, "%s - setting PID filter full mux", name);
+    snprintf(buffer, bufferSize, "0x0000-0x1fff");
+
+  } else {
+
+    overlimit = mpegts_pid_weighted(&wpid, &tr->hf_pids,
+                                    max_pids_count, MPS_WEIGHT_ALLLIMIT);
+
+    if (overlimit > 0 && hd->hd_fullmux_ok) {
+      mpegts_pid_done(&wpid);
+      goto all;
+    }
+
+    if(wpid.count > 0) {
       int begin, prev, curr;
 
+      begin = prev = wpid.pids[0].pid;
       const char *endBuffer = buffer + bufferSize; /* Have the address after the end of buffer on hand to help avoid writing past the buffer. */
       char *pBuffer = buffer; /* Move this pointer through the buffer as we write formatted pids. */
       int firstDelimiter = -1; /* Set this to 'true' so that we can skip writing the first delimiter/space. */
 
       /* Walk the list of pids and keep track of runs of consecutive pids. Setup the state for the first pid. */
-      for (i = 1, prev = begin = wpids.pids[0].pid; i < wpids.count; i++) {
+      for (int i = 1; i < wpid.count; i++) {
 
-        curr = wpids.pids[i].pid;
+        curr = wpid.pids[i].pid;
         /* make sure the pid maps to a max of 0x1FFF, API will reject the call otherwise */
         if(curr > 0x1FFF) {
-          tvherror(LS_TVHDHOMERUN, "pid %d is too large, masking to API maximum of 0x1FFF", curr);
+          tvherror(LS_TVHDHOMERUN, "%s - pid %d is too large, masking to API maximum of 0x1FFF", name, curr);
           curr = (curr & 0x1FFF);
         }
 
         /* Check to see if there is a break in a run of consecutive pids. */
         if(prev + 1 != curr) {
           /* If the current pid is NOT +1 more than the previous pid, then this is the end of a range of pids.
-           * Write out this range of consecutive pids. */
-          tvhdhomerun_frontend_update_pids_appendPidRange(begin, prev, &firstDelimiter, &pBuffer, &endBuffer);
+            * Write out this range of consecutive pids. */
+          tvhdhomerun_frontend_update_pids_append_pid_range(begin, prev, &firstDelimiter, &pBuffer, endBuffer);
 
           /* Also, this is the start of a new range of pids.  Set 'begin' to the beginning of the next range. */
           begin = curr;
@@ -589,26 +612,290 @@ static void tvhdhomerun_frontend_update_pids( mpegts_input_t *mi, mpegts_mux_t *
           break;
       }
       /* We are at the end of the list of pids, write the final range of consecutive pids to the 'buffer'. */
-      tvhdhomerun_frontend_update_pids_appendPidRange(begin, prev, &firstDelimiter, &pBuffer, &endBuffer);
+      tvhdhomerun_frontend_update_pids_append_pid_range(begin, prev, &firstDelimiter, &pBuffer, endBuffer);
 
       if(pBuffer >= endBuffer) { /* We could not fit the list of ranges of pids into the 'buffer' and have an incomplete/mangled 'buffer'
                                 * so as a backup, we will request all pids except NULL packets (0x1fff). */
-        tvhdebug(LS_TVHDHOMERUN, "pfilter list is too big for buffer[%d] = \"%s\"(truncated)", bufferSize, buffer);
+        tvhdebug(LS_TVHDHOMERUN, "%s - pfilter list is too big for buffer[%d] = \"%s\"(truncated)", name, bufferSize, buffer);
         snprintf(buffer, bufferSize, "0x0000-0x1ffe");
       }
     }
+    mpegts_pid_done(&wpid);
   }
-  tvhdebug(LS_TVHDHOMERUN, "setting pfilter to: %s", buffer);
+
+  if (buffer[0] == '\0') {
+    tvh_mutex_unlock(&hfe->hf_dvr_lock);
+    return;
+  }
+
+  tvhtrace(LS_TVHDHOMERUN, "%s - setting pfilter to: %s", name, buffer);
 
   tvh_mutex_lock(&hfe->hf_hdhomerun_device_mutex);
   /* Send the specially formatted list of pid ranges to the hdhomerun device. */
   res = hdhomerun_device_set_tuner_filter(hfe->hf_hdhomerun_tuner, buffer);
   tvh_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
-  if(res < 1)
-    tvherror(LS_TVHDHOMERUN, "failed to set_tuner_filter: %d", res);
+  if (res == 0)
+    tvherror(LS_TVHDHOMERUN, "%s - failed to set_tuner_filter, device %s in use", name, hfe->hf_device->hd_info.friendlyname);
+  if (res < 1)
+    tvherror(LS_TVHDHOMERUN, "%s - failed to set set_tuner_filter, device %s communication error", name, hfe->hf_device->hd_info.friendlyname);
 
-  mpegts_pid_done(&wpids);
-  mpegts_pid_done(&pids);
+  tvh_mutex_unlock(&hfe->hf_dvr_lock);
+}
+
+static ssize_t
+tvhdhomerun_udp_read ( sbuf_t *sb, udp_connection_t *udp, udp_multirecv_t *um )
+{
+  int i, n;
+  struct iovec *iovec;
+  ssize_t res = 0;
+
+  n = udp_multirecv_read(um, udp->fd, UDP_PKTS, &iovec);
+  if (n < 0)
+    return -1;
+
+  for (i = 0; i < n; i++, iovec++) {
+    if (iovec->iov_len <= 0)
+      continue;
+    if (*(uint8_t *)iovec->iov_base != 0x47) {
+      continue;
+    }
+    sbuf_append(sb, iovec->iov_base, iovec->iov_len);
+    res += iovec->iov_len;
+  }
+
+  return res;
+}
+
+static void *
+tvhdhomerun_frontend_input_thread(void *aux)
+{
+  tvhdhomerun_frontend_t *hfe = aux;
+  tvhdhomerun_tune_req_t *tr = NULL;
+  mpegts_mux_instance_t *mmi = NULL;
+  sbuf_t sb;
+  tvhpoll_t *efd;
+  udp_connection_t *udp = NULL;
+  udp_multirecv_t um;
+  char buf[256];
+  char target[64];
+  int nfds;
+  uint64_t last_activity, fatal_timeout;
+  uint8_t lockkey = 0, running = 0;
+
+  hfe->mi_display_name((mpegts_input_t*)hfe, buf, sizeof(buf));
+
+  efd = tvhpoll_create(2);
+  tvhpoll_add1(efd, hfe->hf_dvr_pipe.rd, TVHPOLL_IN, NULL);
+
+  sbuf_init(&sb);
+  udp_multirecv_init(&um, 0, 0);
+
+new_tune:
+  tvhdhomerun_frontend_stop_streaming(hfe);
+  sbuf_free(&sb);
+  udp_multirecv_free(&um);
+  if (udp) {
+    tvhpoll_rem1(efd, udp->fd);
+    udp_close(udp);
+    udp = NULL;
+  }
+  udp_multirecv_init(&um, UDP_PKTS, UDP_PKT_SIZE);
+  sbuf_init_fixed(&sb, UDP_PKTS * UDP_PKT_SIZE);
+  running = 0;
+  mmi = NULL;
+
+  while (tvheadend_is_running()) {
+    tvhpoll_event_t ev;
+    nfds = tvhpoll_wait(efd, &ev, 1, lockkey ? 55 : -1);
+
+    if (lockkey && (getfastmonoclock() - hfe->hf_last_tune > 50000)) { /* 50ms */
+      tvh_mutex_lock(&hfe->hf_hdhomerun_device_mutex);
+      hdhomerun_device_tuner_lockkey_release(hfe->hf_hdhomerun_tuner);
+      tvhtrace(LS_TVHDHOMERUN, "%s - fast input lockkey release", buf);
+      tvh_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
+      lockkey = 0;
+    }
+
+    if (nfds <= 0)
+      continue;
+
+    if (ev.ptr == NULL) {
+      uint8_t cmd;
+      if (read(hfe->hf_dvr_pipe.rd, &cmd, 1) != 1)
+        continue;
+
+      if (cmd == 'e') {
+        tvhdebug(LS_TVHDHOMERUN, "HDHR input thread exit");
+        goto done;
+      }
+      if (cmd == 's') {
+        break;
+      }
+    }
+  }
+
+  if (!tvheadend_is_running())
+    goto done;
+
+  tvh_mutex_lock(&hfe->hf_dvr_lock);
+  tvhdhomerun_frontend_request_cleanup(hfe, tr);
+  tr = hfe->hf_req;
+  hfe->hf_req_thread = tr;
+  tvh_mutex_unlock(&hfe->hf_dvr_lock);
+
+  if (!tr || !tr->hf_mmi)
+    goto new_tune;
+
+  mmi = tr->hf_mmi;
+
+  int res = tvhdhomerun_frontend_lockkey_request(hfe, buf);
+  if(res < 1) {
+    tvherror(LS_TVHDHOMERUN, "%s - failed to acquire lockkey", buf);
+    goto new_tune;
+  } else {
+    lockkey = 1;
+  }
+
+  uint32_t local_ip;
+  int port;
+
+  local_ip = get_local_ip(hfe->hf_hdhomerun_tuner);
+
+  if (local_ip == 0) {
+    tvherror(LS_TVHDHOMERUN, "%s - could not determine local machine IP address", buf);
+    goto new_tune;
+  }
+
+  port = (config.local_port == 0) ? 0 : (config.local_port + hfe->hf_tunerNumber);
+
+  udp = udp_bind(LS_TVHDHOMERUN, "hdhomerun", NULL, port, NULL,
+                 NULL, BUFFER_SIZE, 0, 0);
+  
+  if (udp == NULL || udp == UDP_FATAL_ERROR) {
+    tvherror(LS_TVHDHOMERUN, "%s - udp_bind failed", buf);
+    goto new_tune;
+  }
+
+  if (fcntl(udp->fd, F_SETFL, O_NONBLOCK) != 0) {
+    tvherror(LS_TVHDHOMERUN, "%s - failed to set socket nonblocking (%d)", buf, errno);
+    goto new_tune;
+  }
+
+  if (port == 0) {
+    struct sockaddr_in sin;
+    socklen_t slen = sizeof(sin);
+    if (getsockname(udp->fd, (struct sockaddr *)&sin, &slen) != 0) {
+      tvherror(LS_TVHDHOMERUN, "%s - getsockname failed (%d)", buf, errno);
+      goto new_tune;
+    }
+    port = ntohs(sin.sin_port);
+  }
+
+  snprintf(target, sizeof(target), "udp://%u.%u.%u.%u:%u",
+    (unsigned int)(local_ip >> 24) & 0xFF,
+    (unsigned int)(local_ip >> 16) & 0xFF,
+    (unsigned int)(local_ip >>  8) & 0xFF,
+    (unsigned int)(local_ip >>  0) & 0xFF,
+    port);
+
+  tvh_mutex_lock(&hfe->hf_hdhomerun_device_mutex);
+  int r = hdhomerun_device_set_tuner_target(hfe->hf_hdhomerun_tuner, target);
+  tvh_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
+  if (r < 0) {
+    tvherror(LS_TVHDHOMERUN, "%s - failed to set target, device %s communication error", buf, hfe->hf_device->hd_info.friendlyname);
+    goto new_tune;
+  }
+  if (r == 0) {
+    tvherror(LS_TVHDHOMERUN, "%s - failed to set target, device %s in use", buf, hfe->hf_device->hd_info.friendlyname);
+    goto new_tune;
+  }
+
+  tvhpoll_add1(efd, udp->fd, TVHPOLL_IN, hfe);
+  
+  if (tvhdhomerun_frontend_tune(hfe, mmi)) {
+    goto new_tune;
+  }
+
+  lockkey = 1;
+  running = 1;
+  last_activity = mclk();
+  fatal_timeout = sec2mono(5 + MINMAX(hfe->hf_grace_period, 0, 60));
+
+  while (tvheadend_is_running() && running) {
+
+    tvhpoll_event_t ev;
+    nfds = tvhpoll_wait(efd, &ev, 1, 250);
+
+    if (last_activity + fatal_timeout < mclk()) {
+      tvhwarn(LS_TVHDHOMERUN, "%s - no data received, restarting tune", buf);
+      goto new_tune;
+    }
+
+    if (nfds <= 0)
+      continue;
+
+    if (ev.ptr == NULL) {
+      uint8_t cmd;
+      if (read(hfe->hf_dvr_pipe.rd, &cmd, 1) != 1)
+        continue;
+
+      if (cmd == 'e') {
+        goto done;
+      } else if (cmd == 'x') {
+        running = 0;
+        break;
+      } else if (cmd == 's') {
+        goto new_tune;
+      } else if (cmd == 'c') { 
+        tvhdhomerun_frontend_pid_changed(hfe, buf);
+      }
+      continue;
+    }
+
+    if (ev.ptr == hfe) {
+      ssize_t r = tvhdhomerun_udp_read(&sb, udp, &um);
+      if (r < 0) {
+        if (ERRNO_AGAIN(errno))
+          continue;
+        if (errno == EOVERFLOW) {
+          tvhwarn(LS_TVHDHOMERUN, "%s - recvmsg() EOVERFLOW", buf);
+          continue;
+        }
+        tvherror(LS_TVHDHOMERUN, "%s - multirecv error %d (%s)", buf, errno, strerror(errno));
+        goto new_tune;
+      }
+
+      last_activity = mclk();
+
+      tvh_mutex_lock(&hfe->hf_dvr_lock);
+      if (hfe->hf_req_thread == tr && tr->hf_mmi == mmi)
+        mpegts_input_recv_packets(mmi, &sb, 0, NULL);
+      else {
+        tvh_mutex_unlock(&hfe->hf_dvr_lock);
+        goto new_tune;
+      }
+      tvh_mutex_unlock(&hfe->hf_dvr_lock);
+    }
+  }
+
+  goto new_tune;
+
+done:
+  tvhdhomerun_frontend_stop_streaming(hfe);
+  if (udp) {
+    tvhpoll_rem1(efd, udp->fd);
+    udp_close(udp);
+  }
+  tvhpoll_rem1(efd, hfe->hf_dvr_pipe.rd);
+  tvhdhomerun_frontend_request_cleanup(hfe, tr);
+  tvh_mutex_lock(&hfe->hf_hdhomerun_device_mutex);
+  hdhomerun_device_tuner_lockkey_release(hfe->hf_hdhomerun_tuner);
+  tvh_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
+  tvhtrace(LS_TVHDHOMERUN, "%s - final lockkey release", buf);
+  sbuf_free(&sb);
+  udp_multirecv_free(&um);
+  tvhpoll_destroy(efd);
+  return NULL;
 }
 
 static idnode_set_t *
@@ -656,6 +943,17 @@ const idclass_t tvhdhomerun_frontend_class =
       .name     = N_("Frontend number"),
       .opts     = PO_RDONLY | PO_NOSAVE,
       .off      = offsetof(tvhdhomerun_frontend_t, hf_tunerNumber),
+    },
+    {
+      .type     = PT_INT,
+      .id       = "grace_period",
+      .name     = N_("Grace period"),
+      .desc     = N_("Force the grace period for which HDHomeRun client waits "
+                     "for the data from server. After this grace period, "
+                     "the tuner is handled as dead. The default value is "
+                     "5 seconds."),
+      .opts     = PO_ADVANCED,
+      .off      = offsetof(tvhdhomerun_frontend_t, hf_grace_period),
     },
     {}
   }
@@ -765,20 +1063,36 @@ tvhdhomerun_frontend_wizard_set( tvh_input_t *ti, htsmsg_t *conf, const char *la
 void
 tvhdhomerun_frontend_delete ( tvhdhomerun_frontend_t *hfe )
 {
+  char buf1[256];
+
   lock_assert(&global_lock);
+
+  hfe->mi_display_name((mpegts_input_t *)hfe, buf1, sizeof(buf1));
 
   /* Ensure we're stopped */
   mpegts_input_stop_all((mpegts_input_t*)hfe);
 
+  /* Stop thread */
+  if (hfe->hf_dvr_pipe.wr > 0) {
+    tvh_write(hfe->hf_dvr_pipe.wr, "e", 1);
+    tvhtrace(LS_TVHDHOMERUN, "%s - waiting for control thread", buf1);
+    pthread_join(hfe->hf_dvr_thread, NULL);
+    tvh_pipe_close(&hfe->hf_dvr_pipe);
+    tvhdebug(LS_TVHDHOMERUN, "%s - stopped control thread", buf1);
+  }
+
   mtimer_disarm(&hfe->hf_monitor_timer);
 
+  tvh_mutex_lock(&hfe->hf_hdhomerun_device_mutex);
   hdhomerun_device_tuner_lockkey_release(hfe->hf_hdhomerun_tuner);
+  tvh_mutex_unlock(&hfe->hf_hdhomerun_device_mutex);
+  tvhtrace(LS_TVHDHOMERUN, "%s - frontend delete lockkey release", buf1);
   hdhomerun_device_destroy(hfe->hf_hdhomerun_tuner);
 
   /* Remove from adapter */
   TAILQ_REMOVE(&hfe->hf_device->hd_frontends, hfe, hf_link);
 
-  tvh_mutex_destroy(&hfe->hf_input_thread_mutex);
+  tvh_mutex_destroy(&hfe->hf_dvr_lock);
   tvh_mutex_destroy(&hfe->hf_hdhomerun_device_mutex);
 
   /* Finish */
@@ -823,9 +1137,6 @@ tvhdhomerun_frontend_create(tvhdhomerun_device_t *hd, struct hdhomerun_discover_
   hfe->hf_type     = type;
 
   hfe->hf_hdhomerun_tuner = hdhomerun_device_create(discover_info->device_id, discover_info->ip_addr, frontend_number, hdhomerun_debug_obj);
-
-  hfe->hf_input_thread_running = 0;
-  hfe->hf_input_thread_terminating = 0;
 
   hfe->hf_tunerNumber = frontend_number;
 
@@ -874,8 +1185,11 @@ tvhdhomerun_frontend_create(tvhdhomerun_device_t *hd, struct hdhomerun_discover_
 
   /* mutex init */
   tvh_mutex_init(&hfe->hf_hdhomerun_device_mutex, NULL);
-  tvh_mutex_init(&hfe->hf_input_thread_mutex, NULL);
-  tvh_cond_init(&hfe->hf_input_thread_cond, 1);
+  tvh_mutex_init(&hfe->hf_dvr_lock, NULL);
+
+  tvh_pipe(O_NONBLOCK, &hfe->hf_dvr_pipe);
+  tvh_thread_create(&hfe->hf_dvr_thread, NULL,
+                    tvhdhomerun_frontend_input_thread, hfe, "hdhm-front");
 
   return hfe;
 }

--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun_frontend.c
@@ -623,8 +623,9 @@ all:
     mpegts_pid_done(&wpid);
   }
 
+  tvh_mutex_unlock(&hfe->hf_dvr_lock);
+
   if (buffer[0] == '\0') {
-    tvh_mutex_unlock(&hfe->hf_dvr_lock);
     return;
   }
 
@@ -700,7 +701,7 @@ new_tune:
     udp = NULL;
   }
   udp_multirecv_init(&um, UDP_PKTS, UDP_PKT_SIZE);
-  sbuf_init_fixed(&sb, UDP_PKTS * UDP_PKT_SIZE);
+  sbuf_init(&sb);
   running = 0;
   mmi = NULL;
 

--- a/src/input/mpegts/tvhdhomerun/tvhdhomerun_private.h
+++ b/src/input/mpegts/tvhdhomerun/tvhdhomerun_private.h
@@ -24,9 +24,14 @@
 #include "htsbuf.h"
 #include "tvhdhomerun.h"
 
+#define BUFFER_SIZE    (20000000 / 8)
+#define UDP_PKTS        64
+#define UDP_PKT_SIZE    1472
+
 typedef struct tvhdhomerun_device_info tvhdhomerun_device_info_t;
 typedef struct tvhdhomerun_device      tvhdhomerun_device_t;
 typedef struct tvhdhomerun_frontend    tvhdhomerun_frontend_t;
+typedef struct tvhdhomerun_tune_req    tvhdhomerun_tune_req_t;
 
 
 static struct hdhomerun_debug_t* hdhomerun_debug_obj = 0;
@@ -58,18 +63,19 @@ struct tvhdhomerun_device
   /*
     Flags...
   */
-  int                        hd_fullmux_ok;
-
+  uint8_t                    hd_fullmux_ok;
   int                        hd_pids_max;
-  int                        hd_pids_len;
-  int                        hd_pids_deladd;
 
   dvb_fe_type_t              hd_type;
   char                      *hd_override_type;
 
 };
 
-#define HDHOMERUN_MAX_PIDS 32
+struct tvhdhomerun_tune_req {
+  mpegts_mux_instance_t      *hf_mmi;
+
+  mpegts_apids_t             hf_pids;
+};
 
 struct tvhdhomerun_frontend
 {
@@ -87,35 +93,32 @@ struct tvhdhomerun_frontend
    */
   int                            hf_tunerNumber;
   dvb_fe_type_t                  hf_type;
+  int                            hf_grace_period;
 
   // libhdhomerun objects.
   struct hdhomerun_device_t     *hf_hdhomerun_tuner;
 
   // Tuning information
-  int                            hf_locked;
-  int                            hf_ready;
-  int                            hf_status;
+  uint8_t                        hf_locked;
+  uint8_t                        hf_running;
+  uint8_t                        hf_status;
+  uint8_t                        hf_tables;
+  uint64_t                       hf_last_tune;
 
   // input thread..
-  pthread_t                      hf_input_thread;
-  tvh_mutex_t                    hf_input_thread_mutex;        /* used in condition signaling */
-  tvh_cond_t                     hf_input_thread_cond;         /* used in condition signaling */
-  th_pipe_t                      hf_input_thread_pipe;         /* IPC with input thread */
-  uint8_t                        hf_input_thread_running;      // Indicates if input_thread is running.
-  uint8_t                        hf_input_thread_terminating;  // Used for terminating the input_thread.
+  pthread_t                      hf_dvr_thread;
+  th_pipe_t                      hf_dvr_pipe;
+  tvh_mutex_t                    hf_dvr_lock;
 
+  tvhdhomerun_tune_req_t         *hf_req;
+  tvhdhomerun_tune_req_t         *hf_req_thread;
   // Global lock for the libhdhomerun library since it seems to have some threading-issues.
   tvh_mutex_t                    hf_hdhomerun_device_mutex;
 
   /*
    * Reception
    */
-  char                           hf_pid_filter_buf[1024];
-
   mtimer_t                       hf_monitor_timer;
-
-  mpegts_mux_instance_t         *hf_mmi;
-
 };
 
 /*


### PR DESCRIPTION
This PR introduces an improved alternative to the current HDHomeRun code with the following changes

- Implemented thread-based tuning.
- Optimized input handling with UDP multirecv to minimize packet loss.
- Enhanced debug messaging for better diagnostic reporting.
- Added native unlock system for adapters (replicating functionality `hdhomerun_device_selector_choose_test` from source library).
- Added support for max_pids, full_mux, and fe_override, grace_period options.

Testing and review of this code would be very much appreciated.