### PR TITLE
webui: play any channel from the EPG, including ones with no programme data

### DIFF
--- a/src/webui/static-vue/src/components/VideoPlayerDialog.vue
+++ b/src/webui/static-vue/src/components/VideoPlayerDialog.vue
@@ -31,6 +31,8 @@ import { useI18n } from '@/composables/useI18n'
 import { useVideoPlayer } from '@/composables/useVideoPlayer'
 import { useStreamProfilesStore } from '@/stores/streamProfiles'
 import { channelStreamUrl } from '@/utils/playUrl'
+import { apiCall } from '@/api/client'
+import type { GridResponse, FilterDef } from '@/types/grid'
 
 const { t } = useI18n()
 const player = useVideoPlayer()
@@ -39,14 +41,66 @@ const streamProfiles = useStreamProfilesStore()
 /* localStorage key for the last in-browser profile the user chose. */
 const LAST_PROFILE_KEY = 'tvh:browser-play-profile'
 
+/* Enabled channels for the Channel dropdown. Fetched once (the dialog
+ * is a mounted singleton, so this survives across opens) and shared by
+ * every entry point into the player. */
+interface PlayerChannel {
+  uuid: string
+  name?: string
+  number?: number
+  /* Precomputed "number · name" so the Select's filter matches both. */
+  label: string
+}
+const channels = ref<PlayerChannel[]>([])
+let channelsLoaded = false
+
+async function loadChannels(): Promise<void> {
+  if (channelsLoaded) return
+  try {
+    const resp = await apiCall<GridResponse<PlayerChannel>>('channel/grid', {
+      start: 0,
+      filter: JSON.stringify([
+        { field: 'enabled', type: 'boolean', value: true } satisfies FilterDef,
+      ]),
+      limit: 999_999_999,
+      sort: 'number',
+      dir: 'ASC',
+    })
+    channels.value = (resp.entries ?? []).map((c) => ({
+      ...c,
+      label:
+        typeof c.number === 'number' ? `${c.number} · ${c.name ?? c.uuid}` : (c.name ?? c.uuid),
+    }))
+    channelsLoaded = true
+  } catch (e) {
+    /* Non-fatal — the dropdown just stays empty; a channel passed in
+     * via open() still plays. Logged for visibility. */
+    console.error('VideoPlayerDialog: channel load failed:', e)
+  }
+}
+
+/* The selected channel, bound to the Channel dropdown. Reading/writing
+ * goes through the composable's `current` so switching channels here
+ * re-points the <video> the same way the profile switch does. */
+const selectedChannel = computed<string>({
+  get: () => player.current.value?.channelUuid ?? '',
+  set: (uuid: string) => {
+    const ch = channels.value.find((c) => c.uuid === uuid)
+    player.current.value = ch ? { channelUuid: ch.uuid, title: ch.name ?? ch.uuid } : null
+  },
+})
+
+const hasChannel = computed(() => player.current.value !== null)
+
 const videoEl = ref<HTMLVideoElement | null>(null)
 const playbackError = ref(false)
 /* Human-readable detail from the <video> MediaError. */
 const playbackErrorDetail = ref('')
-/* True while a profile switch tears down + reloads the stream, so
- * the UI shows a hint instead of a frozen frame. Only set once the
- * stream has played at least once — the initial load uses the
- * <video> element's own loading UI. */
+/* True while a profile or channel switch tears down + reloads the
+ * stream, so the UI shows a hint instead of a frozen frame. Both go
+ * through the same src-change reload, so one neutral message covers
+ * them. Only set once the stream has played at least once — the
+ * initial load uses the <video> element's own loading UI. */
 const switching = ref(false)
 const hasPlayed = ref(false)
 
@@ -126,6 +180,7 @@ watch(
       switching.value = false
       hasPlayed.value = false
       void pickInitialProfile()
+      void loadChannels()
       return
     }
     teardownVideo()
@@ -191,35 +246,53 @@ function onPlaying(): void {
     :style="{ width: '800px', maxWidth: 'calc(100vw - 32px)' }"
     :breakpoints="{ '768px': '100vw' }"
   >
-    <!-- Profile switcher — only when there is more than one
-         profile to choose between. A profile that failed to play
-         earlier this session is flagged with a warning icon. -->
-    <div v-if="profiles.length > 1" class="video-player-dialog__toolbar">
-      <label class="video-player-dialog__profile-label" for="video-player-profile">
-        {{ t('Stream profile') }}
+    <!-- Channel + profile switchers. The Channel dropdown is how you
+         pick what to watch (and switch live); the profile switcher
+         appears only when there is more than one profile. A profile
+         that failed to play earlier this session is flagged. -->
+    <div class="video-player-dialog__toolbar">
+      <label class="video-player-dialog__field-label" for="video-player-channel">
+        {{ t('Channel') }}
       </label>
       <Select
-        v-model="selectedProfile"
-        input-id="video-player-profile"
-        :aria-label="t('Stream profile')"
-        :options="profiles"
+        v-model="selectedChannel"
+        input-id="video-player-channel"
+        :aria-label="t('Channel')"
+        :options="channels"
         option-label="label"
-        option-value="name"
-        class="video-player-dialog__profile-select"
-      >
-        <template #option="{ option }">
-          <span class="video-player-dialog__profile-option">
-            <TriangleAlert
-              v-if="streamProfiles.failedProfiles.has(option.name)"
-              :size="14"
-              :stroke-width="2"
-              class="video-player-dialog__profile-warn"
-              :aria-label="t('Failed to play earlier this session')"
-            />
-            <span>{{ option.label }}</span>
-          </span>
-        </template>
-      </Select>
+        option-value="uuid"
+        filter
+        :filter-placeholder="t('Search channels…')"
+        :placeholder="t('Select a channel')"
+        class="video-player-dialog__channel-select"
+      />
+      <template v-if="profiles.length > 1">
+        <label class="video-player-dialog__field-label" for="video-player-profile">
+          {{ t('Stream profile') }}
+        </label>
+        <Select
+          v-model="selectedProfile"
+          input-id="video-player-profile"
+          :aria-label="t('Stream profile')"
+          :options="profiles"
+          option-label="label"
+          option-value="name"
+          class="video-player-dialog__profile-select"
+        >
+          <template #option="{ option }">
+            <span class="video-player-dialog__profile-option">
+              <TriangleAlert
+                v-if="streamProfiles.failedProfiles.has(option.name)"
+                :size="14"
+                :stroke-width="2"
+                class="video-player-dialog__profile-warn"
+                :aria-label="t('Failed to play earlier this session')"
+              />
+              <span>{{ option.label }}</span>
+            </span>
+          </template>
+        </Select>
+      </template>
     </div>
     <div class="video-player-dialog__body">
       <!-- The <video> stays mounted across errors and switches so
@@ -235,7 +308,10 @@ function onPlaying(): void {
         @error="onError"
         @playing="onPlaying"
       />
-      <div v-if="playbackError" class="video-player-dialog__overlay">
+      <div v-if="!hasChannel" class="video-player-dialog__overlay">
+        <p>{{ t('Select a channel to watch.') }}</p>
+      </div>
+      <div v-else-if="playbackError" class="video-player-dialog__overlay">
         <p>
           {{ t('Playback failed. The stream could not be played in the browser using profile "{0}" — try another profile, or use the external player instead.', selectedProfile) }}
         </p>
@@ -244,7 +320,7 @@ function onPlaying(): void {
         </p>
       </div>
       <div v-else-if="switching" class="video-player-dialog__overlay">
-        <p>{{ t('Switching profile…') }}</p>
+        <p>{{ t('Switching…') }}</p>
       </div>
     </div>
   </Dialog>
@@ -258,9 +334,16 @@ function onPlaying(): void {
   padding-bottom: var(--tvh-space-2);
 }
 
-.video-player-dialog__profile-label {
+.video-player-dialog__field-label {
   color: var(--tvh-text-muted);
   font-size: var(--tvh-text-sm);
+}
+
+/* PrimeVue Select for the channel switcher — a touch wider than the
+ * profile one since channel names run longer. Same inline-flex caveat
+ * as the profile select below (don't force display:block). */
+.video-player-dialog__channel-select {
+  min-width: 240px;
 }
 
 /* PrimeVue Select for the profile switcher. `.p-select` is

--- a/src/webui/static-vue/src/components/__tests__/VideoPlayerDialog.test.ts
+++ b/src/webui/static-vue/src/components/__tests__/VideoPlayerDialog.test.ts
@@ -3,14 +3,17 @@
 
 /*
  * VideoPlayerDialog — unit tests. Verifies the <video> src wiring
- * (the profile resolved by the streamProfiles store), the on-close
- * teardown (pause + load) that releases the server-side streaming
- * subscription, and the error overlay.
+ * (the profile resolved by the streamProfiles store), the Channel
+ * dropdown (fetched from channel/grid on open; the sole way to pick
+ * what to watch — issue #2183), the on-close teardown (pause + load)
+ * that releases the server-side streaming subscription, and the error
+ * overlay.
  *
  * jsdom doesn't implement HTMLMediaElement play/pause/load, so we
  * stub those on the prototype.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
 import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils'
 import { setActivePinia, createPinia } from 'pinia'
 import VideoPlayerDialog from '../VideoPlayerDialog.vue'
@@ -26,16 +29,56 @@ vi.mock('@/api/client', () => ({
 const pauseStub = vi.fn()
 const loadStub = vi.fn()
 
+const CHANNELS = [
+  { uuid: 'ch-abc', name: 'BBC One', number: 1 },
+  { uuid: 'ch-def', name: 'ITV', number: 3 },
+]
+
 /* Wire apiMock so the streamProfiles store resolves to one stream
- * profile named "webtv". */
-function mockProfiles() {
+ * profile named "webtv" and channel/grid returns two channels. */
+function mockApi() {
   apiMock.mockImplementation((endpoint: string) => {
     if (endpoint === 'profile/list') {
       return Promise.resolve({ entries: [{ key: 'p1', val: 'webtv' }] })
     }
+    if (endpoint === 'channel/grid') {
+      return Promise.resolve({ entries: CHANNELS })
+    }
     return Promise.resolve({ entries: [] })
   })
 }
+
+/* Minimal v-model-capable stand-in for PrimeVue's Select — a native
+ * <select> so tests can drive channel/profile changes. Class fallthrough
+ * merges, so the channel select keeps its __channel-select class. */
+const SelectStub = defineComponent({
+  props: {
+    modelValue: { type: [String, Number], default: '' },
+    options: { type: Array, default: () => [] },
+    optionValue: { type: String, default: '' },
+    optionLabel: { type: String, default: '' },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () =>
+      h(
+        'select',
+        {
+          class: 'select-stub',
+          value: props.modelValue,
+          onChange: (e: Event) =>
+            emit('update:modelValue', (e.target as HTMLSelectElement).value),
+        },
+        (props.options as Array<Record<string, unknown>>).map((o) =>
+          h(
+            'option',
+            { value: props.optionValue ? o[props.optionValue] : o },
+            String(props.optionLabel ? o[props.optionLabel] : o),
+          ),
+        ),
+      )
+  },
+})
 
 beforeEach(() => {
   setActivePinia(createPinia())
@@ -58,10 +101,7 @@ function mountDialog() {
     global: {
       stubs: {
         Dialog: DIALOG_PASSTHROUGH_STUB,
-        /* The profile switcher only renders with >1 profile; these
-         * tests use one, so Select never mounts — stubbed anyway so
-         * it never needs the PrimeVue plugin's theme config. */
-        Select: { name: 'Select', template: '<div class="select-stub" />' },
+        Select: SelectStub,
       },
     },
   })
@@ -81,7 +121,7 @@ describe('VideoPlayerDialog', () => {
   })
 
   it('renders a <video> with the selected-profile stream URL when open', async () => {
-    mockProfiles()
+    mockApi()
     useVideoPlayer().open(TARGET)
     const wrapper = mountDialog()
     await flushPromises()
@@ -90,8 +130,41 @@ describe('VideoPlayerDialog', () => {
     expect(video.attributes('src')).toBe('/stream/channel/ch-abc?profile=webtv')
   })
 
+  it('fetches enabled channels for the Channel dropdown on open', async () => {
+    mockApi()
+    useVideoPlayer().open(TARGET)
+    mountDialog()
+    await flushPromises()
+    expect(apiMock).toHaveBeenCalledWith(
+      'channel/grid',
+      expect.objectContaining({ sort: 'number', dir: 'ASC' }),
+    )
+  })
+
+  it('opens channel-less with a prompt and no stream when no channel is passed', async () => {
+    mockApi()
+    useVideoPlayer().open() /* Live TV launcher: no channel preselected */
+    const wrapper = mountDialog()
+    await flushPromises()
+    expect(wrapper.text()).toMatch(/Select a channel to watch/)
+    expect(wrapper.find('video').attributes('src')).toBeFalsy()
+  })
+
+  it('points the stream at the channel picked from the dropdown', async () => {
+    mockApi()
+    useVideoPlayer().open()
+    const wrapper = mountDialog()
+    await flushPromises()
+
+    await wrapper.find('.video-player-dialog__channel-select').setValue('ch-def')
+    await flushPromises()
+    expect(wrapper.find('video').attributes('src')).toBe(
+      '/stream/channel/ch-def?profile=webtv',
+    )
+  })
+
   it('tears the video down on close (pause + load)', async () => {
-    mockProfiles()
+    mockApi()
     useVideoPlayer().open(TARGET)
     const wrapper = mountDialog()
     await flushPromises()
@@ -108,7 +181,7 @@ describe('VideoPlayerDialog', () => {
   })
 
   it('shows the error overlay (video stays mounted) on a media error', async () => {
-    mockProfiles()
+    mockApi()
     useVideoPlayer().open(TARGET)
     const wrapper = mountDialog()
     await flushPromises()
@@ -121,7 +194,7 @@ describe('VideoPlayerDialog', () => {
   })
 
   it('flags the profile in the store on a decode error', async () => {
-    mockProfiles()
+    mockApi()
     useVideoPlayer().open(TARGET)
     const wrapper = mountDialog()
     await flushPromises()
@@ -138,7 +211,7 @@ describe('VideoPlayerDialog', () => {
   })
 
   it('does not flag the profile on a transient network error', async () => {
-    mockProfiles()
+    mockApi()
     useVideoPlayer().open(TARGET)
     const wrapper = mountDialog()
     await flushPromises()
@@ -154,7 +227,7 @@ describe('VideoPlayerDialog', () => {
   })
 
   it('clears an earlier failure flag when the profile plays', async () => {
-    mockProfiles()
+    mockApi()
     const store = useStreamProfilesStore()
     store.markProfileFailed('webtv')
     useVideoPlayer().open(TARGET)

--- a/src/webui/static-vue/src/composables/__tests__/useChannelPlay.test.ts
+++ b/src/webui/static-vue/src/composables/__tests__/useChannelPlay.test.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/*
+ * useChannelPlay — the in-browser-vs-external decision for channel-
+ * level playback (issue #2183: play a channel with no EPG). Verifies
+ * it opens the in-browser player when a stream profile is available
+ * and falls back to the external player otherwise.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  ensure: vi.fn(() => Promise.resolve()),
+  open: vi.fn(),
+  openPlay: vi.fn(),
+  canPlayInBrowser: { value: true },
+}))
+
+vi.mock('@/stores/streamProfiles', () => ({
+  useStreamProfilesStore: () => ({
+    ensure: h.ensure,
+    get canPlayInBrowser() {
+      return h.canPlayInBrowser.value
+    },
+  }),
+}))
+vi.mock('@/composables/useVideoPlayer', () => ({
+  useVideoPlayer: () => ({ open: h.open }),
+}))
+vi.mock('@/utils/playUrl', () => ({
+  openPlay: (p: string) => h.openPlay(p),
+}))
+
+import { useChannelPlay } from '../useChannelPlay'
+
+beforeEach(() => {
+  h.ensure.mockClear()
+  h.open.mockClear()
+  h.openPlay.mockClear()
+  h.canPlayInBrowser.value = true
+})
+
+describe('useChannelPlay', () => {
+  it('opens the in-browser player when a stream profile is available', async () => {
+    await useChannelPlay().play('ch-1', 'BBC One')
+    expect(h.ensure).toHaveBeenCalled()
+    expect(h.open).toHaveBeenCalledWith({ channelUuid: 'ch-1', title: 'BBC One' })
+    expect(h.openPlay).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the external player when the browser cannot play', async () => {
+    h.canPlayInBrowser.value = false
+    await useChannelPlay().play('ch-2', 'ITV')
+    expect(h.openPlay).toHaveBeenCalledWith('stream/channel/ch-2')
+    expect(h.open).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op for an empty channel uuid', async () => {
+    await useChannelPlay().play('', '')
+    expect(h.ensure).not.toHaveBeenCalled()
+    expect(h.open).not.toHaveBeenCalled()
+    expect(h.openPlay).not.toHaveBeenCalled()
+  })
+})

--- a/src/webui/static-vue/src/composables/useChannelPlay.ts
+++ b/src/webui/static-vue/src/composables/useChannelPlay.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/*
+ * useChannelPlay — start playback of a live channel, choosing the
+ * in-browser player when the server offers a stream profile and
+ * falling back to the external player otherwise.
+ *
+ * Shared by every channel-level play entry point (the EPG channel-cell
+ * click in Timeline / Magazine and the Watch TV launcher) so the
+ * in-browser-vs-external decision lives in one place — mirroring the
+ * EPG event drawer's "Play in browser" behaviour but without needing
+ * an EPG event. This is what lets a channel with no EPG data still be
+ * played (issue #2183): playback no longer depends on a live event.
+ */
+import { useStreamProfilesStore } from '@/stores/streamProfiles'
+import { useVideoPlayer } from '@/composables/useVideoPlayer'
+import { openPlay } from '@/utils/playUrl'
+
+export function useChannelPlay() {
+  const streamProfiles = useStreamProfilesStore()
+  const player = useVideoPlayer()
+
+  /* Play `channelUuid`; `title` is the player header label (the
+   * channel name). Opens the in-browser modal when a stream profile
+   * is available, otherwise hands off to the external player — the
+   * same fallback the event drawer's play menu uses. */
+  async function play(channelUuid: string, title: string): Promise<void> {
+    if (!channelUuid) return
+    await streamProfiles.ensure()
+    if (streamProfiles.canPlayInBrowser) {
+      player.open({ channelUuid, title })
+    } else {
+      openPlay(`stream/channel/${channelUuid}`)
+    }
+  }
+
+  return { play }
+}

--- a/src/webui/static-vue/src/composables/useVideoPlayer.ts
+++ b/src/webui/static-vue/src/composables/useVideoPlayer.ts
@@ -11,6 +11,10 @@
  * so the EPG drawer offers "Play in browser" for live events only;
  * `current` therefore carries just a channel UUID + a display title.
  *
+ * `current` may be null: the Live TV launcher opens the player with no
+ * channel selected, letting the user pick one from the dialog's own
+ * Channel dropdown. Every other entry point passes a channel.
+ *
  * `profile` is the active stream profile and is mutable while the
  * dialog is open — changing it live-switches the stream. The dialog
  * owns the selection logic (it picks the initial value from the
@@ -34,8 +38,10 @@ const current = ref<PlayTarget | null>(null)
  * the `<video>` element's stream URL. */
 const profile = ref<string>('')
 
-function open(target: PlayTarget): void {
-  current.value = target
+/* Open the player. With no target the player opens channel-less — the
+ * dialog's Channel dropdown is the way to choose what to watch. */
+function open(target?: PlayTarget): void {
+  current.value = target ?? null
   isOpen.value = true
 }
 

--- a/src/webui/static-vue/src/views/epg/EpgMagazine.vue
+++ b/src/webui/static-vue/src/views/epg/EpgMagazine.vue
@@ -48,6 +48,7 @@ import { useEpgViewportEmitter } from '@/composables/useEpgViewportEmitter'
 import { useMagazineEventAllocator } from '@/composables/useMagazineEventAllocator'
 import { useAccessStore } from '@/stores/access'
 import ChannelLogo from '@/components/ChannelLogo.vue'
+import { CirclePlay } from 'lucide-vue-next'
 import DvrOverlayBar from './DvrOverlayBar.vue'
 import type { DvrEntry } from '@/stores/dvrEntries'
 import { extraText } from './epgEventHelpers'
@@ -603,6 +604,8 @@ defineExpose({
         :key="ch.uuid"
         type="button"
         class="epg-magazine__channel-header"
+        :title="t('Play {0}', channelName(ch))"
+        :aria-label="t('Play {0}', channelName(ch))"
         @click="emit('channelClick', ch)"
       >
         <ChannelLogo
@@ -619,6 +622,7 @@ defineExpose({
         <span v-if="channelDisplay.name" class="epg-magazine__channel-name">{{
           channelName(ch)
         }}</span>
+        <CirclePlay :size="18" class="epg-magazine__play" aria-hidden="true" />
       </button>
       <div
         v-if="rightSpacerPx > 0"
@@ -794,6 +798,7 @@ defineExpose({
 }
 
 .epg-magazine__channel-header {
+  position: relative;
   flex: 0 0 var(--epg-channel-w);
   width: var(--epg-channel-w);
   max-width: var(--epg-channel-w);
@@ -826,6 +831,25 @@ defineExpose({
 
 .epg-magazine__channel-header:focus-visible {
   outline: 2px solid var(--tvh-primary);
+}
+
+/* Play affordance — a ▶ that fades in at the top-right of the channel
+ * header on hover/focus, signalling the header plays the channel.
+ * Absolutely positioned + pointer-events:none so it doesn't disturb
+ * the column layout or intercept the header's click. */
+.epg-magazine__play {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  color: var(--tvh-primary);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--tvh-transition);
+}
+
+.epg-magazine__channel-header:hover .epg-magazine__play,
+.epg-magazine__channel-header:focus-visible .epg-magazine__play {
+  opacity: 1;
 }
 
 .epg-magazine__channel-icon {

--- a/src/webui/static-vue/src/views/epg/EpgTimeline.vue
+++ b/src/webui/static-vue/src/views/epg/EpgTimeline.vue
@@ -45,6 +45,7 @@ import { useEpgViewportEmitter } from '@/composables/useEpgViewportEmitter'
 import { useTimelineEventBoxPin } from '@/composables/useTimelineEventBoxPin'
 import { useAccessStore } from '@/stores/access'
 import ChannelLogo from '@/components/ChannelLogo.vue'
+import { CirclePlay } from 'lucide-vue-next'
 import DvrOverlayBar from './DvrOverlayBar.vue'
 import type { DvrEntry } from '@/stores/dvrEntries'
 import { extraText } from './epgEventHelpers'
@@ -617,7 +618,13 @@ defineExpose({
         aria-hidden="true"
       />
       <div v-for="ch in visibleChannels" :key="ch.uuid" class="epg-timeline__row">
-        <button type="button" class="epg-timeline__channel-cell" @click="emit('channelClick', ch)">
+        <button
+          type="button"
+          class="epg-timeline__channel-cell"
+          :title="t('Play {0}', channelName(ch))"
+          :aria-label="t('Play {0}', channelName(ch))"
+          @click="emit('channelClick', ch)"
+        >
           <ChannelLogo
             v-if="channelDisplay.logo"
             :src="iconUrl(ch.icon)"
@@ -632,6 +639,7 @@ defineExpose({
           <span v-if="channelDisplay.name" class="epg-timeline__channel-name">{{
             channelName(ch)
           }}</span>
+          <CirclePlay :size="18" class="epg-timeline__play" aria-hidden="true" />
         </button>
         <div class="epg-timeline__row-body">
           <template v-for="ev in visibleEventsByChannel.get(ch.uuid) ?? []" :key="ev.eventId">
@@ -892,6 +900,26 @@ defineExpose({
 
 .epg-timeline__channel-cell:focus-visible {
   outline: 2px solid var(--tvh-primary);
+}
+
+/* Play affordance — a ▶ that fades in over the right edge of the
+ * channel cell on hover/focus, signalling the cell plays the channel.
+ * Absolutely positioned + pointer-events:none so it doesn't disturb
+ * the logo/number/name flex layout or intercept the cell's click. */
+.epg-timeline__play {
+  position: absolute;
+  right: var(--tvh-space-2);
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--tvh-primary);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--tvh-transition);
+}
+
+.epg-timeline__channel-cell:hover .epg-timeline__play,
+.epg-timeline__channel-cell:focus-visible .epg-timeline__play {
+  opacity: 1;
 }
 
 .epg-timeline__channel-icon {

--- a/src/webui/static-vue/src/views/epg/EpgToolbar.vue
+++ b/src/webui/static-vue/src/views/epg/EpgToolbar.vue
@@ -23,6 +23,7 @@
  */
 import Select from 'primevue/select'
 import EpgViewOptions from './EpgViewOptions.vue'
+import LiveTvButton from './LiveTvButton.vue'
 import type { UseEpgViewState } from '@/composables/useEpgViewState'
 import { useI18n } from '@/composables/useI18n'
 
@@ -112,6 +113,7 @@ const emit = defineEmits<{
       @update:model-value="(v) => { if (typeof v === 'number') state.setDayStart(v) }"
     />
     <span class="epg-toolbar__spacer" />
+    <LiveTvButton />
     <EpgViewOptions
       :options="state.viewOptions.value"
       :defaults="state.currentDefaults.value"

--- a/src/webui/static-vue/src/views/epg/LiveTvButton.vue
+++ b/src/webui/static-vue/src/views/epg/LiveTvButton.vue
@@ -1,0 +1,63 @@
+<!--
+  SPDX-License-Identifier: GPL-3.0-or-later
+  Copyright (C) 2026 Tvheadend contributors
+-->
+<script setup lang="ts">
+/*
+ * LiveTvButton — a toolbar launcher that opens the in-browser player
+ * with no channel preselected. Gives every EPG view a way to start
+ * playback that does NOT depend on an EPG event existing (parity with
+ * the classic UI's "Watch TV" button), so channels with no programme
+ * data are still reachable (issue #2183). It's the primary play path
+ * in the Table view, which has no per-channel row to click, and a
+ * universal fallback in Timeline / Magazine.
+ *
+ * Channel selection lives inside VideoPlayerDialog (its Channel
+ * dropdown), so this button is just the launcher — no channel fetch,
+ * no picker. The `/stream/` route enforces ACCESS_STREAMING
+ * server-side, so no client-side access check here.
+ */
+import { useI18n } from '@/composables/useI18n'
+import { useVideoPlayer } from '@/composables/useVideoPlayer'
+
+const { t } = useI18n()
+const player = useVideoPlayer()
+</script>
+
+<template>
+  <button
+    type="button"
+    class="live-tv-btn"
+    :title="t('Live TV')"
+    :aria-label="t('Live TV')"
+    @click="player.open()"
+  >
+    {{ t('Live TV') }}
+  </button>
+</template>
+
+<style scoped>
+.live-tv-btn {
+  display: inline-flex;
+  align-items: center;
+  height: 32px;
+  padding: 0 12px;
+  background: var(--tvh-bg-page);
+  color: var(--tvh-text);
+  border: 1px solid var(--tvh-border);
+  border-radius: var(--tvh-radius-sm);
+  font: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.live-tv-btn:hover {
+  background: color-mix(in srgb, var(--tvh-primary) var(--tvh-hover-strength), var(--tvh-bg-page));
+}
+
+.live-tv-btn:focus-visible {
+  outline: 2px solid var(--tvh-primary);
+  outline-offset: 1px;
+}
+</style>

--- a/src/webui/static-vue/src/views/epg/MagazineView.vue
+++ b/src/webui/static-vue/src/views/epg/MagazineView.vue
@@ -35,6 +35,7 @@ import EpgEventDrawer from './EpgEventDrawer.vue'
 import EpgToolbar from './EpgToolbar.vue'
 import { useEpgViewState } from '@/composables/useEpgViewState'
 import { useEpgViewWrapper } from '@/composables/useEpgViewWrapper'
+import { useChannelPlay } from '@/composables/useChannelPlay'
 import { useEpgScrollDaySync } from '@/composables/useEpgScrollDaySync'
 import { useEpgInitialScrollToNow } from '@/composables/useEpgInitialScrollToNow'
 import { useMagazineScroll } from '@/composables/useMagazineScroll'
@@ -94,6 +95,12 @@ const effectiveStart = computed(() => magazineRef.value?.effectiveStart ?? state
  * useMagazineScroll, since it consumes scrollToNow). */
 const { now, pxPerMinute, titleOnly, onDvrClick, loadingDaysArray, channels, events } =
   useEpgViewWrapper(state, 'magazine')
+
+/* Clicking a channel header plays that channel — works with no EPG. */
+const channelPlay = useChannelPlay()
+function playChannel(ch: { uuid: string; name?: string }): void {
+  void channelPlay.play(ch.uuid, ch.name ?? '')
+}
 
 const { scrollToNow, scrollToTime } = useMagazineScroll({
   scrollEl,
@@ -226,6 +233,7 @@ onBeforeUnmount(() => {
       :dark-channel-background="state.viewOptions.value.darkChannelBackground"
       class="magazine-view__grid"
       @event-click="state.toggleDrawer"
+      @channel-click="playChannel"
       @dvr-click="onDvrClick"
       @update:active-day="onActiveDayChanged"
       @update:viewport-range="onViewportRangeChanged"

--- a/src/webui/static-vue/src/views/epg/TableView.vue
+++ b/src/webui/static-vue/src/views/epg/TableView.vue
@@ -83,6 +83,7 @@ import Select from 'primevue/select'
 import Popover from 'primevue/popover'
 import EpgEventDrawer, { type EpgEventDetail } from './EpgEventDrawer.vue'
 import EpgTableOptions from './EpgTableOptions.vue'
+import LiveTvButton from './LiveTvButton.vue'
 import ProgressCell, { type ProgressOptions } from '@/components/ProgressCell.vue'
 import { useNowCursor } from '@/composables/useNowCursor'
 import { useAccessStore } from '@/stores/access'
@@ -2265,6 +2266,12 @@ async function onCreateAutoRecClick() {
            two-way bound with the title column funnel via
            `filters.perColumn.title`. See the `titleSearch` block in
            the script for the debounce + sync mechanics. -->
+      <template #toolbarActions>
+        <!-- Primary play path for the Table view: it has no per-channel
+             row to click, so the Live TV launcher is the way to start
+             playback (incl. channels with no EPG). -->
+        <LiveTvButton />
+      </template>
       <template #toolbarRight>
         <!-- Desktop-inline Search input + title-scope dropdown.
              Hidden on phone widths by the media query in scoped

--- a/src/webui/static-vue/src/views/epg/TimelineView.vue
+++ b/src/webui/static-vue/src/views/epg/TimelineView.vue
@@ -30,6 +30,7 @@ import EpgEventDrawer from './EpgEventDrawer.vue'
 import EpgToolbar from './EpgToolbar.vue'
 import { useEpgViewState } from '@/composables/useEpgViewState'
 import { useEpgViewWrapper } from '@/composables/useEpgViewWrapper'
+import { useChannelPlay } from '@/composables/useChannelPlay'
 import { useEpgScrollDaySync } from '@/composables/useEpgScrollDaySync'
 import { useEpgInitialScrollToNow } from '@/composables/useEpgInitialScrollToNow'
 import { useTimelineScroll } from '@/composables/useTimelineScroll'
@@ -141,6 +142,12 @@ const effectiveStart = computed(() => timelineRef.value?.effectiveStart ?? state
  * useTimelineScroll, since it consumes scrollToNow). */
 const { now, pxPerMinute, titleOnly, onDvrClick, loadingDaysArray, channels, events } =
   useEpgViewWrapper(state, 'timeline')
+
+/* Clicking a channel cell plays that channel — works with no EPG. */
+const channelPlay = useChannelPlay()
+function playChannel(ch: { uuid: string; name?: string }): void {
+  void channelPlay.play(ch.uuid, ch.name ?? '')
+}
 
 const { scrollToNow, scrollToTime } = useTimelineScroll({
   scrollEl,
@@ -288,6 +295,7 @@ onBeforeUnmount(() => {
       :dark-channel-background="state.viewOptions.value.darkChannelBackground"
       class="timeline-view__grid"
       @event-click="state.toggleDrawer"
+      @channel-click="playChannel"
       @dvr-click="onDvrClick"
       @update:active-day="onActiveDayChanged"
       @update:viewport-range="onViewportRangeChanged"

--- a/src/webui/static-vue/src/views/epg/__tests__/LiveTvButton.test.ts
+++ b/src/webui/static-vue/src/views/epg/__tests__/LiveTvButton.test.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/*
+ * LiveTvButton — the toolbar launcher that lets any EPG view start
+ * playback without an EPG event (issue #2183). Channel selection lives
+ * in VideoPlayerDialog, so the button's whole job is to open the
+ * player with no channel preselected.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { enableAutoUnmount, mount } from '@vue/test-utils'
+import LiveTvButton from '../LiveTvButton.vue'
+
+const openMock = vi.fn()
+vi.mock('@/composables/useVideoPlayer', () => ({
+  useVideoPlayer: () => ({ open: openMock }),
+}))
+
+enableAutoUnmount(afterEach)
+beforeEach(() => {
+  openMock.mockReset()
+})
+
+describe('LiveTvButton', () => {
+  it('renders a text-only "Live TV" button (no icon)', () => {
+    const w = mount(LiveTvButton)
+    const btn = w.find('.live-tv-btn')
+    expect(btn.text()).toBe('Live TV')
+    expect(btn.find('svg').exists()).toBe(false)
+  })
+
+  it('opens the player with no preselected channel when clicked', async () => {
+    const w = mount(LiveTvButton)
+    await w.find('.live-tv-btn').trigger('click')
+    expect(openMock).toHaveBeenCalledTimes(1)
+    expect(openMock).toHaveBeenCalledWith()
+  })
+})

--- a/src/webui/static-vue/src/views/epg/__tests__/MagazineView.test.ts
+++ b/src/webui/static-vue/src/views/epg/__tests__/MagazineView.test.ts
@@ -145,6 +145,13 @@ vi.mock('@/composables/useEpgInitialScrollToNow', () => ({
   useEpgInitialScrollToNow: () => undefined,
 }))
 
+/* MagazineView now wires channel-cell clicks to useChannelPlay, which
+ * reaches the streamProfiles Pinia store; stub it — playback isn't
+ * exercised by these position-save tests. */
+vi.mock('@/composables/useChannelPlay', () => ({
+  useChannelPlay: () => ({ play: () => Promise.resolve() }),
+}))
+
 vi.mock('@/composables/useTextScale', async () => {
   const { ref: vueRef } = await import('vue')
   return { useTextScale: () => vueRef(1) }


### PR DESCRIPTION
### What

Adds a way to start in-browser playback of **any** channel from the new Vue UI, including channels that carry no EPG data — closing a parity gap with the classic UI's "Watch TV" toolbar button.

Fixes #2183.

### Why

Until now the Vue UI could only launch the in-browser player from an EPG event's drawer. A channel with no programme data has no event to click, so it could not be watched at all from the web UI.

### How

- A **Live TV** button is added to the Timeline, Magazine and Table EPG toolbars. It opens the video player with no channel preselected.
- The player dialog now owns channel selection: a **Channel** dropdown (enabled channels, ordered by number, searchable) sits next to the stream-profile selector. Picking or switching a channel re-points the stream exactly the way switching profile already does, so every enabled channel — EPG or not — is reachable. Until a channel is chosen the dialog shows a "Select a channel to watch." prompt.
- The Timeline and Magazine channel cells also gain a click-to-play affordance that funnels through the same player (in-browser when a stream profile is available, external player otherwise).

The `/stream/` route enforces `ACCESS_STREAMING` server-side, so there is no new client-side access logic.

### Testing

- New/updated Vitest unit tests for the launcher button, the channel-play decision, and the player dialog's channel dropdown; full Vue suite green.
- `vue-tsc`, ESLint and the SPDX header check pass; `npm run build` succeeds.
- Eyeballed at `/gui/`: button appears in all three EPG toolbars; opens the player with the empty Channel dropdown and the prompt; picking a channel starts the stream; switching channels live re-points it.