### PR TITLE
webui: centralise the grid "fetch all" limit in a shared constant

### DIFF
--- a/src/webui/static-vue/src/api/gridConstants.ts
+++ b/src/webui/static-vue/src/api/gridConstants.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/*
+ * Grid-pagination constants shared across grid/list fetches.
+ */
+
+/*
+ * The server's "All" page-size sentinel (`page_size_ui`, `access.c:1518`):
+ * a limit this large tells tvheadend's grid handler (`api_idnode.c`) to
+ * return every row. A fetch that wants the full result set passes this
+ * as its `limit`.
+ */
+export const GRID_LIMIT_ALL = 999_999_999

--- a/src/webui/static-vue/src/components/IdnodeGrid.vue
+++ b/src/webui/static-vue/src/components/IdnodeGrid.vue
@@ -41,6 +41,7 @@ import { levelMatches, propLevel } from '@/types/idnode'
 import type { UiLevel } from '@/types/access'
 import { useAccessStore } from '@/stores/access'
 import { inferEntityClass, useGridStore } from '@/stores/grid'
+import { GRID_LIMIT_ALL } from '@/api/gridConstants'
 import { useIdnodeClassStore } from '@/stores/idnodeClass'
 import { createDebounce } from '@/utils/debounce'
 import { fmtDate } from '@/utils/formatTime'
@@ -85,15 +86,6 @@ type Row = BaseRow
  * `disp_*` mirrors.
  */
 const LANG_FALLBACKS = ['eng', 'en', 'en_US', 'en_GB']
-
-/*
- * Server's "All" sentinel for `page_size_ui` (`access.c:1518`):
- * `999999999` means "no practical pagination". The virtual-
- * scrolled grids use it as the per-fetch limit so the store
- * loads the full dataset on first paint — virtualScroller then
- * materialises only the on-screen rows.
- */
-const ROWS_PER_PAGE_ALL = 999999999
 
 function resolveLangStr(value: Record<string, unknown>): string {
   const navLang = (typeof navigator === 'undefined' ? '' : navigator.language).toLowerCase()
@@ -649,7 +641,7 @@ onMounted(() => {
    * grid loads the first 50 rows then stalls with PrimeVue's
    * loading spinner because virtualScroller sees `total: N`
    * but only N=50 entries in the array. */
-  store.setPage(0, ROWS_PER_PAGE_ALL)
+  store.setPage(0, GRID_LIMIT_ALL)
 })
 
 onBeforeUnmount(() => {

--- a/src/webui/static-vue/src/components/__tests__/IdnodeGrid.test.ts
+++ b/src/webui/static-vue/src/components/__tests__/IdnodeGrid.test.ts
@@ -19,6 +19,7 @@ import IdnodeGrid from '../IdnodeGrid.vue'
 import type { ColumnDef } from '@/types/column'
 import type { BaseRow } from '@/types/grid'
 import type { UiLevel } from '@/types/access'
+import { GRID_LIMIT_ALL } from '@/api/gridConstants'
 
 /* Mock the shared phone-breakpoint singleton with a test-driven
  * ref — happy-dom's matchMedia wiring can't be flipped reliably
@@ -420,11 +421,11 @@ describe('IdnodeGrid', () => {
   it('calls store.setPage with the "all" sentinel on mount', () => {
     /* The grid is virtual-scrolled — it needs the full dataset on
      * the client because there's no page-forward affordance. Mount
-     * calls `store.setPage(0, ROWS_PER_PAGE_ALL)` to override the
+     * calls `store.setPage(0, GRID_LIMIT_ALL)` to override the
      * store's default page-size limit before the initial fetch. */
     mountGrid()
     expect(mockStore.setPage).toHaveBeenCalledOnce()
-    expect(mockStore.setPage).toHaveBeenCalledWith(0, 999999999)
+    expect(mockStore.setPage).toHaveBeenCalledWith(0, GRID_LIMIT_ALL)
   })
 
   it('renders the default error message when store has an error', () => {
@@ -1456,7 +1457,7 @@ describe('IdnodeGrid', () => {
       })
       const wrapper = mountGrid({}, { clientSideFilter: true })
       /* IdnodeGrid's onMounted unconditionally calls setPage(0,
-       * ROWS_PER_PAGE_ALL) — see the comment in IdnodeGrid.vue.
+       * GRID_LIMIT_ALL) — see the comment in IdnodeGrid.vue.
        * Reset the mock so the assertion targets the PrimeVue
        * `@page` event path specifically. */
       mockStore.setPage.mockClear()

--- a/src/webui/static-vue/src/composables/useEpgViewState.ts
+++ b/src/webui/static-vue/src/composables/useEpgViewState.ts
@@ -47,6 +47,7 @@ import { readStoredJson, writeStoredJson } from '@/utils/storage'
 import { addLocalDaysEpoch, startOfLocalDayEpoch as startOfLocalDay } from '@/utils/localDay'
 import { useIsPhone } from './useIsPhone'
 import { apiCall } from '@/api/client'
+import { GRID_LIMIT_ALL } from '@/api/gridConstants'
 import { cometClient } from '@/api/comet'
 import { dropDeletedEvents, mergeFreshEvents } from './epgEventMerge'
 import { decideCometTier } from './epgCometTiering'
@@ -846,7 +847,7 @@ export function useEpgViewState(opts: UseEpgViewStateOpts = {}): UseEpgViewState
         filter: JSON.stringify([
           { field: 'enabled', type: 'boolean', value: true } satisfies FilterDef,
         ]),
-        limit: 999_999_999,
+        limit: GRID_LIMIT_ALL,
         sort: 'number',
         dir: 'ASC',
       })
@@ -941,7 +942,7 @@ export function useEpgViewState(opts: UseEpgViewStateOpts = {}): UseEpgViewState
     loadingDays.value = new Set(loadingDays.value).add(epoch)
     const params: Record<string, unknown> = {
       start: 0,
-      limit: 999_999_999,
+      limit: GRID_LIMIT_ALL,
       sort: 'start',
       dir: 'ASC',
       filter: JSON.stringify([
@@ -1037,7 +1038,7 @@ export function useEpgViewState(opts: UseEpgViewStateOpts = {}): UseEpgViewState
     try {
       const params: Record<string, unknown> = {
         start: 0,
-        limit: 999_999_999,
+        limit: GRID_LIMIT_ALL,
         sort: 'start',
         dir: 'ASC',
       }
@@ -1265,7 +1266,7 @@ export function useEpgViewState(opts: UseEpgViewStateOpts = {}): UseEpgViewState
     try {
       const resp = await apiCall<GridResponse<ChannelTag>>('channeltag/grid', {
         start: 0,
-        limit: 999_999_999,
+        limit: GRID_LIMIT_ALL,
         sort: 'index',
         dir: 'ASC',
       })

--- a/src/webui/static-vue/src/stores/dvrEntries.ts
+++ b/src/webui/static-vue/src/stores/dvrEntries.ts
@@ -32,6 +32,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { apiCall } from '@/api/client'
+import { GRID_LIMIT_ALL } from '@/api/gridConstants'
 import { cometClient } from '@/api/comet'
 import { createDebounce } from '@/utils/debounce'
 import type { IdnodeNotification } from '@/types/comet'
@@ -71,7 +72,7 @@ export const useDvrEntriesStore = defineStore('dvrEntries', () => {
     try {
       const resp = await apiCall<GridResponse>('dvr/entry/grid_upcoming', {
         start: 0,
-        limit: 999_999_999,
+        limit: GRID_LIMIT_ALL,
       })
       entries.value = Array.isArray(resp?.entries) ? resp.entries : []
       loaded.value = true


### PR DESCRIPTION
### What

Introduces a shared `GRID_LIMIT_ALL` constant for the "return every row" page-size limit and uses it at every grid/list fetch site, replacing the repeated inline `999_999_999` literal.

### Why

The value `999_999_999` is the server's `page_size_ui` "All" sentinel (`access.c:1518`) — a limit this large tells the grid handler (`api_idnode.c`) to return the full result set. It was duplicated inline across the EPG, DVR and idnode grid fetches, and once as a local constant in `IdnodeGrid.vue`. Centralising it documents the intent and gives a single source of truth.

### How

- New `src/api/gridConstants.ts` exporting `GRID_LIMIT_ALL` (with the `access.c:1518` note).
- Converted all call sites: `useEpgViewState.ts` (×4), `dvrEntries.ts`, and `IdnodeGrid.vue` (its local `ROWS_PER_PAGE_ALL` now derives from the shared constant). The `IdnodeGrid` test asserts against the constant rather than the literal.

Pure refactor — no behavioural change.

### Testing

- Full Vue unit suite green; `vue-tsc`, ESLint and the SPDX header check pass; `npm run build` succeeds.