### PR TITLE
XMLTV EPG Grabber - Channel Matching Remediation

### DIFF
--- a/src/epggrab/channel.c
+++ b/src/epggrab/channel.c
@@ -74,9 +74,20 @@ int epggrab_channel_match_name ( epggrab_channel_t *ec, channel_t *ch )
 {
   const char *name, *s;
   htsmsg_field_t *f;
+  char ubuf[UUID_HEX_SIZE];
 
   if (!epggrab_channel_check(ec, ch))
     return 0;
+
+  //Check for a match to a channel UUID.
+  channel_get_uuid(ch, ubuf);
+  if (ec->names)
+    HTSMSG_FOREACH(f, ec->names)
+      if ((s = htsmsg_field_get_str(f)) != NULL)
+      {
+        if (!strcasecmp(s, ubuf))
+          return 1;        
+      }
 
   name = channel_get_name(ch, NULL);
   if (name == NULL)
@@ -288,19 +299,31 @@ static int
 epggrab_channel_autolink( epggrab_channel_t *ec )
 {
   channel_t *ch;
+  int chnum = 0;  //Default to not searching channel numbers.
+  if (ec->mod->type == EPGGRAB_INT || ec->mod->type == EPGGRAB_EXT)
+  {
+    chnum = ((epggrab_module_ext_t *)ec->mod)->xmltv_chnum;  //This is the grabber 'Channel numbers (heuristic)' flag.
+  }
 
   CHANNEL_FOREACH(ch)
     if (epggrab_channel_match_epgid(ec, ch))
       if (epggrab_channel_link(ec, ch, NULL))
         return 1;
+
+  //Only test channel number if the module flag is set.
+  if(chnum)
+  {
+    CHANNEL_FOREACH(ch)
+      if (epggrab_channel_match_number(ec, ch))
+        if (epggrab_channel_link(ec, ch, NULL))
+          return 1;              
+  }
+
   CHANNEL_FOREACH(ch)
     if (epggrab_channel_match_name(ec, ch))
       if (epggrab_channel_link(ec, ch, NULL))
         return 1;
-  CHANNEL_FOREACH(ch)
-    if (epggrab_channel_match_number(ec, ch))
-      if (epggrab_channel_link(ec, ch, NULL))
-        return 1;
+
   return 0;
 }
 

--- a/src/epggrab/module/xmltv.c
+++ b/src/epggrab/module/xmltv.c
@@ -1218,6 +1218,13 @@ static int _xmltv_parse_channel
           /* Skip extra spaces between channel number and actual name */
           while (*cur == ' ') ++cur;
         }
+        else
+        {
+          //If the 'space separator' test fails, reset the name position.
+          //Without this, the '4Music' example above will be recognised as 'Music'
+          //because *cur no longer points to the beginning of the name.
+          cur = name;
+        }
       }
 
       if (cur && *cur)


### PR DESCRIPTION
Closes #2187

**1a:** Reorder the 'Grabber Channel' to 'Broadcast Channel' matching logic so that channel number matching is performed before name matching.

**1b:** Only perform channel number matching when the  'Channel numbers (heuristic)' option is enabled.

**2:** When 'Channel numbers (heuristic)' is enabled, fix issue where leading numerals in a channel name were removed when not followed by a space.  EG: Both '123 ABC' and '123ABC' result in a channel name of 'ABC'.

**3:** Add `display-name` XMLTV element test against the TVH channel UUID as well as the TVH channel name.