### PR TITLE
webui: use the shared GRID_LIMIT_ALL in the video player channel fetch

### DIFF
--- a/src/webui/static-vue/src/components/VideoPlayerDialog.vue
+++ b/src/webui/static-vue/src/components/VideoPlayerDialog.vue
@@ -32,6 +32,7 @@ import { useVideoPlayer } from '@/composables/useVideoPlayer'
 import { useStreamProfilesStore } from '@/stores/streamProfiles'
 import { channelStreamUrl } from '@/utils/playUrl'
 import { apiCall } from '@/api/client'
+import { GRID_LIMIT_ALL } from '@/api/gridConstants'
 import type { GridResponse, FilterDef } from '@/types/grid'
 
 const { t } = useI18n()
@@ -62,7 +63,7 @@ async function loadChannels(): Promise<void> {
       filter: JSON.stringify([
         { field: 'enabled', type: 'boolean', value: true } satisfies FilterDef,
       ]),
-      limit: 999_999_999,
+      limit: GRID_LIMIT_ALL,
       sort: 'number',
       dir: 'ASC',
     })


### PR DESCRIPTION
### What

Points `VideoPlayerDialog`'s channel-picker fetch at the shared `GRID_LIMIT_ALL` constant instead of the inline `999_999_999` literal.

### Why

#2185 centralised the "fetch all" limit into `GRID_LIMIT_ALL` and converted every call site that existed on master at the time. `VideoPlayerDialog`'s channel fetch was still on the (then-unmerged) #2184 branch, so it kept the inline literal. Now that both have landed, this converts the one remaining site so every grid/list fetch uses the single source of truth.

### Testing

Dialog unit test green; `vue-tsc`, ESLint and the SPDX header check pass; `npm run build` succeeds.