### PR TITLE
webui: show ATSC fractional channel numbers

### DIFF
--- a/src/webui/static-vue/src/components/VideoPlayerDialog.vue
+++ b/src/webui/static-vue/src/components/VideoPlayerDialog.vue
@@ -47,7 +47,8 @@ const LAST_PROFILE_KEY = 'tvh:browser-play-profile'
 interface PlayerChannel {
   uuid: string
   name?: string
-  number?: number
+  /* Integer LCN, or a string for ATSC fractional numbers ("10.1"). */
+  number?: number | string
   /* Precomputed "number · name" so the Select's filter matches both. */
   label: string
 }
@@ -66,11 +67,15 @@ async function loadChannels(): Promise<void> {
       sort: 'number',
       dir: 'ASC',
     })
-    channels.value = (resp.entries ?? []).map((c) => ({
-      ...c,
-      label:
-        typeof c.number === 'number' ? `${c.number} · ${c.name ?? c.uuid}` : (c.name ?? c.uuid),
-    }))
+    channels.value = (resp.entries ?? []).map((c) => {
+      /* number is an int, or an ATSC fractional string ("10.1"); ?? ''
+       * guards absent/empty so the label never shows "undefined". */
+      const numStr = String(c.number ?? '')
+      return {
+        ...c,
+        label: numStr ? `${numStr} · ${c.name ?? c.uuid}` : (c.name ?? c.uuid),
+      }
+    })
     channelsLoaded = true
   } catch (e) {
     /* Non-fatal — the dropdown just stays empty; a channel passed in

--- a/src/webui/static-vue/src/views/epg/EpgMagazine.vue
+++ b/src/webui/static-vue/src/views/epg/EpgMagazine.vue
@@ -73,7 +73,9 @@ const { t } = useI18n()
 export interface MagazineChannel {
   uuid: string
   name?: string
-  number?: number
+  /* number | string — the server sends a string for ATSC fractional
+   * LCNs (e.g. "10.1"). See channelNumber() in epgGridShared. */
+  number?: number | string
   icon?: string
 }
 

--- a/src/webui/static-vue/src/views/epg/EpgTimeline.vue
+++ b/src/webui/static-vue/src/views/epg/EpgTimeline.vue
@@ -69,7 +69,9 @@ const { t } = useI18n()
 export interface TimelineChannel {
   uuid: string
   name?: string
-  number?: number
+  /* number | string — the server sends a string for ATSC fractional
+   * LCNs (e.g. "10.1"). See channelNumber() in epgGridShared. */
+  number?: number | string
   icon?: string
 }
 

--- a/src/webui/static-vue/src/views/epg/__tests__/epgGridShared.test.ts
+++ b/src/webui/static-vue/src/views/epg/__tests__/epgGridShared.test.ts
@@ -2,7 +2,28 @@
 // Copyright (C) 2026 Tvheadend contributors
 
 import { describe, expect, it } from 'vitest'
-import { computeVisibleIndexRange, eventOverlapsTimeRange } from '@/views/epg/epgGridShared'
+import {
+  channelNumber,
+  computeVisibleIndexRange,
+  eventOverlapsTimeRange,
+} from '@/views/epg/epgGridShared'
+
+describe('channelNumber', () => {
+  it('renders an integer LCN', () => {
+    expect(channelNumber({ uuid: 'a', number: 10 })).toBe('10')
+  })
+
+  it('renders an ATSC fractional LCN the server sends as a string', () => {
+    /* Regression: fractional numbers arrive as a string, not a number,
+     * and were previously dropped in the EPG channel column (#2190). */
+    expect(channelNumber({ uuid: 'a', number: '10.1' })).toBe('10.1')
+  })
+
+  it('renders nothing for an absent or empty number', () => {
+    expect(channelNumber({ uuid: 'a' })).toBe('')
+    expect(channelNumber({ uuid: 'a', number: '' })).toBe('')
+  })
+})
 
 describe('computeVisibleIndexRange', () => {
   it('returns first N items (plus overscan) at scrollPos 0', () => {

--- a/src/webui/static-vue/src/views/epg/epgGridShared.ts
+++ b/src/webui/static-vue/src/views/epg/epgGridShared.ts
@@ -42,7 +42,9 @@ export interface GridEvent {
 export interface GridChannel {
   uuid: string
   name?: string
-  number?: number
+  /* Integer LCN for most channels; the server sends a string for
+   * ATSC fractional numbers (e.g. "10.1"), so both shapes arrive. */
+  number?: number | string
 }
 
 /* Bucket events by channelUuid for O(channels) row rendering instead
@@ -123,7 +125,9 @@ export function iconUrl(icon: string | undefined): string | null {
 }
 
 export function channelNumber(ch: GridChannel): string {
-  return typeof ch.number === 'number' ? String(ch.number) : ''
+  /* Integer LCN, or an ATSC fractional string ("10.1"); ?? '' guards
+   * absent/empty so we never render "undefined". */
+  return String(ch.number ?? '')
 }
 
 export function channelName(ch: GridChannel): string {


### PR DESCRIPTION
### What

Fixes fractional (ATSC `[major].[minor]`) channel numbers being hidden in the Vue UI's EPG Timeline and Magazine channel columns.

Fixes #2190.

### Why

The server returns a channel's `number` as an **integer** for most channels but as a **string** for ATSC fractional LCNs (e.g. `"10.1"`). The channel-number renderer (`channelNumber()` in `epgGridShared.ts`, used by both EPG views) only handled the integer case via `typeof === 'number'`, so string numbers rendered as empty and the column showed nothing. The Live TV channel-picker label (`VideoPlayerDialog`) had the same gap.

### How

- `channelNumber()` now renders the string form as-is (integers still `String()`-ified; absent/empty → nothing).
- Widened the channel `number` type to `number | string` where it's rendered (`GridChannel`, `TimelineChannel`, `MagazineChannel`, the player's `PlayerChannel`) and updated the Live TV label to include a string number.
- Added unit coverage in `epgGridShared.test.ts` (integer, `"10.1"`, and empty/absent).

Channel *sorting* is out of scope — it already runs on the runtime value and the reporter's issue is display-only.

### Testing

Repro (per the report): edit any service to a fractional channel number (e.g. `10.1`) — it now shows in the Timeline/Magazine channel column and the Live TV picker. `vue-tsc`, ESLint, the SPDX header check and the full Vue unit suite pass; `npm run build` succeeds.