### PR TITLE
webui: add an expert-level raw data section to the Vue EPG drawer

### DIFF
--- a/src/api/api_epg.c
+++ b/src/api/api_epg.c
@@ -761,6 +761,72 @@ api_epg_load
   return 0;
 }
 
+/*
+ * Raw matcher-eye view of one event, for the web UI's inspector.
+ *
+ * Returns only the delta the normal api_epg_entry payload cannot
+ * provide: the originating grabber module and the full
+ * multi-language variants of the text fields (api_epg_entry
+ * resolves a single language; the autorec matcher iterates the
+ * whole lang_str tree).  The episode-link URI rides along so the
+ * inspector renders from a single payload; internal tvh:// URIs
+ * are suppressed exactly as in api_epg_entry, since every
+ * consumer (DVR dedup included) treats them as no URI at all.
+ */
+static const struct {
+  const char *name;
+  size_t      offset;
+} api_epg_raw_texts[] = {
+  { "title",       offsetof(epg_broadcast_t, title) },
+  { "subtitle",    offsetof(epg_broadcast_t, subtitle) },
+  { "summary",     offsetof(epg_broadcast_t, summary) },
+  { "description", offsetof(epg_broadcast_t, description) },
+};
+
+static int
+api_epg_raw
+  ( access_t *perm, void *opaque, const char *op, htsmsg_t *args, htsmsg_t **resp )
+{
+  uint32_t id;
+  epg_broadcast_t *e;
+  htsmsg_t *m, *texts;
+  lang_str_t *ls;
+  int i;
+
+  if (htsmsg_get_u32(args, "eventId", &id))
+    return EINVAL;
+
+  m = htsmsg_create_map();
+
+  /* Main Job */
+  tvh_mutex_lock(&global_lock);
+  e = epg_broadcast_find_by_id(id);
+  if (e == NULL) {
+    tvh_mutex_unlock(&global_lock);
+    htsmsg_destroy(m);
+    return ENOENT;
+  }
+  htsmsg_add_u32(m, "eventId", id);
+  if (e->grabber) {
+    htsmsg_add_str(m, "grabberId", e->grabber->id);
+    if (e->grabber->name)
+      htsmsg_add_str(m, "grabberName", e->grabber->name);
+  }
+  if (e->episodelink && strncasecmp(e->episodelink->uri, "tvh://", 6))
+    htsmsg_add_str(m, "episodeUri", e->episodelink->uri);
+  texts = htsmsg_create_map();
+  for (i = 0; i < ARRAY_SIZE(api_epg_raw_texts); i++) {
+    ls = *(lang_str_t **)((char *)e + api_epg_raw_texts[i].offset);
+    if (ls)
+      htsmsg_add_msg(texts, api_epg_raw_texts[i].name, lang_str_serialize_map(ls));
+  }
+  htsmsg_add_msg(m, "texts", texts);
+  tvh_mutex_unlock(&global_lock);
+
+  *resp = m;
+  return 0;
+}
+
 static int
 api_epg_content_type_list(access_t *perm, void *opaque, const char *op,
                           htsmsg_t *args, htsmsg_t **resp)
@@ -783,6 +849,7 @@ void api_epg_init ( void )
     { "epg/events/alternative", ACCESS_ANONYMOUS, api_epg_alternative, NULL },
     { "epg/events/related",     ACCESS_ANONYMOUS, api_epg_related, NULL },
     { "epg/events/load",        ACCESS_ANONYMOUS, api_epg_load, NULL },
+    { "epg/events/raw",         ACCESS_ANONYMOUS, api_epg_raw, NULL },
     { "epg/content_type/list",  ACCESS_ANONYMOUS, api_epg_content_type_list, NULL },
 
     { NULL },

--- a/src/webui/static-vue/src/composables/__tests__/useEpgRawFetch.test.ts
+++ b/src/webui/static-vue/src/composables/__tests__/useEpgRawFetch.test.ts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/*
+ * useEpgRawFetch unit tests. The composable is a thin one-shot
+ * fetch wrapper (same shape as useEpgRelatedFetch); what's worth
+ * pinning is the state contract the drawer's Raw data section
+ * relies on: loading toggles around the call, an error clears any
+ * previously-held payload (a stale raw view for the wrong event
+ * would silently mislead a rule author), and reset() returns the
+ * section to its pristine collapsed-state semantics.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useEpgRawFetch, type EpgEventRaw } from '../useEpgRawFetch'
+
+const apiCallMock = vi.fn()
+
+vi.mock('@/api/client', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+}))
+
+const SAMPLE: EpgEventRaw = {
+  eventId: 42,
+  grabberId: 'eit',
+  grabberName: 'EIT: DVB Grabber',
+  texts: {
+    title: { eng: 'Evening News', dut: 'Avondnieuws' },
+    summary: { eng: 'Daily news roundup.' },
+  },
+}
+
+beforeEach(() => {
+  apiCallMock.mockReset()
+})
+
+describe('useEpgRawFetch', () => {
+  it('calls the raw endpoint with the event id and stores the payload', async () => {
+    apiCallMock.mockResolvedValueOnce(SAMPLE)
+    const { raw, loading, error, fetch } = useEpgRawFetch()
+
+    await fetch(42)
+
+    expect(apiCallMock).toHaveBeenCalledWith('epg/events/raw', { eventId: 42 })
+    expect(raw.value).toEqual(SAMPLE)
+    expect(loading.value).toBe(false)
+    expect(error.value).toBeNull()
+  })
+
+  it('sets loading while the request is in flight', async () => {
+    let resolve!: (v: EpgEventRaw) => void
+    apiCallMock.mockReturnValueOnce(
+      new Promise<EpgEventRaw>((r) => {
+        resolve = r
+      }),
+    )
+    const { loading, fetch } = useEpgRawFetch()
+
+    const p = fetch(42)
+    expect(loading.value).toBe(true)
+    resolve(SAMPLE)
+    await p
+    expect(loading.value).toBe(false)
+  })
+
+  it('clears a previously-held payload when a later fetch fails', async () => {
+    apiCallMock.mockResolvedValueOnce(SAMPLE)
+    const { raw, error, fetch } = useEpgRawFetch()
+    await fetch(42)
+    expect(raw.value).toEqual(SAMPLE)
+
+    apiCallMock.mockRejectedValueOnce(new Error('boom'))
+    await fetch(43)
+
+    expect(raw.value).toBeNull()
+    expect(error.value?.message).toBe('boom')
+  })
+
+  it('wraps non-Error rejections', async () => {
+    apiCallMock.mockRejectedValueOnce('plain string failure')
+    const { error, fetch } = useEpgRawFetch()
+
+    await fetch(42)
+
+    expect(error.value).toBeInstanceOf(Error)
+    expect(error.value?.message).toBe('plain string failure')
+  })
+
+  it('reset() returns to the pristine state', async () => {
+    apiCallMock.mockResolvedValueOnce(SAMPLE)
+    const { raw, loading, error, fetch, reset } = useEpgRawFetch()
+    await fetch(42)
+
+    reset()
+
+    expect(raw.value).toBeNull()
+    expect(loading.value).toBe(false)
+    expect(error.value).toBeNull()
+  })
+
+  it('discards a response that lands after reset()', async () => {
+    let resolve!: (v: EpgEventRaw) => void
+    apiCallMock.mockReturnValueOnce(
+      new Promise<EpgEventRaw>((r) => {
+        resolve = r
+      }),
+    )
+    const { raw, loading, error, fetch, reset } = useEpgRawFetch()
+
+    const p = fetch(42)
+    reset()
+    resolve(SAMPLE)
+    await p
+
+    expect(raw.value).toBeNull()
+    expect(loading.value).toBe(false)
+    expect(error.value).toBeNull()
+  })
+
+  it('lets a newer fetch win over a slower older one', async () => {
+    const OTHER: EpgEventRaw = {
+      eventId: 43,
+      grabberId: 'xmltv',
+      texts: { title: { dut: 'Ander programma' } },
+    }
+    let resolveFirst!: (v: EpgEventRaw) => void
+    apiCallMock.mockReturnValueOnce(
+      new Promise<EpgEventRaw>((r) => {
+        resolveFirst = r
+      }),
+    )
+    apiCallMock.mockResolvedValueOnce(OTHER)
+    const { raw, loading, fetch } = useEpgRawFetch()
+
+    const first = fetch(42)
+    const second = fetch(43)
+    await second
+    resolveFirst(SAMPLE)
+    await first
+
+    expect(raw.value).toEqual(OTHER)
+    expect(loading.value).toBe(false)
+  })
+})

--- a/src/webui/static-vue/src/composables/useEpgRawFetch.ts
+++ b/src/webui/static-vue/src/composables/useEpgRawFetch.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/*
+ * useEpgRawFetch — one-shot fetch for `api/epg/events/raw`
+ * (ACCESS_ANONYMOUS, registered in `src/api/api_epg.c`).
+ *
+ * Powers the EpgEventDrawer's expert-level "Raw data" section: the
+ * event's fields as the autorec matcher consumes them. The endpoint
+ * returns only the delta the `events/load` payload cannot provide —
+ * the originating grabber module and the full multi-language
+ * variants of the text fields (the normal payload resolves one
+ * language).
+ *
+ * `texts` is deliberately an open map keyed by field name: the
+ * server side is table-driven, so a future lang_str field appears
+ * here with zero client changes.
+ *
+ * One-shot semantics like useEpgRelatedFetch: fetched on demand
+ * when the section is expanded, no Comet subscription — the raw
+ * view is a snapshot for rule authoring, not a live surface.
+ */
+
+import { ref } from 'vue'
+import { apiCall } from '@/api/client'
+
+export interface EpgEventRaw {
+  eventId: number
+  /* epggrab module that originated this broadcast (epg_object.grabber);
+   * absent on events whose grabber module is gone. */
+  grabberId?: string
+  grabberName?: string
+  /* Episode-link URI; internal `tvh://` URIs are suppressed just
+   * as in the grid payload, so absence means "no usable URI". */
+  episodeUri?: string
+  /* field name → { language code → text }, all languages */
+  texts?: Record<string, Record<string, string>>
+}
+
+export function useEpgRawFetch() {
+  const raw = ref<EpgEventRaw | null>(null)
+  const loading = ref(false)
+  const error = ref<Error | null>(null)
+  /* Request generation: reset() and every fetch() bump it, and a
+   * completion only applies while its generation is still current.
+   * Without this, a response landing after reset() (event switch)
+   * or after a newer fetch would repopulate `raw` with another
+   * event's payload — exactly the stale-wrong-event view this
+   * composable exists to prevent. Last request wins. */
+  let generation = 0
+
+  async function fetch(eventId: number): Promise<void> {
+    const gen = ++generation
+    loading.value = true
+    error.value = null
+    try {
+      const result = await apiCall<EpgEventRaw>('epg/events/raw', { eventId })
+      if (gen !== generation) return
+      raw.value = result
+    } catch (e) {
+      if (gen !== generation) return
+      error.value = e instanceof Error ? e : new Error(String(e))
+      raw.value = null
+    } finally {
+      if (gen === generation) loading.value = false
+    }
+  }
+
+  function reset(): void {
+    generation++
+    raw.value = null
+    loading.value = false
+    error.value = null
+  }
+
+  return { raw, loading, error, fetch, reset }
+}

--- a/src/webui/static-vue/src/views/epg/EpgEventDrawer.vue
+++ b/src/webui/static-vue/src/views/epg/EpgEventDrawer.vue
@@ -52,6 +52,7 @@ import { useStreamProfilesStore } from '@/stores/streamProfiles'
 import { useAccessStore } from '@/stores/access'
 import { useDvrConfigStore } from '@/stores/dvrConfig'
 import { useEpgContentTypeStore } from '@/stores/epgContentTypes'
+import { useEpgRawFetch } from '@/composables/useEpgRawFetch'
 import { useI18n } from '@/composables/useI18n'
 import { useResizableDrawerWidth } from '@/composables/useResizableDrawerWidth'
 
@@ -192,6 +193,21 @@ export interface EpgEventDetail {
    * the server-side `create_by_series` endpoint falls back to a
    * title-based AutoRec. Server emits via `api_epg.c:110`. */
   serieslinkUri?: string
+  /* Episode-link URI (per-episode counterpart of `serieslinkUri`,
+   * used by DVR duplicate detection). The grid payload suppresses
+   * internal `tvh://` URIs (`api_epg.c:108`), so the raw section
+   * renders the unfiltered value from `epg/events/raw` instead of
+   * this field. */
+  episodeUri?: string
+  /* Season number (`epnum.s_num`), emitted only when nonzero
+   * (`api_epg.c:163`) — key absence is the matcher's
+   * season-leaf-passes state. */
+  seasonNumber?: number
+  /* New/repeat broadcast flags (`is_new` / `is_repeat`), each
+   * emitted only when set (`api_epg.c:140-142`) — both keys absent
+   * is the state the `new_or_unknown` broadcast_type matches. */
+  new?: number
+  repeat?: number
 }
 
 interface Props {
@@ -741,8 +757,245 @@ watch(
   () => props.event?.eventId,
   () => {
     imageFailed.value = false
-  },
+  }
 )
+
+/* ---- Raw data (expert view level) ----
+ *
+ * The event's fields as the autorec matcher consumes them. The
+ * normal drawer groups display-process the data — one resolved
+ * language per text field, localised genre labels, `extraText()`
+ * collapsing subtitle/summary/description elsewhere in the EPG —
+ * so a rule author cannot tell which field actually holds the
+ * text to match, or that an event carries no DVB genre at all
+ * (source-dependent: e.g. XMLTV events have none, so content-type
+ * filters silently fail there). Switching a channel's EPG source
+ * can therefore silently break an existing rule; this section
+ * makes that visible.
+ *
+ * Data comes from two places:
+ *   - `api/epg/events/raw` (useEpgRawFetch, one-shot): the delta
+ *     the grid payload cannot provide — originating grabber module,
+ *     all-language variants of the text fields + the unfiltered
+ *     episode-link URI (the grid suppresses internal `tvh://`
+ *     ones). Fetched only
+ *     when the section is first expanded for an event: the payload
+ *     repeats every text field in every language, and the section
+ *     is a niche surface even at expert level.
+ *   - The event object the drawer already holds: raw genre codes,
+ *     episode string, serieslink URI, channel UUID.
+ *
+ * Layout is field-major (all language variants of one field
+ * together — a regex fires if ANY variant matches, so they belong
+ * in one glance). Rows render only when populated; every unset
+ * field, fixed-row or not, is named on the single compact "Not
+ * present" line (`rawAbsentFields`). Seeing which fields are
+ * UNPOPULATED is the point, but per-field `{not set}` markers
+ * proved noisy next to the collected line, and the distinction
+ * they implied is untestable at the matcher anyway.
+ *
+ * Values render verbatim (no KodiText) — this is the matcher's
+ * view, not the display view.
+ *
+ * The catch-all at the end surfaces event-object keys this file
+ * does not know (`KNOWN_EVENT_KEYS`), so a future server-side
+ * field appears here with zero client edits. Same idea on the
+ * text fields: `rawTextBlocks` unions the known four with
+ * whatever field names the raw endpoint returns (its serializer
+ * is table-driven server-side).
+ */
+const rawFetch = useEpgRawFetch()
+const rawOpen = ref(false)
+
+/* Collapse + forget on re-target: the section is a per-event
+ * snapshot, and an open section auto-fetching for every event the
+ * user clicks through would defeat the fetch-on-demand design. */
+watch(
+  () => props.event?.eventId,
+  () => {
+    rawOpen.value = false
+    rawFetch.reset()
+  }
+)
+
+function onRawToggle(e: Event): void {
+  const open = (e.currentTarget as HTMLDetailsElement).open
+  rawOpen.value = open
+  if (!open || !props.event || rawFetch.loading.value) return
+  /* Reuse a held payload only when it belongs to the displayed
+   * event; anything else (null, error retry, other event) fetches.
+   * The composable already discards stale completions — this keyed
+   * reuse just makes the gate correct on its own terms. */
+  if (rawFetch.raw.value?.eventId === props.event.eventId) return
+  rawFetch.fetch(props.event.eventId)
+}
+
+/* The four lang_str-backed text fields the matcher iterates, in
+ * the server's serializer order. Unioned with any additional
+ * field names the endpoint returns; empty ones are listed on the
+ * "Not present" line instead of rendering a row. */
+const RAW_TEXT_FIELDS = ['title', 'subtitle', 'summary', 'description']
+
+interface RawTextBlock {
+  name: string
+  variants: { lang: string; text: string }[]
+}
+
+const rawTextBlocks = computed<RawTextBlock[]>(() => {
+  const texts = rawFetch.raw.value?.texts ?? {}
+  const names = [...RAW_TEXT_FIELDS]
+  for (const k of Object.keys(texts)) {
+    if (!names.includes(k)) names.push(k)
+  }
+  return names
+    .map((name) => ({
+      name,
+      variants: Object.entries(texts[name] ?? {}).map(([lang, text]) => ({ lang, text })),
+    }))
+    .filter((block) => block.variants.length > 0)
+})
+
+/* Row labels are the technical field names — matcher leaf names
+ * where the field is matchable (dvr_autorec_expr.c vocabulary),
+ * payload keys otherwise — untranslated: they are the identifiers
+ * a rule author types, not captions. Text rows therefore render
+ * `block.name` directly (payload key == matcher leaf name for all
+ * four, and a server-added field shows its payload name anyway). */
+
+const rawGrabberLine = computed<{ id: string; name?: string } | null>(() => {
+  const r = rawFetch.raw.value
+  if (!r || (!r.grabberId && !r.grabberName)) return null
+  return {
+    id: r.grabberId ?? r.grabberName ?? '',
+    name: r.grabberName !== r.grabberId ? r.grabberName : undefined,
+  }
+})
+
+/* DVB content-type codes as the matcher compares them (the
+ * Classification group shows only the localised labels). The label
+ * rides along muted for orientation. */
+const rawGenreCodes = computed<{ code: string; label?: string }[]>(() =>
+  (props.event?.genre ?? []).map((c) => ({
+    code: `0x${c.toString(16).padStart(2, '0')}`,
+    label: contentTypes.labels.get(c),
+  }))
+)
+
+/* Compact absence line: every matcher-visible field unset on this
+ * event, named in row order. One row instead of a wall of
+ * per-field `{not set}` markers — on sparse sources (EIT) the
+ * markers would drown the populated fields, and mixing marker
+ * rows with a collected line read as two kinds of absence when
+ * there is only one: set-but-empty and key-absent are
+ * indistinguishable to the matcher (the API emits keys only when
+ * populated), so one line covers all of it.
+ *
+ * Absence tests mirror the matcher's own evaluation
+ * (`dvr_autorec_expr.c`): `present(year|season|star_rating)` test
+ * `!= 0` and the API emits those keys only when nonzero;
+ * `broadcast_type` reads is_new/is_repeat, emitted as `new` /
+ * `repeat` only when set — both keys absent is the
+ * "new_or_unknown"-matches state this row makes visible.
+ *
+ * Names are the matcher's `present` vocabulary (payload keys for
+ * the non-matchable episodeOnscreen/episodeUri). Hence `genre`
+ * here while the populated row is labelled `content_type`: each
+ * is the exact token a rule uses in that situation — codes match
+ * via the `content_type` leaf, absence tests via
+ * `present: "genre"`. */
+const rawAbsentFields = computed<string[]>(() => {
+  const ev = props.event
+  const raw = rawFetch.raw.value
+  if (!ev || !raw) return []
+  const texts = raw.texts ?? {}
+  const out: string[] = []
+  if (!Object.keys(texts.title ?? {}).length) out.push('title')
+  if (!Object.keys(texts.subtitle ?? {}).length) out.push('subtitle')
+  if (!Object.keys(texts.summary ?? {}).length) out.push('summary')
+  if (!Object.keys(texts.description ?? {}).length) out.push('description')
+  if (!ev.genre?.length) out.push('genre')
+  if (!ev.episodeOnscreen) out.push('episodeOnscreen')
+  if (!ev.serieslinkUri) out.push('serieslink')
+  if (!raw.episodeUri) out.push('episodeUri')
+  if (!ev.copyright_year) out.push('year')
+  if (ev.seasonNumber === undefined) out.push('season')
+  if (!ev.starRating) out.push('star_rating')
+  if (ev.new === undefined && ev.repeat === undefined) out.push('broadcast_type')
+  /* Rowless fields last: when populated these live in the pretty
+   * groups (credits, keyword and category are lists shown mostly
+   * verbatim there), so the raw section only tracks their absence. */
+  if (!ev.credits || Object.keys(ev.credits).length === 0) out.push('credits')
+  if (!ev.keyword?.length) out.push('keyword')
+  if (!ev.category?.length) out.push('category')
+  return out
+})
+
+/* broadcast_type leaf vocabulary from the new/repeat payload
+ * flags; null (no row) when neither flag is present — that state
+ * is named on the absence line instead. */
+const rawBroadcastType = computed<string | null>(() => {
+  const ev = props.event
+  if (!ev) return null
+  const parts: string[] = []
+  if (ev.new !== undefined) parts.push('new')
+  if (ev.repeat !== undefined) parts.push('repeat')
+  return parts.length ? parts.join(', ') : null
+})
+
+/* Every key of EpgEventDetail this drawer version knows about —
+ * the catch-all below renders anything else the server put in the
+ * event object. Extend together with the interface. */
+const KNOWN_EVENT_KEYS = new Set([
+  'eventId',
+  'title',
+  'subtitle',
+  'summary',
+  'description',
+  'channelName',
+  'channelNumber',
+  'channelUuid',
+  'channelIcon',
+  'start',
+  'stop',
+  'episodeOnscreen',
+  'genre',
+  'hd',
+  'widescreen',
+  'audiodesc',
+  'dvrState',
+  'dvrUuid',
+  'category',
+  'keyword',
+  'starRating',
+  'ageRating',
+  'ratingLabel',
+  'ratingLabelIcon',
+  'copyright_year',
+  'first_aired',
+  'image',
+  'credits',
+  'serieslinkUri',
+  'episodeUri',
+  'seasonNumber',
+  'new',
+  'repeat',
+])
+
+function formatRawValue(v: unknown): string {
+  if (typeof v === 'string') return v
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v)
+  if (Array.isArray(v) && v.every((x) => typeof x === 'string' || typeof x === 'number'))
+    return v.join(', ')
+  return JSON.stringify(v)
+}
+
+const rawExtraEntries = computed<{ key: string; value: string }[]>(() => {
+  const ev = props.event
+  if (!ev) return []
+  return Object.entries(ev as unknown as Record<string, unknown>)
+    .filter(([k, v]) => !KNOWN_EVENT_KEYS.has(k) && v !== undefined && v !== null)
+    .map(([k, v]) => ({ key: k, value: formatRawValue(v) }))
+})
 
 function fmtDuration(start: number | undefined, stop: number | undefined): string {
   if (typeof start !== 'number' || typeof stop !== 'number') return ''
@@ -1060,11 +1313,144 @@ const flags = computed(() => {
           />
         </div>
       </details>
+
+      <!--
+        Raw data — expert view level only, collapsed by default;
+        expanding fetches the raw endpoint once per event. Shows the
+        event as the autorec matcher consumes it (see the script-setup
+        block comment for the full rationale). Values are verbatim —
+        no KodiText, no fallback collapsing, explicit markers for
+        unpopulated fields. Row labels are technical field names
+        (matcher leaves / payload keys), deliberately untranslated.
+      -->
+      <details
+        v-if="access.uilevel === 'expert'"
+        class="epg-event-drawer__group epg-event-drawer__group--readonly"
+        :open="rawOpen"
+        @toggle="onRawToggle"
+      >
+        <summary class="epg-event-drawer__group-title">{{ t('Raw data') }}</summary>
+        <div class="epg-event-drawer__group-body">
+          <p v-if="rawFetch.loading.value" class="epg-event-drawer__raw-note">
+            {{ t('Loading…') }}
+          </p>
+          <p v-else-if="rawFetch.error.value" class="epg-event-drawer__raw-note">
+            {{ t('Failed to load raw event data') }}: {{ rawFetch.error.value.message }}
+          </p>
+          <template v-else-if="rawFetch.raw.value">
+            <!-- Field-major text blocks: every language variant of a
+                 field together. Empty fields have no row; they are
+                 named on the "Not present" line below. -->
+            <div
+              v-for="block in rawTextBlocks"
+              :key="block.name"
+              class="ifld epg-event-drawer__raw-row"
+            >
+              <span class="ifld__label">{{ block.name }}</span>
+              <span class="ifld__value">
+                <span class="epg-event-drawer__raw-variants">
+                  <span
+                    v-for="v in block.variants"
+                    :key="v.lang"
+                    class="epg-event-drawer__raw-variant"
+                  >
+                    <span class="epg-event-drawer__raw-lang">{{ v.lang }}</span>
+                    <span class="epg-event-drawer__raw-text">{{ v.text }}</span>
+                  </span>
+                </span>
+              </span>
+            </div>
+            <div v-if="rawGenreCodes.length" class="ifld epg-event-drawer__raw-row">
+              <span class="ifld__label">content_type</span>
+              <span class="ifld__value">
+                <span
+                  v-for="g in rawGenreCodes"
+                  :key="g.code"
+                  class="epg-event-drawer__raw-variant"
+                >
+                  <span class="epg-event-drawer__raw-mono">{{ g.code }}</span>
+                  <span v-if="g.label" class="epg-event-drawer__raw-empty">{{ g.label }}</span>
+                </span>
+              </span>
+            </div>
+            <div v-if="event.episodeOnscreen" class="ifld epg-event-drawer__raw-row">
+              <span class="ifld__label">episodeOnscreen</span>
+              <span class="ifld__value">{{ event.episodeOnscreen }}</span>
+            </div>
+            <div v-if="event.serieslinkUri" class="ifld epg-event-drawer__raw-row">
+              <span class="ifld__label">serieslink</span>
+              <span class="ifld__value epg-event-drawer__raw-mono">{{ event.serieslinkUri }}</span>
+            </div>
+            <div v-if="rawFetch.raw.value.episodeUri" class="ifld epg-event-drawer__raw-row">
+              <span class="ifld__label">episodeUri</span>
+              <span class="ifld__value epg-event-drawer__raw-mono">
+                {{ rawFetch.raw.value.episodeUri }}
+              </span>
+            </div>
+            <!-- Numeric/flag matcher leaves. Other drawer groups
+                 show these formatted (star rating as N / 10 ★);
+                 here they are the verbatim leaf values, labelled
+                 with the leaf tokens. broadcast_type renders the
+                 leaf vocabulary derived from the new/repeat flags.
+                 Guards mirror the absence checks below exactly. -->
+            <div v-if="event.copyright_year" class="ifld epg-event-drawer__raw-row">
+              <span class="ifld__label">year</span>
+              <span class="ifld__value">{{ event.copyright_year }}</span>
+            </div>
+            <div v-if="event.seasonNumber !== undefined" class="ifld epg-event-drawer__raw-row">
+              <span class="ifld__label">season</span>
+              <span class="ifld__value">{{ event.seasonNumber }}</span>
+            </div>
+            <div v-if="event.starRating" class="ifld epg-event-drawer__raw-row">
+              <span class="ifld__label">star_rating</span>
+              <span class="ifld__value">{{ event.starRating }}</span>
+            </div>
+            <div v-if="rawBroadcastType" class="ifld epg-event-drawer__raw-row">
+              <span class="ifld__label">broadcast_type</span>
+              <span class="ifld__value">{{ rawBroadcastType }}</span>
+            </div>
+            <div v-if="event.channelUuid" class="ifld epg-event-drawer__raw-row">
+              <span class="ifld__label">channel</span>
+              <span class="ifld__value epg-event-drawer__raw-mono">{{ event.channelUuid }}</span>
+            </div>
+            <!-- Grabber module id is the technical value; the human
+                 name rides along muted, same idiom as the
+                 content_type codes above. -->
+            <div v-if="rawGrabberLine" class="ifld epg-event-drawer__raw-row">
+              <span class="ifld__label">grabber</span>
+              <span class="ifld__value">
+                <span class="epg-event-drawer__raw-variant">
+                  <span class="epg-event-drawer__raw-mono">{{ rawGrabberLine.id }}</span>
+                  <span v-if="rawGrabberLine.name" class="epg-event-drawer__raw-empty">
+                    {{ rawGrabberLine.name }}
+                  </span>
+                </span>
+              </span>
+            </div>
+            <!-- Catch-all: event-object keys this drawer version does
+                 not know. A field added server-side appears here with
+                 zero client edits. -->
+            <div
+              v-for="entry in rawExtraEntries"
+              :key="entry.key"
+              class="ifld epg-event-drawer__raw-row"
+            >
+              <span class="ifld__label">{{ entry.key }}</span>
+              <span class="ifld__value epg-event-drawer__raw-text">{{ entry.value }}</span>
+            </div>
+            <!-- Last row by design: absence is the footnote to the
+                 data above, not a data row itself. -->
+            <div v-if="rawAbsentFields.length" class="ifld epg-event-drawer__raw-row">
+              <span class="ifld__label">{{ t('Not present') }}</span>
+              <span class="ifld__value epg-event-drawer__raw-empty">
+                {{ rawAbsentFields.join(', ') }}
+              </span>
+            </div>
+          </template>
+        </div>
+      </details>
     </div>
-    <PlayProfileDialog
-      :channel-uuid="playProfileChannel"
-      @close="playProfileChannel = null"
-    />
+    <PlayProfileDialog :channel-uuid="playProfileChannel" @close="playProfileChannel = null" />
     <!--
       Related / alternative showings browser. `event-selected` (dialog
       row double-click) is intentionally not bound — the user is
@@ -1352,6 +1738,67 @@ const flags = computed(() => {
   width: auto;
   vertical-align: middle;
   margin-right: var(--tvh-space-2);
+}
+
+/* ---- Raw data section ----
+ *
+ * Multi-line values (language variants, long URIs) need the label
+ * top-aligned instead of the default center of the shared .ifld
+ * row. */
+.epg-event-drawer__group-body .epg-event-drawer__raw-row {
+  align-items: start;
+}
+
+/* One field's language variants, stacked. */
+.epg-event-drawer__raw-variants {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* One language row: [lang code] verbatim text. Baseline-aligned
+ * so the small code doesn't float against multi-line text. */
+.epg-event-drawer__raw-variant {
+  display: flex;
+  align-items: baseline;
+  gap: var(--tvh-space-2);
+}
+
+/* Language code as stored in the lang_str tree — plain muted
+ * monospace, not the pretty badge chip: the raw section prints
+ * the technical value, not a display treatment. */
+.epg-event-drawer__raw-lang {
+  font-family: ui-monospace, monospace;
+  color: var(--tvh-text-muted);
+}
+
+/* Verbatim value text — preserve the whitespace the matcher sees. */
+.epg-event-drawer__raw-text {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+/* Identifier-shaped values (genre codes, serieslink URI, channel
+ * UUID) — monospace, breakable so long URIs can't force a
+ * horizontal scroll in a 320 px drawer. */
+.epg-event-drawer__raw-mono {
+  font-family: ui-monospace, monospace;
+  overflow-wrap: anywhere;
+}
+
+/* Explicit unpopulated / secondary marker. Making empties visible
+ * is the section's founding purpose — a silent gap would repeat
+ * the exact problem it exists to solve. */
+.epg-event-drawer__raw-empty {
+  color: var(--tvh-text-muted);
+  font-style: italic;
+}
+
+/* Loading / error line inside the group. */
+.epg-event-drawer__raw-note {
+  margin: 0;
+  color: var(--tvh-text-muted);
+  font-size: var(--tvh-text-md);
 }
 
 /* Description body — free-form text inside the Description group. */


### PR DESCRIPTION
The Vue EPG drawer collapses subtitle || summary || description into
one display line, hiding even more of the event's fields than the
ExtJS interface does, so an autorec author cannot tell which field
actually holds the text a rule must match. Which fields are populated
differs per EPG source: an OTA EIT event and an xmltv event for the
same channel fill different fields, and xmltv events often carry no
DVB genre, so content-type filters silently fail there. Switching a
channel's EPG source can therefore silently break an existing rule,
with nothing in the UI to show why.

At Expert view level the event drawer gains a read-only "Raw data"
section showing the event as the matcher sees it. Every populated
field gets its own row, labelled with its technical name - the exact
token a rule uses - and the four text fields show all language
variants. Genre appears as the raw DVB content_type code, and episode
numbering, series/episode link URIs, the channel uuid and the EPG
source (grabber module id) each get a row. Fields the event does not
carry are collected on a single "Not present" footnote line: the
matcher treats empty and missing alike, so rows only render when
populated. Unknown payload keys render generically, so future fields
surface without UI work.

The data comes from a new endpoint, api/epg/events/raw?eventId=N
(ACCESS_ANONYMOUS, following the events/related precedent), which
returns only the delta the grid payload lacks: the grabber id, the
all-language variants of title/subtitle/summary/description, and the
episode-link URI (internal tvh:// URIs are suppressed just as in the
grid payload; every consumer, DVR dedup included, treats them as no
URI at all). The serializer is table-driven; extending the payload is
one table row. The drawer fetches on first expand of the section and
combines the result with the already-loaded grid payload.

The ExtJS interface is untouched: per maintainer guidance, new UI
surface goes to the Vue interface.

If this lands, a follow-up PR to the documentation repo will add
epg/events/raw to the JSON API pages.


