### PR TITLE
webui: filter the EPG Table by content type from its column header

### DIFF
--- a/src/webui/static-vue/src/components/DataGrid.vue
+++ b/src/webui/static-vue/src/components/DataGrid.vue
@@ -1231,6 +1231,12 @@ function filterTitleFor(col: ColumnDef): string {
   if (col.filterType === 'string') {
     return t('Filter: contains "{0}"', String(v))
   }
+  if (col.filterType === 'genre') {
+    /* Value is an array of content-type codes; the consumer owns the
+     * code→label map, so keep the tooltip generic. */
+    const n = Array.isArray(v) ? v.length : 0
+    return t('Filter: {0} content type(s)', n)
+  }
   if (col.filterType === 'enum' && col.enumSource) {
     const opts = Array.isArray(col.enumSource)
       ? col.enumSource

--- a/src/webui/static-vue/src/components/IdnodeGrid.vue
+++ b/src/webui/static-vue/src/components/IdnodeGrid.vue
@@ -1652,6 +1652,9 @@ function onFilter(event: { filters: Record<string, unknown> }) {
       })
       continue
     }
+    /* 'genre' is an EPG-Table-only content-type filter — idnode grids
+     * never carry such a column, so it's not part of this wire shape. */
+    if (col.filterType === 'genre') continue
     if (value === null || value === undefined || value === '') continue
     filters.push({
       field: col.field,

--- a/src/webui/static-vue/src/components/OnlyMultiSelect.vue
+++ b/src/webui/static-vue/src/components/OnlyMultiSelect.vue
@@ -48,6 +48,7 @@ const {
   filter = false,
   showToggleAll = true,
   onlyLabel,
+  appendTo,
 } = defineProps<{
   modelValue: T[]
   options: ReadonlyArray<Option<T>>
@@ -55,6 +56,12 @@ const {
   ariaLabel: string
   filter?: boolean
   showToggleAll?: boolean
+  /* Where PrimeVue teleports the dropdown panel. Defaults to
+   * MultiSelect's own 'body'. Pass 'self' when this sits inside
+   * another dismissable overlay (e.g. a column-filter popover), so
+   * clicking an option isn't treated as an outside-click that
+   * dismisses the parent overlay. */
+  appendTo?: 'body' | 'self'
   /* Label for the per-row "Only" link. Defaults to the
    * translated 'Only' string. Caller can override (e.g. for
    * disambiguation when multiple OnlyMultiSelects sit in the
@@ -118,6 +125,7 @@ function isAllSelected(values: readonly T[]): boolean {
     :aria-label="ariaLabel"
     :filter="filter"
     :show-toggle-all="showToggleAll"
+    :append-to="appendTo"
     @update:model-value="emit('update:modelValue', $event as T[])"
   >
     <template #value="slotProps">

--- a/src/webui/static-vue/src/composables/__tests__/useEpgGenreOptions.test.ts
+++ b/src/webui/static-vue/src/composables/__tests__/useEpgGenreOptions.test.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/*
+ * useEpgGenreOptions — the content-type filter option list shared by
+ * the EPG Table view-options popover and the "Content Type" column
+ * filter (issue #2194). Verifies it restricts to major-group codes and
+ * lazily loads the content-type store.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  ensure: vi.fn(),
+  labels: new Map<number, string>([
+    [0x10, 'Movie/Drama'],
+    [0x11, 'Detective'] /* subtype — excluded */,
+    [0x20, 'News/Current affairs'],
+    [0x30, 'Show/Game show'],
+    [0x33, 'Talk show'] /* subtype — excluded */,
+  ]),
+}))
+
+vi.mock('@/stores/epgContentTypes', () => ({
+  useEpgContentTypeStore: () => ({ labels: h.labels, ensure: h.ensure }),
+}))
+
+import { useEpgGenreOptions } from '../useEpgGenreOptions'
+
+beforeEach(() => {
+  h.ensure.mockClear()
+})
+
+describe('useEpgGenreOptions', () => {
+  it('lists only major-group codes (low nibble zero) with their labels', () => {
+    const opts = useEpgGenreOptions()
+    expect(opts.value.map((o) => o.value)).toEqual([0x10, 0x20, 0x30])
+    expect(opts.value.find((o) => o.value === 0x10)?.label).toBe('Movie/Drama')
+    /* Subtypes (non-zero low nibble) are dropped. */
+    expect(opts.value.map((o) => o.value)).not.toContain(0x11)
+    expect(opts.value.map((o) => o.value)).not.toContain(0x33)
+  })
+
+  it('lazily ensures the content-type store is loaded', () => {
+    useEpgGenreOptions()
+    expect(h.ensure).toHaveBeenCalled()
+  })
+})

--- a/src/webui/static-vue/src/composables/useEpgGenreOptions.ts
+++ b/src/webui/static-vue/src/composables/useEpgGenreOptions.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/*
+ * Content-type (EIT genre) filter options for the EPG Table view,
+ * shared by the view-options popover and the "Content Type" column
+ * filter so both offer the same list from one source.
+ *
+ * Options are sourced from the shared EPG content-types store (the
+ * same store the event drawer's Classification block uses); `ensure()`
+ * is idempotent and lazily triggers the first fetch. Before the labels
+ * arrive the list is empty and the MultiSelect just shows its
+ * placeholder.
+ */
+import { computed, type ComputedRef } from 'vue'
+import { useEpgContentTypeStore } from '@/stores/epgContentTypes'
+
+export interface GenreOption {
+  value: number
+  label: string
+}
+
+export function useEpgGenreOptions(): ComputedRef<GenreOption[]> {
+  const contentTypes = useEpgContentTypeStore()
+  contentTypes.ensure()
+
+  return computed<GenreOption[]>(() => {
+    const out: GenreOption[] = []
+    for (const [code, name] of contentTypes.labels.entries()) {
+      /* Restrict to MAJOR-group codes (low nibble zero — 0x10 / 0x20
+       * / ... / 0xF0). The server's `epg_genre_list_contains`
+       * (`src/epg.c:2256`) widens the match mask to `0xF0` only when
+       * the selected code has a zero low nibble (`partial && !(code &
+       * 0x0F)`), so picking a major group catches every event tagged
+       * with any subtype underneath it. Picking a subtype (e.g.
+       * "Detective" = 0x11) requires an exact match — most
+       * broadcasters only tag the major group, so subtype picks
+       * return empty results in practice. Cell + drawer rendering
+       * keep using the full label map for lookup.
+       *
+       * No explicit "Any" entry — MultiSelect represents the
+       * empty-filter state via an empty model-value array. */
+      if (code & 0x0f) continue
+      out.push({ value: code, label: name })
+    }
+    return out
+  })
+}

--- a/src/webui/static-vue/src/types/column.ts
+++ b/src/webui/static-vue/src/types/column.ts
@@ -82,8 +82,12 @@ export interface ColumnDef {
    *     the server bypasses label-resolution entirely (clean,
    *     locale-stable). Multi-select awaits an upstream PR that
    *     grows the generic idnode filter machinery into OR-compose
-   *     semantics on the same field. */
-  filterType?: 'string' | 'numeric' | 'boolean' | 'enum'
+   *     semantics on the same field.
+   *   - 'genre'   — EPG Table content-type multiselect. The control
+   *     and its state are view-specific (the consumer renders the
+   *     `#columnFilter` slot and owns the value); this type just
+   *     enables the column-header filter menu + funnel for it. */
+  filterType?: 'string' | 'numeric' | 'boolean' | 'enum' | 'genre'
   /* Optional formatter for the cell value (e.g. timestamps -> dates). */
   format?: (value: unknown, row: BaseRow) => string
   /*

--- a/src/webui/static-vue/src/views/epg/EpgTableOptions.vue
+++ b/src/webui/static-vue/src/views/epg/EpgTableOptions.vue
@@ -36,7 +36,7 @@ import { ArrowDown, ArrowUp, X } from 'lucide-vue-next'
 import type { GroupableFieldDef } from '@/types/grid'
 import { useI18n } from '@/composables/useI18n'
 import { useIsPhone } from '@/composables/useIsPhone'
-import { useEpgContentTypeStore } from '@/stores/epgContentTypes'
+import { useEpgGenreOptions } from '@/composables/useEpgGenreOptions'
 import type { ChannelTag } from '@/composables/useEpgViewState'
 import type {
   EpgViewOptions,
@@ -154,38 +154,10 @@ function setTimeWindow(timeWindow: TimeWindow) {
   emit('update:options', { ...props.options, timeWindow })
 }
 
-/* Genre / content-type filter — sources options from the shared
- * EPG content-types store (same store the event drawer's
- * Classification block uses). `ensure()` is idempotent; calling
- * here triggers the first fetch lazily when the popover first
- * mounts. Empty-store fallback shows just "Any" so the dropdown
- * still works before the labels arrive. */
-const contentTypes = useEpgContentTypeStore()
-contentTypes.ensure()
-
-interface GenreOption { value: number; label: string }
-const genreOptions = computed<GenreOption[]>(() => {
-  const out: GenreOption[] = []
-  for (const [code, name] of contentTypes.labels.entries()) {
-    /* Restrict the filter dropdown to MAJOR-group codes (low
-     * nibble zero — 0x10 / 0x20 / ... / 0xF0). The server's
-     * `epg_genre_list_contains` (`src/epg.c:2256`) widens the
-     * match mask to `0xF0` only when the selected code has a
-     * zero low nibble (`partial && !(code & 0x0F)`), so picking
-     * a major group catches every event tagged with any subtype
-     * underneath it. Picking a subtype (e.g. "Detective" =
-     * 0x11) requires an exact match — most broadcasters only
-     * tag the major group, so subtype picks return empty
-     * results in practice. Cell + drawer rendering keep using
-     * the full label map for lookup.
-     *
-     * No explicit "Any" entry — MultiSelect represents the
-     * empty-filter state via an empty model-value array. */
-    if (code & 0x0f) continue
-    out.push({ value: code, label: name })
-  }
-  return out
-})
+/* Genre / content-type filter options — shared with the "Content
+ * Type" column filter via useEpgGenreOptions (major-group codes only;
+ * see the composable for the server-match rationale). */
+const genreOptions = useEpgGenreOptions()
 
 function setGenre(genre: number[]) {
   emit('update:options', { ...props.options, genre })

--- a/src/webui/static-vue/src/views/epg/TableView.vue
+++ b/src/webui/static-vue/src/views/epg/TableView.vue
@@ -79,6 +79,7 @@ import { useI18n } from '@/composables/useI18n'
 import DataGrid from '@/components/DataGrid.vue'
 import DrillDownCell from '@/components/DrillDownCell.vue'
 import SearchInput from '@/components/SearchInput.vue'
+import OnlyMultiSelect from '@/components/OnlyMultiSelect.vue'
 import Select from 'primevue/select'
 import Popover from 'primevue/popover'
 import EpgEventDrawer, { type EpgEventDetail } from './EpgEventDrawer.vue'
@@ -88,6 +89,7 @@ import ProgressCell, { type ProgressOptions } from '@/components/ProgressCell.vu
 import { useNowCursor } from '@/composables/useNowCursor'
 import { useAccessStore } from '@/stores/access'
 import { useEpgContentTypeStore } from '@/stores/epgContentTypes'
+import { useEpgGenreOptions } from '@/composables/useEpgGenreOptions'
 import { useEpgViewState, type EpgRow } from '@/composables/useEpgViewState'
 import type { TitleSearchMode } from './epgViewOptions'
 import {
@@ -184,6 +186,24 @@ const fmtGenre = (v: unknown) => {
       typeof c === 'number' ? (contentTypes.labels.get(c) ?? `0x${c.toString(16)}`) : String(c)
     )
     .join(', ')
+}
+
+/* Content-type filter options for the "Content Type" column filter —
+ * the same major-group list the view-options popover uses. */
+const genreOptions = useEpgGenreOptions()
+
+/* Commit a content-type selection from the column filter to the
+ * shared view-options state (drives the server `genre` filter via
+ * epgTableFilters). Stored in canonical ascending order — the
+ * MultiSelect emits values in click order, and a stable shape keeps
+ * order-insensitive comparisons cheap. (The view-options popover
+ * writes viewOptions.genre directly via update:options, so its
+ * arrays may be click-ordered — comparisons must sort both sides.) */
+function setGenre(genre: number[]) {
+  state.setViewOptions({
+    ...state.viewOptions.value,
+    genre: [...genre].sort((a, b) => a - b),
+  })
 }
 
 
@@ -301,6 +321,10 @@ const baseCols: ColumnDef[] = [
     field: 'genre',
     label: t('Content type'),
     sortable: false,
+    /* Content-type multiselect filter — the column-header funnel /
+     * kebab "Filter…" opens it; state lives in viewOptions.genre and
+     * the popover content is rendered by the `#columnFilter` slot. */
+    filterType: 'genre',
     minVisible: 'desktop',
     width: 140,
     format: fmtGenre,
@@ -1157,6 +1181,14 @@ const dtFilters = computed(() => ({
   channelName: { value: filters.value.perColumn.channelName ?? null, matchMode: 'contains' },
   title: { value: filters.value.perColumn.title ?? null, matchMode: 'contains' },
   episodeOnscreen: { value: filters.value.perColumn.episodeOnscreen ?? null, matchMode: 'contains' },
+  /* Content-type filter lives in viewOptions.genre, not perColumn.
+   * Surfaced here so PrimeVue renders the column funnel and
+   * `filterActiveFor` lights it only when a content type is picked
+   * (null → inactive). */
+  genre: {
+    value: state.viewOptions.value.genre.length ? state.viewOptions.value.genre : null,
+    matchMode: 'in',
+  },
 }))
 
 function onFilter(event: { filters: Record<string, unknown> }) {
@@ -1169,6 +1201,22 @@ function onFilter(event: { filters: Record<string, unknown> }) {
     }
   }
   filters.value = { ...filters.value, perColumn: next }
+
+  /* Content-type isn't a perColumn field — it lives in
+   * viewOptions.genre. Apply / Clear in its column funnel arrive
+   * here as an array (or null when cleared); mirror it into the
+   * shared view-options state. Compare as sorted sets: MultiSelect
+   * emits values in click order (both here and in the view-options
+   * popover), so an order-sensitive comparison would treat the same
+   * set as a change and trigger a redundant refetch. */
+  const genreMeta = event.filters.genre as { value?: unknown } | undefined
+  const genreVal = genreMeta?.value
+  const nextGenre = Array.isArray(genreVal) ? (genreVal as number[]) : []
+  const sortedNext = [...nextGenre].sort((a, b) => a - b)
+  const sortedCur = [...state.viewOptions.value.genre].sort((a, b) => a - b)
+  if (sortedNext.join(',') !== sortedCur.join(',')) {
+    setGenre(sortedNext)
+  }
 }
 
 /* Display labels for the per-column filter fields, surfaced in
@@ -2257,6 +2305,26 @@ async function onCreateAutoRecClick() {
           :aria-label="t('Filter {0}', col.label ?? col.field)"
           @input="filterProps.filterModel.value = ($event.target as HTMLInputElement).value"
           @keydown.enter="filterProps.filterCallback()"
+        />
+        <!-- Content-type filter: the same multiselect the view-options
+             popover uses. Selections only update the local filter model
+             so the popover stays open for picking several; committing to
+             viewOptions.genre happens on Apply / Clear via onFilter (same
+             as the string columns). Empty maps to null so the funnel goes
+             inactive. `append-to="self"` keeps the dropdown panel inside
+             this overlay so option clicks aren't treated as outside-
+             clicks that dismiss it. -->
+        <OnlyMultiSelect
+          v-else-if="col.filterType === 'genre'"
+          class="epg-table-grid__col-filter-genre"
+          :model-value="(filterProps.filterModel.value as number[] | null) ?? []"
+          :options="genreOptions"
+          :placeholder="t('Any')"
+          :aria-label="t('Content type')"
+          :filter="true"
+          append-to="self"
+          @update:model-value="(v) => { filterProps.filterModel.value = (v as number[]).length ? v : null }"
+          @only="(code) => { filterProps.filterModel.value = [code as number] }"
         />
       </template>
 


### PR DESCRIPTION
### What

Adds a content-type filter to the EPG **Table** view's "Content Type" column header — a funnel + kebab "Filter…" that opens a content-type multiselect.

Fixes #2194.

### Why

Content-type filtering already existed in the Vue UI, but only inside the view-options popover. The "Content Type" column itself had no filter affordance: it isn't sortable and had no column filter, so its header showed no funnel or kebab at all (the kebab hides when a column has no actions). Users coming from the classic UI — which exposes a dedicated content-type filter — clicked the column, nothing happened, and reasonably concluded the feature was gone.

### How

- The genre column gains a `filterType: 'genre'`, so its header shows the standard funnel + kebab "Filter…" like the other filterable columns.
- The popover renders the **same** content-type multiselect used by the view-options popover; the shared option list is extracted into a `useEpgGenreOptions` composable (one source, no duplication).
- Content-type state stays in `viewOptions.genre` (→ `epgTableFilters`), so the column filter and the popover stay in sync. Selections accumulate in the open popover and commit on **Apply** — consistent with the existing Title/Channel column filters.
- The multiselect's dropdown panel is rendered with `appendTo="self"` so option clicks land inside the filter overlay rather than dismissing it.
- Small supporting bits: a `filterTitleFor` branch in `DataGrid` for the funnel tooltip; a defensive skip in `IdnodeGrid` (idnode grids never carry a genre column); `'genre'` added to the `ColumnDef.filterType` union.

No new filtering capability — just the missing entry point on the column where users look for it.

### Testing

- New unit test for `useEpgGenreOptions` (major-group option list, lazy store load).
- Full Vue unit suite green; `vue-tsc`, ESLint, the SPDX header check pass; `npm run build` succeeds.
- Eyeballed at `/gui/`: the Content Type column header now has a funnel/kebab; "Filter…" opens the multiselect, stays open across multiple picks, Apply filters and lights the funnel, Clear removes it, and it stays in sync with the view-options popover.