### PR TITLE
webui: show recording status in the EPG Table view

### DIFF
--- a/src/webui/static-vue/src/composables/useEpgViewState.ts
+++ b/src/webui/static-vue/src/composables/useEpgViewState.ts
@@ -1199,20 +1199,28 @@ export function useEpgViewState(opts: UseEpgViewStateOpts = {}): UseEpgViewState
     }
   }
 
-  watch(dayStart, () => {
-    /* `dayStart` is now scroll-derived — it tracks the centre-day
-     * of the viewport and drives the day-button highlight. Fetches
-     * are NOT triggered here any more; the renderer's scroll
-     * listener calls `ensureDaysLoaded` directly. We still kick
-     * the DVR-entries cache fetch on first navigation (idempotent).
-     * Gated on DVR access — `dvr/entry/grid_upcoming` requires
-     * ACCESS_RECORDER and would pop a Digest dialog on anonymous
-     * users navigating to EPG. They see the EPG fine (the events
-     * grid is ACCESS_ANONYMOUS); they just don't get the
-     * scheduled / recording overlay markers, which there's
-     * nothing for them to act on anyway. */
-    if (useAccessStore().has('dvr')) dvrEntriesStore.ensure()
-  })
+  /* Prime the DVR-entries cache as soon as DVR access is known.
+   * Gated on DVR access — `dvr/entry/grid_upcoming` requires
+   * ACCESS_RECORDER and would pop a Digest dialog on anonymous
+   * users navigating to EPG. They see the EPG fine (the events
+   * grid is ACCESS_ANONYMOUS); they just don't get the
+   * scheduled / recording markers, which there's nothing for
+   * them to act on anyway.
+   *
+   * Reactive on the access flag (not a one-shot check) because the
+   * access response may not have landed yet when the view mounts.
+   * Must NOT be keyed on day navigation (`dayStart`): the Table
+   * view never changes `dayStart`, and an unloaded store discards
+   * every `dvrentry` Comet notification (`dvrEntries.ts` gates its
+   * handler on `loaded`), which froze the Table's dvrState column
+   * and drawer buttons until a manual page reload. */
+  watch(
+    () => useAccessStore().has('dvr'),
+    (hasDvr) => {
+      if (hasDvr) dvrEntriesStore.ensure()
+    },
+    { immediate: true }
+  )
 
   /* Auto-advance `dayStart` when the calendar day rolls over while
    * the tab is open. The minute-ticker (`nowEpoch`) ticks live so

--- a/src/webui/static-vue/src/views/epg/DvrStateCell.vue
+++ b/src/webui/static-vue/src/views/epg/DvrStateCell.vue
@@ -1,0 +1,101 @@
+<!--
+  SPDX-License-Identifier: GPL-3.0-or-later
+  Copyright (C) 2026 Tvheadend contributors
+-->
+<script setup lang="ts">
+/*
+ * DvrStateCell — per-row recording-status icon for the EPG Table view.
+ *
+ * The `epg/events/grid` row carries a `dvrState` column joined from
+ * the matching DVR entry (`api_epg.c`, `dvr_entry_schedstatus` at
+ * `dvr_db.c:704`). Timeline / Magazine surface that state via the DVR
+ * overlay bars; this cell is the Table view's equivalent — an at-a-
+ * glance marker (with a tooltip naming the state) instead of having
+ * to open each event's drawer. Mirrors the classic UI's per-row
+ * `dvrState` icon.
+ *
+ * Only in-progress / upcoming states render; completed states and
+ * events with no DVR entry show nothing — same scope as the
+ * Timeline / Magazine overlay, which draws upcoming windows only.
+ */
+import { computed } from 'vue'
+import { Circle, Clock, TriangleAlert } from 'lucide-vue-next'
+import { useI18n } from '@/composables/useI18n'
+
+const props = defineProps<{
+  /* The row's `dvrState` (cell value) — absent when no DVR entry. */
+  value?: unknown
+}>()
+
+const { t } = useI18n()
+
+type Kind = 'recording' | 'recordingError' | 'scheduled'
+
+/* State taxonomy in `dvr_db.c:704-737`. Exact-match the error state
+ * first — it shares the 'recording' prefix. */
+const kind = computed<Kind | null>(() => {
+  const s = typeof props.value === 'string' ? props.value : ''
+  if (s === 'recordingError') return 'recordingError'
+  if (s.startsWith('recording')) return 'recording'
+  if (s.startsWith('scheduled')) return 'scheduled'
+  return null
+})
+
+const label = computed<string>(() => {
+  switch (kind.value) {
+    case 'recording':
+      return t('Recording')
+    case 'recordingError':
+      return t('Recording (errors)')
+    case 'scheduled':
+      return t('Scheduled for recording')
+    default:
+      return ''
+  }
+})
+</script>
+
+<template>
+  <span v-if="kind" class="dvr-state-cell" :title="label" role="img" :aria-label="label">
+    <Circle
+      v-if="kind === 'recording'"
+      :size="10"
+      fill="currentColor"
+      class="dvr-state-cell__recording"
+      aria-hidden="true"
+    />
+    <TriangleAlert
+      v-else-if="kind === 'recordingError'"
+      :size="14"
+      class="dvr-state-cell__error"
+      aria-hidden="true"
+    />
+    <Clock v-else :size="14" class="dvr-state-cell__scheduled" aria-hidden="true" />
+  </span>
+</template>
+
+<style scoped>
+.dvr-state-cell {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+
+/* Red dot for an in-progress recording — the same visual shorthand
+ * broadcast UIs use for "on air / recording". */
+.dvr-state-cell__recording {
+  color: var(--tvh-error);
+}
+
+/* In-progress recording that has hit stream errors. */
+.dvr-state-cell__error {
+  color: var(--tvh-warning);
+}
+
+/* Upcoming scheduled recording — muted so a page full of scheduled
+ * events doesn't shout. */
+.dvr-state-cell__scheduled {
+  color: var(--tvh-text-muted);
+}
+</style>

--- a/src/webui/static-vue/src/views/epg/TableView.vue
+++ b/src/webui/static-vue/src/views/epg/TableView.vue
@@ -82,6 +82,7 @@ import SearchInput from '@/components/SearchInput.vue'
 import Select from 'primevue/select'
 import Popover from 'primevue/popover'
 import EpgEventDrawer, { type EpgEventDetail } from './EpgEventDrawer.vue'
+import DvrStateCell from './DvrStateCell.vue'
 import EpgTableOptions from './EpgTableOptions.vue'
 import LiveTvButton from './LiveTvButton.vue'
 import ProgressCell, { type ProgressOptions } from '@/components/ProgressCell.vue'
@@ -229,6 +230,22 @@ provide('epg-progress-options', progressOptions)
  * funnel UI is rendered by PrimeVue's filter-display="menu" mode
  * driven by `initialFilters` below. */
 const baseCols: ColumnDef[] = [
+  {
+    /* Per-row recording-status icon (red dot = recording, clock =
+     * scheduled) — the Table view's counterpart of the Timeline /
+     * Magazine DVR overlay, and of the classic UI's per-row
+     * `dvrState` icon. Leading position so recording state scans
+     * down the left edge. Icon-only: the header label is
+     * suppressed but still names the column in the column picker
+     * and on hover. */
+    field: 'dvrState',
+    label: t('Recording'),
+    hideHeaderLabel: true,
+    sortable: false,
+    minVisible: 'desktop',
+    width: 44,
+    cellComponent: DvrStateCell,
+  },
   {
     field: 'channelName',
     label: t('Channel'),
@@ -385,6 +402,7 @@ const LOCKED_COLUMNS = new Set(['title', 'channelName'])
  * would create two contradictory controls. Locked columns are also
  * excluded — they always render. */
 const TOGGLEABLE_COLUMN_FIELDS = new Set([
+  'dvrState',
   'channelNumber',
   'start',
   'stop',

--- a/src/webui/static-vue/src/views/epg/__tests__/DvrStateCell.test.ts
+++ b/src/webui/static-vue/src/views/epg/__tests__/DvrStateCell.test.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/*
+ * DvrStateCell — the EPG Table's per-row recording-status icon.
+ * Verifies the dvrState → icon mapping (taxonomy in
+ * dvr_db.c:704-737) and that non-upcoming states render nothing.
+ */
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import DvrStateCell from '../DvrStateCell.vue'
+
+function mountCell(value: unknown) {
+  return mount(DvrStateCell, { props: { value } })
+}
+
+describe('DvrStateCell', () => {
+  it('shows the recording dot for an in-progress recording', () => {
+    const w = mountCell('recording')
+    expect(w.find('.dvr-state-cell__recording').exists()).toBe(true)
+    expect(w.find('.dvr-state-cell').attributes('aria-label')).toBe('Recording')
+  })
+
+  it('shows the warning icon for a recording with errors', () => {
+    const w = mountCell('recordingError')
+    expect(w.find('.dvr-state-cell__error').exists()).toBe(true)
+    expect(w.find('.dvr-state-cell__recording').exists()).toBe(false)
+  })
+
+  it('shows the clock for a scheduled recording', () => {
+    const w = mountCell('scheduled')
+    expect(w.find('.dvr-state-cell__scheduled').exists()).toBe(true)
+    expect(w.find('.dvr-state-cell').attributes('aria-label')).toBe(
+      'Scheduled for recording',
+    )
+  })
+
+  it('renders nothing for completed states, unknown values and absent state', () => {
+    for (const v of ['completed', 'completedError', 'unknown', '', undefined, 42]) {
+      const w = mountCell(v)
+      expect(w.find('.dvr-state-cell').exists()).toBe(false)
+      w.unmount()
+    }
+  })
+})


### PR DESCRIPTION
### What

Adds a per-row recording-status icon to the EPG **Table** view, so scheduled and in-progress recordings are visible at a glance — parity with the DVR overlay bars in Timeline/Magazine and with the classic UI's per-row `dvrState` icon.

Follow-up to the request in #2194 ([comment](https://github.com/tvheadend/tvheadend/issues/2194#issuecomment-5037421804)).

### Why

The Table view gave no visual cue which events record; the only way to check was opening each event's drawer one by one.

### How

- New `DvrStateCell` rendering the row's `dvrState` (already joined into every `epg/events/grid` row by the server — no extra fetch):
  - red dot — recording now
  - warning triangle — recording with errors
  - clock (muted) — scheduled
  - nothing for events without a DVR entry / completed states (same scope as the Timeline/Magazine overlay)
  - tooltip + `aria-label` name the state
- Leading, icon-only, toggleable column in the Table view (the "Recording" label still appears in the column picker and on header hover). Desktop layout only for now — on phone cards an empty labelled pair would render on every non-recording event.
- **Staleness fix**: the DVR-entries cache was primed only inside `watch(dayStart, …)` — day navigation the Table view never performs. The unloaded cache discarded every `dvrentry` Comet notification, so the new column (and the drawer's Record/Stop buttons in Table view — a pre-existing latent issue) stayed stale until a page reload. The cache is now primed reactively on DVR access (`immediate` watch on `access.has('dvr')`), keeping the ACCESS_RECORDER gating for anonymous users.

### Testing

- New unit tests for the `dvrState` → icon mapping (recording / recordingError / scheduled / none).
- Full Vue unit suite green; `vue-tsc`, ESLint, the SPDX header check pass; `npm run build` succeeds.
- Eyeballed at `/gui/`: icons render in the Table view; scheduling/cancelling a recording from the event drawer updates the column within ~a second without a reload; Timeline/Magazine overlays unchanged; column toggles via view options.