### PR TITLE
webui: draw signal strength and SNR bars in the Status Stream view

### DIFF
--- a/src/webui/static-vue/src/views/status/SignalBarCell.vue
+++ b/src/webui/static-vue/src/views/status/SignalBarCell.vue
@@ -1,0 +1,141 @@
+<!--
+  SPDX-License-Identifier: GPL-3.0-or-later
+  Copyright (C) 2026 Tvheadend contributors
+-->
+<script setup lang="ts">
+/*
+ * SignalBarCell — Signal-strength / SNR cell for the Status → Stream
+ * grid, mirroring the classic UI's ProgressColumn rendering
+ * (`static/app/status.js`, `extensions.js` Ext.ux.grid.ProgressColumn).
+ *
+ * The input feed reports each metric with a scale discriminator
+ * (`signal_scale` / `snr_scale`, DVBv5 semantics):
+ *   - 1 (relative)  — dimensionless 0..65535. Rendered as a coloured
+ *     bar filled to value/65535 with the raw value beside it and the
+ *     percentage as the hover tooltip. Colour thresholds follow the
+ *     classic ProgressColumn: green above 2/3, amber above 1/3, red
+ *     below.
+ *   - 2 (decibel)   — value ×0.001 is dB (SNR) / dBm (signal).
+ *     Rendered as text only: a bar against the relative ceiling would
+ *     be meaningless for dB values (the classic UI draws one anyway —
+ *     a wart, not a feature worth parity), and dB "goodness" ranges
+ *     are modulation-dependent, so no honest fill exists.
+ *   - other / absent — nothing (tuner doesn't report the metric).
+ *
+ * One component serves both columns: the column's `field` picks the
+ * matching scale field and decibel unit.
+ */
+import { computed } from 'vue'
+import type { ColumnDef } from '@/types/column'
+
+const props = defineProps<{
+  value?: unknown
+  row?: Record<string, unknown>
+  col?: ColumnDef
+}>()
+
+/* Relative-scale ceiling (DVBv5 relative scale is 16-bit). */
+const CEILING = 65535
+
+const isSnr = computed(() => props.col?.field === 'snr')
+
+const scale = computed<number>(() => {
+  const s = props.row?.[isSnr.value ? 'snr_scale' : 'signal_scale']
+  return typeof s === 'number' ? s : 0
+})
+
+const num = computed<number | null>(() =>
+  typeof props.value === 'number' ? props.value : null,
+)
+
+type Mode = 'bar' | 'text'
+
+const mode = computed<Mode | null>(() => {
+  if (num.value === null) return null
+  if (scale.value === 1) return 'bar'
+  /* Classic guards SNR dB on > 0 (a zero reading means "no lock",
+   * not 0.0 dB); signal dBm is legitimately negative. */
+  if (scale.value === 2 && (!isSnr.value || num.value > 0)) return 'text'
+  return null
+})
+
+const pct = computed<number>(() =>
+  Math.max(0, Math.min(100, ((num.value ?? 0) / CEILING) * 100)),
+)
+
+/* Classic ProgressColumn `colored` thresholds: green above 2/3 of the
+ * ceiling, amber above 1/3, red below. */
+const tone = computed<'good' | 'mid' | 'low'>(() => {
+  if (pct.value > 66) return 'good'
+  if (pct.value > 33) return 'mid'
+  return 'low'
+})
+
+const text = computed<string>(() => {
+  if (num.value === null) return ''
+  if (scale.value === 1) return String(num.value)
+  return `${(num.value * 0.001).toFixed(1)} ${isSnr.value ? 'dB' : 'dBm'}`
+})
+
+/* Hover tooltip on the bar variant — the percentage gives new users
+ * the "out of how much?" context the raw 0..65535 value lacks. */
+const pctLabel = computed(() => `${Math.round(pct.value)}%`)
+</script>
+
+<template>
+  <span v-if="mode === 'bar'" class="signal-bar-cell" :title="pctLabel">
+    <span class="signal-bar-cell__track" aria-hidden="true">
+      <span
+        class="signal-bar-cell__fill"
+        :class="`signal-bar-cell__fill--${tone}`"
+        :style="{ width: `${pct}%` }"
+      />
+    </span>
+    <span class="signal-bar-cell__text">{{ text }}</span>
+  </span>
+  <template v-else-if="mode === 'text'">{{ text }}</template>
+</template>
+
+<style scoped>
+.signal-bar-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tvh-space-2);
+  width: 100%;
+}
+
+.signal-bar-cell__track {
+  flex: 1 1 auto;
+  min-width: 40px;
+  max-width: 96px;
+  height: 8px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--tvh-text) 12%, transparent);
+  overflow: hidden;
+}
+
+.signal-bar-cell__fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+}
+
+.signal-bar-cell__fill--good {
+  background: var(--tvh-success);
+}
+
+.signal-bar-cell__fill--mid {
+  background: var(--tvh-warning);
+}
+
+.signal-bar-cell__fill--low {
+  background: var(--tvh-error);
+}
+
+/* Raw value beside the bar — tabular digits so the column doesn't
+ * jitter as readings tick. */
+.signal-bar-cell__text {
+  flex: 0 0 auto;
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/src/webui/static-vue/src/views/status/StreamView.vue
+++ b/src/webui/static-vue/src/views/status/StreamView.vue
@@ -26,6 +26,7 @@
  * a few rarely-useful raw-counter columns.
  */
 import StatusGrid from '@/components/StatusGrid.vue'
+import SignalBarCell from './SignalBarCell.vue'
 import ActionMenu from '@/components/ActionMenu.vue'
 import BandwidthChartView from '@/components/BandwidthChartView.vue'
 import { ChartLine } from 'lucide-vue-next'
@@ -54,22 +55,6 @@ const fmtPids = (v: unknown) => {
    * wide enough to dominate the row.
    */
   return sorted.join(', ')
-}
-
-const fmtSignal = (v: unknown, row: StatusEntry) => {
-  const scale = row.signal_scale
-  const n = typeof v === 'number' ? v : 0
-  if (scale === 1) return String(n)
-  if (scale === 2) return `${(n * 0.001).toFixed(1)} dBm`
-  return ''
-}
-
-const fmtSnr = (v: unknown, row: StatusEntry) => {
-  const scale = row.snr_scale
-  const n = typeof v === 'number' ? v : 0
-  if (scale === 1) return String(n)
-  if (scale === 2 && n > 0) return `${(n * 0.001).toFixed(1)} dB`
-  return ''
 }
 
 /*
@@ -113,12 +98,15 @@ const cols: ColumnDef[] = [
     format: fmtKbps,
   },
   {
+    /* Coloured bar for relative-scale readings, dB(m) text for
+     * decibel tuners — see SignalBarCell. */
     field: 'signal',
     label: t('Signal Strength'),
     sortable: true,
     minVisible: 'phone',
     phoneOrder: 1,
-    format: fmtSignal,
+    width: 170,
+    cellComponent: SignalBarCell,
   },
   {
     field: 'snr',
@@ -126,7 +114,8 @@ const cols: ColumnDef[] = [
     sortable: true,
     minVisible: 'phone',
     phoneOrder: 2,
-    format: fmtSnr,
+    width: 170,
+    cellComponent: SignalBarCell,
   },
   { field: 'unc', label: t('Uncorrected Blocks'), sortable: true, minVisible: 'desktop' },
   { field: 'te', label: t('Transport Errors'), sortable: true, minVisible: 'desktop' },

--- a/src/webui/static-vue/src/views/status/__tests__/SignalBarCell.test.ts
+++ b/src/webui/static-vue/src/views/status/__tests__/SignalBarCell.test.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/*
+ * SignalBarCell — Signal / SNR rendering for the Status → Stream grid
+ * (issue #2197). Verifies the scale-driven modes: relative (1) → bar +
+ * raw value with classic ProgressColumn colour thresholds, decibel
+ * (2) → dB(m) text only, other → nothing.
+ */
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SignalBarCell from '../SignalBarCell.vue'
+
+function mountCell(
+  value: unknown,
+  row: Record<string, unknown>,
+  field: 'signal' | 'snr' = 'signal',
+) {
+  return mount(SignalBarCell, { props: { value, row, col: { field } } })
+}
+
+describe('SignalBarCell', () => {
+  it('renders a bar with the raw value for the relative scale', () => {
+    const w = mountCell(45000, { signal_scale: 1 })
+    expect(w.find('.signal-bar-cell__track').exists()).toBe(true)
+    expect(w.find('.signal-bar-cell__text').text()).toBe('45000')
+    /* 45000 / 65535 ≈ 68.7% */
+    expect(w.find('.signal-bar-cell').attributes('title')).toBe('69%')
+    expect(w.find('.signal-bar-cell__fill').attributes('style')).toContain('68.6')
+  })
+
+  it('applies the classic colour thresholds (green > 2/3, amber > 1/3, red below)', () => {
+    expect(
+      mountCell(60000, { signal_scale: 1 }).find('.signal-bar-cell__fill--good').exists(),
+    ).toBe(true)
+    expect(
+      mountCell(30000, { signal_scale: 1 }).find('.signal-bar-cell__fill--mid').exists(),
+    ).toBe(true)
+    expect(
+      mountCell(10000, { signal_scale: 1 }).find('.signal-bar-cell__fill--low').exists(),
+    ).toBe(true)
+  })
+
+  it('renders decibel readings as text only — no bar', () => {
+    const sig = mountCell(-52340, { signal_scale: 2 })
+    expect(sig.find('.signal-bar-cell__track').exists()).toBe(false)
+    expect(sig.text()).toBe('-52.3 dBm')
+
+    const snr = mountCell(12300, { snr_scale: 2 }, 'snr')
+    expect(snr.text()).toBe('12.3 dB')
+  })
+
+  it('renders nothing for SNR dB readings of zero (no lock, not 0.0 dB)', () => {
+    const w = mountCell(0, { snr_scale: 2 }, 'snr')
+    expect(w.text()).toBe('')
+  })
+
+  it('renders nothing for unknown scales or non-numeric values', () => {
+    expect(mountCell(45000, {}).text()).toBe('')
+    expect(mountCell(undefined, { signal_scale: 1 }).text()).toBe('')
+    expect(mountCell('x', { signal_scale: 1 }).text()).toBe('')
+  })
+})


### PR DESCRIPTION
### What

Renders Signal Strength and SNR in the Vue Status → Stream grid as coloured bars (for relative-scale readings) instead of bare integers — parity with the classic UI's ProgressColumn.

Fixes #2197.

### Why

Tuners reporting the DVBv5 **relative** scale deliver a dimensionless 0..65535 value; printed raw it reads as a meaningless integer ("45000") unless you know the ceiling. The classic UI draws a coloured progress bar there.

### How

A new `SignalBarCell` serves both columns, keyed on the row's scale discriminator (`signal_scale` / `snr_scale`):

- **Relative (1)**: compact coloured bar filled to `value / 65535` — classic ProgressColumn thresholds (green above 2/3, amber above 1/3, red below) — with the raw value beside it and the **percentage as the hover tooltip** (the "out of how much?" context the raw number lacks).
- **Decibel (2)**: text only (`-52.3 dBm` / `12.3 dB`). Intentionally no bar: the classic UI fills its bar with `dB×1000 / 65535`, which is meaningless for dB readings, and honest dB "goodness" ranges are modulation-dependent. SNR `0` on the dB scale renders nothing (no lock), matching the classic renderer's guard.
- **Other / absent**: empty cell, as before.

The previous text formatters' semantics are preserved inside the cell; the phone card's Signal/SNR row picks up the same rendering automatically.

### Testing

- New unit tests for the cell (bar + raw value + percent tooltip, colour thresholds, dB text modes, SNR no-lock guard, unknown-scale fallbacks).
- Full status-view suite green; `vue-tsc`, ESLint and the SPDX header check pass; `npm run build` succeeds.
- Eyeballed on a live install: bars render and tick live for relative-scale tuners, colours track signal quality, phone card unaffected.