### PR TITLE
wizard: flag the setup wizard password fields as passwords

### DIFF
--- a/src/webui/static-vue/src/views/wizard/WizardStepGeneric.vue
+++ b/src/webui/static-vue/src/views/wizard/WizardStepGeneric.vue
@@ -56,14 +56,6 @@ import { useWizardStore, type WizardStepName } from '@/stores/wizard'
 import { addExternalLinkAttrs, renderMarkdown, rewriteStaticUrls } from '@/utils/markdown'
 import type { IdnodeProp } from '@/types/idnode'
 
-/*
- * Wizard password-field workaround scope — see handleLoaded
- * below. Module-scope Set for O(1) lookup; matched in the
- * loaded-emit patch loop. Deletable once
- * src/wizard.c:434, 452 add `.opts = PO_PASSWORD,`.
- */
-const WIZARD_PASSWORD_IDS = new Set(['admin_password', 'password'])
-
 interface Props {
   /* Canonical step name. Drives the load/save endpoints and the
    * prev/next route resolution. Route components pass this as a
@@ -144,26 +136,6 @@ function handleLoaded(params: IdnodeProp[]): void {
    * resolve under `/gui/wizard/channels/...`. Same root cause
    * as the wizard icon URL fix. */
   descriptionHtml.value = addExternalLinkAttrs(rewriteStaticUrls(renderMarkdown(rawDesc)))
-  /* Client-side overlay: flip `password: true` on the wizard's
-   * admin_password + password fields so IdnodeFieldString masks
-   * them and renders the show/hide toggle. The C-side wizard
-   * (src/wizard.c:434, 452) declares both as plain PT_STR
-   * without `.opts = PO_PASSWORD`, so the server returns them
-   * tagged as regular strings. Other consumers (access.c:2314,
-   * cclient.c:1386) already declare PO_PASSWORD correctly, so
-   * this scoped patch in the wizard wrapper is safe; it doesn't
-   * affect any non-wizard surface. `params` is the same reactive
-   * array IdnodeConfigForm stored in its `fieldProps` ref a
-   * moment ago — mutating the prop objects in place propagates
-   * through Vue's deep reactivity and the field renderer
-   * re-evaluates `isPassword`. The overlay is redundant once
-   * `src/wizard.c` adds `.opts = PO_PASSWORD,` to both prop
-   * declarations (pending). */
-  for (const p of params) {
-    if (WIZARD_PASSWORD_IDS.has(p.id) && p.type === 'str') {
-      p.password = true
-    }
-  }
   /* Re-emit upward so wrappers can capture baseline values. */
   emit('loaded', params)
 }

--- a/src/webui/static-vue/src/views/wizard/__tests__/WizardStepGeneric.test.ts
+++ b/src/webui/static-vue/src/views/wizard/__tests__/WizardStepGeneric.test.ts
@@ -99,28 +99,6 @@ vi.mock('@/components/IdnodeConfigForm.vue', () => ({
           ),
           h(
             'button',
-            {
-              /* Fire a wizard-login-shaped payload that
-               * deliberately omits PO_PASSWORD on the password
-               * fields — the WizardStepGeneric workaround
-               * should patch them on the way through. */
-              class: 'fire-loaded-login',
-              onClick: () =>
-                emit('loaded', [
-                  { id: 'admin_password', type: 'str', value: '' },
-                  { id: 'password', type: 'str', value: '' },
-                  /* A non-password str field with id "username"
-                   * to verify the workaround doesn't over-match. */
-                  { id: 'username', type: 'str', value: '' },
-                  /* A numeric "password" field would be weird
-                   * but defensive: verify type guard skips it. */
-                  { id: 'password', type: 'int', value: 0 },
-                ] as IdnodeProp[]),
-            },
-            'fire-loaded-login',
-          ),
-          h(
-            'button',
             { class: 'fire-saved', onClick: () => save() },
             'fire-saved',
           ),
@@ -196,39 +174,6 @@ describe('WizardStepGeneric — chrome rendering', () => {
     expect(wrapper.emitted('loaded')).toHaveLength(1)
     const payload = wrapper.emitted('loaded')![0][0] as IdnodeProp[]
     expect(payload.find((p) => p.id === 'icon')?.value).toBe('/img/wizard-network.png')
-  })
-})
-
-describe('WizardStepGeneric — wizard password-field workaround', () => {
-  /*
-   * The wizard's `admin_password` + `password` PT_STR props in
-   * src/wizard.c don't set PO_PASSWORD, so the server returns
-   * them tagged as regular strings. WizardStepGeneric.handleLoaded
-   * patches `password: true` in place on those two ids so
-   * IdnodeFieldString masks them. This block pins:
-   *   - the two known ids get patched
-   *   - non-password ids (username) are left alone
-   *   - non-str types with id="password" (defensive) are skipped
-   *   - the patch happens before re-emitting upward
-   */
-  it('patches password:true on admin_password and password (str type only)', async () => {
-    const wrapper = mountStep({ step: 'login' })
-    await wrapper.find('.fire-loaded-login').trigger('click')
-    const payload = wrapper.emitted('loaded')![0][0] as IdnodeProp[]
-    const adminPwd = payload.find(
-      (p) => p.id === 'admin_password' && p.type === 'str',
-    )
-    const userPwd = payload.find((p) => p.id === 'password' && p.type === 'str')
-    const username = payload.find((p) => p.id === 'username')
-    const intPassword = payload.find((p) => p.id === 'password' && p.type === 'int')
-    expect(adminPwd?.password).toBe(true)
-    expect(userPwd?.password).toBe(true)
-    /* Non-password fields stay untouched. */
-    expect(username?.password).toBeUndefined()
-    /* Defensive: non-str fields whose id happens to be "password"
-     * (none exist today, but the workaround's type guard pins
-     * this contract) are skipped. */
-    expect(intPassword?.password).toBeUndefined()
   })
 })
 

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -436,6 +436,7 @@ wizard_page_t *wizard_login(const char *lang)
       .desc     = N_("Enter an administrator password."),
       .get      = wizard_get_value_admin_password,
       .set      = wizard_set_value_admin_password,
+      .opts     = PO_PASSWORD,
       .group    = 2
     },
     {
@@ -454,6 +455,7 @@ wizard_page_t *wizard_login(const char *lang)
       .desc     = N_("Enter a non-admin user password."),
       .get      = wizard_get_value_password,
       .set      = wizard_set_value_password,
+      .opts     = PO_PASSWORD,
       .group    = 3
     },
     ICON(),


### PR DESCRIPTION
### What

Marks the setup wizard's two password fields (`admin_password`, `password` on the login step) with `PO_PASSWORD`, so web UIs render them as masked password inputs instead of clear text.

### Why

The login step declares both props as plain `PT_STR` with no `.opts = PO_PASSWORD`. `PO_PASSWORD` is what `prop_serialize()` translates into the `password: true` JSON-metadata field that the web UIs key off for input-type masking — without it, both the classic and the new UI displayed the wizard's password values in plain text as you type. Other password-bearing consumers (`access.c`, `cclient.c`) already declare the flag; the wizard was the odd one out.

### How

- `src/wizard.c`: `.opts = PO_PASSWORD,` on both prop declarations (the two username fields stay plain, as intended).
- The new UI had a scoped client-side overlay that patched `password: true` onto exactly these two field ids to compensate — with the server metadata now correct, that workaround (and its unit-test pin) is removed. Net: +2 C lines, −83 workaround lines.

The wizard's save path is untouched — the `*`-placeholder round-trip logic in `wizard.c` behaves exactly as before.

### Testing

- Built and ran the wizard: the login step's Admin password / Password fields now render as `<input type="password">` (with the new UI's show/hide toggle); usernames stay plain; saving the step sets the passwords correctly.
- Verifiable in the classic UI too — same metadata drives its form renderer.
- Vue unit suite green (workaround tests removed with the workaround); `vue-tsc` + ESLint pass; full `make` clean.