### PR TITLE
prop: fix octal handling of permission values (PT_PERM)

### DIFF
--- a/src/prop.c
+++ b/src/prop.c
@@ -240,7 +240,11 @@ prop_write_values
       case PT_PERM: {
         if (!(snew = htsmsg_field_get_str(f)))
           continue;
-        u32 = (int)strtol(snew, NULL, 0);
+        /* Permissions are always octal. Base 8 (not auto-detect)
+         * so a serialized value whose leading zero was consumed by
+         * the "%04o" padding (e.g. setgid "2775") still reads back
+         * as the octal it was written from. */
+        u32 = (int)strtol(snew, NULL, 8);
         PROP_UPDATE(u32, uint32_t);
         break;
       }
@@ -363,7 +367,10 @@ prop_read_value
       lang_str_serialize(*(lang_str_t **)val, m, name);
       break;
     case PT_PERM:
-      snprintf(buf, sizeof(buf), "%04o", *(uint32_t *)val);
+      /* Explicit leading zero (not just zero-padding) so values
+       * with a special bit set (e.g. setgid 02775) keep an octal
+       * marker that any base-auto-detecting parser honours. */
+      snprintf(buf, sizeof(buf), "0%03o", *(const uint32_t *)val);
       htsmsg_add_str(m, name, buf);
       break;
     case PT_NONE:
@@ -498,7 +505,8 @@ prop_serialize_value
         /* TODO? */
         break;
       case PT_PERM:
-        snprintf(buf, sizeof(buf), "%04o", pl->def.u32);
+        /* Same explicit octal marker as the value serializer. */
+        snprintf(buf, sizeof(buf), "0%03o", pl->def.u32);
         htsmsg_add_str(m, "default", buf);
         break;
       case PT_NONE:

--- a/src/webui/static/app/idnode.js
+++ b/src/webui/static/app/idnode.js
@@ -482,7 +482,9 @@ tvheadend.IdNodeField = function(conf)
         } else {
 
             if (this.type == 'perm') {
-                c['regex'] = /^[0][0-7]{3}$/;
+                /* 0 + 3 digits, or 0 + 4 when a special bit
+                 * (setuid/setgid/sticky) is set, e.g. 02775. */
+                c['regex'] = /^0[0-7]{3,4}$/;
                 c['maskRe'] = /[0-7]/;
                 c['allowBlank'] = false;
                 c['blankText'] = _('You must provide a value - use octal chmod notation, e.g. 0664');
@@ -861,7 +863,8 @@ tvheadend.idnode_editor_field = function(f, conf)
                 value: value,
                 disabled: d,
                 width: 125,
-                regex: /^[0][0-7]{3}$/,
+                /* 0 + 3 digits, or 0 + 4 with a special bit set. */
+                regex: /^0[0-7]{3,4}$/,
                 maskRe: /[0-7]/,
                 allowBlank: false,
                 blankText: _('You must provide a value - use octal chmod notation, e.g. 0664')


### PR DESCRIPTION
### What

Fixes silent corruption of permission values (`PT_PERM` fields — the DVR profile's **File permissions** and **Directory permissions**) whenever a special bit (setuid / setgid / sticky) is set, and widens the web UI's permission-field validation so such values can be entered and displayed.

### Background: what these fields do, and why 4-digit values are legitimate

Every recording run applies these values to the filesystem: directories in the recording path are created with *Directory permissions* (`dvr_rec.c` → `makedirs()`), and recording files are created with *File permissions* (every muxer: `open(..., O_CREAT, perms)` + `fchmod()`).

Permissions have four octal digits: the familiar rwx triplet (`775`) plus a leading **special-bit** digit — setuid (4), setgid (2), sticky (1). These are everyday values on shared boxes — `02775` (setgid, "new entries inherit the directory's group") is the classic shape for shared media trees, `01777` (sticky) the `/tmp` model. So 4-digit values are legitimate input for these fields — and exactly the case that breaks.

### The bug, step by step

The two halves of PT_PERM handling disagree about octal notation:

- **Serializing** (`src/prop.c`) uses `"%04o"` — octal, *padded* to 4 digits. `0775` → `"0775"` (the padding keeps the leading zero). But `02775` already has 4 digits → `"2775"` — **the octal marker is gone**.
- **Parsing** uses `strtol(s, NULL, 0)` — base auto-detection: leading `0` means octal, anything else means **decimal**.

Put together:

| step | value |
|---|---|
| admin configures directory permissions | `02775` |
| serialized (config file / API response) | `"2775"` |
| parsed back (no leading `0` → decimal) | 2775₁₀ = **`05327`** |
| next cycle | `"5327"` → 5327₁₀ = `012317` → … |

Every **config load** (restart) re-parses the stored string, and every save that echoes a serialized value does the same — the value drifts further each cycle, silently. Reproduced against an unpatched build:

```
save "02775"        -> reads back "2775"    (octal marker lost)
echo "2775" back    -> reads back "5327"    (decimal reinterpretation)
echo "5327" back    -> reads back "12317"   (drifting further)
restart with 02775  -> reads back "5327"    (the load alone corrupts)
```

### What the corrupted value does on disk

The corrupted mode is applied to real recordings. Measured with the same syscall sequences the code uses (`makedirs()`: `mkdir` + corrective `chmod`; muxers: `open(O_CREAT)` + `fchmod`):

```
intended:   drwxrwsr-x   directories        -rw-rw-r--   files
actual:     d-ws-w-rwt   directories        --ws-w-rwt   files
```
*(directory bits vary slightly with umask — `d-wx-w-rwt` in daemon mode — broken the same way)*

Recording files become **setuid and world-writable**; their directories can no longer be listed by their owner or entered by the group — while everyone else gains write access. A by-the-book configuration ends in a security-relevant state, with no error reported anywhere.

### Why this was never reported

The asymmetry is as old as `PT_PERM` itself — parse, serialize *and* the web UI's field validation all shipped in the same commit (220833201, 2014). Three shields kept it invisible for a decade:

1. The UI validation (`/^[0][0-7]{3}$/`) has **never accepted a 4-digit value** — a trigger value could only enter via the raw API or a hand-edited config.
2. Every UI-enterable value (`0xxx`, including the defaults `0775`/`0664`) keeps its padding zero and round-trips perfectly.
3. When it did bite, the symptom — wrong permissions appearing after a restart — is indistinguishable from umask/mount/Samba issues, so nothing pointed back at a config round-trip.

### The fix

Two changes in `src/prop.c`, belt and braces:
1. **Parse as octal always** (`strtol(…, 8)`) — the fields are documented "octal, e.g. 0775". This also *repairs* already-corrupted stores: `"2775"` on disk loads as `02775` again.
2. **Serialize with an explicit leading zero** (`"0%03o"` → `"02775"`). Base-auto-detecting parsers (older versions, third-party clients) read this correctly too, so mixed versions stay safe. Same fix for the class-metadata `default`.

Plus the required companion change: widen the web UI's permission-field validation to `/^[0][0-7]{3,4}$/`. With the corrected serializer a stored special-bit value renders as five characters (`"02775"`), which the old pattern would reject — making such profiles uneditable in the UI.

### Testing

- Unpatched build: reproduced the full corruption chain and the restart corruption (transcript above).
- Patched build, via the API: `"2775"` (prefix-less) reads back repaired as `02775`; repeated echo-saves stay stable; `02775` survives restart; plain values (`0664`, `0775`) round-trip unchanged; metadata `default` serializes correctly.
- Filesystem effect verified with the code's exact syscall sequences under both umask regimes.
- UI field accepts `02775`, still rejects malformed input.