### PR TITLE
mpegts: preserve stream mapping across PID switches

### DIFF
--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -868,25 +868,25 @@ pass_muxer_rewrite_enabled(const pass_muxer_t *pm)
          pm->pm_rewrite_sdt || pm->pm_rewrite_nit || pm->pm_rewrite_eit;
 }
 
-static uint8_t *
+static int
 pass_muxer_output_buffer(pass_muxer_t *pm, const uint8_t *src, size_t len)
 {
   uint8_t *buf;
 
   if (!pm->pm_pid_active)
-    return (uint8_t *)src;
+    return 0;
   if (pm->pm_pid_buf_size < len) {
     buf = realloc(pm->pm_pid_buf, len);
     if (buf == NULL) {
       pm->pm_error = ENOMEM;
       pm->m_errors++;
-      return NULL;
+      return -1;
     }
     pm->pm_pid_buf = buf;
     pm->pm_pid_buf_size = len;
   }
   memcpy(pm->pm_pid_buf, src, len);
-  return pm->pm_pid_buf;
+  return 0;
 }
 
 static int
@@ -916,15 +916,24 @@ pass_muxer_parse_tables(pass_muxer_t *pm, const uint8_t *src, int len, int pid)
 }
 
 static void
-pass_muxer_process_payload(pass_muxer_t *pm, const uint8_t *src,
-                           uint8_t *out, int len, int pid)
+pass_muxer_flush_table(muxer_t *m, pass_muxer_t *pm, const uint8_t *pkt,
+                       size_t write_len, const uint8_t *src, int len, int pid)
+{
+  if (write_len)
+    pass_muxer_write(m, pkt, write_len);
+  pass_muxer_parse_tables(pm, src, len, pid);
+}
+
+static void
+pass_muxer_process_payload(pass_muxer_t *pm, const uint8_t *src, size_t offset,
+                           int len, int pid)
 {
   uint16_t output_pid;
 
   output_pid = pass_muxer_map_pid(pm, pid);
   if (output_pid != pid ||
       (pm->pm_pid_rewrite_cc && pm->pm_pid_rewrite_cc[output_pid]))
-    pass_muxer_remap_ts(pm, out, len, output_pid);
+    pass_muxer_remap_ts(pm, pm->pm_pid_buf + offset, len, output_pid);
   else
     pass_muxer_track_cc(pm, src, len, output_pid);
 }
@@ -935,38 +944,39 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
   pass_muxer_t *pm = (pass_muxer_t*)m;
   int len;
   int pid;
-  uint8_t *out;
-  uint8_t *pkt;
+  const uint8_t *out;
+  const uint8_t *pkt;
   const uint8_t *src;
   size_t left;
+  size_t offset;
   size_t write_len;
 
   src = pktbuf_ptr(pb);
-  pkt = (uint8_t *)src;
+  pkt = src;
   write_len = pktbuf_len(pb);
   if (pass_muxer_rewrite_enabled(pm)) {
-    pkt = pass_muxer_output_buffer(pm, src, write_len);
-    if (pkt == NULL)
+    if (pass_muxer_output_buffer(pm, src, write_len))
       return;
 
-    out = pkt;
+    out = pm->pm_pid_active ? pm->pm_pid_buf : src;
+    pkt = out;
     left = write_len;
+    offset = 0;
     write_len = 0;
     while (left > 0) {
       pid = (src[1] & 0x1f) << 8 | src[2];
       len = mpegts_word_count(src, left, 0x001FFF00);
       if (pass_muxer_rewrite_pid(pm, pid)) {
-        if (write_len)
-          pass_muxer_write(m, pkt, write_len);
+        pass_muxer_flush_table(m, pm, pkt, write_len, src, len, pid);
         pkt = out + len;
         write_len = 0;
-        pass_muxer_parse_tables(pm, src, len, pid);
       } else {
-        pass_muxer_process_payload(pm, src, out, len, pid);
+        pass_muxer_process_payload(pm, src, offset, len, pid);
         write_len += len;
       }
       src += len;
       out += len;
+      offset += len;
       left -= len;
     }
   }

--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -30,6 +30,8 @@
 #include "muxer_pass.h"
 #include "spawn.h"
 
+#define PASS_PID_COUNT 8192
+
 typedef struct pass_muxer {
   muxer_t;
 
@@ -46,6 +48,12 @@ typedef struct pass_muxer {
 
   /* Streaming components */
   streaming_start_t *pm_ss;
+  uint16_t          *pm_pid_map;
+  int8_t            *pm_pid_cc;
+  uint8_t           *pm_pid_rewrite_cc;
+  uint8_t           *pm_pid_buf;
+  size_t             pm_pid_buf_size;
+  uint8_t            pm_pid_active;
 
   /* TS muxing */
   uint8_t  pm_rewrite_sdt;
@@ -71,6 +79,179 @@ typedef struct pass_muxer {
 
 static void
 pass_muxer_write(muxer_t *m, const void *data, size_t size);
+
+static uint16_t
+pass_muxer_map_pid(pass_muxer_t *pm, uint16_t pid)
+{
+  if (pm->pm_pid_map == NULL || pid >= PASS_PID_COUNT)
+    return pid;
+  return pm->pm_pid_map[pid];
+}
+
+static int
+pass_muxer_component_match(const streaming_start_component_t *old,
+                           const streaming_start_component_t *new)
+{
+  int score;
+
+  if (old->es_type != new->es_type)
+    return -1;
+
+  score = old->es_index == new->es_index ? 8 : 0;
+  if (!memcmp(old->es_lang, new->es_lang, sizeof(old->es_lang)))
+    score += 4;
+  if (old->es_audio_type == new->es_audio_type)
+    score += 2;
+  if (old->es_parent_pid == new->es_parent_pid)
+    score++;
+  return score;
+}
+
+static int
+pass_muxer_stable_component(const streaming_start_component_t *ssc)
+{
+  return ssc->es_pid >= 0 && ssc->es_pid < PASS_PID_COUNT &&
+         (SCT_ISAV(ssc->es_type) || ssc->es_type == SCT_TELETEXT ||
+          ssc->es_type == SCT_DVBSUB);
+}
+
+static int
+pass_muxer_pid_conflict(const streaming_start_t *ss,
+                        const streaming_start_component_t *ssc,
+                        uint16_t output_pid)
+{
+  int i;
+
+  if (output_pid == ssc->es_pid)
+    return 0;
+  if (output_pid == DVB_PAT_PID || output_pid == ss->ss_pmt_pid)
+    return 1;
+  for (i = 0; i < ss->ss_num_components; i++)
+    if (&ss->ss_components[i] != ssc &&
+        ss->ss_components[i].es_pid == output_pid)
+      return 1;
+  return 0;
+}
+
+static void
+pass_muxer_update_pid_map(pass_muxer_t *pm, const streaming_start_t *ss)
+{
+  uint16_t *map;
+  int8_t *cc;
+  uint8_t *rewrite_cc, *used, claimed[PASS_PID_COUNT] = { 0 };
+  const streaming_start_component_t *old, *new;
+  int best, best_score, i, j, score;
+  uint16_t output_pid;
+
+  if (!pm->pm_seekable || !pm->m_config.u.pass.m_rewrite_pmt)
+    return;
+
+  map = malloc(sizeof(*map) * PASS_PID_COUNT);
+  if (map == NULL)
+    return;
+  for (i = 0; i < PASS_PID_COUNT; i++)
+    map[i] = i;
+
+  if (pm->pm_pid_map == NULL) {
+    cc = malloc(PASS_PID_COUNT);
+    rewrite_cc = calloc(PASS_PID_COUNT, sizeof(*rewrite_cc));
+    if (cc == NULL || rewrite_cc == NULL) {
+      free(map);
+      free(cc);
+      free(rewrite_cc);
+      return;
+    }
+    memset(cc, -1, PASS_PID_COUNT);
+    pm->pm_pid_map = map;
+    pm->pm_pid_cc = cc;
+    pm->pm_pid_rewrite_cc = rewrite_cc;
+    return;
+  }
+
+  used = calloc(pm->pm_ss ? pm->pm_ss->ss_num_components : 0, sizeof(*used));
+  if (pm->pm_ss && used == NULL) {
+    free(map);
+    return;
+  }
+  if (pm->pm_ss) {
+    for (i = 0; i < ss->ss_num_components; i++) {
+      new = &ss->ss_components[i];
+      if (!pass_muxer_stable_component(new))
+        continue;
+
+      best = -1;
+      best_score = -1;
+      for (j = 0; j < pm->pm_ss->ss_num_components; j++) {
+        old = &pm->pm_ss->ss_components[j];
+        if (used[j] || !pass_muxer_stable_component(old))
+          continue;
+        score = pass_muxer_component_match(old, new);
+        if (score > best_score) {
+          best = j;
+          best_score = score;
+        }
+      }
+      if (best < 0)
+        continue;
+
+      old = &pm->pm_ss->ss_components[best];
+      output_pid = pass_muxer_map_pid(pm, old->es_pid);
+      if (output_pid >= PASS_PID_COUNT)
+        continue;
+      if (claimed[output_pid] || pass_muxer_pid_conflict(ss, new, output_pid))
+        continue;
+
+      used[best] = 1;
+      claimed[output_pid] = 1;
+      map[new->es_pid] = output_pid;
+      if (new->es_pid != output_pid) {
+        pm->pm_pid_active = 1;
+        pm->pm_pid_rewrite_cc[output_pid] = 1;
+        tvhdebug(LS_PASS, "%s: remap input PID %d (%s) to stable PID %d",
+                 pm->pm_filename ?: "Pass muxer", new->es_pid,
+                 streaming_component_type2txt(new->es_type), output_pid);
+      }
+    }
+  }
+
+  free(used);
+  free(pm->pm_pid_map);
+  pm->pm_pid_map = map;
+}
+
+static void
+pass_muxer_track_cc(pass_muxer_t *pm, const uint8_t *tsb, int len, uint16_t pid)
+{
+  if (pm->pm_pid_cc == NULL || pid >= PASS_PID_COUNT)
+    return;
+  while (len >= 188) {
+    pm->pm_pid_cc[pid] = tsb[3] & 0x0f;
+    tsb += 188;
+    len -= 188;
+  }
+}
+
+static void
+pass_muxer_remap_ts(pass_muxer_t *pm, uint8_t *pkt, int len,
+                    uint16_t output_pid)
+{
+  int adaptation_control, cc, left;
+
+  for (left = len; left >= 188; pkt += 188, left -= 188) {
+    adaptation_control = (pkt[3] >> 4) & 0x03;
+    cc = pkt[3] & 0x0f;
+    if (pm->pm_pid_cc && pm->pm_pid_cc[output_pid] >= 0) {
+      cc = pm->pm_pid_cc[output_pid];
+      if (adaptation_control == 1 || adaptation_control == 3)
+        cc = (cc + 1) & 0x0f;
+      pkt[3] = (pkt[3] & 0xf0) | cc;
+    }
+    pkt[1] = (pkt[1] & 0xe0) | (output_pid >> 8);
+    pkt[2] = output_pid & 0xff;
+    if (pm->pm_pid_cc)
+      pm->pm_pid_cc[output_pid] = cc;
+  }
+}
 
 /*
  * Rewrite a PAT packet to only include the service included in the transport stream.
@@ -137,6 +318,10 @@ pass_muxer_pmt_cb(mpegts_psi_table_t *mt, const uint8_t *buf, int len)
   out[ol + 0] = pm->pm_dst_sid >> 8;
   out[ol + 1] = pm->pm_dst_sid & 0xff;
   memcpy(out + ol + 2, buf + 2, 7);
+  pid = (buf[5] & 0x1f) << 8 | buf[6];
+  pid = pass_muxer_map_pid(pm, pid);
+  out[ol + 5] = (out[ol + 5] & 0xe0) | (pid >> 8);
+  out[ol + 6] = pid & 0xff;
 
   ol  += 9;     /* skip common descriptors */
   buf += 9 + l;
@@ -165,6 +350,9 @@ pass_muxer_pmt_cb(mpegts_psi_table_t *mt, const uint8_t *buf, int len)
     }
     if (i < pm->pm_ss->ss_num_components) {
       memcpy(out + ol, buf, 5 + l);
+      pid = pass_muxer_map_pid(pm, pid);
+      out[ol + 1] = (out[ol + 1] & 0xe0) | (pid >> 8);
+      out[ol + 2] = pid & 0xff;
       ol += 5 + l;
     }
 
@@ -450,6 +638,8 @@ pass_muxer_reconfigure(muxer_t* m, const struct streaming_start *ss)
   pm->pm_rewrite_nit = !!pm->m_config.u.pass.m_rewrite_nit;
   pm->pm_rewrite_eit = !!pm->m_config.u.pass.m_rewrite_eit;
 
+  pass_muxer_update_pid_map(pm, ss);
+
   for(i=0; i < ss->ss_num_components; i++) {
     ssc = &ss->ss_components[i];
     if (!SCT_ISVIDEO(ssc->es_type) && !SCT_ISAUDIO(ssc->es_type))
@@ -625,18 +815,33 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
 {
   pass_muxer_t *pm = (pass_muxer_t*)m;
   int l, pid;
-  uint8_t *tsb, *pkt = pktbuf_ptr(pb);
+  uint8_t *buf, *outb, *src = pktbuf_ptr(pb), *pkt = src;
   size_t  len = pktbuf_len(pb), len2;
   
   /* Rewrite PAT/PMT in operation */
   if (pm->m_config.u.pass.m_rewrite_pat || pm->m_config.u.pass.m_rewrite_pmt ||
       pm->pm_rewrite_sdt || pm->pm_rewrite_nit || pm->pm_rewrite_eit) {
 
-    for (tsb = pktbuf_ptr(pb), len2 = pktbuf_len(pb), len = 0;
-         len2 > 0; tsb += l, len2 -= l) {
+    if (pm->pm_pid_active) {
+      if (pm->pm_pid_buf_size < len) {
+        buf = realloc(pm->pm_pid_buf, len);
+        if (buf == NULL) {
+          pm->pm_error = ENOMEM;
+          pm->m_errors++;
+          return;
+        }
+        pm->pm_pid_buf = buf;
+        pm->pm_pid_buf_size = len;
+      }
+      memcpy(pm->pm_pid_buf, src, len);
+      pkt = pm->pm_pid_buf;
+    }
 
-      pid = (tsb[1] & 0x1f) << 8 | tsb[2];
-      l = mpegts_word_count(tsb, len2, 0x001FFF00);
+    for (outb = pkt, len2 = pktbuf_len(pb), len = 0;
+         len2 > 0; src += l, outb += l, len2 -= l) {
+
+      pid = (src[1] & 0x1f) << 8 | src[2];
+      l = mpegts_word_count(src, len2, 0x001FFF00);
 
       /* Process */
       if ( (pm->m_config.u.pass.m_rewrite_pat && pid == DVB_PAT_PID) ||
@@ -650,40 +855,48 @@ pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
           pass_muxer_write(m, pkt, len);
 
         /* Store new start point (after these packets) */
-        pkt = tsb + l;
+        pkt = outb + l;
         len = 0;
 
         /* PAT */
         if (pid == DVB_PAT_PID) {
 
-          dvb_table_parse(&pm->pm_pat, "-", tsb, l, 1, 0, pass_muxer_pat_cb);
+          dvb_table_parse(&pm->pm_pat, "-", src, l, 1, 0, pass_muxer_pat_cb);
 
         /* SDT */
         } else if (pid == DVB_SDT_PID) {
         
-          dvb_table_parse(&pm->pm_sdt, "-", tsb, l, 1, 0, pass_muxer_sdt_cb);
+          dvb_table_parse(&pm->pm_sdt, "-", src, l, 1, 0, pass_muxer_sdt_cb);
 
         /* NIT */
         } else if (pid == DVB_NIT_PID) {
         
-          dvb_table_parse(&pm->pm_nit, "-", tsb, l, 1, 0, pass_muxer_nit_cb);
+          dvb_table_parse(&pm->pm_nit, "-", src, l, 1, 0, pass_muxer_nit_cb);
 
         /* EIT */
         } else if (pid == DVB_EIT_PID) {
         
-          dvb_table_parse(&pm->pm_eit, "-", tsb, l, 1, 0, pass_muxer_eit_cb);
+          dvb_table_parse(&pm->pm_eit, "-", src, l, 1, 0, pass_muxer_eit_cb);
         }
 		
         /* PMT */
         if (pid == pm->pm_pmt_pid) {
 
-          dvb_table_parse(&pm->pm_pmt, "-", tsb, l, 1, 0, pass_muxer_pmt_cb);
+          dvb_table_parse(&pm->pm_pmt, "-", src, l, 1, 0, pass_muxer_pmt_cb);
 
         }
 
       /* Record */
       } else {
-        len += l;
+        uint16_t output_pid = pass_muxer_map_pid(pm, pid);
+        if (output_pid != pid ||
+            (pm->pm_pid_rewrite_cc && pm->pm_pid_rewrite_cc[output_pid])) {
+          pass_muxer_remap_ts(pm, outb, l, output_pid);
+          len += l;
+        } else {
+          pass_muxer_track_cc(pm, src, l, output_pid);
+          len += l;
+        }
       }
     }
   }
@@ -765,6 +978,11 @@ pass_muxer_destroy(muxer_t *m)
 
   if (pm->pm_ss)
     streaming_start_unref(pm->pm_ss);
+
+  free(pm->pm_pid_map);
+  free(pm->pm_pid_cc);
+  free(pm->pm_pid_rewrite_cc);
+  free(pm->pm_pid_buf);
 
   dvb_table_parse_done(&pm->pm_pat);
   dvb_table_parse_done(&pm->pm_pmt);

--- a/src/muxer/muxer_pass.c
+++ b/src/muxer/muxer_pass.c
@@ -81,7 +81,7 @@ static void
 pass_muxer_write(muxer_t *m, const void *data, size_t size);
 
 static uint16_t
-pass_muxer_map_pid(pass_muxer_t *pm, uint16_t pid)
+pass_muxer_map_pid(const pass_muxer_t *pm, uint16_t pid)
 {
   if (pm->pm_pid_map == NULL || pid >= PASS_PID_COUNT)
     return pid;
@@ -133,86 +133,134 @@ pass_muxer_pid_conflict(const streaming_start_t *ss,
   return 0;
 }
 
+static uint16_t *
+pass_muxer_pid_map_create(void)
+{
+  uint16_t *map;
+  int i;
+
+  map = malloc(sizeof(*map) * PASS_PID_COUNT);
+  if (map == NULL)
+    return NULL;
+  for (i = 0; i < PASS_PID_COUNT; i++)
+    map[i] = i;
+  return map;
+}
+
+static int
+pass_muxer_pid_state_init(pass_muxer_t *pm, uint16_t *map)
+{
+  int8_t *cc;
+  uint8_t *rewrite_cc;
+
+  cc = malloc(PASS_PID_COUNT);
+  rewrite_cc = calloc(PASS_PID_COUNT, sizeof(*rewrite_cc));
+  if (cc == NULL || rewrite_cc == NULL) {
+    free(cc);
+    free(rewrite_cc);
+    return -1;
+  }
+  memset(cc, -1, PASS_PID_COUNT);
+  pm->pm_pid_map = map;
+  pm->pm_pid_cc = cc;
+  pm->pm_pid_rewrite_cc = rewrite_cc;
+  return 0;
+}
+
+static int
+pass_muxer_best_component(const pass_muxer_t *pm,
+                          const streaming_start_component_t *new,
+                          const uint8_t *used)
+{
+  const streaming_start_component_t *old;
+  int best;
+  int best_score;
+  int i;
+  int score;
+
+  best = -1;
+  best_score = -1;
+  for (i = 0; i < pm->pm_ss->ss_num_components; i++) {
+    old = &pm->pm_ss->ss_components[i];
+    if (used[i] || !pass_muxer_stable_component(old))
+      continue;
+    score = pass_muxer_component_match(old, new);
+    if (score > best_score) {
+      best = i;
+      best_score = score;
+    }
+  }
+  return best;
+}
+
+static void
+pass_muxer_map_component(pass_muxer_t *pm, const streaming_start_t *ss,
+                         const streaming_start_component_t *new,
+                         uint16_t *map, uint8_t *used, uint8_t *claimed)
+{
+  const streaming_start_component_t *old;
+  int best;
+  uint16_t output_pid;
+
+  if (!pass_muxer_stable_component(new))
+    return;
+  best = pass_muxer_best_component(pm, new, used);
+  if (best < 0)
+    return;
+
+  old = &pm->pm_ss->ss_components[best];
+  output_pid = pass_muxer_map_pid(pm, old->es_pid);
+  if (output_pid >= PASS_PID_COUNT || claimed[output_pid] ||
+      pass_muxer_pid_conflict(ss, new, output_pid))
+    return;
+
+  used[best] = 1;
+  claimed[output_pid] = 1;
+  map[new->es_pid] = output_pid;
+  if (new->es_pid == output_pid)
+    return;
+
+  pm->pm_pid_active = 1;
+  pm->pm_pid_rewrite_cc[output_pid] = 1;
+  tvhdebug(LS_PASS, "%s: remap input PID %d (%s) to stable PID %d",
+           pm->pm_filename ?: "Pass muxer", new->es_pid,
+           streaming_component_type2txt(new->es_type), output_pid);
+}
+
 static void
 pass_muxer_update_pid_map(pass_muxer_t *pm, const streaming_start_t *ss)
 {
   uint16_t *map;
-  int8_t *cc;
-  uint8_t *rewrite_cc, *used, claimed[PASS_PID_COUNT] = { 0 };
-  const streaming_start_component_t *old, *new;
-  int best, best_score, i, j, score;
-  uint16_t output_pid;
+  uint8_t *used;
+  uint8_t claimed[PASS_PID_COUNT] = { 0 };
+  int i;
 
   if (!pm->pm_seekable || !pm->m_config.u.pass.m_rewrite_pmt)
     return;
 
-  map = malloc(sizeof(*map) * PASS_PID_COUNT);
+  map = pass_muxer_pid_map_create();
   if (map == NULL)
     return;
-  for (i = 0; i < PASS_PID_COUNT; i++)
-    map[i] = i;
 
   if (pm->pm_pid_map == NULL) {
-    cc = malloc(PASS_PID_COUNT);
-    rewrite_cc = calloc(PASS_PID_COUNT, sizeof(*rewrite_cc));
-    if (cc == NULL || rewrite_cc == NULL) {
+    if (pass_muxer_pid_state_init(pm, map))
       free(map);
-      free(cc);
-      free(rewrite_cc);
-      return;
-    }
-    memset(cc, -1, PASS_PID_COUNT);
-    pm->pm_pid_map = map;
-    pm->pm_pid_cc = cc;
-    pm->pm_pid_rewrite_cc = rewrite_cc;
     return;
   }
 
-  used = calloc(pm->pm_ss ? pm->pm_ss->ss_num_components : 0, sizeof(*used));
-  if (pm->pm_ss && used == NULL) {
+  if (pm->pm_ss == NULL) {
+    free(pm->pm_pid_map);
+    pm->pm_pid_map = map;
+    return;
+  }
+
+  used = calloc(pm->pm_ss->ss_num_components, sizeof(*used));
+  if (used == NULL) {
     free(map);
     return;
   }
-  if (pm->pm_ss) {
-    for (i = 0; i < ss->ss_num_components; i++) {
-      new = &ss->ss_components[i];
-      if (!pass_muxer_stable_component(new))
-        continue;
-
-      best = -1;
-      best_score = -1;
-      for (j = 0; j < pm->pm_ss->ss_num_components; j++) {
-        old = &pm->pm_ss->ss_components[j];
-        if (used[j] || !pass_muxer_stable_component(old))
-          continue;
-        score = pass_muxer_component_match(old, new);
-        if (score > best_score) {
-          best = j;
-          best_score = score;
-        }
-      }
-      if (best < 0)
-        continue;
-
-      old = &pm->pm_ss->ss_components[best];
-      output_pid = pass_muxer_map_pid(pm, old->es_pid);
-      if (output_pid >= PASS_PID_COUNT)
-        continue;
-      if (claimed[output_pid] || pass_muxer_pid_conflict(ss, new, output_pid))
-        continue;
-
-      used[best] = 1;
-      claimed[output_pid] = 1;
-      map[new->es_pid] = output_pid;
-      if (new->es_pid != output_pid) {
-        pm->pm_pid_active = 1;
-        pm->pm_pid_rewrite_cc[output_pid] = 1;
-        tvhdebug(LS_PASS, "%s: remap input PID %d (%s) to stable PID %d",
-                 pm->pm_filename ?: "Pass muxer", new->es_pid,
-                 streaming_component_type2txt(new->es_type), output_pid);
-      }
-    }
-  }
+  for (i = 0; i < ss->ss_num_components; i++)
+    pass_muxer_map_component(pm, ss, &ss->ss_components[i], map, used, claimed);
 
   free(used);
   free(pm->pm_pid_map);
@@ -235,7 +283,9 @@ static void
 pass_muxer_remap_ts(pass_muxer_t *pm, uint8_t *pkt, int len,
                     uint16_t output_pid)
 {
-  int adaptation_control, cc, left;
+  int adaptation_control;
+  int cc;
+  int left;
 
   for (left = len; left >= 188; pkt += 188, left -= 188) {
     adaptation_control = (pkt[3] >> 4) & 0x03;
@@ -810,99 +860,119 @@ pass_muxer_write(muxer_t *m, const void *data, size_t size)
 /**
  * Write TS packets to the file descriptor
  */
+static int
+pass_muxer_rewrite_enabled(const pass_muxer_t *pm)
+{
+  return pm->m_config.u.pass.m_rewrite_pat ||
+         pm->m_config.u.pass.m_rewrite_pmt ||
+         pm->pm_rewrite_sdt || pm->pm_rewrite_nit || pm->pm_rewrite_eit;
+}
+
+static uint8_t *
+pass_muxer_output_buffer(pass_muxer_t *pm, const uint8_t *src, size_t len)
+{
+  uint8_t *buf;
+
+  if (!pm->pm_pid_active)
+    return (uint8_t *)src;
+  if (pm->pm_pid_buf_size < len) {
+    buf = realloc(pm->pm_pid_buf, len);
+    if (buf == NULL) {
+      pm->pm_error = ENOMEM;
+      pm->m_errors++;
+      return NULL;
+    }
+    pm->pm_pid_buf = buf;
+    pm->pm_pid_buf_size = len;
+  }
+  memcpy(pm->pm_pid_buf, src, len);
+  return pm->pm_pid_buf;
+}
+
+static int
+pass_muxer_rewrite_pid(const pass_muxer_t *pm, int pid)
+{
+  return (pm->m_config.u.pass.m_rewrite_pat && pid == DVB_PAT_PID) ||
+         (pm->m_config.u.pass.m_rewrite_pmt && pid == pm->pm_pmt_pid) ||
+         (pm->pm_rewrite_sdt && pid == DVB_SDT_PID) ||
+         (pm->pm_rewrite_nit && pid == DVB_NIT_PID) ||
+         (pm->pm_rewrite_eit && pid == DVB_EIT_PID);
+}
+
+static void
+pass_muxer_parse_tables(pass_muxer_t *pm, const uint8_t *src, int len, int pid)
+{
+  if (pid == DVB_PAT_PID)
+    dvb_table_parse(&pm->pm_pat, "-", src, len, 1, 0, pass_muxer_pat_cb);
+  else if (pid == DVB_SDT_PID)
+    dvb_table_parse(&pm->pm_sdt, "-", src, len, 1, 0, pass_muxer_sdt_cb);
+  else if (pid == DVB_NIT_PID)
+    dvb_table_parse(&pm->pm_nit, "-", src, len, 1, 0, pass_muxer_nit_cb);
+  else if (pid == DVB_EIT_PID)
+    dvb_table_parse(&pm->pm_eit, "-", src, len, 1, 0, pass_muxer_eit_cb);
+
+  if (pid == pm->pm_pmt_pid)
+    dvb_table_parse(&pm->pm_pmt, "-", src, len, 1, 0, pass_muxer_pmt_cb);
+}
+
+static void
+pass_muxer_process_payload(pass_muxer_t *pm, const uint8_t *src,
+                           uint8_t *out, int len, int pid)
+{
+  uint16_t output_pid;
+
+  output_pid = pass_muxer_map_pid(pm, pid);
+  if (output_pid != pid ||
+      (pm->pm_pid_rewrite_cc && pm->pm_pid_rewrite_cc[output_pid]))
+    pass_muxer_remap_ts(pm, out, len, output_pid);
+  else
+    pass_muxer_track_cc(pm, src, len, output_pid);
+}
+
 static void
 pass_muxer_write_ts(muxer_t *m, pktbuf_t *pb)
 {
   pass_muxer_t *pm = (pass_muxer_t*)m;
-  int l, pid;
-  uint8_t *buf, *outb, *src = pktbuf_ptr(pb), *pkt = src;
-  size_t  len = pktbuf_len(pb), len2;
-  
-  /* Rewrite PAT/PMT in operation */
-  if (pm->m_config.u.pass.m_rewrite_pat || pm->m_config.u.pass.m_rewrite_pmt ||
-      pm->pm_rewrite_sdt || pm->pm_rewrite_nit || pm->pm_rewrite_eit) {
+  int len;
+  int pid;
+  uint8_t *out;
+  uint8_t *pkt;
+  const uint8_t *src;
+  size_t left;
+  size_t write_len;
 
-    if (pm->pm_pid_active) {
-      if (pm->pm_pid_buf_size < len) {
-        buf = realloc(pm->pm_pid_buf, len);
-        if (buf == NULL) {
-          pm->pm_error = ENOMEM;
-          pm->m_errors++;
-          return;
-        }
-        pm->pm_pid_buf = buf;
-        pm->pm_pid_buf_size = len;
-      }
-      memcpy(pm->pm_pid_buf, src, len);
-      pkt = pm->pm_pid_buf;
-    }
+  src = pktbuf_ptr(pb);
+  pkt = (uint8_t *)src;
+  write_len = pktbuf_len(pb);
+  if (pass_muxer_rewrite_enabled(pm)) {
+    pkt = pass_muxer_output_buffer(pm, src, write_len);
+    if (pkt == NULL)
+      return;
 
-    for (outb = pkt, len2 = pktbuf_len(pb), len = 0;
-         len2 > 0; src += l, outb += l, len2 -= l) {
-
+    out = pkt;
+    left = write_len;
+    write_len = 0;
+    while (left > 0) {
       pid = (src[1] & 0x1f) << 8 | src[2];
-      l = mpegts_word_count(src, len2, 0x001FFF00);
-
-      /* Process */
-      if ( (pm->m_config.u.pass.m_rewrite_pat && pid == DVB_PAT_PID) ||
-           (pm->m_config.u.pass.m_rewrite_pmt && pid == pm->pm_pmt_pid) ||
-           (pm->pm_rewrite_sdt && pid == DVB_SDT_PID) ||
-           (pm->pm_rewrite_nit && pid == DVB_NIT_PID) ||
-           (pm->pm_rewrite_eit && pid == DVB_EIT_PID) ) {
-
-        /* Flush */
-        if (len)
-          pass_muxer_write(m, pkt, len);
-
-        /* Store new start point (after these packets) */
-        pkt = outb + l;
-        len = 0;
-
-        /* PAT */
-        if (pid == DVB_PAT_PID) {
-
-          dvb_table_parse(&pm->pm_pat, "-", src, l, 1, 0, pass_muxer_pat_cb);
-
-        /* SDT */
-        } else if (pid == DVB_SDT_PID) {
-        
-          dvb_table_parse(&pm->pm_sdt, "-", src, l, 1, 0, pass_muxer_sdt_cb);
-
-        /* NIT */
-        } else if (pid == DVB_NIT_PID) {
-        
-          dvb_table_parse(&pm->pm_nit, "-", src, l, 1, 0, pass_muxer_nit_cb);
-
-        /* EIT */
-        } else if (pid == DVB_EIT_PID) {
-        
-          dvb_table_parse(&pm->pm_eit, "-", src, l, 1, 0, pass_muxer_eit_cb);
-        }
-		
-        /* PMT */
-        if (pid == pm->pm_pmt_pid) {
-
-          dvb_table_parse(&pm->pm_pmt, "-", src, l, 1, 0, pass_muxer_pmt_cb);
-
-        }
-
-      /* Record */
+      len = mpegts_word_count(src, left, 0x001FFF00);
+      if (pass_muxer_rewrite_pid(pm, pid)) {
+        if (write_len)
+          pass_muxer_write(m, pkt, write_len);
+        pkt = out + len;
+        write_len = 0;
+        pass_muxer_parse_tables(pm, src, len, pid);
       } else {
-        uint16_t output_pid = pass_muxer_map_pid(pm, pid);
-        if (output_pid != pid ||
-            (pm->pm_pid_rewrite_cc && pm->pm_pid_rewrite_cc[output_pid])) {
-          pass_muxer_remap_ts(pm, outb, l, output_pid);
-          len += l;
-        } else {
-          pass_muxer_track_cc(pm, src, l, output_pid);
-          len += l;
-        }
+        pass_muxer_process_payload(pm, src, out, len, pid);
+        write_len += len;
       }
+      src += len;
+      out += len;
+      left -= len;
     }
   }
 
-  if (len)
-    pass_muxer_write(m, pkt, len);
+  if (write_len)
+    pass_muxer_write(m, pkt, write_len);
 }
 
 

--- a/src/timeshift.c
+++ b/src/timeshift.c
@@ -41,6 +41,18 @@ struct timeshift_conf timeshift_conf;
 memoryinfo_t timeshift_memoryinfo = { .my_name = "Timeshift" };
 memoryinfo_t timeshift_memoryinfo_ram = { .my_name = "Timeshift RAM buffer" };
 
+void
+timeshift_play_start_set(timeshift_t *ts, streaming_start_t *ss)
+{
+  if (ss == ts->smt_play)
+    return;
+  if (ss)
+    streaming_start_ref(ss);
+  if (ts->smt_play)
+    streaming_start_unref(ts->smt_play);
+  ts->smt_play = ss;
+}
+
 /*
  * Packet log
  */
@@ -439,6 +451,8 @@ timeshift_destroy(streaming_target_t *pad)
 
   if (ts->smt_start)
     streaming_start_unref(ts->smt_start);
+  if (ts->smt_play)
+    streaming_start_unref(ts->smt_play);
 
   if (ts->path)
     free(ts->path);

--- a/src/timeshift/private.h
+++ b/src/timeshift/private.h
@@ -136,6 +136,7 @@ typedef struct timeshift {
   uint8_t                         audio_packet_counter; ///< Counter for audio packets in audio-only streams
 
   streaming_start_t          *smt_start;  ///< Streaming start info
+  streaming_start_t          *smt_play;   ///< Stream info currently sent to the client
 
 } timeshift_t;
 
@@ -173,6 +174,7 @@ ssize_t timeshift_write_eof     ( timeshift_file_t *tsf );
  */
 void *timeshift_reader ( void *p );
 void *timeshift_writer ( void *p );
+void timeshift_play_start_set ( timeshift_t *ts, streaming_start_t *ss );
 
 /*
  * File management

--- a/src/timeshift/timeshift_reader.c
+++ b/src/timeshift/timeshift_reader.c
@@ -252,6 +252,33 @@ static ssize_t _read_msg ( timeshift_file_t *tsf, int fd, streaming_message_t **
   return cnt;
 }
 
+static streaming_message_t *
+_timeshift_find_sstart(timeshift_file_t *tsf, off_t pos)
+{
+  timeshift_index_data_t *ti;
+
+  ti = TAILQ_LAST(&tsf->sstart, timeshift_index_data_list);
+  while (ti && ti->pos > pos)
+    ti = TAILQ_PREV(ti, timeshift_index_data_list, link);
+
+  return ti ? ti->data : NULL;
+}
+
+static void
+_timeshift_apply_sstart(timeshift_t *ts, timeshift_file_t *tsf, off_t pos)
+{
+  streaming_message_t *sm = _timeshift_find_sstart(tsf, pos);
+  streaming_start_t *ss;
+
+  if (sm == NULL || (ss = sm->sm_data) == ts->smt_play)
+    return;
+
+  tvhdebug(LS_TIMESHIFT, "ts %d replay stream start at buffer position %" PRId64,
+           ts->id, (int64_t)pos);
+  streaming_target_deliver2(ts->output, streaming_msg_clone(sm));
+  timeshift_play_start_set(ts, ss);
+}
+
 /* **************************************************************************
  * Utilities
  * *************************************************************************/
@@ -411,11 +438,12 @@ static int _timeshift_read
 {
   timeshift_file_t *tsf = seek->file;
   ssize_t r;
-  off_t off = 0;
+  off_t off;
 
   *sm = NULL;
 
   if (tsf) {
+    off = tsf->roff;
 
     /* Open file */
     if (tsf->rfd < 0 && !tsf->ram) {
@@ -440,6 +468,9 @@ static int _timeshift_read
     }
     tvhtrace(LS_TIMESHIFT, "ts %d seek to %jd (fd %i) read msg %p/%"PRId64" (%"PRId64")",
              ts->id, (intmax_t)off, tsf->rfd, *sm, *sm ? (*sm)->sm_time : -1, (int64_t)r);
+
+    if (*sm)
+      _timeshift_apply_sstart(ts, tsf, off);
 
     /* Special case - EOF */
     if (r <= sizeof(size_t) || tsf->roff > tsf->size || *sm == NULL) {

--- a/src/timeshift/timeshift_reader.c
+++ b/src/timeshift/timeshift_reader.c
@@ -270,7 +270,10 @@ _timeshift_apply_sstart(timeshift_t *ts, timeshift_file_t *tsf, off_t pos)
   streaming_message_t *sm = _timeshift_find_sstart(tsf, pos);
   streaming_start_t *ss;
 
-  if (sm == NULL || (ss = sm->sm_data) == ts->smt_play)
+  if (sm == NULL)
+    return;
+  ss = sm->sm_data;
+  if (ss == ts->smt_play)
     return;
 
   tvhdebug(LS_TIMESHIFT, "ts %d replay stream start at buffer position %" PRId64,

--- a/src/timeshift/timeshift_writer.c
+++ b/src/timeshift/timeshift_writer.c
@@ -381,13 +381,15 @@ static void _process_msg
       tvh_mutex_lock(&ts->state_mutex);
       if (!teletext) /* do not use time from teletext packets */
         ts->buf_time = sm->sm_time;
+      if (sm->sm_type == SMT_START)
+        _update_smt_start(ts, (streaming_start_t *)sm->sm_data);
       if (ts->state == TS_LIVE) {
+        if (sm->sm_type == SMT_START)
+          timeshift_play_start_set(ts, (streaming_start_t *)sm->sm_data);
         streaming_target_deliver2(ts->output, streaming_msg_clone(sm));
         if (sm->sm_type == SMT_PACKET)
           timeshift_packet_log("liv", ts, sm);
       }
-      if (sm->sm_type == SMT_START)
-        _update_smt_start(ts, (streaming_start_t *)sm->sm_data);
       /* do buffering, but without teletext packets */
       if (ts->dobuf && !teletext) {
         if ((tsf = timeshift_filemgr_get(ts, sm->sm_time)) != NULL) {


### PR DESCRIPTION
## Summary

- restore the active stream map after timeshift seeks
- keep pass-through recording PIDs stable when a service changes its source PIDs

## Dependency

Depends on #2204, which ensures that teletext streams have unique component indexes. The stable PID mapping introduced here uses those indexes when matching replacement streams.

## Problem

Some services change their video, audio, or teletext PIDs while remaining on the same service.

Replacing the active elementary streams also changed the stream map exposed to pass-through recordings and timeshift playback. Players could consequently lose tracks or fail to seek reliably.

## Implementation

The pass muxer now maintains an output stream map and maps replacement source streams to the established output PIDs.

This keeps the output PMT, PCR PID, and elementary stream PIDs consistent while the underlying service changes its source streams.

Timeshift restores its stream map after a seek.

No external API changes are required.

## Validation

- `git diff --check origin/master...HEAD`
- successful Docker build
- pass-through recording keeps its output stream PIDs stable across source PID changes
- video and audio continuity counters remain valid across the stream replacement