### PR TITLE
webui: honour dedup-skipped recordings in the new UI

### DIFF
--- a/src/webui/static-vue/src/views/dvr/UpcomingView.vue
+++ b/src/webui/static-vue/src/views/dvr/UpcomingView.vue
@@ -21,6 +21,12 @@
  *                    start time is close enough for sorting purposes
  *                    and is what the grid endpoint returns directly.)
  *   - `sched_status` "scheduled" / "recording" / etc. Plain string.
+ *
+ * `duplicates: 0` mirrors the ExtJS grid (`dvr.js:508`): the server
+ * includes dedup-skipped reruns by default (`api_dvr.c`), and without
+ * the param they'd show as ordinary "Scheduled" rows although they
+ * will not record. The EPG event drawer explains the skip for such
+ * entries (its "rerun of" note), matching the classic details dialog.
  *   - `pri`          priority enum (server renders to a localized
  *                    string in the `pri` field for the grid view).
  *
@@ -449,6 +455,7 @@ function buildActions(selection: BaseRow[], clearSelection: () => void): ActionD
     help-page="class/dvrentry"
     :columns="cols"
     store-key="dvr-upcoming"
+    :extra-params="{ duplicates: 0 }"
     :default-sort="{ key: 'start_real', dir: 'ASC' }"
     :virtual-scroller-options="{ itemSize: 36, lazy: false }"
     count-label="recordings"

--- a/src/webui/static-vue/src/views/dvr/__tests__/UpcomingView.test.ts
+++ b/src/webui/static-vue/src/views/dvr/__tests__/UpcomingView.test.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/* eslint-disable vue/one-component-per-file -- inline stub components
+ * for the grid and its heavy drawer/editor companions; each is a
+ * throwaway harness, not a real component. */
+
+/*
+ * UpcomingView — pins the `duplicates: 0` grid parameter (issue
+ * #2207). The server's grid_upcoming endpoint INCLUDES dedup-skipped
+ * rerun entries by default; without the param they render as ordinary
+ * "Scheduled for recording" rows although they will not record. The
+ * ExtJS Upcoming grid has always passed duplicates=0 (dvr.js) — this
+ * test keeps the Vue view from silently regressing to the default.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { enableAutoUnmount, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import UpcomingView from '../UpcomingView.vue'
+
+/* Capture the props UpcomingView hands to the grid; the grid itself
+ * (store wiring, fetching, virtual scroller) is out of scope here. */
+const gridProps = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }))
+vi.mock('@/components/IdnodeGrid.vue', () => ({
+  default: defineComponent({
+    name: 'IdnodeGrid',
+    inheritAttrs: false,
+    setup(_, { attrs }) {
+      gridProps.current = attrs as Record<string, unknown>
+      return () => h('div', { class: 'idnode-grid-stub' })
+    },
+  }),
+}))
+/* The drawer/editor/dialog companions drag Pinia-heavy dependency
+ * trees — stub them out; this test only inspects the grid mount. */
+vi.mock('@/views/epg/EpgEventDrawer.vue', () => ({
+  default: defineComponent({ name: 'EpgEventDrawer', render: () => null }),
+}))
+vi.mock('@/components/IdnodeEditor.vue', () => ({
+  default: defineComponent({ name: 'IdnodeEditor', render: () => null }),
+}))
+vi.mock('@/components/EpgRelatedDialog.vue', () => ({
+  default: defineComponent({ name: 'EpgRelatedDialog', render: () => null }),
+}))
+/* useEditorMode syncs the edit target with the route — no real
+ * router in the harness. */
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: {}, hash: '', fullPath: '/dvr/upcoming' }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}))
+/* PrimeVue's injection-based confirm/toast services aren't installed
+ * in the harness — same mock idiom as useBulkAction.test.ts. */
+vi.mock('@/composables/useConfirmDialog', () => ({
+  useConfirmDialog: () => ({ ask: vi.fn(() => Promise.resolve(true)) }),
+}))
+vi.mock('@/composables/useToastNotify', () => ({
+  useToastNotify: () => ({ success: vi.fn(), error: vi.fn(), info: vi.fn() }),
+}))
+
+enableAutoUnmount(afterEach)
+
+describe('UpcomingView — dedup-skipped entries', () => {
+  it('requests the grid with duplicates: 0 (hide skipped reruns, ExtJS parity)', () => {
+    setActivePinia(createPinia())
+    mount(UpcomingView)
+    expect(gridProps.current?.endpoint).toBe('dvr/entry/grid_upcoming')
+    expect(gridProps.current?.['extra-params']).toEqual({ duplicates: 0 })
+  })
+})

--- a/src/webui/static-vue/src/views/epg/EpgEventDrawer.vue
+++ b/src/webui/static-vue/src/views/epg/EpgEventDrawer.vue
@@ -224,16 +224,47 @@ const selectedConfigUuid = ref<string>('')
 const relatedVisible = ref(false)
 const relatedMode = ref<EpgRelatedMode>('related')
 
+/* Epoch of the broadcast this event's DVR entry is a rerun of, when
+ * the dedup logic will skip it — null otherwise. The grid row's
+ * `dvrState` cannot carry this (a skipped rerun is still plain
+ * "scheduled", `dvr_db.c:704`), so it's read from the DVR entry's
+ * read-only `duplicate` property ("Rerun of", `dvr_db.c`) via a
+ * targeted `idnode/load` when the drawer opens on a scheduled entry.
+ * Drives the "Will be skipped" note — the Vue counterpart of the
+ * classic DVR details dialog's red rerun warning (`dvr.js:71`). */
+const duplicateOf = ref<number | null>(null)
+
+async function loadDuplicateOf(dvrUuid: string): Promise<void> {
+  try {
+    /* idnode/load nests property values in `params: [{id, value}]`. */
+    const resp = await apiCall<{
+      entries?: { params?: { id: string; value?: unknown }[] }[]
+    }>('idnode/load', { uuid: dvrUuid })
+    /* Ignore a stale response if the drawer moved on meanwhile. */
+    if (props.event?.dvrUuid !== dvrUuid) return
+    const v = resp.entries?.[0]?.params?.find((p) => p.id === 'duplicate')?.value
+    duplicateOf.value = typeof v === 'number' && v > 0 ? v : null
+  } catch {
+    /* Non-fatal — the note just doesn't render. */
+  }
+}
+
 watch(
   () => props.event,
   (ev) => {
     selectedConfigUuid.value = ''
     /* A re-targeted drawer closes any open showings dialog. */
     relatedVisible.value = false
+    duplicateOf.value = null
     if (!ev) return
     /* Genre code → localised label resolution; idempotent fetch. */
     contentTypes.ensure()
     if (!access.data?.dvr) return
+    /* Skipped-rerun check — only meaningful while merely scheduled
+     * (a recording/completed entry evidently wasn't skipped). */
+    if (ev.dvrUuid && ev.dvrState?.startsWith('scheduled')) {
+      void loadDuplicateOf(ev.dvrUuid)
+    }
     dvrConfig.ensure().then(() => {
       /* Land on the first entry — the auto-created default config
        * (title "(Default profile)" sorts first via the leading paren).
@@ -867,6 +898,17 @@ const flags = computed(() => {
         class="epg-event-drawer__actions"
       />
       <!--
+        Dedup-skip warning — this entry is scheduled but the
+        duplicate-detection will skip it as a rerun. Mirrors the
+        classic details dialog's red note; msgids reused from it so
+        existing translations apply.
+      -->
+      <p v-if="duplicateOf !== null" class="epg-event-drawer__skip-note">
+        {{ t('Will be skipped') }}
+        {{ t('because it is a rerun of:') }}
+        {{ fmtDate(duplicateOf) }}
+      </p>
+      <!--
         Channel identity strip — sits above the field groups,
         outside the .ifld grid because the 40 px logo wouldn't align
         cleanly with the 1-line text rows.
@@ -1176,6 +1218,20 @@ const flags = computed(() => {
  */
 .epg-event-drawer__actions {
   flex: 0 0 auto !important;
+}
+
+/* Dedup-skip warning — scheduled entry the duplicate detection will
+ * skip. Warning tint (not error red): nothing failed, the entry just
+ * won't fire. */
+.epg-event-drawer__skip-note {
+  flex: 0 0 auto;
+  margin: 0;
+  padding: var(--tvh-space-2) var(--tvh-space-3);
+  border: 1px solid var(--tvh-warning);
+  border-radius: var(--tvh-radius-sm);
+  background: color-mix(in srgb, var(--tvh-warning) 12%, transparent);
+  color: var(--tvh-text);
+  font-size: var(--tvh-text-md);
 }
 
 /* Channel identity strip. */


### PR DESCRIPTION
### What

Fixes the new UI showing dedup-skipped rerun entries as ordinary scheduled recordings, and adds the classic details dialog's "Will be skipped — rerun of …" explanation to the new UI's EPG event drawer.

Fixes #2207.

### Why

`api/dvr/entry/grid_upcoming` includes dedup-skipped entries unless the client passes `duplicates=0` (`api_dvr.c`). The classic Upcoming grid has always passed it (`dvr.js`); the new Upcoming view did not — skipped reruns appeared as normal "Scheduled for recording" rows although they will not record, and the two UIs disagreed on the row set and count (exactly as reported).

### How

Two halves, mirroring how the classic UI handles the same situation:

1. **Upcoming view**: pass `duplicates: 0` through the grid's existing extra-params mechanism — skipped reruns disappear from the list and the count, matching the classic grid. A unit test pins the parameter so it can't silently regress.
2. **EPG event drawer**: a hidden rerun still needs an explanation *somewhere* (the classic UI provides it in its details dialog, `epg.js:71`). When the drawer opens on a scheduled entry it loads the DVR entry's read-only `duplicate` property via a targeted `idnode/load` — the schedule status cannot carry this, since a skipped rerun still reports plain `"scheduled"` (`dvr_db.c:704`) — and renders an amber note: *"Will be skipped because it is a rerun of: `<date>`"*. The note reuses the classic message ids, so all existing translations apply unchanged.

The richer alternative from the report — showing skipped entries in the grid greyed-out behind a show/hide toggle — is a genuine enhancement beyond what either UI does today and is deliberately left for a separate PR if there's appetite; this one is strictly classic-parity.

### Testing

- New unit test pinning `duplicates: 0` + endpoint on the Upcoming grid mount; full Vue suite green; `vue-tsc`, ESLint, SPDX header check, `npm run build` all pass.
- Verified against a live instance: the endpoint accepts `duplicates=0` in the UI's wire form, and the drawer's `idnode/load` fetch was validated against a real DVR entry (`params[]` shape, `duplicate` present as a number, `0` for a non-duplicate → no note; the C getter returns the original broadcast's start time when the dedup logic matches, so a real duplicate renders the note with the original's date).
- What I could not stage locally is a live dedup-skipped entry (needs an autorec + rerun in EPG) — @pimzand, since you have the scenario at hand and wrote such a precise report: could you verify this branch on your build? Expected: the rerun disappears from the new UI's Upcoming view (count matches classic), and opening the rerun's event in the EPG shows the amber "Will be skipped" note with the original broadcast date.