### PR TITLE
webui: reveal dedup-skipped reruns in the Upcoming view on demand

### DIFF
--- a/src/webui/static-vue/src/components/DataGrid.vue
+++ b/src/webui/static-vue/src/components/DataGrid.vue
@@ -238,6 +238,12 @@ interface Props {
    * prop. */
   countLabel?: string
 
+  /* Optional per-row class resolver, applied to the desktop table's
+   * <tr> (PrimeVue's `rowClass`) AND the phone card root, so a
+   * consumer's row-state styling (e.g. DVR Upcoming's dedup-skipped
+   * dimming) covers both layouts from one function. */
+  rowClass?: (row: Row) => string | undefined
+
   /*
    * Active group-by field. When set, the table renders with
    * PrimeVue's subheader row-grouping mode — rows cluster by this
@@ -369,6 +375,7 @@ const props = withDefaults(defineProps<Props>(), {
   phoneItemSize: 88,
   sortLockedByGroup: false,
   countLabel: undefined,
+  rowClass: undefined,
   groupField: null,
   groupOrder: 'ASC',
   groupableFields: () => [],
@@ -1759,6 +1766,7 @@ defineExpose({
               `${bemPrefix}__card`,
               isRowSelected(row as Row) ? 'data-grid__card--selected' : null,
               isRowSelected(row as Row) ? `${bemPrefix}__card--selected` : null,
+              rowClass?.(row as Row) ?? null,
             ]"
             :style="{ height: `${phoneItemSize}px` }"
           >
@@ -1913,6 +1921,7 @@ defineExpose({
               `${bemPrefix}__card`,
               isRowSelected(item.row) ? 'data-grid__card--selected' : null,
               isRowSelected(item.row) ? `${bemPrefix}__card--selected` : null,
+              rowClass?.(item.row as Row) ?? null,
             ]"
           >
           <label
@@ -2018,6 +2027,7 @@ defineExpose({
         :value="entriesForTable"
         :loading="loading"
         :data-key="keyField"
+        :row-class="rowClass"
         :selection-mode="
           selectable === true ? 'multiple' : selectable === 'single' ? 'single' : undefined
         "

--- a/src/webui/static-vue/src/components/IdnodeGrid.vue
+++ b/src/webui/static-vue/src/components/IdnodeGrid.vue
@@ -205,6 +205,9 @@ interface Props {
    * → "748 services"). Falls back to "rows" when unsupplied.
    */
   countLabel?: string
+  /* Per-row class resolver, threaded to DataGrid (desktop <tr> and
+   * phone card root alike). See DataGrid's `rowClass` prop. */
+  rowClass?: (row: BaseRow) => string | undefined
   /*
    * Override DataGrid's default phone-mode card height (px)
    * when the phone path also virtualises (i.e.
@@ -430,6 +433,7 @@ const props = withDefaults(defineProps<Props>(), {
   notificationClass: undefined,
   filters: undefined,
   extraParams: undefined,
+  rowClass: undefined,
   virtualScrollerOptions: undefined,
   countLabel: undefined,
   phoneItemSize: undefined,
@@ -2695,6 +2699,7 @@ defineExpose({
     :edit-mode="effectiveEditMode"
     :phone-item-size="phoneItemSize"
     :count-label="countLabel"
+    :row-class="rowClass"
     :sort-field="sortField"
     :sort-order="sortOrder"
     :group-field="groupField"

--- a/src/webui/static-vue/src/views/dvr/UpcomingView.vue
+++ b/src/webui/static-vue/src/views/dvr/UpcomingView.vue
@@ -22,11 +22,14 @@
  *                    and is what the grid endpoint returns directly.)
  *   - `sched_status` "scheduled" / "recording" / etc. Plain string.
  *
- * `duplicates: 0` mirrors the ExtJS grid (`dvr.js:508`): the server
- * includes dedup-skipped reruns by default (`api_dvr.c`), and without
- * the param they'd show as ordinary "Scheduled" rows although they
- * will not record. The EPG event drawer explains the skip for such
- * entries (its "rerun of" note), matching the classic details dialog.
+ * Dedup-skipped reruns: hidden by default (`duplicates=0`, mirroring
+ * the ExtJS grid at `dvr.js:508` — the server includes them unless
+ * asked not to, `api_dvr.c`, and they'd show as ordinary "Scheduled"
+ * rows although they will not record). A "Skipped reruns" setting in
+ * the grid-settings popover's Filters section reveals them dimmed
+ * with a "Will be skipped" status — see the showSkipped block below.
+ * The EPG event drawer explains the skip per-entry (its "rerun of"
+ * note).
  *   - `pri`          priority enum (server renders to a localized
  *                    string in the `pri` field for the grid view).
  *
@@ -48,7 +51,7 @@
  * we follow ExtJS in showing "Abort" to the user.
  *
  */
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import IdnodeGrid from '@/components/IdnodeGrid.vue'
 import ActionMenu from '@/components/ActionMenu.vue'
 import IdnodeEditor from '@/components/IdnodeEditor.vue'
@@ -56,7 +59,7 @@ import EpgRelatedDialog from '@/components/EpgRelatedDialog.vue'
 import EpgEventDrawer, { type EpgEventDetail } from '@/views/epg/EpgEventDrawer.vue'
 import type { EpgRelatedMode } from '@/composables/useEpgRelatedFetch'
 import type { ColumnDef } from '@/types/column'
-import type { BaseRow } from '@/types/grid'
+import type { BaseRow, GlobalFilterSpec } from '@/types/grid'
 import type { ActionDef } from '@/types/action'
 import { useBulkAction } from '@/composables/useBulkAction'
 import { useEditorMode } from '@/composables/useEditorMode'
@@ -73,6 +76,68 @@ import { useAccessStore } from '@/stores/access'
 
 const access = useAccessStore()
 const kodiFmt = makeKodiPlainFmt(() => !!access.data?.label_formatting)
+
+/*
+ * "Skipped reruns" view setting, surfaced in the grid-settings
+ * popover's Filters section (the GlobalFilterSpec machinery — same
+ * idiom as DvbServices' "Hide" select). Hidden (default): the grid
+ * fetches with `duplicates=0` — dedup-skipped rerun entries are
+ * hidden, matching the classic grid. Shown: `duplicates=1` brings
+ * them back, dimmed with a "Will be skipped" status, so the one list
+ * people consult for "what will actually record" can also explain
+ * what will NOT — something neither UI offered before (the classic
+ * grid hides them with no way back). Persisted per-browser.
+ * IdnodeGrid seeds each spec's `current` into the fetch params and
+ * refetches on change; the non-default pick lights the Filters
+ * section's accent chip for free.
+ */
+const SHOW_SKIPPED_KEY = 'tvh-dvr-upcoming:show-skipped'
+const showSkipped = ref(loadShowSkipped())
+function loadShowSkipped(): boolean {
+  try {
+    return localStorage.getItem(SHOW_SKIPPED_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+watch(showSkipped, (v) => {
+  try {
+    if (v) localStorage.setItem(SHOW_SKIPPED_KEY, '1')
+    else localStorage.removeItem(SHOW_SKIPPED_KEY)
+  } catch {
+    /* Private mode / storage disabled — remembering is best-effort. */
+  }
+})
+
+const gridFilters = computed<GlobalFilterSpec[]>(() => [
+  {
+    kind: 'select',
+    key: 'duplicates',
+    label: t('Skipped reruns'),
+    options: [
+      { value: '0', label: t('Hidden') },
+      { value: '1', label: t('Shown (dimmed)') },
+    ],
+    current: showSkipped.value ? '1' : '0',
+  },
+])
+
+function onFilterChange(key: string, value: string) {
+  if (key === 'duplicates') showSkipped.value = value === '1'
+}
+
+/* A dedup-skipped entry carries the original broadcast's start time
+ * in the read-only `duplicate` field ("Rerun of", `dvr_db.c`) — the
+ * grid rows include it, and it's the only marker: `sched_status`
+ * still reads plain "scheduled" for a skipped rerun. */
+function isSkipped(row: BaseRow): boolean {
+  const d = (row as Record<string, unknown>).duplicate
+  return typeof d === 'number' && d > 0
+}
+
+function rowClassFor(row: BaseRow): string | undefined {
+  return isSkipped(row) ? 'upcoming__row--skipped' : undefined
+}
 
 /*
  * Column set roughly matches the ExtJS Upcoming view's `list` (see
@@ -115,7 +180,14 @@ const cols: ColumnDef[] = [
    * phone-promotion would silently drop via the level filter
    * anyway. Phone cards intentionally surface basic-level
    * fields only. */
-  { field: 'sched_status', ...DVR_FIELDS.sched_status },
+  {
+    field: 'sched_status',
+    ...DVR_FIELDS.sched_status,
+    /* A skipped rerun's server status still says "Scheduled for
+     * recording" — override with the honest label (classic msgid,
+     * translations ride along) when the toggle reveals such rows. */
+    format: (v, row) => (isSkipped(row) ? t('Will be skipped') : String(v ?? '')),
+  },
   { field: 'comment', ...DVR_FIELDS.comment, editable: true },
 
   /* Advanced — server's PO_ADVANCED flag will gate visibility on basic users */
@@ -455,7 +527,8 @@ function buildActions(selection: BaseRow[], clearSelection: () => void): ActionD
     help-page="class/dvrentry"
     :columns="cols"
     store-key="dvr-upcoming"
-    :extra-params="{ duplicates: 0 }"
+    :filters="gridFilters"
+    :row-class="rowClassFor"
     :default-sort="{ key: 'start_real', dir: 'ASC' }"
     :virtual-scroller-options="{ itemSize: 36, lazy: false }"
     count-label="recordings"
@@ -463,6 +536,7 @@ function buildActions(selection: BaseRow[], clearSelection: () => void): ActionD
     edit-mode="cell"
     :before-edit="(row) => row.sched_status?.toString().startsWith('recording') ? 'cannot edit a row currently recording' : true"
     class="upcoming__grid"
+    @filter-change="onFilterChange"
     @row-dblclick="(row) => openEditor([row])"
   >
     <template #empty>
@@ -506,5 +580,29 @@ function buildActions(selection: BaseRow[], clearSelection: () => void): ActionD
 
 .upcoming__empty {
   color: var(--tvh-text-muted);
+}
+
+</style>
+
+<!-- Unscoped: the skipped-row class lands on PrimeVue's <tr> (and the
+     phone card root) two component levels below this view, so scoped
+     [data-v] anchoring can't reach it. No ancestor anchor either:
+     IdnodeGrid is a multi-root template, so a fallthrough class on it
+     never reaches the DOM — the row class itself is the namespace
+     (only this view's rowClass resolver emits it). Same unscoped-
+     rules pattern as the EPG views. -->
+<style>
+/* Dedup-skipped rows — struck through (the classic UI's duplicate
+ * treatment, ext.css .x-epg-duplicate) and dimmed, on the desktop
+ * table and the phone card alike. The status column carries the
+ * "Will be skipped" wording. */
+tr.upcoming__row--skipped > td {
+  opacity: 0.55;
+  text-decoration: line-through;
+}
+
+.data-grid__card.upcoming__row--skipped {
+  opacity: 0.55;
+  text-decoration: line-through;
 }
 </style>

--- a/src/webui/static-vue/src/views/dvr/__tests__/UpcomingView.test.ts
+++ b/src/webui/static-vue/src/views/dvr/__tests__/UpcomingView.test.ts
@@ -6,21 +6,32 @@
  * throwaway harness, not a real component. */
 
 /*
- * UpcomingView — pins the `duplicates: 0` grid parameter (issue
- * #2207). The server's grid_upcoming endpoint INCLUDES dedup-skipped
- * rerun entries by default; without the param they render as ordinary
- * "Scheduled for recording" rows although they will not record. The
- * ExtJS Upcoming grid has always passed duplicates=0 (dvr.js) — this
- * test keeps the Vue view from silently regressing to the default.
+ * UpcomingView — dedup-skipped rerun handling (issue #2207).
+ *
+ * The server's grid_upcoming endpoint INCLUDES dedup-skipped rerun
+ * entries by default; they'd render as ordinary "Scheduled for
+ * recording" rows although they will not record. The view declares a
+ * "Skipped reruns" GlobalFilterSpec (grid-settings popover, Filters
+ * section); IdnodeGrid seeds each spec's `current` into the fetch
+ * params — the production contract DvbServices' "Hide" select rides
+ * daily. Pins:
+ *   - the spec defaults to `duplicates` = '0' (hidden, ExtJS parity),
+ *   - a filter-change flips it to '1' and persists across mounts,
+ *   - skipped rows (duplicate > 0) classify as dimmed via the
+ *     grid's rowClass hook; normal rows don't,
+ *   - the status column formats skipped rows as "Will be skipped".
  */
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, h } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, nextTick } from 'vue'
 import { enableAutoUnmount, mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import UpcomingView from '../UpcomingView.vue'
+import type { ColumnDef } from '@/types/column'
+import type { BaseRow, GlobalFilterSpec } from '@/types/grid'
 
 /* Capture the props UpcomingView hands to the grid; the grid itself
- * (store wiring, fetching, virtual scroller) is out of scope here. */
+ * (store wiring, fetching, virtual scroller, the filters→params
+ * seeding) is out of scope here. */
 const gridProps = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }))
 vi.mock('@/components/IdnodeGrid.vue', () => ({
   default: defineComponent({
@@ -60,11 +71,67 @@ vi.mock('@/composables/useToastNotify', () => ({
 
 enableAutoUnmount(afterEach)
 
+beforeEach(() => {
+  setActivePinia(createPinia())
+  localStorage.clear()
+  gridProps.current = null
+})
+
+const SKIPPED_ROW = { uuid: 'd1', duplicate: 1_700_000_000 } as BaseRow
+const NORMAL_ROW = { uuid: 'n1', duplicate: 0 } as BaseRow
+
+function skipFilterSpec(): GlobalFilterSpec | undefined {
+  const specs = gridProps.current?.filters as GlobalFilterSpec[] | undefined
+  return specs?.find((f) => f.key === 'duplicates')
+}
+
 describe('UpcomingView — dedup-skipped entries', () => {
-  it('requests the grid with duplicates: 0 (hide skipped reruns, ExtJS parity)', () => {
-    setActivePinia(createPinia())
+  it('declares the duplicates filter defaulting to "0" (hidden, ExtJS parity)', () => {
     mount(UpcomingView)
     expect(gridProps.current?.endpoint).toBe('dvr/entry/grid_upcoming')
-    expect(gridProps.current?.['extra-params']).toEqual({ duplicates: 0 })
+    const spec = skipFilterSpec()!
+    expect(spec.current).toBe('0')
+    /* First option is the default — drives the popover's accent chip. */
+    expect(spec.options[0].value).toBe('0')
+  })
+
+  it('a filter change flips the spec to "1" and persists the choice', async () => {
+    const w = mount(UpcomingView)
+    const onChange = gridProps.current?.onFilterChange as (k: string, v: string) => void
+    onChange('duplicates', '1')
+    await nextTick()
+    expect(skipFilterSpec()?.current).toBe('1')
+    expect(localStorage.getItem('tvh-dvr-upcoming:show-skipped')).toBe('1')
+
+    /* A fresh mount honours the persisted choice. */
+    w.unmount()
+    mount(UpcomingView)
+    expect(skipFilterSpec()?.current).toBe('1')
+  })
+
+  it('ignores filter changes for other keys', async () => {
+    mount(UpcomingView)
+    const onChange = gridProps.current?.onFilterChange as (k: string, v: string) => void
+    onChange('hidemode', '1')
+    await nextTick()
+    expect(skipFilterSpec()?.current).toBe('0')
+  })
+
+  it('classifies skipped rows as dimmed via the rowClass hook', () => {
+    mount(UpcomingView)
+    const rowClass = gridProps.current?.['row-class'] as (r: BaseRow) => string | undefined
+    expect(rowClass(SKIPPED_ROW)).toBe('upcoming__row--skipped')
+    expect(rowClass(NORMAL_ROW)).toBeUndefined()
+    expect(rowClass({ uuid: 'x' } as BaseRow)).toBeUndefined()
+  })
+
+  it('formats the status column as "Will be skipped" for skipped rows', () => {
+    mount(UpcomingView)
+    const cols = gridProps.current?.columns as ColumnDef[]
+    const status = cols.find((c) => c.field === 'sched_status')!
+    expect(status.format?.('Scheduled for recording', SKIPPED_ROW)).toBe('Will be skipped')
+    expect(status.format?.('Scheduled for recording', NORMAL_ROW)).toBe(
+      'Scheduled for recording',
+    )
   })
 })


### PR DESCRIPTION
> [!NOTE]
> #2208 has merged — this branch is now rebased onto master and carries the single commit described below.

### What

The follow-up discussed in #2207/#2208: with the Upcoming view now hiding dedup-skipped reruns (classic parity), this adds the opt-in way to *see* them — a **"Skipped reruns"** setting in the grid-settings popover's Filters section (`Hidden` by default / `Shown (dimmed)`).

When shown, skipped entries render **struck through and dimmed** — the classic UI's own duplicate treatment (`ext.css` `.x-epg-duplicate`) — with the status column reading **"Will be skipped"** (classic message id, so existing translations apply). Picking the non-default lights the Filters section's accent chip, and the choice persists per browser.

This makes Upcoming the first list in either UI that can show what the duplicate detection will *not* record — the classic grid hardcodes `duplicates=0` with no way back.

### How

- The setting rides the existing `GlobalFilterSpec` machinery (the same mechanism as the Services view's "Hide" select): the grid seeds the value into every fetch and refetches on change — no new fetch plumbing.
- Skipped rows are recognised by the entry's read-only `duplicate` field (present in every grid row; the schedule status itself still reads plain `"scheduled"` for a skipped rerun).
- New small piece of shared machinery: a per-row class hook threaded `IdnodeGrid → DataGrid` onto the desktop `<tr>` and the phone card root alike, so one resolver styles both layouts.
- The row styling is deliberately unscoped and anchored on the row class alone — `IdnodeGrid` is a multi-root template, so a fallthrough class on it never reaches the DOM, and scoped `[data-v]` anchors can't reach PrimeVue's rows two component levels down.

### Testing

- Unit tests pin: the filter spec defaults to hidden (ExtJS-parity fetch), the flip + per-browser persistence, the row classification, and the status-column override. Full Vue suite green; `vue-tsc`, ESLint, SPDX check, build all pass.
- Verified against a live instance with 20 real dedup-skipped entries (manufactured by scheduling under "record all" and then tightening the DVR profile's duplicate handling — the same "settings changed after entries existed" path that produces such entries in the wild): default view shows only the recording entries; the setting reveals the 20 skipped ones struck-through with correct "Will be skipped" statuses.
- @pimzand — you offered to test this follow-up; it composes with #2208 on this branch, so your existing setup should exercise both.

### RFC: the EPG side (your observation 2)

@pimzand's #2208 review noted that the EPG "will record" indicators (Table clock, Timeline/Magazine stripe — both UIs) overclaim for skipped reruns, and nothing invites the user to open the event and find the note. The schedule status string cannot carry dup-ness, so fixing that honestly needs a small **additive server field** on the EPG rows — e.g. `dvrDuplicate: <original broadcast's start>` next to `dvrUuid`/`dvrState` in the `api_epg` DVR join. The new UI would then render a distinct "skipped" state (dimmed stripe / distinct icon), and the classic UI could adopt the same field if wanted. Before building it: does that wire shape look right, or would you rather see dup-ness folded differently? Opinions welcome — that would be a third, server-touching PR.