### PR TITLE
support: getmuxlist: fix configure failure during git branch reset

### DIFF
--- a/support/getmuxlist
+++ b/support/getmuxlist
@@ -16,8 +16,7 @@ if [ -d "${DIR}/.git" ]; then
   hash1=$(git rev-parse HEAD)
   hash2=$(git rev-parse origin/${BRANCH})
   if [ "$hash1" != "$hash2" ]; then
-    git reset --hard origin/master > /dev/null 2>&1 || exit 1
-    git pull > /dev/null 2>&1 || exit 1
+    git reset --hard "origin/${BRANCH}" > /dev/null 2>&1 || exit 1
   else
     if [ ! -r README ]; then
       git reset --hard > /dev/null 2>&1 || exit 1


### PR DESCRIPTION
Fixes "ERROR: Failed to fetch dvb-scan data (use --disable-dvbscan)" in ./configure due to the hardcoded reset against the master branch of the dtv-scan-tables repo which no longer exists.

Fixes #2209 