### PR TITLE
ci: build aarch64 debs natively on arm64 runners

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -81,7 +81,9 @@ jobs:
     # Run steps on a matrix
     strategy:
       matrix:
-       arch: [ armv7, aarch64]
+       # aarch64 is not emulated here: it builds natively on arm64
+       # runners in build-deb-native below.
+       arch: [ armv7 ]
        distro: [ stretch, buster, bullseye, bookworm, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04, ubuntu24.04 ]
        include:
          - arch: armv6
@@ -90,8 +92,6 @@ jobs:
            distro: buster
          - arch: armv6
            distro: bullseye
-         - arch: aarch64
-           distro: ubuntu_latest
 
     steps:
       - uses: actions/checkout@v3
@@ -181,21 +181,53 @@ jobs:
           if-no-files-found: error
 
   build-deb-native:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: vue
     continue-on-error: true
-    name: Build on native ${{ matrix.container[1] }}
+    name: Build on ${{ matrix.container[2] || format('native {0}', matrix.container[1]) }}
 
     strategy:
       matrix:
+        runner: ["ubuntu-latest"]
         container: [["i386/ubuntu:trusty", "i386-ubuntu-trusty"], ["ubuntu:trusty", "ubuntu-trusty"], ["i386/ubuntu:xenial", "i386-ubuntu-xenial"], ["ubuntu:xenial", "ubuntu-xenial"], ["ubuntu:bionic", "ubuntu-bionic"], ["ubuntu:focal", "ubuntu-focal"], ["ubuntu:jammy", "ubuntu-jammy"], ["ubuntu:noble", "ubuntu-noble"], ["ubuntu:plucky", "ubuntu-plucky"], ["ubuntu:questing", "ubuntu-questing"], ["ubuntu:resolute", "ubuntu-resolute"], ["i386/debian:stretch", "i386-debian-stretch"], ["debian:stretch", "debian-stretch"], ["i386/debian:buster", "i386-debian-buster"], ["debian:buster", "debian-buster"], ["i386/debian:bullseye", "i386-debian-bullseye"], ["debian:bullseye", "debian-bullseye"], ["i386/debian:bookworm", "i386-debian-bookworm"], ["debian:bookworm", "debian-bookworm"], ["i386/debian:trixie", "i386-debian-trixie"], ["debian:trixie", "debian-trixie"], ["i386/debian:sid", "i386-debian-sid"], ["debian:sid", "debian-sid"]]
+        # aarch64 legs on GitHub's arm64 runners, replacing the QEMU-emulated
+        # aarch64 builds formerly in build-crosscompile:
+        # uraimo/run-on-arch-action cannot run on arm64 hosts (its QEMU
+        # helper image is amd64-only, uraimo/run-on-arch-action#161).
+        # Each include entry overrides both matrix axes, so it is added as
+        # its own combination instead of cross-multiplying with the
+        # ubuntu-latest legs above.
+        # The third container element is the display name: these legs keep
+        # the job names of the QEMU builds they replace, so the required
+        # status checks on master keep matching by name.
+        include:
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/debian:stretch", "arm64-debian-stretch", "stretch aarch64"]
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/debian:buster", "arm64-debian-buster", "buster aarch64"]
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/debian:bullseye", "arm64-debian-bullseye", "bullseye aarch64"]
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/debian:bookworm", "arm64-debian-bookworm", "bookworm aarch64"]
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/ubuntu:xenial", "arm64-ubuntu-xenial", "ubuntu16.04 aarch64"]
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/ubuntu:bionic", "arm64-ubuntu-bionic", "ubuntu18.04 aarch64"]
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/ubuntu:focal", "arm64-ubuntu-focal", "ubuntu20.04 aarch64"]
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/ubuntu:jammy", "arm64-ubuntu-jammy", "ubuntu22.04 aarch64"]
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/ubuntu:noble", "arm64-ubuntu-noble", "ubuntu24.04 aarch64"]
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/ubuntu:latest", "arm64-ubuntu-latest", "ubuntu_latest aarch64"]
     steps:
       - name: Setup container
         run: |
           docker pull ${{ matrix.container[0] }}
           docker run --name build-container -d -e GITHUB_ACTIONS=true -v ${{ github.workspace }}:/workspace ${{ matrix.container[0] }} tail -f /dev/null
       - name: Fix old debian apt
-        if: matrix.container[0] == 'debian:stretch' || matrix.container[0] == 'i386/debian:stretch' || matrix.container[0] == 'debian:buster' || matrix.container[0] == 'i386/debian:buster'
+        if: endsWith(matrix.container[0], 'debian:stretch') || endsWith(matrix.container[0], 'debian:buster')
         env:
           SCRIPT: |
             sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list

--- a/.github/workflows/build-cloudsmith.yml
+++ b/.github/workflows/build-cloudsmith.yml
@@ -81,7 +81,9 @@ jobs:
     # Run steps on a matrix
     strategy:
       matrix:
-       arch: [ armv7, aarch64]
+       # aarch64 is not emulated here: it builds natively on arm64
+       # runners in build-deb-native below.
+       arch: [ armv7 ]
        distro: [ stretch, buster, bullseye, bookworm, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04, ubuntu24.04, ubuntu_latest ]
        include:
          - arch: armv6
@@ -189,22 +191,54 @@ jobs:
           if-no-files-found: error
 
   build-deb-native:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: vue
     continue-on-error: true
-    name: Build on native ${{ matrix.container[1] }}
+    name: Build on ${{ matrix.container[2] || format('native {0}', matrix.container[1]) }}
     env:
       PCLOUD_TOKEN: ${{ secrets.PCLOUD_TOKEN }}
     strategy:
       matrix:
+        runner: ["ubuntu-latest"]
         container: [["i386/ubuntu:trusty", "i386-ubuntu-trusty"], ["ubuntu:trusty", "ubuntu-trusty"], ["i386/ubuntu:xenial", "i386-ubuntu-xenial"], ["ubuntu:xenial", "ubuntu-xenial"], ["ubuntu:bionic", "ubuntu-bionic"], ["ubuntu:focal", "ubuntu-focal"], ["ubuntu:jammy", "ubuntu-jammy"], ["ubuntu:noble", "ubuntu-noble"], ["ubuntu:plucky", "ubuntu-plucky"], ["ubuntu:questing", "ubuntu-questing"], ["ubuntu:resolute", "ubuntu-resolute"], ["i386/debian:stretch", "i386-debian-stretch"], ["debian:stretch", "debian-stretch"], ["i386/debian:buster", "i386-debian-buster"], ["debian:buster", "debian-buster"], ["i386/debian:bullseye", "i386-debian-bullseye"], ["debian:bullseye", "debian-bullseye"], ["i386/debian:bookworm", "i386-debian-bookworm"], ["debian:bookworm", "debian-bookworm"], ["i386/debian:trixie", "i386-debian-trixie"], ["debian:trixie", "debian-trixie"], ["i386/debian:sid", "i386-debian-sid"], ["debian:sid", "debian-sid"]]
+        # aarch64 legs on GitHub's arm64 runners, replacing the QEMU-emulated
+        # aarch64 builds formerly in build-crosscompile:
+        # uraimo/run-on-arch-action cannot run on arm64 hosts (its QEMU
+        # helper image is amd64-only, uraimo/run-on-arch-action#161).
+        # Each include entry overrides both matrix axes, so it is added as
+        # its own combination instead of cross-multiplying with the
+        # ubuntu-latest legs above.
+        # The third container element is the display name: these legs keep
+        # the job names of the QEMU builds they replace, so the required
+        # status checks on master keep matching by name.
+        include:
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/debian:stretch", "arm64-debian-stretch", "stretch aarch64"]
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/debian:buster", "arm64-debian-buster", "buster aarch64"]
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/debian:bullseye", "arm64-debian-bullseye", "bullseye aarch64"]
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/debian:bookworm", "arm64-debian-bookworm", "bookworm aarch64"]
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/ubuntu:xenial", "arm64-ubuntu-xenial", "ubuntu16.04 aarch64"]
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/ubuntu:bionic", "arm64-ubuntu-bionic", "ubuntu18.04 aarch64"]
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/ubuntu:focal", "arm64-ubuntu-focal", "ubuntu20.04 aarch64"]
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/ubuntu:jammy", "arm64-ubuntu-jammy", "ubuntu22.04 aarch64"]
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/ubuntu:noble", "arm64-ubuntu-noble", "ubuntu24.04 aarch64"]
+          - runner: ubuntu-24.04-arm
+            container: ["arm64v8/ubuntu:latest", "arm64-ubuntu-latest", "ubuntu_latest aarch64"]
     steps:
       - name: Setup container
         run: |
           docker pull ${{ matrix.container[0] }}
           docker run --name build-container -d -e GITHUB_ACTIONS=true -v ${{ github.workspace }}:/workspace ${{ matrix.container[0] }} tail -f /dev/null
       - name: Fix old debian apt
-        if: matrix.container[0] == 'debian:stretch' || matrix.container[0] == 'i386/debian:stretch' || matrix.container[0] == 'debian:buster' || matrix.container[0] == 'i386/debian:buster'
+        if: endsWith(matrix.container[0], 'debian:stretch') || endsWith(matrix.container[0], 'debian:buster')
         env:
           SCRIPT: |
             sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list


### PR DESCRIPTION
Fixes #2212

**What**

Move the aarch64 deb builds from QEMU emulation (uraimo/run-on-arch-action on x86 runners) to native arm64 runners (`ubuntu-24.04-arm`), in both `build-ci.yml` and `build-cloudsmith.yml`.

Rather than adding a new job, the existing `build-deb-native` job gains a `runner` matrix axis, the same pattern `build-el-rpm-native` already uses for its almalinux aarch64 legs. The ten aarch64 containers are `include:` entries carrying `runner: ubuntu-24.04-arm`, so they are added as standalone matrix combinations and every build step stays shared with the x86 legs; future changes to the build steps automatically cover all architectures. The only per-arch delta is the "Fix old debian apt" condition, rewritten with `endsWith()` so the `arm64v8/` images match alongside the plain and `i386/` ones.

The armv6/armv7 legs are untouched: run-on-arch-action stays for those, and `build-crosscompile` simply loses its aarch64 entries.

**Why**

As discussed in #2212: run-on-arch-action cannot run on arm64 hosts at all (its QEMU helper image is amd64-only, uraimo/run-on-arch-action#161), so the emulated aarch64 legs cannot simply be re-hosted on arm64 runners. Emulation also makes them the slowest part of every PR run (29 to 97 minutes per leg), and it adds a third-party failure mode: one aarch64 leg recently failed in 19 seconds because the binfmt helper pull got a 502 from Docker Hub before checkout even ran.

**Testing**

Dispatched on a fork with this matrix, all legs green:

- all ten aarch64 legs: 2.4 to 6.8 minutes each (against 29 to 97 minutes emulated), packages built with `ffmpeg_static yes` and uploaded as artifacts;
- `debian:stretch` and `i386/debian:stretch` control legs on `ubuntu-latest`, confirming the runner axis and the rewritten apt condition leave the x86 path unchanged;
- no sources.list changes were needed: archive.debian.org serves arm64 packages for stretch and buster, and ports.ubuntu.com still carries xenial arm64.

The `build-ci.yml` half demonstrates itself in this PR's own checks. The `build-cloudsmith.yml` half only runs on push to master, so it proves itself on the first post-merge push; its cloudsmith upload steps are carried over unchanged from the x86 legs.
