### PR TITLE
ci: share the rpm build steps and add native Fedora aarch64 legs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -45,6 +45,8 @@ body:
         - Fedora 40
         - Fedora 41
         - Fedora 42
+        - Fedora 43
+        - Fedora 44
         - Fedora Rawhide
         - FreeBSD (all)
         - Raspberry Pi OS (Buster)

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -293,23 +293,28 @@ jobs:
 
   build-rpm-native:
     needs: vue
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     continue-on-error: true
-    name: Build on native fedora:${{ matrix.releasever }}
+    name: Build on native fedora:${{ matrix.releasever }} ${{ matrix.runner == 'ubuntu-latest' && 'x86_64' || 'aarch64' }}
 
     strategy:
       matrix:
         releasever: ["37", "38", "39", "40", "41", "42", "43", "44", "rawhide"]
+        runner: ["ubuntu-latest"]
+        # the include entries add combinations (their runner value differs
+        # from the base axis), so only recent releases build on aarch64
+        include:
+          - releasever: "43"
+            runner: ubuntu-24.04-arm
+          - releasever: "44"
+            runner: ubuntu-24.04-arm
+          - releasever: "rawhide"
+            runner: ubuntu-24.04-arm
     container:
       image: "fedora:${{ matrix.releasever }}"
     steps:
-      - name: rpmfusion-free
-        run: |
-          dnf install -y "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-${{ matrix.releasever }}.noarch.rpm"
-      - name: dependencies
-        run: |
-          dnf install -y gcc-c++ gcc-c++ which rpm-build rpmdevtools git make cmake gettext-devel dbus-devel avahi-devel openssl-devel zlib-devel libdvbcsa-devel wget bzip2 uriparser-devel pcre2-devel python python-requests ccache systemd-units systemd-devel
-          dnf install -y openssl-devel-engine || true
+      - name: git for checkout, zstd for the cache
+        run: dnf install -y git zstd
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -325,21 +330,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .staticlib
-          key: staticlib-fedora-${{ matrix.releasever }}-${{ github.sha }}
+          key: staticlib-fedora-${{ matrix.releasever }}-${{ matrix.runner }}-${{ github.sha }}
           restore-keys: |
-            staticlib-fedora-${{ matrix.releasever }}-
+            staticlib-fedora-${{ matrix.releasever }}-${{ matrix.runner }}-
       - name: build
-        run: |
-          mkdir -p .staticlib
-          export STATICLIB_CACHE="$PWD/.staticlib"
-          export VUE_FILE_CACHE="$PWD/.vuecache"
-          export TVH_EXTRA_CONFIGURE="--enable-vue_cache --disable-vue_build"
-          ./configure --disable-dvbscan --disable-libfdkaac_static --disable-ffmpeg_static --disable-hdhomerun_static --disable-libfdkaac_static --disable-libopus_static --disable-libtheora_static --disable-libvorbis_static --disable-libvpx_static --disable-libx264_static --disable-libx265_static --enable-libfdkaac --enable-hdhomerun_client --enable-libsystemd_daemon --python=/usr/bin/python3 $TVH_EXTRA_CONFIGURE && make -C rpm build -j$(nproc) || (echo "PARALLEL BUILD FAILED, DOING SINGLE THREADED BUILD" && make -C rpm build)
+        run: support/ci-rpm-build.sh ${{ matrix.releasever }}
       - name: copy-result
         run: cp rpm/RPMS/*/tvheadend*.rpm .
       - uses: actions/upload-artifact@v4
         with:
-          name: Tvheadend-Fedora-${{ matrix.releasever }}
+          name: Tvheadend-Fedora-${{ matrix.releasever }}-${{ matrix.runner == 'ubuntu-latest' && 'x86_64' || 'aarch64' }}
           path: tvheadend*.rpm
           if-no-files-found: error
       - name: upload-cloudsmith
@@ -358,15 +358,8 @@ jobs:
     container:
       image: "almalinux:${{ matrix.releasever }}"
     steps:
-      - name: rpmfusion-free
-        run: |
-          dnf install -y dnf-plugins-core
-          dnf config-manager --set-enabled crb
-          dnf install -y "https://download1.rpmfusion.org/free/el/rpmfusion-free-release-${{ matrix.releasever }}.noarch.rpm"
-      - name: dependencies
-        run: |
-          dnf install -y gcc-c++ gcc-c++ which rpm-build rpmdevtools git make cmake gettext-devel dbus-devel avahi-devel openssl-devel zlib-devel libdvbcsa-devel wget bzip2 uriparser-devel pcre2-devel python python-requests ccache systemd-units systemd-devel
-          dnf install -y openssl-devel-engine || true
+      - name: git for checkout, zstd for the cache
+        run: dnf install -y git zstd
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -386,12 +379,7 @@ jobs:
           restore-keys: |
             staticlib-el-${{ matrix.releasever }}-${{ matrix.runner }}-
       - name: build
-        run: |
-          mkdir -p .staticlib
-          export STATICLIB_CACHE="$PWD/.staticlib"
-          export VUE_FILE_CACHE="$PWD/.vuecache"
-          export TVH_EXTRA_CONFIGURE="--enable-vue_cache --disable-vue_build"
-          ./configure --disable-dvbscan --disable-libfdkaac_static --disable-ffmpeg_static --disable-hdhomerun_static --disable-libfdkaac_static --disable-libopus_static --disable-libtheora_static --disable-libvorbis_static --disable-libvpx_static --disable-libx264_static --disable-libx265_static --enable-libfdkaac --enable-hdhomerun_client --enable-libsystemd_daemon --python=/usr/bin/python3 $TVH_EXTRA_CONFIGURE && make -C rpm build -j$(nproc)
+        run: support/ci-rpm-build.sh ${{ matrix.releasever }}
       - name: copy-result
         run: cp rpm/RPMS/*/tvheadend*.rpm .
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build-cloudsmith.yml
+++ b/.github/workflows/build-cloudsmith.yml
@@ -308,24 +308,29 @@ jobs:
 
   build-rpm-native:
     needs: vue
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     continue-on-error: true
-    name: Build on native fedora:${{ matrix.releasever }}
+    name: Build on native fedora:${{ matrix.releasever }} ${{ matrix.runner == 'ubuntu-latest' && 'x86_64' || 'aarch64' }}
     env:
       PCLOUD_TOKEN: ${{ secrets.PCLOUD_TOKEN }}
     strategy:
       matrix:
         releasever: ["37", "38", "39", "40", "41", "42", "43", "44", "rawhide"]
+        runner: ["ubuntu-latest"]
+        # the include entries add combinations (their runner value differs
+        # from the base axis), so only recent releases build on aarch64
+        include:
+          - releasever: "43"
+            runner: ubuntu-24.04-arm
+          - releasever: "44"
+            runner: ubuntu-24.04-arm
+          - releasever: "rawhide"
+            runner: ubuntu-24.04-arm
     container:
       image: "fedora:${{ matrix.releasever }}"
     steps:
-      - name: rpmfusion-free
-        run: |
-          dnf install -y "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-${{ matrix.releasever }}.noarch.rpm"
-      - name: dependencies
-        run: |
-          dnf install -y gcc-c++ gcc-c++ which rpm-build rpmdevtools git make cmake gettext-devel dbus-devel avahi-devel openssl-devel zlib-devel libdvbcsa-devel wget bzip2 uriparser-devel pcre2-devel python python-requests ccache systemd-units systemd-devel
-          dnf install -y openssl-devel-engine || true
+      - name: git for checkout, zstd for the cache
+        run: dnf install -y git zstd
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -341,21 +346,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .staticlib
-          key: staticlib-fedora-${{ matrix.releasever }}-${{ github.sha }}
+          key: staticlib-fedora-${{ matrix.releasever }}-${{ matrix.runner }}-${{ github.sha }}
           restore-keys: |
-            staticlib-fedora-${{ matrix.releasever }}-
+            staticlib-fedora-${{ matrix.releasever }}-${{ matrix.runner }}-
       - name: build
-        run: |
-          mkdir -p .staticlib
-          export STATICLIB_CACHE="$PWD/.staticlib"
-          export VUE_FILE_CACHE="$PWD/.vuecache"
-          export TVH_EXTRA_CONFIGURE="--enable-vue_cache --disable-vue_build"
-          ./configure --disable-dvbscan --disable-libfdkaac_static --disable-ffmpeg_static --disable-hdhomerun_static --disable-libfdkaac_static --disable-libopus_static --disable-libtheora_static --disable-libvorbis_static --disable-libvpx_static --disable-libx264_static --disable-libx265_static --enable-libfdkaac --enable-hdhomerun_client --enable-libsystemd_daemon --python=/usr/bin/python3 $TVH_EXTRA_CONFIGURE && make -C rpm build -j$(nproc) || (echo "PARALLEL BUILD FAILED, DOING SINGLE THREADED BUILD" && make -C rpm build)
+        run: support/ci-rpm-build.sh ${{ matrix.releasever }}
       - name: copy-result
         run: cp rpm/RPMS/*/tvheadend*.rpm .
       - uses: actions/upload-artifact@v4
         with:
-          name: Tvheadend-Fedora-${{ matrix.releasever }}
+          name: Tvheadend-Fedora-${{ matrix.releasever }}-${{ matrix.runner == 'ubuntu-latest' && 'x86_64' || 'aarch64' }}
           path: tvheadend*.rpm
           if-no-files-found: error
       - name: upload-cloudsmith
@@ -380,15 +380,8 @@ jobs:
     container:
       image: "almalinux:${{ matrix.releasever }}"
     steps:
-      - name: rpmfusion-free
-        run: |
-          dnf install -y dnf-plugins-core
-          dnf config-manager --set-enabled crb
-          dnf install -y "https://download1.rpmfusion.org/free/el/rpmfusion-free-release-${{ matrix.releasever }}.noarch.rpm"
-      - name: dependencies
-        run: |
-          dnf install -y gcc-c++ gcc-c++ which rpm-build rpmdevtools git make cmake gettext-devel dbus-devel avahi-devel openssl-devel zlib-devel libdvbcsa-devel wget bzip2 uriparser-devel pcre2-devel python python-requests ccache systemd-units systemd-devel
-          dnf install -y openssl-devel-engine || true
+      - name: git for checkout, zstd for the cache
+        run: dnf install -y git zstd
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -408,12 +401,7 @@ jobs:
           restore-keys: |
             staticlib-el-${{ matrix.releasever }}-${{ matrix.runner }}-
       - name: build
-        run: |
-          mkdir -p .staticlib
-          export STATICLIB_CACHE="$PWD/.staticlib"
-          export VUE_FILE_CACHE="$PWD/.vuecache"
-          export TVH_EXTRA_CONFIGURE="--enable-vue_cache --disable-vue_build"
-          ./configure --disable-dvbscan --disable-libfdkaac_static --disable-ffmpeg_static --disable-hdhomerun_static --disable-libfdkaac_static --disable-libopus_static --disable-libtheora_static --disable-libvorbis_static --disable-libvpx_static --disable-libx264_static --disable-libx265_static --enable-libfdkaac --enable-hdhomerun_client --enable-libsystemd_daemon --python=/usr/bin/python3 $TVH_EXTRA_CONFIGURE && make -C rpm build -j$(nproc)
+        run: support/ci-rpm-build.sh ${{ matrix.releasever }}
       - name: copy-result
         run: cp rpm/RPMS/*/tvheadend*.rpm .
       - uses: actions/upload-artifact@v4

--- a/support/ci-rpm-build.sh
+++ b/support/ci-rpm-build.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Shared CI build for the rpm based distros (Fedora and the Enterprise
+# Linux clones): install the build dependencies, including RPM Fusion
+# for libfdk-aac, then configure and build the packages into rpm/RPMS/.
+# Used by build-ci.yml and build-cloudsmith.yml on every fedora:* and
+# almalinux:* leg, on both x86_64 and aarch64.
+#
+# Usage: support/ci-rpm-build.sh <releasever>
+#   <releasever>  release as used in the container tag and the RPM Fusion
+#                 package name: "44", "rawhide", "9", ...
+
+set -e
+
+releasever="$1"
+if [ -z "$releasever" ]; then
+    echo "Usage: $0 <releasever>" >&2
+    exit 2
+fi
+
+# The EL clones keep part of the build dependencies in the CRB
+# repository, and RPM Fusion publishes their release package under
+# free/el/ instead of free/fedora/
+. /etc/os-release
+if [ "$ID" = "fedora" ]; then
+    fusion=fedora
+else
+    fusion=el
+    dnf install -y dnf-plugins-core
+    dnf config-manager --set-enabled crb
+fi
+
+dnf install -y "https://download1.rpmfusion.org/free/$fusion/rpmfusion-free-release-$releasever.noarch.rpm"
+dnf install -y gcc-c++ which rpm-build rpmdevtools git make cmake gettext-devel dbus-devel avahi-devel openssl-devel zlib-devel libdvbcsa-devel wget bzip2 uriparser-devel pcre2-devel python python-requests ccache systemd-units systemd-devel
+# not packaged on all releases
+dnf install -y openssl-devel-engine || true
+
+mkdir -p .staticlib
+export STATICLIB_CACHE="$PWD/.staticlib"
+export VUE_FILE_CACHE="$PWD/.vuecache"
+# also forwarded by rpm/Makefile into the %configure run inside rpmbuild
+export TVH_EXTRA_CONFIGURE="--enable-vue_cache --disable-vue_build"
+
+./configure --disable-dvbscan --disable-libfdkaac_static --disable-ffmpeg_static --disable-hdhomerun_static --disable-libopus_static --disable-libtheora_static --disable-libvorbis_static --disable-libvpx_static --disable-libx264_static --disable-libx265_static --enable-libfdkaac --enable-hdhomerun_client --enable-libsystemd_daemon --python=/usr/bin/python3 $TVH_EXTRA_CONFIGURE
+
+make -C rpm build -j"$(nproc)" || {
+    echo "PARALLEL BUILD FAILED, DOING SINGLE THREADED BUILD"
+    make -C rpm build
+}


### PR DESCRIPTION
#2213 straightened out the aarch64 builds for the deb-based distros: the build steps became shared across architectures through a runner matrix axis, and QEMU emulation was replaced with native arm64 runners. This is the follow-up announced there, giving the rpm-based distros similar treatment.

The fedora and almalinux jobs in build-ci.yml and build-cloudsmith.yml carried four near-identical copies of the dnf and configure steps, so any change to the rpm build had to be made four times. This folds them into one shared script, `support/ci-rpm-build.sh`, which detects Fedora vs the Enterprise Linux clones via `/etc/os-release` (EL additionally enables CRB and uses the `free/el/` RPM Fusion path). The jobs now only install git and zstd before checkout; everything else runs from the checked-out script.

With the build steps shared, the fedora job gets the same runner axis the almalinux job already has, adding native aarch64 legs (ubuntu-24.04-arm) for the recent releases: 43, 44 and rawhide. The matrix include entries add combinations rather than expanding the cross-product, so the existing x86_64 coverage is unchanged.

Behaviour notes:

- The fedora job names gain an arch suffix ("Build on native fedora:44 x86_64"), matching the almalinux naming. None of the renamed jobs are required status checks.
- The fedora artifact names gain the same suffix to stay unique across arches, and the fedora cache keys gain the runner name, costing each fedora leg a one-time cold static-deps rebuild.
- zstd is installed next to git because the full dependency install, which previously ran before the staticlib cache step and pulled zstd in transitively, now runs from the script after it. actions/cache includes the compression method in the cache version, so the restore needs zstd present just as the save does; most of the base images do not ship it.
- The parallel-build fallback to a single-threaded make, previously fedora-only, now also applies to the almalinux legs.
- A duplicated gcc-c++ in the dnf line and a duplicated --disable-libfdkaac_static in the configure line were dropped.

Separately, this also adds Fedora 43 and 44 to the bug report template's version dropdown, which currently stops at 42. That fix is independent of CI: both releases are out and in use, and affected users cannot currently select their version when filing a bug.

Verified with a full run of the CI workflow on my fork: https://github.com/pimzand/tvheadend/actions/runs/30863599610. All 16 rpm legs pass (9 + 3 fedora, 2 + 2 almalinux), the inner rpmbuild `%configure` receives the Vue flags via `tvh_extra_configure` and reports `vue_cache yes`, the staticlib cache restores on the almalinux and older Fedora legs, and all 16 rpm artifacts upload under unique names.
