### PR TITLE
webgui: single-word navigation improvements

### DIFF
--- a/src/webui/static-vue/src/components/NavRail.vue
+++ b/src/webui/static-vue/src/components/NavRail.vue
@@ -116,8 +116,8 @@ const NAV_SECTIONS: NavSection[] = [
     id: 'tv',
     label: t('TV'),
     items: [
-      { routeName: 'epg', label: t('Electronic Program Guide'), icon: Calendar },
-      { routeName: 'dvr', label: t('Digital Video Recorder'), icon: Video },
+      { routeName: 'epg', label: t('Guide'), icon: Calendar },
+      { routeName: 'dvr', label: t('Recordings'), icon: Video },
     ],
   },
   {

--- a/src/webui/static-vue/src/views/DvrLayout.vue
+++ b/src/webui/static-vue/src/views/DvrLayout.vue
@@ -50,10 +50,10 @@ interface DvrTab {
 }
 
 const ALL_TABS: DvrTab[] = [
-  { to: '/dvr/upcoming', label: t('Upcoming / Current Recordings') },
-  { to: '/dvr/finished', label: t('Finished Recordings') },
-  { to: '/dvr/failed', label: t('Failed Recordings') },
-  { to: '/dvr/removed', label: t('Removed Recordings'), requiredLevel: 'expert' },
+  { to: '/dvr/upcoming', label: t('Upcoming / Current') },
+  { to: '/dvr/finished', label: t('Finished') },
+  { to: '/dvr/failed', label: t('Failed') },
+  { to: '/dvr/removed', label: t('Removed'), requiredLevel: 'expert' },
   { to: '/dvr/autorecs', label: t('Autorecs') },
   { to: '/dvr/timers', label: t('Timers') },
 ]

--- a/support/cloudsmith.sh
+++ b/support/cloudsmith.sh
@@ -84,11 +84,11 @@ case $DISTRO in
                 PKGMGR="dnf"
                 OS="fedora"
                 TARGET=$VERSION;;
-            45)
-                echo -e "${YELLOW}Fedora 45 (current rawhide) is not (yet) supported by Cloudsmith${NC}"
+            45|46)
+                echo -e "${YELLOW}Fedora $VERSION (rawhide) is not supported by Cloudsmith${NC}"
                 exit 0;;
             *)
-                echo -e "${RED}Fedora release $VERSION could not be recognized${NC}" 
+                echo -e "${RED}Fedora $VERSION is not recognized${NC}"
                 exit 1;;
         esac;;
     *)


### PR DESCRIPTION
Simplify top-level navigation to use single-word terms for the Electronic Programme Guide (Guide) and Digital Video Recorder (Recordings) without resorting to acronyms. Then simplify the Recordings navigation by removing duplicate 'Recordings' text from several tab labels.