### PR TITLE
Unify usage of definitions in C source files

### DIFF
--- a/src/descrambler/capmt.c
+++ b/src/descrambler/capmt.c
@@ -1123,7 +1123,7 @@ capmt_notify_server(capmt_t *capmt, capmt_service_t *ct, int force)
   tvh_mutex_unlock(&capmt->capmt_mutex);
 }
 
-#if CONFIG_LINUXDVB
+#if ENABLE_LINUXDVB
 #ifdef CAPMT_OSCAM_SO_WRAPPER
 static void
 capmt_abort(capmt_t *capmt, int keystate)
@@ -1559,7 +1559,7 @@ show_connection(capmt_t *capmt, const char *what)
   }
 }
 
-#if CONFIG_LINUXDVB
+#if ENABLE_LINUXDVB
 static void 
 handle_ca0(capmt_t *capmt)
 {
@@ -1785,7 +1785,7 @@ handle_single(capmt_t *capmt)
   capmt->capmt_poll = NULL;
 }
 
-#if CONFIG_LINUXDVB
+#if ENABLE_LINUXDVB
 #ifdef CAPMT_OSCAM_SO_WRAPPER
 static void 
 handle_ca0_wrapper(capmt_t *capmt)
@@ -1921,7 +1921,7 @@ capmt_thread(void *aux)
 
     if (capmt->capmt_sock[0] >= 0) {
       caclient_set_status((caclient_t *)capmt, CACLIENT_STATUS_CONNECTED);
-#if CONFIG_LINUXDVB
+#if ENABLE_LINUXDVB
       if (capmt_oscam_new(capmt)) {
         handle_single(capmt);
       } else {

--- a/src/main.c
+++ b/src/main.c
@@ -78,7 +78,7 @@
 #include "memoryinfo.h"
 #include "watchdog.h"
 #include "tprofile.h"
-#if CONFIG_LINUXDVB_CA
+#if ENABLE_LINUXDVB_CA
 #include "input/mpegts/en50221/en50221.h"
 #endif
 
@@ -1289,7 +1289,7 @@ main(int argc, char **argv)
   tvh_thread_create(&mtimer_tid, NULL, mtimer_thread, NULL, "mtimer");
   tvh_thread_create(&tasklet_tid, NULL, tasklet_thread, NULL, "tasklet");
 
-#if CONFIG_LINUXDVB_CA
+#if ENABLE_LINUXDVB_CA
   en50221_register_apps();
 #endif
 

--- a/src/muxer.c
+++ b/src/muxer.c
@@ -25,7 +25,7 @@
 #include "muxer/muxer_mkv.h"
 #include "muxer/muxer_pass.h"
 #include "muxer/muxer_audioes.h"
-#if CONFIG_LIBAV
+#if ENABLE_LIBAV
 #include "muxer/muxer_libav.h"
 #endif
 
@@ -332,7 +332,7 @@ muxer_create(muxer_config_t *m_cfg, muxer_hints_t *hints)
   if(!m)
     m = audioes_muxer_create(m_cfg, hints);
 
-#if CONFIG_LIBAV
+#if ENABLE_LIBAV
   if(!m)
     m = lav_muxer_create(m_cfg, hints);
 #endif

--- a/src/webui/webui.c
+++ b/src/webui/webui.c
@@ -2819,7 +2819,7 @@ webui_init(int xspf)
     hp->hp_flags = HTTP_PATH_NO_VERIFICATION;
   }
 
-#if CONFIG_SATIP_SERVER
+#if ENABLE_SATIP_SERVER
   http_path_add("/satip_server", NULL, satip_server_http_page, ACCESS_ANONYMOUS);
 #endif
 


### PR DESCRIPTION
For most definitions exist a `CONFIG_<SUFFIX>` and a `ENABLE_<SUFFIX>` version, both being set to the same value.

Only use one version of each definition in the C source files.