### PR TITLE
transcoding: use the new lavc supported-config API

### DIFF
--- a/src/transcoding/codec/codec.c
+++ b/src/transcoding/codec/codec.c
@@ -115,11 +115,30 @@ codec_get_title(const AVCodec *self)
 
 /* TVHCodec ================================================================= */
 
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100)
+static const void *
+tvh_codec_supported_config(const AVCodec *codec, enum AVCodecConfig config)
+{
+    const void *configs = NULL;
+
+    if (avcodec_get_supported_config(NULL, codec, config, 0, &configs, NULL)) {
+        return NULL;
+    }
+    return configs;
+}
+#endif
+
+
 static void
 tvh_codec_video_init(TVHVideoCodec *self, const AVCodec *codec)
 {
     if (!self->pix_fmts) {
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100)
+        self->pix_fmts =
+            tvh_codec_supported_config(codec, AV_CODEC_CONFIG_PIX_FORMAT);
+#else
         self->pix_fmts = codec->pix_fmts;
+#endif
     }
 }
 
@@ -131,15 +150,28 @@ tvh_codec_audio_init(TVHAudioCodec *self, const AVCodec *codec)
     };
 
     if (!self->sample_fmts) {
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100)
+        self->sample_fmts =
+            tvh_codec_supported_config(codec, AV_CODEC_CONFIG_SAMPLE_FORMAT);
+#else
         self->sample_fmts = codec->sample_fmts;
+#endif
     }
     if (!self->sample_rates) {
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100)
+        self->sample_rates =
+            tvh_codec_supported_config(codec, AV_CODEC_CONFIG_SAMPLE_RATE);
+#else
         self->sample_rates = codec->supported_samplerates;
+#endif
         if (!self->sample_rates)
             self->sample_rates = default_sample_rates;
     }
     if (!self->channel_layouts) {
-#if LIBAVCODEC_VERSION_MAJOR > 59
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100)
+        self->channel_layouts =
+            tvh_codec_supported_config(codec, AV_CODEC_CONFIG_CHANNEL_LAYOUT);
+#elif LIBAVCODEC_VERSION_MAJOR > 59
         self->channel_layouts = codec->ch_layouts;
 #else
         self->channel_layouts = codec->channel_layouts;


### PR DESCRIPTION
FFmpeg 9.0 (libavcodec 63) removed the `AVCodec` configuration arrays `pix_fmts`,
`sample_fmts`, `supported_samplerates` and `ch_layouts`, so the codec profile
defaults no longer compile:

```
src/transcoding/codec/codec.c:122:31: error: 'AVCodec' has no member named 'pix_fmts'
src/transcoding/codec/codec.c:134:34: error: 'AVCodec' has no member named 'sample_fmts'
src/transcoding/codec/codec.c:137:35: error: 'AVCodec' has no member named 'supported_samplerates'
src/transcoding/codec/codec.c:143:38: error: 'AVCodec' has no member named 'ch_layouts'
```

`avcodec_get_supported_config()` was added in libavcodec 61.13.100 (FFmpeg 7.1)
when those fields were deprecated, and is the replacement. It hands back the same
arrays with the same config-specific terminators, or NULL when the codec accepts
every value, so nothing downstream of `tvh_codec_init()` changes — including the
`supported_samplerates == NULL` case that falls back to `default_sample_rates`.

The new API is used wherever it is available and the direct field access is kept
for older libavcodec.

### Testing

| libavcodec | without the patch | with the patch |
|---|---|---|
| 62.11.100 (FFmpeg 8.0.1) | builds | builds clean |
| 63.1.101 (FFmpeg 9.0.1) | fails with the four errors above | builds and links clean |

Full builds of `master` against both, with `--enable-libav`.
