### PR TITLE
transcoding: fix the buffersink format options on FFmpeg 8 and 9

### DIFF
--- a/src/transcoding/transcode/audio.c
+++ b/src/transcoding/transcode/audio.c
@@ -287,7 +287,22 @@ tvh_audio_context_open_filters(TVHContext *self, AVDictionary **opts)
         return -1;
     }
 
-#if LIBAVCODEC_VERSION_MAJOR > 59
+#if TVH_BUFFERSINK_ARRAY_OPTS
+    int ret = tvh_context_open_filters(self,
+        "abuffer", source_args,                           // source
+        filters,                                          // filters
+        "abuffersink",                                    // sink
+        "channel_layouts", AV_OPT_SET_ARRAY,              // sink option: channel_layout
+        AV_OPT_TYPE_CHLAYOUT,
+        &self->oavctx->ch_layout,
+        "sample_formats",  AV_OPT_SET_ARRAY,              // sink option: sample_fmt
+        AV_OPT_TYPE_SAMPLE_FMT,
+        &self->oavctx->sample_fmt,
+        "samplerates",     AV_OPT_SET_ARRAY,              // sink option: sample_rate
+        AV_OPT_TYPE_INT,
+        &self->oavctx->sample_rate,
+        NULL);                                            // _IMPORTANT!_
+#elif LIBAVCODEC_VERSION_MAJOR > 59
     char ch_layout[64];
     av_channel_layout_describe(&self->oavctx->ch_layout, ch_layout, sizeof(ch_layout));
     

--- a/src/transcoding/transcode/context.c
+++ b/src/transcoding/transcode/context.c
@@ -110,6 +110,9 @@ _context_filters_apply_sink_options(TVHContext *self, va_list ap)
 #if LIBAVCODEC_VERSION_MAJOR > 59
     const char *opt_val_char = NULL;
     av_opt_set_type opt_type = AV_OPT_SET_UNKNOWN;
+#if TVH_BUFFERSINK_ARRAY_OPTS
+    enum AVOptionType opt_val_type = AV_OPT_TYPE_FLAGS;
+#endif
     char err_desciption[32];
 #endif
     int opt_size = 0;
@@ -118,18 +121,28 @@ _context_filters_apply_sink_options(TVHContext *self, va_list ap)
     while ((opt_name = va_arg(ap, const char *))) {
 #if LIBAVCODEC_VERSION_MAJOR > 59
         opt_type = (av_opt_set_type) va_arg(ap, int);
-        opt_size = va_arg(ap, int);
-        if (opt_type == AV_OPT_SET_BIN) {
-            opt_val = va_arg(ap, const uint8_t *);
-            ret = av_opt_set_bin(self->oavfltctx, opt_name, opt_val, opt_size, AV_OPT_SEARCH_CHILDREN);}
-        else {
-            if (opt_type == AV_OPT_SET_STRING) {
+        switch (opt_type) {
+#if TVH_BUFFERSINK_ARRAY_OPTS
+            case AV_OPT_SET_ARRAY:
+                opt_val_type = (enum AVOptionType) va_arg(ap, int);
+                opt_val = va_arg(ap, const uint8_t *);
+                ret = av_opt_set_array(self->oavfltctx, opt_name, AV_OPT_SEARCH_CHILDREN,
+                                       0, 1, opt_val_type, opt_val);
+                break;
+#endif
+            case AV_OPT_SET_BIN:
+                opt_size = va_arg(ap, int);
+                opt_val = va_arg(ap, const uint8_t *);
+                ret = av_opt_set_bin(self->oavfltctx, opt_name, opt_val, opt_size, AV_OPT_SEARCH_CHILDREN);
+                break;
+            case AV_OPT_SET_STRING:
+                opt_size = va_arg(ap, int);
                 opt_val_char = va_arg(ap, const char *);
-                ret = av_opt_set(self->oavfltctx, opt_name, opt_val_char, AV_OPT_SEARCH_CHILDREN);} 
-            else {
+                ret = av_opt_set(self->oavfltctx, opt_name, opt_val_char, AV_OPT_SEARCH_CHILDREN);
+                break;
+            default:
                 tvh_context_log(self, LOG_ERR, "filters: failed to set option: '%s' with error: 'AV_OPT_SET_UNKNOWN'", opt_name);
                 return ret;
-            }
         }
         if (ret) {
             switch (ret) {

--- a/src/transcoding/transcode/context.c
+++ b/src/transcoding/transcode/context.c
@@ -599,10 +599,10 @@ tvh_context_open_filters(TVHContext *self,
         ret = AVERROR_FILTER_NOT_FOUND;
         goto finish;
     }
-    ret = avfilter_graph_create_filter(&self->oavfltctx, oavflt, "out",
-                                       NULL, NULL, self->avfltgraph);
-    if (ret < 0) {
+    if (!(self->oavfltctx = avfilter_graph_alloc_filter(self->avfltgraph, oavflt,
+                                                       "out"))) {
         tvh_context_log(self, LOG_ERR, "filters: failed to create 'out' filter");
+        ret = AVERROR(ENOMEM);
         goto finish;
     }
 
@@ -612,6 +612,13 @@ tvh_context_open_filters(TVHContext *self,
     ret = _context_filters_apply_sink_options(self, ap);
     va_end(ap);
     if (ret) {
+        goto finish;
+    }
+
+    // the format options are not runtime options, so the sink can only be
+    // initialized once all of them have been applied
+    if ((ret = avfilter_init_dict(self->oavfltctx, NULL)) < 0) {
+        tvh_context_log(self, LOG_ERR, "filters: failed to init 'out' filter");
         goto finish;
     }
 

--- a/src/transcoding/transcode/internals.h
+++ b/src/transcoding/transcode/internals.h
@@ -31,6 +31,7 @@
 #include <libavfilter/avfilter.h>
 #include <libavfilter/buffersrc.h>
 #include <libavfilter/buffersink.h>
+#include <libavutil/opt.h>
 #include <libavutil/pixdesc.h>
 
 
@@ -56,12 +57,18 @@ typedef enum {
     OPEN_ENCODER_POST
 } TVHOpenPhase;
 
+// buffersink gained array-type format options in libavfilter 10.6.100 and
+// lost the int-list/string ones in libavfilter 12
+#define TVH_BUFFERSINK_ARRAY_OPTS \
+    (LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(10, 6, 100))
+
 #if LIBAVCODEC_VERSION_MAJOR > 59
 // this is needed to separate av_opt_set-s from _context_filters_apply_sink_options
 typedef enum {
     AV_OPT_SET_UNKNOWN,
     AV_OPT_SET_BIN,
-    AV_OPT_SET_STRING
+    AV_OPT_SET_STRING,
+    AV_OPT_SET_ARRAY
 } av_opt_set_type;
 #endif
 
@@ -185,7 +192,9 @@ void
 tvh_context_close(TVHContext *self, int flush);
 
 /* __VA_ARGS__ = NULL terminated list of sink options
-   sink option = (const char *name, av_opt_set_type opt_set_type, int size, const uint8_t *value) */
+   sink option = (const char *name, av_opt_set_type opt_set_type, int size, const uint8_t *value)
+   AV_OPT_SET_ARRAY takes the element type in place of the size:
+   sink option = (const char *name, AV_OPT_SET_ARRAY, enum AVOptionType type, const void *value) */
 int
 tvh_context_open_filters(TVHContext *self,
                          const char *source_name, const char *source_args,

--- a/src/transcoding/transcode/video.c
+++ b/src/transcoding/transcode/video.c
@@ -321,7 +321,15 @@ tvh_video_context_open_filters(TVHContext *self)
         return -1;
     }
 
-#if LIBAVCODEC_VERSION_MAJOR > 59
+#if TVH_BUFFERSINK_ARRAY_OPTS
+    int ret = tvh_context_open_filters(self,
+        "buffer", source_args,                                  // source
+        strlen(filters) ? filters : "null",                     // filters
+        "buffersink",                                           // sink
+        "pixel_formats", AV_OPT_SET_ARRAY,                      // sink option: pix_fmt
+        AV_OPT_TYPE_PIXEL_FMT, &self->oavctx->pix_fmt,
+        NULL);                                                  // _IMPORTANT!_
+#elif LIBAVCODEC_VERSION_MAJOR > 59
     int ret = tvh_context_open_filters(self,
         "buffer", source_args,                                  // source
         strlen(filters) ? filters : "null",                     // filters


### PR DESCRIPTION
The transcoder cannot tell its buffersink what the encoder wants, so the sink is
left unconstrained and the negotiated format is whatever the decoder produced.
Two independent causes, one commit each.

**1. `transcoding: init the filter sink after setting its options`**

The buffersink format options are not runtime options, and since libavutil 60
(FFmpeg 8.0) `av_opt_set*()` refuses them once the object carries
`AV_CLASS_STATE_INITIALIZED`:

```
Option 'pix_fmts' is not a runtime option and so cannot be set after the object has been initialized
```

`avfilter_graph_create_filter()` initializes the filter it creates, and
`tvh_context_open_filters()` applies the sink options afterwards, so every one of
them fails with `AVERROR(EINVAL)`:

```
transcode: 0004: 02:AAC-LATM: [mp2 => aac]: filters: failed to set option: 'channel_layouts'
```

libavfilter only gained the state flag the check reads in FFmpeg 8.0
(`avfilter_class.state_flags_offset`), and libavutil 59 logged the rejection but
carried on, which is why this was not seen on FFmpeg 7.x — see #1764.

Allocating the sink with `avfilter_graph_alloc_filter()` leaves it
uninitialized; `avfilter_init_dict()` is called once all the options have been
applied. That is the documented order for options that must be set before init,
and it works on every libavfilter the tree supports.

**2. `transcoding: set the sink formats through the array options`**

libavfilter 12 (FFmpeg 9.0) removed the int-list/string format options of
buffersink and abuffersink:

```
filters: failed to set option: 'pix_fmts' with error: 'AVERROR_OPTION_NOT_FOUND'
filters: failed to set option: 'ch_layouts' with error: 'AVERROR_OPTION_NOT_FOUND'
```

The array-type replacements — `pixel_formats`, `sample_formats`, `samplerates`,
`channel_layouts` — arrived in libavfilter 10.6.100 (FFmpeg 7.1) and are set with
`av_opt_set_array()`, so `AV_OPT_SET_ARRAY` is added as a third option kind,
carrying the element type where the other kinds carry a size.

This also repairs the audio sink from 10.6.100 onwards, where the old names still
exist: `asink_query_formats()` only consults the deprecated `sample_fmts` /
`sample_rates` lists when no new-style list is set at all, and `common_init()`
parses the deprecated `ch_layouts` string into the new `channel_layouts` array.
Setting the layout as a string therefore made libavfilter ignore the sample
format and the sample rate entirely.

Passing the layout as an `AVChannelLayout` also drops the describe/parse round
trip through a 64 byte string.

### Testing

Built `master` against FFmpeg 8.0.1 (lavfi 11.4.100) and a locally built FFmpeg
9.0.1 (lavfi 12.1.101). A graph assembled the way `tvh_context_open_filters()`
assembles it, asking for nv12 from yuv420p input and s16/44100 stereo from
fltp/48000 input through `aresample`:

| | lavfi 11.4.100 | lavfi 12.1.101 |
|---|---|---|
| before | video nv12 ok, audio came back **fltp/48000** | options refused, graph never opened |
| after | video nv12, audio **s16/44100** | video nv12, audio **s16/44100** |

Frames were pushed through and pulled back out in each case, and
`av_buffersink_set_frame_size()` still applies.
