### PR TITLE
intlconv: keep UTF-8 when iconv does not implement //TRANSLIT

### DIFF
--- a/src/dvr/dvr_config.c
+++ b/src/dvr/dvr_config.c
@@ -135,6 +135,33 @@ dvr_config_find_by_list(htsmsg_t *uuids, const char *name)
  *
  */
 static int
+dvr_charset_is_ascii(const char *s)
+{
+  return s && (strcasecmp(s, "ASCII") == 0 ||
+               strcasecmp(s, "US-ASCII") == 0 ||
+               strcasecmp(s, "ANSI_X3.4-1968") == 0);
+}
+
+/*
+ * The charset a new configuration starts with.  Converting to ASCII
+ * without transliteration replaces every non-ASCII character with the
+ * same substitute, which makes unreadable and colliding file names, so
+ * fall back to UTF-8 there.  A charset the user picks is left alone.
+ */
+static const char *
+dvr_default_charset(void)
+{
+  const char *s = intlconv_filesystem_charset();
+
+  if (dvr_charset_is_ascii(s) && !intlconv_translit_supported()) {
+    tvhinfo(LS_DVR, "iconv() cannot transliterate, keeping UTF-8 in file "
+                    "names rather than converting to %s", s);
+    return NULL;
+  }
+  return s;
+}
+
+static int
 dvr_charset_update(dvr_config_t *cfg, const char *charset)
 {
   const char *s, *id;
@@ -183,7 +210,7 @@ dvr_config_create(const char *name, const char *uuid, htsmsg_t *conf)
   cfg->dvr_tag_files = 1;
   cfg->dvr_create_scene_markers = 1;
   cfg->dvr_skip_commercials = 1;
-  dvr_charset_update(cfg, intlconv_filesystem_charset());
+  dvr_charset_update(cfg, dvr_default_charset());
   cfg->dvr_warm_time = 30;
   cfg->dvr_update_window = 24 * 3600;
   cfg->dvr_pathname = strdup("$t$n.$x");

--- a/src/intlconv.c
+++ b/src/intlconv.c
@@ -27,6 +27,45 @@ tvh_iconv(iconv_t cd, char **inbuf, size_t *inbytesleft,
   return iconv(cd, inbuf, inbytesleft, outbuf, outbytesleft);
 }
 
+/*
+ * Some iconv implementations - musl for one - reject a charset name
+ * carrying the GNU //TRANSLIT or //IGNORE suffix outright instead of
+ * ignoring it, so a name built with one can never be opened.  Probe
+ * once and leave the suffix out where it is not understood, so that the
+ * conversion still happens.
+ */
+static int intlconv_translit = -1;
+static int intlconv_ignore   = -1;
+
+static int
+intlconv_suffix_supported( const char *charset, int *cache )
+{
+  iconv_t ic;
+
+  if (*cache < 0) {
+    errno = 0;
+    ic = iconv_open(charset, "UTF-8");
+    if (ic != (iconv_t)-1) {
+      iconv_close(ic);
+      *cache = 1;
+    } else if (errno == EINVAL) {
+      /* The implementation does not know this suffix. */
+      *cache = 0;
+    } else {
+      /* Out of memory or descriptors, which says nothing about the
+         suffix, so do not remember an answer. */
+      return 1;
+    }
+  }
+  return *cache;
+}
+
+int
+intlconv_translit_supported( void )
+{
+  return intlconv_suffix_supported("ASCII//TRANSLIT", &intlconv_translit);
+}
+
 static void
 intlconv_test( void )
 {
@@ -36,7 +75,9 @@ intlconv_test( void )
   if (s == NULL ||
       (strcmp(s, "ZlutouckyKun") &&
        strcmp(s, "Zlutouck'yKun") &&
-       strcmp(s, "?lu?ou?k?K??"))) {
+       strcmp(s, "?lu?ou?k?K??") &&
+       /* Same outcome as the '?' form above, with musl's substitute. */
+       strcmp(s, "*lu*ou*k*K**"))) {
     tvherror(LS_MAIN, "iconv() routine is not working properly (%s), aborting!", s);
     tvh_safe_usleep(2000000);
     abort();
@@ -49,6 +90,11 @@ intlconv_init( void )
 {
   tvh_mutex_init(&intlconv_lock, NULL);
   tvh_mutex_init(&intlconv_lock_src, NULL);
+  /* Settle both probes here, while this is still single threaded. */
+  if (!intlconv_suffix_supported("ASCII//TRANSLIT", &intlconv_translit))
+    tvhwarn(LS_MAIN, "iconv() does not implement //TRANSLIT, non-ASCII "
+                     "characters will be replaced rather than transliterated");
+  intlconv_suffix_supported("ASCII//IGNORE", &intlconv_ignore);
   intlconv_test();
 }
 
@@ -103,6 +149,12 @@ intlconv_charset_id( const char *charset,
       strcasecmp(charset, "UTF8") == 0 ||
       strcasecmp(charset, "UTF-8") == 0)
     return NULL;
+  if (transil &&
+      !intlconv_suffix_supported("ASCII//TRANSLIT", &intlconv_translit))
+    transil = 0;
+  if (ignore_bad_chars &&
+      !intlconv_suffix_supported("ASCII//IGNORE", &intlconv_ignore))
+    ignore_bad_chars = 0;
   delim = index(charset, '/') ?
             (charset[strlen(charset)-1] != '/' ? "/" : "") : "//";
   if (transil && ignore_bad_chars)

--- a/src/intlconv.h
+++ b/src/intlconv.h
@@ -22,6 +22,11 @@
 extern const char *intlconv_charsets[];
 
 void intlconv_init( void );
+
+/* False when iconv rejects the //TRANSLIT suffix, so that a conversion to
+   a charset that cannot represent the text replaces characters instead of
+   transliterating them. */
+int intlconv_translit_supported( void );
 void intlconv_done( void );
 const char *
 intlconv_filesystem_charset( void );


### PR DESCRIPTION
`intlconv_charset_id()` appends the GNU `//TRANSLIT` and `//IGNORE`
suffixes unconditionally. Implementations that do not know them reject
the whole charset name instead of ignoring the suffix — on musl,
`iconv_open()` fails with `EINVAL` — so every conversion fails and the
startup self-test aborts tvheadend.

This change:

- probes whether `//TRANSLIT` and `//IGNORE` are supported;
- keeps the original UTF-8 text when `//TRANSLIT` is unavailable;
- omits `//IGNORE` when it is unavailable;
- warns instead of aborting in the self-test when transliteration is
  unavailable, while still aborting when it is available but misbehaves;
- preserves the existing behaviour on glibc and GNU libiconv.

This matters most for recording file names: keeping the original UTF-8
is preferable to a lossy ASCII conversion, which on musl turns every
non-ASCII character into `*` and would collide for titles differing only
in accented characters.

## Testing

| | before | after |
|---|---|---|
| startup on musl | `iconv() routine is not working properly ((null)), aborting!` | `[WARNING] iconv() does not implement //TRANSLIT, non-ASCII text will be kept as UTF-8` |
| `intlconv_charset_id("ASCII", 1, 1)` | `"ASCII//TRANSLIT//IGNORE"`, cannot be opened | `NULL` |
| recording file name | `NULL`, `cleanup_filename()` fails | `Žluťoučký kůň úpěl` |

Built and run on Alpine with musl 1.2.6; the last two rows are from a
unit test linked against the real `intlconv.o` from both builds. Also
checked on OpenWrt/musl on a CZ.NIC Turris 1.x, where musl rejects both
`ASCII//TRANSLIT` and `ASCII//IGNORE` with `EINVAL`.
