### PR TITLE
mpegts: don't move an untuned mux to the active scan queue

### DIFF
--- a/src/input/mpegts/mpegts_mux.c
+++ b/src/input/mpegts/mpegts_mux.c
@@ -89,21 +89,21 @@ mpegts_mux_instance_create0
 }
 
 static void
+mpegts_mux_scan_timeout_arm ( mpegts_mux_t *mm, mpegts_input_t *mi )
+{
+  mtimer_arm_rel(&mm->mm_scan_timeout, mpegts_mux_scan_timeout, mm,
+                 sec2mono(mpegts_input_grace(mi, mm)));
+}
+
+static void
 mpegts_mux_scan_active
   ( mpegts_mux_t *mm, const char *buf, mpegts_input_t *mi )
 {
-  int t;
-
   /* Setup scan */
   if (mm->mm_scan_state == MM_SCAN_STATE_PEND ||
       mm->mm_scan_state == MM_SCAN_STATE_IPEND) {
     mpegts_network_scan_mux_active(mm);
-
-    /* Get timeout */
-    t = mpegts_input_grace(mi, mm);
-  
-    /* Setup timeout */
-    mtimer_arm_rel(&mm->mm_scan_timeout, mpegts_mux_scan_timeout, mm, sec2mono(t));
+    mpegts_mux_scan_timeout_arm(mm, mi);
   }
 }
 
@@ -1356,7 +1356,8 @@ mpegts_mux_set_tsid ( mpegts_mux_t *mm, uint32_t tsid, int force )
   mm->mm_tsid = tsid;
   tvhtrace(LS_MPEGTS, "%s - set tsid %04X (%d)", mm->mm_nicename, tsid, tsid);
   idnode_changed(&mm->mm_id);
-  mpegts_network_scan_mux_reactivate(mm);
+  if (mpegts_network_scan_mux_reactivate(mm))
+    mpegts_mux_scan_timeout_arm(mm, mm->mm_active->mmi_input);
   return 1;
 }
 

--- a/src/input/mpegts/mpegts_network_scan.c
+++ b/src/input/mpegts/mpegts_network_scan.c
@@ -92,7 +92,10 @@ mpegts_network_scan_do_mux ( mpegts_mux_queue_t *q, mpegts_mux_t *mm )
          state == MM_SCAN_STATE_ACTIVE);
 
   /* Don't try to subscribe already tuned muxes */
-  if (mm->mm_active) return 0;
+  if (mm->mm_active) {
+    tvhtrace(LS_MPEGTS, "%s - scan skipped, mux is already tuned", mm->mm_nicename);
+    return 0;
+  }
 
   /* Attempt to tune */
   r = mpegts_mux_subscribe(mm, NULL, "scan", mm->mm_scan_weight,
@@ -292,8 +295,10 @@ mpegts_network_scan_mux_reactivate ( mpegts_mux_t *mm )
    * is orphaned - it is taken out of the scan queues, but nothing is able
    * to finish the scan for it, so it never returns to the idle state.
    */
-  if (mm->mm_active == NULL)
+  if (mm->mm_active == NULL) {
+    tvhtrace(LS_MPEGTS, "%s - scan not reactivated, mux is not tuned", mm->mm_nicename);
     return 0;
+  }
   mpegts_network_scan_queue_del0(mm);
   mm->mm_scan_init  = 0;
   mm->mm_scan_state = MM_SCAN_STATE_ACTIVE;

--- a/src/input/mpegts/mpegts_network_scan.c
+++ b/src/input/mpegts/mpegts_network_scan.c
@@ -282,16 +282,23 @@ mpegts_network_scan_mux_active ( mpegts_mux_t *mm )
 }
 
 /* Mux has been reactivated */
-void
+int
 mpegts_network_scan_mux_reactivate ( mpegts_mux_t *mm )
 {
   mpegts_network_t *mn = mm->mm_network;
   if (mm->mm_scan_state == MM_SCAN_STATE_ACTIVE)
-    return;
+    return 0;
+  /* Only a tuned mux may be moved to the active queue. Otherwise, the mux
+   * is orphaned - it is taken out of the scan queues, but nothing is able
+   * to finish the scan for it, so it never returns to the idle state.
+   */
+  if (mm->mm_active == NULL)
+    return 0;
   mpegts_network_scan_queue_del0(mm);
   mm->mm_scan_init  = 0;
   mm->mm_scan_state = MM_SCAN_STATE_ACTIVE;
   TAILQ_INSERT_TAIL(&mn->mn_scan_active, mm, mm_scan_link);
+  return 1;
 }
 
 /******************************************************************************

--- a/src/input/mpegts/mpegts_network_scan.c
+++ b/src/input/mpegts/mpegts_network_scan.c
@@ -134,11 +134,40 @@ mpegts_network_scan_do_mux ( mpegts_mux_queue_t *q, mpegts_mux_t *mm )
   return 0;
 }
 
+/*
+ * A mux in the active queue which is not tuned and has no scan timeout
+ * armed can never be finished - nothing is left to call
+ * mpegts_mux_scan_done() for it. It is out of the scan queues, so it is
+ * never tried again either, and as it stays out of the idle state it
+ * blocks the network scan for good. Put such a mux back to the queue.
+ */
+static void
+mpegts_network_scan_active_check ( mpegts_network_t *mn )
+{
+  mpegts_mux_t *mm, *nxt;
+  int weight, flags;
+
+  for (mm = TAILQ_FIRST(&mn->mn_scan_active); mm != NULL; mm = nxt) {
+    nxt = TAILQ_NEXT(mm, mm_scan_link);
+    if (mm->mm_active || mtimer_armed(&mm->mm_scan_timeout))
+      continue;
+    tvhwarn(LS_MPEGTS, "%s - stuck in the active scan queue, requeueing",
+            mm->mm_nicename);
+    weight = mm->mm_scan_weight ?: SUBSCRIPTION_PRIO_SCAN_INIT;
+    flags  = mm->mm_scan_flags;
+    mpegts_network_scan_queue_del(mm);
+    mpegts_network_scan_queue_add(mm, weight, flags, 0);
+  }
+}
+
 void
 mpegts_network_scan_timer_cb ( void *p )
 {
   mpegts_network_t *mn = p;
   mpegts_mux_t *mm, *nxt = NULL;
+
+  /* Rescue muxes which can no longer finish their scan */
+  mpegts_network_scan_active_check(mn);
 
   /* Process standard Q */
   for (mm = TAILQ_FIRST(&mn->mn_scan_pend); mm != NULL; mm = nxt) {

--- a/src/input/mpegts/mpegts_network_scan.h
+++ b/src/input/mpegts/mpegts_network_scan.h
@@ -45,7 +45,7 @@ void mpegts_network_scan_mux_done    ( mpegts_mux_t *mm );
 void mpegts_network_scan_mux_partial ( mpegts_mux_t *mm );
 void mpegts_network_scan_mux_cancel  ( mpegts_mux_t *mm, int reinsert );
 void mpegts_network_scan_mux_active  ( mpegts_mux_t *mm );
-void mpegts_network_scan_mux_reactivate ( mpegts_mux_t *mm );
+int  mpegts_network_scan_mux_reactivate ( mpegts_mux_t *mm );
 
 /*
  * Init / Teardown

--- a/src/tvheadend.h
+++ b/src/tvheadend.h
@@ -156,6 +156,9 @@ void GTIMER_FCN(mtimer_arm_abs)
 
 void mtimer_disarm(mtimer_t *mti);
 
+static inline int mtimer_armed(const mtimer_t *mti)
+  { return mti->mti_callback != NULL; }
+
 
 
 /*


### PR DESCRIPTION
## Problem

A DVB network scan can stall permanently, leaving some muxes never scanned. The
setup wizard's progress bar sticks below 100% (80% in my case) and the scan never
resumes — not after the 120s safety re-arm, not ever. Nothing is logged.

## Cause

`mpegts_mux_set_tsid()` calls `mpegts_network_scan_mux_reactivate()` every time a
mux's TSID changes. The TSID is frequently learned from the NIT of a *different*
mux, so this also fires for muxes that are merely sitting in the scan queue and
have never been tuned.

`mpegts_network_scan_mux_reactivate()` then takes the mux out of `mn_scan_pend`
and puts it into `mn_scan_active` with no subscription, no `mm_active` and no
`mm_scan_timeout` armed. `mpegts_network_scan_timer_cb()` only walks
`mn_scan_pend` and `mn_scan_ipend`, so the mux is never tried again; and since
nothing is left to call `mpegts_mux_scan_done()` for it, it never returns to
`MM_SCAN_STATE_IDLE`. It sits in ACTIVE for good. As the wizard progress is
derived from the count of muxes not in the idle state, the scan looks frozen.

The unconditional reactivation goes back to cec33bc6e (issue #4942). Note that
`reactivate()` early-returns when the mux is already ACTIVE, so its only live
effect today is on muxes that are *not* being scanned — precisely the case that
breaks.

## Reproducer

uk-Oxford from dtv-scan-tables, DVB-T, reproducible on every run.

The NIT reports 634.167/657.833/601.833 MHz, further than the 2 kHz tolerance in
`dvb_network_find_mux()` from the configured 634/658/602, so new mux objects are
created for those (TSID supplied at construction, so no `set_tsid()` call). But it
reports 538000000 and 554000000 exactly, so the queued 538MHz and 554MHz muxes are
matched and updated through `mpegts_mux_set_onid()`/`mpegts_mux_set_tsid()` while
674MHz is still being scanned. Both are orphaned. Eight of the ten muxes complete
and the scan stops at 80%.

## Changes

1. **mpegts: don't move an untuned mux to the active scan queue** — the fix. Only
   reactivate a mux which is really tuned, and arm its scan timeout so the scan
   can complete.
2. **mpegts: trace the silent scan-queue skips** — the early returns in
   `mpegts_network_scan_do_mux()` and `mpegts_network_scan_mux_reactivate()` say
   nothing, so a mux dropping out of the scan leaves no trace at all. Diagnosing
   this needed reconstructing the queue order from mux UUIDs to work out which
   entry the scanner had passed over.
3. **mpegts: rescue muxes stuck in the active scan queue** — defensive. Sweep
   `mn_scan_active` for muxes with no `mm_active` and no armed `mm_scan_timeout`
   and requeue them, so a bug of this shape degrades into a warning and a retry
   instead of a scan that hangs in silence. Adds `mtimer_armed()`.

Patches 2 and 3 are independent of the fix and can be dropped if unwanted.

## Testing

Before: 8/10 muxes scanned, stuck at 80% indefinitely.

After: all ten muxes scan in ~80s, 216 services found, OTA EIT grab follows
normally. The new trace shows the guard declining exactly the two affected muxes:

```
12:28:58 mpegts: 538MHz in DVB-T Network - scan not reactivated, mux is not tuned
12:29:03 mpegts: 554MHz in DVB-T Network - scan not reactivated, mux is not tuned
```

The watchdog in patch 3 did not fire, which confirms patch 1 covers the whole root
cause. Its requeue path is therefore not exercised by this reproducer.

Tested on LibreELEC (aarch64, Amlogic) with a Sony CXD2837ER DVB-T/T2/C tuner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
