### PR TITLE
webui: add a Dark theme to the Vue interface

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -138,18 +138,20 @@ jobs:
           # publicly in your project's package repository, so it is vital that
           # no secrets are present in the container state or logs.
           install: |
-            if [ "${{ matrix.distro }}" = "buster" ] && [ "${{ matrix.arch }}" = "armv6" ]; then
-              echo "Skipping source list modification for buster on armv6"
-            else
-              case "${{ matrix.distro }}" in
-                jessie|stretch|buster)
-                  sed -i 's/archive.raspbian.org/legacy.raspbian.org/g' /etc/apt/sources.list
-                  sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
-                  sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list
-                  sed -i '/${{ matrix.distro }}-updates/d' /etc/apt/sources.list
-                  ;;
-              esac
-            fi
+            case "${{ matrix.distro }}" in
+              jessie|stretch|buster)
+                sed -i 's/archive.raspbian.org/legacy.raspbian.org/g' /etc/apt/sources.list
+                sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
+                sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list
+                sed -i '/${{ matrix.distro }}-updates/d' /etc/apt/sources.list
+                ;;
+              bullseye)
+                sed -i 's|//deb.debian.org/debian-security|//snapshot.debian.org/archive/debian-security/20260901T000000Z|g' /etc/apt/sources.list
+                sed -i 's|//security.debian.org/debian-security|//snapshot.debian.org/archive/debian-security/20260901T000000Z|g' /etc/apt/sources.list
+                sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
+                echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
+                ;;
+            esac
             case "${{ matrix.distro }}" in
               ubuntu*|jessie|stretch|buster|bullseye|bookworm|trixie)
                 apt-get update -y
@@ -227,12 +229,22 @@ jobs:
           docker pull ${{ matrix.container[0] }}
           docker run --name build-container -d -e GITHUB_ACTIONS=true -v ${{ github.workspace }}:/workspace ${{ matrix.container[0] }} tail -f /dev/null
       - name: Fix old debian apt
-        if: endsWith(matrix.container[0], 'debian:stretch') || endsWith(matrix.container[0], 'debian:buster')
+        if: endsWith(matrix.container[0], 'debian:stretch') || endsWith(matrix.container[0], 'debian:buster') || endsWith(matrix.container[0], 'debian:bullseye')
         env:
           SCRIPT: |
-            sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
-            sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list
-            sed -i '/stretch-updates/d' /etc/apt/sources.list
+            case "${{ matrix.container[0] }}" in
+              *bullseye)
+                sed -i 's|//deb.debian.org/debian-security|//snapshot.debian.org/archive/debian-security/20260901T000000Z|g' /etc/apt/sources.list
+                sed -i 's|//security.debian.org/debian-security|//snapshot.debian.org/archive/debian-security/20260901T000000Z|g' /etc/apt/sources.list
+                sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
+                echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
+                ;;
+              *)
+                sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
+                sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list
+                sed -i '/stretch-updates/d' /etc/apt/sources.list
+                ;;
+            esac
         run: docker exec build-container bash -c "$SCRIPT"
       - name: dependencies
         env:

--- a/.github/workflows/build-cloudsmith.yml
+++ b/.github/workflows/build-cloudsmith.yml
@@ -148,18 +148,20 @@ jobs:
           # publicly in your project's package repository, so it is vital that
           # no secrets are present in the container state or logs.
           install: |
-            if [ "${{ matrix.distro }}" = "buster" ] && [ "${{ matrix.arch }}" = "armv6" ]; then
-              echo "Skipping source list modification for buster on armv6"
-            else
-              case "${{ matrix.distro }}" in
-                jessie|stretch|buster)
-                  sed -i 's/archive.raspbian.org/legacy.raspbian.org/g' /etc/apt/sources.list
-                  sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
-                  sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list
-                  sed -i '/${{ matrix.distro }}-updates/d' /etc/apt/sources.list
-                  ;;
-              esac
-            fi
+            case "${{ matrix.distro }}" in
+              jessie|stretch|buster)
+                sed -i 's/archive.raspbian.org/legacy.raspbian.org/g' /etc/apt/sources.list
+                sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
+                sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list
+                sed -i '/${{ matrix.distro }}-updates/d' /etc/apt/sources.list
+                ;;
+              bullseye)
+                sed -i 's|//deb.debian.org/debian-security|//snapshot.debian.org/archive/debian-security/20260901T000000Z|g' /etc/apt/sources.list
+                sed -i 's|//security.debian.org/debian-security|//snapshot.debian.org/archive/debian-security/20260901T000000Z|g' /etc/apt/sources.list
+                sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
+                echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
+                ;;
+            esac
             case "${{ matrix.distro }}" in
               ubuntu*|jessie|stretch|buster|bullseye|bookworm|trixie)
                 apt-get update -y
@@ -238,12 +240,22 @@ jobs:
           docker pull ${{ matrix.container[0] }}
           docker run --name build-container -d -e GITHUB_ACTIONS=true -v ${{ github.workspace }}:/workspace ${{ matrix.container[0] }} tail -f /dev/null
       - name: Fix old debian apt
-        if: endsWith(matrix.container[0], 'debian:stretch') || endsWith(matrix.container[0], 'debian:buster')
+        if: endsWith(matrix.container[0], 'debian:stretch') || endsWith(matrix.container[0], 'debian:buster') || endsWith(matrix.container[0], 'debian:bullseye')
         env:
           SCRIPT: |
-            sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
-            sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list
-            sed -i '/stretch-updates/d' /etc/apt/sources.list
+            case "${{ matrix.container[0] }}" in
+              *bullseye)
+                sed -i 's|//deb.debian.org/debian-security|//snapshot.debian.org/archive/debian-security/20260901T000000Z|g' /etc/apt/sources.list
+                sed -i 's|//security.debian.org/debian-security|//snapshot.debian.org/archive/debian-security/20260901T000000Z|g' /etc/apt/sources.list
+                sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
+                echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
+                ;;
+              *)
+                sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
+                sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list
+                sed -i '/stretch-updates/d' /etc/apt/sources.list
+                ;;
+            esac
         run: docker exec build-container bash -c "$SCRIPT"
       - name: dependencies
         env:

--- a/Makefile.ffmpeg
+++ b/Makefile.ffmpeg
@@ -53,9 +53,9 @@ NASM_DIFFS     = remove-invalid-pure_func-qualifiers.diff
 
 LIBX264_VER    = 7ed753b10a61d0be95f683289dfb925b800b0676
 LIBX264        = x264-$(LIBX264_VER)
-LIBX264_TB     = $(LIBX264).tar.bz2
-LIBX264_URL    = https://code.videolan.org/videolan/x264/-/archive/$(LIBX264_VER)/$(LIBX264_TB)
-LIBX264_SHA1   = 39132c219a6bae73b322fdfbb3012c6988f3a456
+LIBX264_TB     = $(LIBX264).tar.gz
+LIBX264_URL    = https://github.com/mirror/x264/archive/$(LIBX264_VER)/$(LIBX264_TB)
+LIBX264_SHA1   = f9e8d38178352c87e1a60adbbd249b661c0896de
 
 LIBX265_VER    = 4.1
 LIBX265        = x265_$(LIBX265_VER)
@@ -223,7 +223,7 @@ endif
 
 $(LIB_ROOT)/$(LIBX264)/.tvh_download:
 	$(call DOWNLOAD,$(LIBX264_URL),$(LIB_ROOT)/$(LIBX264_TB),$(LIBX264_SHA1))
-	$(call UNTAR,$(LIBX264_TB),j)
+	$(call UNTAR,$(LIBX264_TB),z)
 	@touch $@
 
 $(LIB_ROOT)/$(LIBX264)/.tvh_build: \

--- a/docs/property/themes.md
+++ b/docs/property/themes.md
@@ -4,6 +4,11 @@ Option           | Description
 -----------------|------------
 **Blue**         | Use the (default) blue theme.
 **Gray**         | Use the gray theme.
+**Dark**         | Use the dark theme, a low-glare palette for night-time use.
 **Access**       | Use the high contrast accessibility theme.
+
+The **Dark** theme styles the Vue web interface only. The legacy
+ExtJS interface has no dark stylesheet of its own and falls back to
+**Blue** when this theme is selected.
 
 This setting can be overridden on a per-user basis, see [Access Entries](class/access).

--- a/src/access.c
+++ b/src/access.c
@@ -1509,6 +1509,7 @@ theme_get_ui_list ( void *p, const char *lang )
   static struct strtab_str tab[] = {
     { N_("Blue"),     "blue"  },
     { N_("Gray"),     "gray"  },
+    { N_("Dark"),     "dark"  },
     { N_("Access"),   "access" },
   };
   return strtab2htsmsg_str(tab, 1, lang);

--- a/src/webui/static-vue/README.md
+++ b/src/webui/static-vue/README.md
@@ -85,8 +85,16 @@ Bootstrap entry points: `index.html` → `src/main.ts` → `src/App.vue`.
   UI-chrome strings use a `t(…)` composable backed by the same
   `/locale.js` catalog the ExtJS UI uses, so shared wording is
   translated once.
-- **Themes.** Three themes (Blue / Grey / Access) are server-driven
-  via the access object and applied through CSS custom properties.
+- **Themes.** Four themes (Blue / Grey / Dark / Access) are
+  server-driven via the access object and applied through CSS custom
+  properties. Blue and Grey are light; Dark is the low-glare night
+  palette and Access the high-contrast white-on-dark variant. Adding
+  one means a `[data-theme='<name>']` block in `styles/tokens.css`,
+  the same selector in the shared list at the top of
+  `styles/primevue.css`, an entry in `theme_get_ui_list()`
+  (`src/access.c`), and — for a dark palette — the selector added to
+  `darkModeSelector` in `main.ts` so PrimeVue's teleported overlays
+  follow.
 - **Responsive.** Desktop tables, tablet horizontal scroll, phone
   card lists; drawers go full-width on phone.
 

--- a/src/webui/static-vue/src/components/IdnodeEditor.vue
+++ b/src/webui/static-vue/src/components/IdnodeEditor.vue
@@ -2314,7 +2314,7 @@ onBeforeUnmount(() => {
 
 .idnode-editor__btn--save {
   background: var(--tvh-primary);
-  color: #fff;
+  color: var(--tvh-on-primary, #fff);
   border-color: var(--tvh-primary);
 }
 

--- a/src/webui/static-vue/src/components/IdnodeGrid.vue
+++ b/src/webui/static-vue/src/components/IdnodeGrid.vue
@@ -3459,7 +3459,7 @@ defineExpose({
  * drawer's 88%-primary mix-with-black. */
 .idnode-grid__edit-btn--primary:not(:disabled) {
   background: var(--tvh-primary);
-  color: #fff;
+  color: var(--tvh-on-primary, #fff);
   border-color: var(--tvh-primary);
 }
 

--- a/src/webui/static-vue/src/main.ts
+++ b/src/webui/static-vue/src/main.ts
@@ -41,26 +41,37 @@ async function bootstrap() {
       options: {
         cssLayer: { name: 'primevue', order: 'tvh-base, primevue' },
         /*
-         * Activate Aura's dark palette exactly when the Access theme is
-         * on. PrimeVue's default `darkModeSelector` is `'system'`, which
-         * follows the OS `prefers-color-scheme`; we bind it to our own
-         * `data-theme` attribute instead, so PrimeVue's light/dark tracks
-         * the app's theme rather than the OS. Access is our only dark
-         * variant (tokens.css sets `[data-theme="access"]` to a
-         * #000/#1a1a1a white-on-dark palette + `color-scheme: dark`); the
-         * Blue and Gray themes are light and don't match, so Aura stays
-         * light for them.
+         * Activate Aura's dark palette exactly when one of our dark
+         * themes is on. PrimeVue's default `darkModeSelector` is
+         * `'system'`, which follows the OS `prefers-color-scheme`; we
+         * bind it to our own `data-theme` attribute instead, so
+         * PrimeVue's light/dark tracks the app's theme rather than the
+         * OS. Both Dark (the low-glare night palette) and Access (the
+         * high-contrast white-on-dark variant) set `color-scheme: dark`
+         * in tokens.css; Blue and Gray are light and don't match, so
+         * Aura stays light for them.
          *
          * This is what makes teleported overlays (Select dropdown,
          * MultiSelect, Datepicker, menus, the paginator rows-per-page
-         * popup) go dark under Access. They render into <body>, outside
-         * any component's scoped CSS, and use Aura's own component tokens
-         * (e.g. `select.overlay.background`) rather than the `--tvh-*`
-         * tokens mapped in primevue.css — so without a matching
-         * `darkModeSelector` they keep Aura's light surface (white) on a
-         * dark page.
+         * popup) go dark under those themes. They render into <body>,
+         * outside any component's scoped CSS, and use Aura's own
+         * component tokens (e.g. `select.overlay.background`) rather
+         * than the `--tvh-*` tokens mapped in primevue.css — so without
+         * a matching `darkModeSelector` they keep Aura's light surface
+         * (white) on a dark page.
+         *
+         * Passed as an array, which @primeuix/styled flattens into one
+         * properly scoped rule per entry:
+         *   :root[data-theme="dark"],:host[data-theme="dark"]{…}
+         *   :root[data-theme="access"],:host[data-theme="access"]{…}
+         *
+         * A single comma-separated string would NOT work. Its `attr`
+         * matcher is /^\[(.*)\]$/, so `[a], [b]` still matches as one
+         * selector and expands to `:root[a], [b],:host[a], [b]` —
+         * leaving `[b]` unanchored, so Aura's dark tokens land on any
+         * element carrying that attribute instead of the document root.
          */
-        darkModeSelector: '[data-theme="access"]',
+        darkModeSelector: ['[data-theme="dark"]', '[data-theme="access"]'],
       },
     },
   })

--- a/src/webui/static-vue/src/styles/__tests__/darkTheme.test.ts
+++ b/src/webui/static-vue/src/styles/__tests__/darkTheme.test.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Tvheadend contributors
+
+/*
+ * Palette contract for the Dark theme.
+ *
+ * Dark is the low-glare night palette (as opposed to Access, the
+ * high-contrast accessibility variant). Three things about it are
+ * easy to break by accident and expensive to notice by eye, so they
+ * are pinned here:
+ *
+ *   1. Completeness. Every literal colour declared in :root has to be
+ *      re-declared for the theme. A token added to :root later with a
+ *      light value would otherwise be inherited verbatim and render a
+ *      light patch on a dark surface. The test derives the required
+ *      set from tokens.css itself rather than restating it, so a new
+ *      token is covered the moment it lands.
+ *   2. Native chrome. `color-scheme: dark` makes the browser draw
+ *      checkboxes, radios, scrollbars and date pickers dark. Without
+ *      it :root's `color-scheme: light` is inherited and native
+ *      widgets render as light rectangles on the dark surface.
+ *   3. Legibility. The foreground/background pairs the palette is
+ *      built around meet WCAG AA (4.5:1).
+ *
+ * Parsed with postcss for the same reason as themeScale.test.ts:
+ * happy-dom's getComputedStyle doesn't resolve custom properties from
+ * injected stylesheets, and parsing the shipped CSS pins the real
+ * source of truth.
+ */
+import { describe, it, expect } from 'vitest'
+import postcss, { type Root, type Rule, type Declaration } from 'postcss'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const tokensCss = readFileSync(
+  resolve(process.cwd(), 'src/styles/tokens.css'),
+  'utf8',
+)
+const ast: Root = postcss.parse(tokensCss)
+
+function findTopLevelRule(selector: string): Rule {
+  let found: Rule | undefined
+  ast.walkRules((rule) => {
+    if (rule.parent?.type !== 'root') return
+    if (rule.selectors.map((s) => s.trim()).includes(selector)) found = rule
+  })
+  if (!found) throw new Error(`Top-level rule not found: ${selector}`)
+  return found
+}
+
+/* Map of custom-property name -> value for one rule. */
+function declsOf(rule: Rule): Map<string, string> {
+  const out = new Map<string, string>()
+  rule.walkDecls((d: Declaration) => {
+    if (d.prop.startsWith('--')) out.set(d.prop, d.value.trim())
+  })
+  return out
+}
+
+const LITERAL_COLOR = /#[0-9a-f]{3,8}\b|\brgba?\(/i
+
+/*
+ * A token needs a per-theme value when it holds a literal colour.
+ * Tokens built from other tokens (--tvh-dvr-overlay-bg mixes
+ * --tvh-primary, for instance) are derived on purpose and must keep
+ * inheriting, so anything referencing var() is excluded.
+ */
+function literalColorTokens(rule: Rule): string[] {
+  return [...declsOf(rule)]
+    .filter(([, v]) => LITERAL_COLOR.test(v) && !v.includes('var('))
+    .map(([prop]) => prop)
+}
+
+const root = findTopLevelRule(':root')
+const dark = findTopLevelRule("[data-theme='dark']")
+const darkDecls = declsOf(dark)
+
+/* --- WCAG relative luminance / contrast, per WCAG 2.x definitions. --- */
+
+function parseHex(hex: string): [number, number, number] {
+  let h = hex.replace('#', '').trim()
+  if (h.length === 3) h = [...h].map((c) => c + c).join('')
+  return [0, 2, 4].map((i) => Number.parseInt(h.slice(i, i + 2), 16) / 255) as [
+    number,
+    number,
+    number,
+  ]
+}
+
+function luminance(hex: string): number {
+  const [r, g, b] = parseHex(hex).map((c) =>
+    c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4,
+  )
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+function contrast(a: string, b: string): number {
+  const [la, lb] = [luminance(a), luminance(b)]
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05)
+}
+
+function token(name: string): string {
+  const v = darkDecls.get(name)
+  if (v === undefined) throw new Error(`Dark theme does not declare ${name}`)
+  return v
+}
+
+describe('Dark theme completeness', () => {
+  it('re-declares every literal colour token from :root', () => {
+    const required = literalColorTokens(root)
+    /* Sanity check on the derivation itself — if the filter ever
+     * matches nothing, the completeness assertion below would pass
+     * vacuously. */
+    expect(required.length).toBeGreaterThan(5)
+    expect(required.filter((t) => !darkDecls.has(t))).toEqual([])
+  })
+
+  it('opts native widgets into dark rendering', () => {
+    /* :root pins `color-scheme: light` so light themes keep light
+     * native controls; a dark palette has to opt back out or the
+     * browser draws checkboxes and scrollbars light. */
+    let colorScheme: string | undefined
+    dark.walkDecls('color-scheme', (d: Declaration) => {
+      colorScheme = d.value.trim()
+    })
+    expect(colorScheme).toBe('dark')
+  })
+
+  it('defines --tvh-on-primary, which the light themes leave unset', () => {
+    /* The primary has to be light enough to read as text on the dark
+     * page, which makes #fff over it illegible — so text on primary
+     * fills reads --tvh-on-primary instead, falling back to #fff for
+     * the light themes that do not declare it. */
+    expect(darkDecls.has('--tvh-on-primary')).toBe(true)
+    expect(declsOf(root).has('--tvh-on-primary')).toBe(false)
+  })
+})
+
+describe('Dark theme surfaces', () => {
+  it('keeps the surface lighter than the page, as the light themes do', () => {
+    /* Elevation has to read the same way in every theme: a raised
+     * surface is lighter than the page it sits on. */
+    expect(luminance(token('--tvh-bg-surface'))).toBeGreaterThan(
+      luminance(token('--tvh-bg-page')),
+    )
+  })
+
+  it('stops short of pure black and pure white', () => {
+    /* #fff on #000 haloes on OLED panels and is tiring at night. */
+    expect(luminance(token('--tvh-bg-page'))).toBeGreaterThan(0)
+    expect(luminance(token('--tvh-text'))).toBeLessThan(1)
+  })
+})
+
+describe('Dark theme contrast (WCAG AA, 4.5:1)', () => {
+  it.each([
+    ['body text on surface', '--tvh-text', '--tvh-bg-surface'],
+    ['body text on page', '--tvh-text', '--tvh-bg-page'],
+    ['muted text on surface', '--tvh-text-muted', '--tvh-bg-surface'],
+    ['muted text on page', '--tvh-text-muted', '--tvh-bg-page'],
+    ['primary as text on page', '--tvh-primary', '--tvh-bg-page'],
+    ['primary as text on surface', '--tvh-primary', '--tvh-bg-surface'],
+    ['on-primary over primary', '--tvh-on-primary', '--tvh-primary'],
+    ['success on surface', '--tvh-success', '--tvh-bg-surface'],
+    ['warning on surface', '--tvh-warning', '--tvh-bg-surface'],
+    ['error on surface', '--tvh-error', '--tvh-bg-surface'],
+  ])('%s meets 4.5:1', (_label, fg, bg) => {
+    expect(contrast(token(fg), token(bg))).toBeGreaterThanOrEqual(4.5)
+  })
+})

--- a/src/webui/static-vue/src/styles/__tests__/themeScale.test.ts
+++ b/src/webui/static-vue/src/styles/__tests__/themeScale.test.ts
@@ -87,6 +87,15 @@ describe('--tvh-text-scale per theme (desktop)', () => {
     expect(getDecl(rule, '--tvh-text-scale')).toBe('1.5')
   })
 
+  it("[data-theme='dark'] inherits the :root scale of 1", () => {
+    /* Dark is a colour-only theme — it deliberately does NOT touch
+     * --tvh-text-scale, unlike Access. Asserting absence keeps a
+     * future edit from quietly giving the night palette a different
+     * text size from Blue/Gray. */
+    const dark = findTopLevelRule("[data-theme='dark']")
+    expect(() => getDecl(dark, '--tvh-text-scale')).toThrow()
+  })
+
   it("[data-theme='gray'] inherits the :root scale of 1", () => {
     /* Gray intentionally does NOT override --tvh-text-scale on
      * desktop — the cascade from :root delivers scale=1. Asserting
@@ -98,13 +107,14 @@ describe('--tvh-text-scale per theme (desktop)', () => {
 })
 
 describe('--tvh-text-scale per theme (phone @media max-width: 767px)', () => {
-  it('Blue and Gray have no phone override — inherit desktop scale 1', () => {
+  it('Blue, Gray and Dark have no phone override — inherit desktop scale 1', () => {
     /* Asserting absence: if a future edit accidentally adds a phone
-     * override for either default-scale theme, the test fails. The
+     * override for any default-scale theme, the test fails. The
      * architecture supports the override (just add the selector to
      * the @media block); we deliberately don't apply one today. */
     expect(() => findMediaRule('max-width: 767px', ':root')).toThrow()
     expect(() => findMediaRule('max-width: 767px', "[data-theme='gray']")).toThrow()
+    expect(() => findMediaRule('max-width: 767px', "[data-theme='dark']")).toThrow()
   })
 
   it("[data-theme='access'] scales 1.15 on phone", () => {

--- a/src/webui/static-vue/src/styles/base.css
+++ b/src/webui/static-vue/src/styles/base.css
@@ -117,7 +117,7 @@
     z-index: 100;
     padding: var(--tvh-space-2) var(--tvh-space-3);
     background: var(--tvh-primary);
-    color: #fff;
+    color: var(--tvh-on-primary, #fff);
     border-radius: var(--tvh-radius-sm);
   }
 

--- a/src/webui/static-vue/src/styles/primevue.css
+++ b/src/webui/static-vue/src/styles/primevue.css
@@ -8,15 +8,17 @@
  * automatically pick up the active theme.
  *
  * The base block applies to all themes via the cascade. Per-theme blocks
- * (gray, access) inherit and only override what differs. PrimeVue's
+ * (gray, dark, access) inherit and only override what differs. PrimeVue's
  * variable surface for DataTable et al. is large; here we map the ones
  * that visibly affect the grid + the small set of common controls
  * (buttons, paginator, headers). Theme name spelling matches the
- * server's enum (access.c:1499-1508 — "blue", "gray", "access").
+ * server's enum in theme_get_ui_list() — "blue", "gray", "dark",
+ * "access".
  */
 
 :root,
 [data-theme='gray'],
+[data-theme='dark'],
 [data-theme='access'] {
   /* Core content tokens */
   --p-primary-color: var(--tvh-primary);

--- a/src/webui/static-vue/src/styles/tokens.css
+++ b/src/webui/static-vue/src/styles/tokens.css
@@ -4,10 +4,11 @@
 /*
  * Tvheadend Vue UI — design tokens
  *
- * Three themes via [data-theme] selectors per brief §6.4: Blue (the
- * default in :root), Gray, and Access. Access is the high-contrast
- * white-on-dark variant and needs stronger interaction tints than
- * the subtle Blue/Grey defaults.
+ * Four themes via [data-theme] selectors: Blue (the default in
+ * :root), Gray, Dark and Access. Dark is the low-glare night
+ * palette and Access the high-contrast white-on-dark variant; both
+ * need stronger interaction tints than the subtle Blue/Gray
+ * defaults, and both opt back in to `color-scheme: dark`.
  */
 
 :root {
@@ -122,6 +123,70 @@
   --tvh-active-strength: 18%;
 }
 
+[data-theme='dark'] {
+  /*
+   * Night-use dark theme.
+   *
+   * Distinct from Access below: Access is the high-contrast
+   * accessibility variant (true black, white borders, 1.5x text),
+   * this is a low-glare everyday dark palette — dark slate surfaces,
+   * off-white text, subtle borders and no text scaling.
+   *
+   * Pure white on pure black haloes on OLED panels and is tiring to
+   * read at night, so text stops short of #fff and the page short of
+   * #000. Surface stays LIGHTER than page, mirroring the light
+   * themes' raised-surface relationship (page #f8fafc < surface
+   * #ffffff), so elevation reads the same way in every theme.
+   *
+   * Opt native widgets (checkboxes, radios, scrollbars, date
+   * pickers) into dark rendering, for the same reason :root forces
+   * them light — see the comment there.
+   */
+  color-scheme: dark;
+
+  /*
+   * Deliberately no --tvh-text-scale: this theme changes colour
+   * only, and inherits the :root scale of 1.
+   */
+
+  --tvh-primary: #60a5fa;
+  --tvh-bg-page: #0f141a;
+  --tvh-bg-surface: #171d25;
+  --tvh-border: #29313b;
+  --tvh-border-strong: #3c4653;
+  --tvh-text: #e6eaf0;
+  --tvh-text-muted: #98a3b3;
+  --tvh-success: #4ade80;
+  --tvh-warning: #fbbf24;
+  --tvh-error: #f87171;
+
+  /*
+   * Text/icon colour for elements filled with --tvh-primary.
+   *
+   * The light themes leave this undefined and consuming sites fall
+   * back to #fff, which is right over their #2563eb (5.2:1). Here
+   * the primary has to be light so it stays legible AS text on the
+   * dark page (7.3:1), and #fff over it would be 2.5:1. A near-black
+   * on-colour restores 7.5:1, so both directions pass AAA.
+   */
+  --tvh-on-primary: #0b1017;
+
+  /*
+   * Subtle interaction tints wash out over a dark surface, so both
+   * strengths sit above the light themes' 8%/14% — but well below
+   * Access's 30%/50%, which is assertive by design.
+   */
+  --tvh-hover-strength: 16%;
+  --tvh-active-strength: 26%;
+
+  /*
+   * Light scroll-fade tint — a dark one is invisible against these
+   * surfaces. Softer than Access's 0.18 to suit the calmer palette.
+   * See the comment on the default in :root.
+   */
+  --tvh-scroll-fade: rgba(255, 255, 255, 0.14);
+}
+
 [data-theme='access'] {
   /*
    * High-contrast white-on-dark theme. True black palette per
@@ -174,8 +239,8 @@
 /*
  * Phone-mode text-scale overrides.
  *
- * Blue and Gray keep their desktop scale of 1 on phone — same
- * text size as desktop, deliberate. Access scales smaller on phone
+ * Blue, Gray and Dark keep their desktop scale of 1 on phone —
+ * same text size as desktop, deliberate. Access scales smaller on phone
  * than on desktop (1.15 vs 1.5) because desktop's 1.5× would push
  * grid headers and toolbar action labels past the visual viewport.
  * To add a phone override for a future theme, add that theme's

--- a/src/webui/static-vue/src/views/epg/EpgToolbar.vue
+++ b/src/webui/static-vue/src/views/epg/EpgToolbar.vue
@@ -182,7 +182,7 @@ const emit = defineEmits<{
 
 .epg-toolbar__day-btn--active {
   background: var(--tvh-primary);
-  color: #fff;
+  color: var(--tvh-on-primary, #fff);
   border-color: var(--tvh-primary);
 }
 
@@ -218,7 +218,7 @@ const emit = defineEmits<{
 
 .epg-toolbar__day-pick--active:deep(.p-select-label),
 .epg-toolbar__day-pick--active:deep(.p-select-dropdown) {
-  color: #fff;
+  color: var(--tvh-on-primary, #fff);
 }
 
 .epg-toolbar__spacer {

--- a/src/webui/webui.c
+++ b/src/webui/webui.c
@@ -2705,6 +2705,49 @@ static int http_file_test(const char *path)
   return -1;
 }
 
+#define WEBUI_THEME_DEFAULT "blue"
+
+/*
+ * Serve a per-theme stylesheet as a CSS import, falling back to the
+ * default theme when the active one has no legacy ExtJS variant.
+ *
+ * Themes added for the Vue interface (currently "dark") ship no
+ * xtheme-<name>.css / ext-<name>.css of their own, because those are
+ * full ExtJS widget themes rather than a token palette. Without this
+ * fallback the legacy interface would answer its own theme.css
+ * request with 400 and render entirely unstyled for anyone who
+ * picked such a theme.
+ *
+ * `prefix`/`suffix` bracket the theme name: the source tree is probed
+ * for src/webui/<prefix><name><suffix> and, when that exists, the
+ * matching /<prefix><name><suffix> URL is imported.
+ */
+static int
+http_theme_css(http_connection_t *hc, const char *prefix,
+               const char *suffix, const char *theme)
+{
+  const char *names[2] = { theme, WEBUI_THEME_DEFAULT };
+  char rel[128];
+  char buf[256];
+  int i;
+
+  for (i = 0; i < 2; i++) {
+    if (names[i] == NULL || names[i][0] == '\0')
+      continue;
+    /* Don't probe the same file twice when the theme IS the default. */
+    if (i && names[0] && !strcmp(names[0], names[1]))
+      break;
+    snprintf(rel, sizeof(rel), "%s%s%s", prefix, names[i], suffix);
+    snprintf(buf, sizeof(buf), "src/webui/%s", rel);
+    if (http_file_test(buf))
+      continue;
+    snprintf(buf, sizeof(buf), "/%s", rel);
+    http_css_import(hc, buf);
+    return 0;
+  }
+  return HTTP_STATUS_BAD_REQUEST;
+}
+
 /**
  *
  */
@@ -2742,39 +2785,15 @@ http_redir(http_connection_t *hc, const char *remain, void *opaque)
     }
     if (!strcmp(components[0], "theme.css")) {
       theme = access_get_theme(hc->hc_access);
-      if (theme) {
-        snprintf(buf, sizeof(buf), "src/webui/static/tvh.%s.css.gz", theme);
-        if (!http_file_test(buf)) {
-          snprintf(buf, sizeof(buf), "/static/tvh.%s.css.gz", theme);
-          http_css_import(hc, buf);
-          return 0;
-        }
-      }
-      return HTTP_STATUS_BAD_REQUEST;
+      return http_theme_css(hc, "static/tvh.", ".css.gz", theme);
     }
     if (!strcmp(components[0], "theme.debug.css")) {
       theme = access_get_theme(hc->hc_access);
-      if (theme) {
-        snprintf(buf, sizeof(buf), "src/webui/static/extjs/resources/css/xtheme-%s.css", theme);
-        if (!http_file_test(buf)) {
-          snprintf(buf, sizeof(buf), "/static/extjs/resources/css/xtheme-%s.css", theme);
-          http_css_import(hc, buf);
-          return 0;
-        }
-      }
-      return HTTP_STATUS_BAD_REQUEST;
+      return http_theme_css(hc, "static/extjs/resources/css/xtheme-", ".css", theme);
     }
     if (!strcmp(components[0], "theme.app.debug.css")) {
       theme = access_get_theme(hc->hc_access);
-      if (theme) {
-        snprintf(buf, sizeof(buf), "src/webui/static/app/ext-%s.css", theme);
-        if (!http_file_test(buf)) {
-          snprintf(buf, sizeof(buf), "/static/app/ext-%s.css", theme);
-          http_css_import(hc, buf);
-          return 0;
-        }
-      }
-      return HTTP_STATUS_BAD_REQUEST;
+      return http_theme_css(hc, "static/app/ext-", ".css", theme);
     }
   }
 


### PR DESCRIPTION
## Problem

The Vue interface ships two light themes (Blue, Gray) and Access. Access is a
high-contrast accessibility variant — true black page, white borders, 1.5x text
— which makes it the only option for using the interface at night, and its
contrast and text scaling are assertive by design rather than comfortable for
long sessions.

## The theme

Dark is a low-glare night palette. It changes colour only, so it stays a drop-in
alternative to Blue and Gray rather than a second accessibility mode:

|                     | Dark                | Access              |
|---------------------|---------------------|---------------------|
| page / surface      | `#0f141a` / `#171d25` | `#000` / `#1a1a1a` |
| text / muted        | `#e6eaf0` / `#98a3b3` | `#fff` / `#d0d0d0` |
| borders             | `#29313b` / `#3c4653` | `#fff` / `#fff`    |
| hover / active tint | 16% / 26%           | 30% / 50%           |
| text scale          | 1 (inherits :root)  | 1.5 desktop, 1.15 phone |

Design notes:

- **Neither pure black nor pure white.** Both haloe on OLED panels and are
  tiring to read at night.
- **Surface lighter than page**, mirroring the light themes (`#f8fafc` page <
  `#ffffff` surface), so elevation reads the same way in every theme.
- **`color-scheme: dark`.** `:root` pins `color-scheme: light` so the light
  themes keep light native controls; a dark palette has to opt back out or the
  browser draws checkboxes, radios, scrollbars and date pickers light against
  the dark surface.
- **Interaction tints at 16%/26%**, above the light themes' 8%/14% because
  subtle tints wash out over a dark surface, below Access's 30%/50%.
- **Scroll-overflow fade inverts** to a light tint; a dark one is invisible
  against these surfaces.
- **`--tvh-on-primary`.** The primary has to be light enough to read as text on
  the dark page (7.3:1), which leaves it too light to sit behind white (2.5:1).
  The theme defines a near-black on-colour for text over primary fills,
  restoring 7.5:1.
- **`darkModeSelector` becomes an array** so Aura's dark palette activates for
  both dark themes. This is what takes teleported overlays (Select, MultiSelect,
  Datepicker, menus, the paginator popup) dark — they render into `<body>`,
  outside any component's scoped CSS. It has to be an array, not a
  comma-separated string: `@primeuix/styled`'s `attr` matcher is
  `/^\[(.*)\]$/`, so `[a], [b]` passes as a single selector and expands to
  `:root[a], [b],:host[a], [b]`, leaving `[b]` unanchored.

## Also in this PR

Two preparatory commits, ordered first so no commit in the series leaves a
theme selectable that breaks something:

1. **`webui: fall back to the default theme for legacy stylesheets`** —
   `http_redir()` answers the legacy interface's `theme.css` with 400 when no
   stylesheet is named after the active theme. Every theme has shipped a full
   ExtJS widget theme so far, so the miss could not happen; a Vue-only palette
   has no `xtheme-<name>.css` / `ext-<name>.css`, and selecting one would leave
   the legacy interface entirely unstyled. The three near-identical handlers
   become one helper that tries the active theme, then the default.

   Dark therefore styles the Vue interface only, and the legacy interface falls
   back to Blue. A real ExtJS dark theme is a much larger job; `docs/property/
   themes.md` states the limitation.

2. **`webui: colour text on primary fills via --tvh-on-primary`** — three
   dialogs already read `var(--tvh-on-primary, #fff)`; five other sites
   hardcoded `#fff`. No theme defined the token, so this is a no-op for Blue,
   Gray and Access, and lets one token move all eight sites for a theme that
   needs it.

## Testing

- New `styles/__tests__/darkTheme.test.ts` pins what is easy to break unseen:
  that **every literal colour declared in `:root` is re-declared** by the theme
  (derived from tokens.css itself, so a token added later is covered the moment
  it lands — otherwise it would be inherited light and paint a light patch on a
  dark surface), that `color-scheme` is dark, that surface stays lighter than
  page, and the contrast ratios. `themeScale.test.ts` gains the Dark cases,
  asserting it declares no text scale at desktop or phone.
- Every foreground/background pair the palette is built around meets WCAG AA.
  Body text is 14:1 on surface; the weakest pair is error-on-surface at 6.1:1.
- `vitest` over `src/styles` (30 pass), `stylelint`, `eslint`, `vue-tsc`, the
  SPDX header check, and a full `vite build` confirming the tokens reach the
  bundled CSS. `access.o` and `webui/webui.o` compile clean.
- The wider Vue suite has pre-existing failures in 16 timer/debounce/comet test
  files, unchanged by this branch (verified by stashing: identical results with
  and without).

## Screenshots
<img width="1512" height="830" alt="image" src="https://github.com/user-attachments/assets/df6c0de8-cf9b-43da-b72f-ff2d1a0ee650" />

<img width="1512" height="833" alt="image" src="https://github.com/user-attachments/assets/a9bea196-fb27-4968-ae8e-39a98eee910f" />

<img width="1512" height="830" alt="image" src="https://github.com/user-attachments/assets/dfc25d05-8904-44a5-ba37-c530244b40ad" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
