### PR TITLE
webui: reduce themes to Light/Dark/Access and add Auto theme

### DIFF
--- a/docs/property/themes.md
+++ b/docs/property/themes.md
@@ -2,13 +2,12 @@
 
 Option           | Description
 -----------------|------------
-**Blue**         | Use the (default) blue theme.
-**Gray**         | Use the gray theme.
+**Light**        | Use the (default) light theme.
 **Dark**         | Use the dark theme, a low-glare palette for night-time use.
 **Access**       | Use the high contrast accessibility theme.
 
 The **Dark** theme styles the Vue web interface only. The legacy
-ExtJS interface has no dark stylesheet of its own and falls back to
-**Blue** when this theme is selected.
+ExtJS interface has no dark stylesheet of its own and falls back to its
+light one when this theme is selected.
 
 This setting can be overridden on a per-user basis, see [Access Entries](class/access).

--- a/docs/property/themes.md
+++ b/docs/property/themes.md
@@ -4,10 +4,16 @@ Option           | Description
 -----------------|------------
 **Light**        | Use the (default) light theme.
 **Dark**         | Use the dark theme, a low-glare palette for night-time use.
+**Auto**         | Follow the browser or operating system, switching between **Light** and **Dark** as that setting changes.
 **Access**       | Use the high contrast accessibility theme.
 
-The **Dark** theme styles the Vue web interface only. The legacy
+**Auto** tracks the host's `prefers-color-scheme`, so the interface
+follows a system that switches itself at sunset without the theme
+needing to be changed by hand. The switch takes effect as soon as the
+host setting changes; no reload is needed.
+
+**Dark** and **Auto** style the Vue web interface only. The legacy
 ExtJS interface has no dark stylesheet of its own and falls back to its
-light one when this theme is selected.
+light one when either theme is selected.
 
 This setting can be overridden on a per-user basis, see [Access Entries](class/access).

--- a/src/access.c
+++ b/src/access.c
@@ -320,10 +320,10 @@ const char *
 access_get_theme(access_t *a)
 {
   if (a == NULL)
-    return "blue";
+    return "light";
   if (tvh_str_default(a->aa_theme, NULL) == NULL) {
     if (tvh_str_default(config.theme_ui, NULL) == NULL)
-      return "blue";
+      return "light";
     return config.theme_ui;
   }
   return a->aa_theme;
@@ -1507,8 +1507,7 @@ htsmsg_t *
 theme_get_ui_list ( void *p, const char *lang )
 {
   static struct strtab_str tab[] = {
-    { N_("Blue"),     "blue"  },
-    { N_("Gray"),     "gray"  },
+    { N_("Light"),    "light" },
     { N_("Dark"),     "dark"  },
     { N_("Access"),   "access" },
   };

--- a/src/access.c
+++ b/src/access.c
@@ -1509,6 +1509,7 @@ theme_get_ui_list ( void *p, const char *lang )
   static struct strtab_str tab[] = {
     { N_("Light"),    "light" },
     { N_("Dark"),     "dark"  },
+    { N_("Auto"),     "auto"  },
     { N_("Access"),   "access" },
   };
   return strtab2htsmsg_str(tab, 1, lang);

--- a/src/config.c
+++ b/src/config.c
@@ -1482,6 +1482,39 @@ config_migrate_v24 ( void )
 }
 
 /*
+ * v24 -> v25 : "blue" and "gray" themes replaced by "light"
+ */
+static void
+config_migrate_v25 ( void )
+{
+  htsmsg_t *c, *e;
+  htsmsg_field_t *f;
+  const char *s;
+
+  /*
+   * config_boot() has already loaded config.theme_ui into memory by
+   * the time the migrations run, so the global default is retuned
+   * there; config_migrate() saves the idnode when it finishes.
+   */
+  s = tvh_str_default(config.theme_ui, NULL);
+  if (s && (!strcmp(s, "blue") || !strcmp(s, "gray")))
+    tvh_str_set(&config.theme_ui, "light");
+
+  /* Access entries are loaded later, so rewrite them on disk. */
+  if ((c = hts_settings_load("accesscontrol")) != NULL) {
+    HTSMSG_FOREACH(f, c) {
+      if (!(e = htsmsg_field_get_map(f))) continue;
+      s = htsmsg_get_str(e, "themeui");
+      if (s == NULL) continue;
+      if (strcmp(s, "blue") && strcmp(s, "gray")) continue;
+      htsmsg_set_str(e, "themeui", "light");
+      hts_settings_save(e, "accesscontrol/%s", htsmsg_field_name(f));
+    }
+    htsmsg_destroy(c);
+  }
+}
+
+/*
  * Perform backup
  */
 static void
@@ -1606,7 +1639,8 @@ static const config_migrate_t config_migrate_table[] = {
   config_migrate_v21,
   config_migrate_v22,
   config_migrate_v23,
-  config_migrate_v24
+  config_migrate_v24,
+  config_migrate_v25
 };
 
 /*
@@ -1780,7 +1814,7 @@ config_boot
   config.epg_cut_window = 5*60;
   config.epg_update_window = 24*3600;
   config_scanfile_ok = 0;
-  config.theme_ui = strdup("blue");
+  config.theme_ui = strdup("light");
   config.chname_num = 1;
   config.iptv_tpool_count = 2;
   config.date_mask = strdup("");

--- a/src/webui/static-vue/src/components/ActionMenu.vue
+++ b/src/webui/static-vue/src/components/ActionMenu.vue
@@ -756,7 +756,7 @@ defineExpose({ visibleCount })
   /* Stay clear of host theme classes that scope styling to
    * `.action-menu` descendants — popover is now a sibling of
    * <body>, no longer a descendant of the host. Re-apply the
-   * theme background + border tokens here so dark / Grey / Access
+   * theme background + border tokens here so the Dark and Access
    * themes still paint the popover correctly. (These tokens
    * already resolve at the :root level — the popover inherits
    * them by virtue of being under <body>.) */

--- a/src/webui/static-vue/src/components/__tests__/IdnodeConfigForm.test.ts
+++ b/src/webui/static-vue/src/components/__tests__/IdnodeConfigForm.test.ts
@@ -265,10 +265,10 @@ describe('IdnodeConfigForm — mandatoryFields', () => {
       id: 'theme_ui',
       type: 'str',
       caption: 'Theme',
-      value: 'blue',
+      value: 'light',
       enum: [
-        { key: 'blue', val: 'Blue' },
-        { key: 'gray', val: 'Gray' },
+        { key: 'light', val: 'Light' },
+        { key: 'dark', val: 'Dark' },
       ],
     },
   ] as const
@@ -1135,7 +1135,7 @@ describe('IdnodeConfigForm — access refetch on save', () => {
     access.data = { admin: true, dvr: true, uilevel: 'expert' }
 
     const wrapper = await mountWithParams(
-      [{ id: 'theme_ui', type: 'str', caption: 'Theme', value: 'blue' }],
+      [{ id: 'theme_ui', type: 'str', caption: 'Theme', value: 'light' }],
       { accessRefetchFields: ['theme_ui'] } as never
     )
     /* Subsequent calls: config/save, access/whoami, config/load. */
@@ -1156,7 +1156,7 @@ describe('IdnodeConfigForm — access refetch on save', () => {
 
     const wrapper = await mountWithParams(
       [
-        { id: 'theme_ui', type: 'str', caption: 'Theme', value: 'blue' },
+        { id: 'theme_ui', type: 'str', caption: 'Theme', value: 'light' },
         { id: 'name', type: 'str', caption: 'Name', value: '' },
       ],
       { accessRefetchFields: ['theme_ui'] } as never

--- a/src/webui/static-vue/src/composables/__tests__/useChartTheme.test.ts
+++ b/src/webui/static-vue/src/composables/__tests__/useChartTheme.test.ts
@@ -9,11 +9,11 @@ import { useChartTheme, type ChartTheme } from '../useChartTheme'
 /* Inject a tiny stylesheet so getComputedStyle returns real values
  * during the test — happy-dom defaults to '' for unset custom
  * properties. */
-function applyTheme(name: 'blue' | 'access'): void {
+function applyTheme(name: 'light' | 'access'): void {
   const style = document.getElementById('test-theme-css') ?? document.createElement('style')
   style.id = 'test-theme-css'
   style.textContent =
-    name === 'blue'
+    name === 'light'
       ? `:root {
           --tvh-primary: #2563eb;
           --tvh-success: #16a34a;
@@ -39,7 +39,7 @@ function applyTheme(name: 'blue' | 'access'): void {
 }
 
 beforeEach(() => {
-  applyTheme('blue')
+  applyTheme('light')
 })
 
 afterEach(() => {

--- a/src/webui/static-vue/src/composables/useChartTheme.ts
+++ b/src/webui/static-vue/src/composables/useChartTheme.ts
@@ -6,7 +6,7 @@
  * option presets for the bandwidth chart.
  *
  * Reads CSS custom properties from the document root so the chart
- * picks up the active theme (Blue / Gray / Access) and re-runs on
+ * picks up the active theme (Light / Dark / Access) and re-runs on
  * theme switch via a MutationObserver on `[data-theme]`.
  *
  * The palette is an 8-entry array sourced from the theme's state

--- a/src/webui/static-vue/src/main.ts
+++ b/src/webui/static-vue/src/main.ts
@@ -48,8 +48,8 @@ async function bootstrap() {
          * PrimeVue's light/dark tracks the app's theme rather than the
          * OS. Both Dark (the low-glare night palette) and Access (the
          * high-contrast white-on-dark variant) set `color-scheme: dark`
-         * in tokens.css; Blue and Gray are light and don't match, so
-         * Aura stays light for them.
+         * in tokens.css; Light does not match, so Aura stays light
+         * for it.
          *
          * This is what makes teleported overlays (Select dropdown,
          * MultiSelect, Datepicker, menus, the paginator rows-per-page

--- a/src/webui/static-vue/src/main.ts
+++ b/src/webui/static-vue/src/main.ts
@@ -49,7 +49,9 @@ async function bootstrap() {
          * OS. Both Dark (the low-glare night palette) and Access (the
          * high-contrast white-on-dark variant) set `color-scheme: dark`
          * in tokens.css; Light does not match, so Aura stays light
-         * for it.
+         * for it. Auto never reaches the DOM under its own name — the
+         * access store resolves it to `light` or `dark` first — so it
+         * is covered by whichever of the two is in effect.
          *
          * This is what makes teleported overlays (Select dropdown,
          * MultiSelect, Datepicker, menus, the paginator rows-per-page

--- a/src/webui/static-vue/src/stores/__tests__/access.test.ts
+++ b/src/webui/static-vue/src/stores/__tests__/access.test.ts
@@ -7,7 +7,7 @@
  * `accessUpdate` remains the live-update channel and the only path on
  * pre-v20 servers (where whoami 404s and must be swallowed).
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import { nextTick } from 'vue'
 
@@ -94,5 +94,106 @@ describe('access store — preloadFromHttp', () => {
     })
     await nextTick()
     expect(document.documentElement.dataset.theme).toBe('dark')
+  })
+})
+
+/*
+ * The Auto theme is resolved in the store rather than in CSS: the
+ * server sends "auto", the client answers it from the host's
+ * prefers-color-scheme, and `data-theme` only ever carries a palette
+ * tokens.css actually declares. These tests pin both halves of that —
+ * the initial resolution and the live follow when the host flips.
+ */
+function stubPrefersDark(initial: boolean) {
+  const listeners = new Set<() => void>()
+  const mql = {
+    matches: initial,
+    media: '(prefers-color-scheme: dark)',
+    addEventListener: (_: string, fn: () => void) => {
+      listeners.add(fn)
+    },
+    removeEventListener: (_: string, fn: () => void) => {
+      listeners.delete(fn)
+    },
+  }
+  vi.stubGlobal('matchMedia', () => mql)
+  return {
+    /* Flip the host preference the way a browser would. */
+    set(next: boolean) {
+      mql.matches = next
+      listeners.forEach((fn) => fn())
+    },
+  }
+}
+
+function sendTheme(theme: string) {
+  h.listeners.get('accessUpdate')?.({
+    notificationClass: 'accessUpdate',
+    ...WHOAMI,
+    theme,
+  })
+}
+
+describe('access store — Auto theme', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("resolves 'auto' to light when the host prefers light", async () => {
+    stubPrefersDark(false)
+    useAccessStore()
+
+    sendTheme('auto')
+    await nextTick()
+    expect(document.documentElement.dataset.theme).toBe('light')
+  })
+
+  it("resolves 'auto' to dark when the host prefers dark", async () => {
+    stubPrefersDark(true)
+    useAccessStore()
+
+    sendTheme('auto')
+    await nextTick()
+    expect(document.documentElement.dataset.theme).toBe('dark')
+  })
+
+  it('follows the host preference while Auto is selected', async () => {
+    const host = stubPrefersDark(false)
+    useAccessStore()
+
+    sendTheme('auto')
+    await nextTick()
+    expect(document.documentElement.dataset.theme).toBe('light')
+
+    /* No reload, no new accessUpdate — the media-query listener
+     * re-resolves on its own. */
+    host.set(true)
+    expect(document.documentElement.dataset.theme).toBe('dark')
+
+    host.set(false)
+    expect(document.documentElement.dataset.theme).toBe('light')
+  })
+
+  it('ignores the host preference while a concrete theme is selected', async () => {
+    const host = stubPrefersDark(false)
+    useAccessStore()
+
+    sendTheme('access')
+    await nextTick()
+    expect(document.documentElement.dataset.theme).toBe('access')
+
+    /* The listener stays attached for the life of the store; it must
+     * be inert for anything but Auto. */
+    host.set(true)
+    expect(document.documentElement.dataset.theme).toBe('access')
+  })
+
+  it("never puts 'auto' in the DOM", async () => {
+    stubPrefersDark(true)
+    useAccessStore()
+
+    sendTheme('auto')
+    await nextTick()
+    expect(document.documentElement.dataset.theme).not.toBe('auto')
   })
 })

--- a/src/webui/static-vue/src/stores/__tests__/access.test.ts
+++ b/src/webui/static-vue/src/stores/__tests__/access.test.ts
@@ -90,9 +90,9 @@ describe('access store — preloadFromHttp', () => {
     h.listeners.get('accessUpdate')?.({
       notificationClass: 'accessUpdate',
       ...WHOAMI,
-      theme: 'gray',
+      theme: 'dark',
     })
     await nextTick()
-    expect(document.documentElement.dataset.theme).toBe('gray')
+    expect(document.documentElement.dataset.theme).toBe('dark')
   })
 })

--- a/src/webui/static-vue/src/stores/access.ts
+++ b/src/webui/static-vue/src/stores/access.ts
@@ -200,29 +200,52 @@ export const useAccessStore = defineStore('access', () => {
 
   /*
    * Server-driven theme application. The wire value of `theme` (per
-   * theme_get_ui_list() — "light", "dark", "access") drives the
-   * `[data-theme=<value>]` selector in tokens.css and primevue.css.
-   * Configuration → General → Theme writes to `config.theme_ui`,
-   * the server resolves it via `access_get_theme()`, and the next
-   * mailbox accessUpdate reflects the new value. Existing connected
-   * sessions still need a forced reload to pick up the change
-   * because the server emits `accessUpdate` only at WS-connect
-   * time; the General page's save handler triggers that reload
-   * automatically.
+   * theme_get_ui_list() — "light", "dark", "auto", "access") drives
+   * the `[data-theme=<value>]` selector in tokens.css and
+   * primevue.css. Configuration → General → Theme writes to
+   * `config.theme_ui`, the server resolves it via
+   * `access_get_theme()`, and the next mailbox accessUpdate reflects
+   * the new value. Existing connected sessions still need a forced
+   * reload to pick up the change because the server emits
+   * `accessUpdate` only at WS-connect time; the General page's save
+   * handler triggers that reload automatically.
+   *
+   * "auto" is the one value that never reaches the DOM. It means
+   * "whatever the host is set to", which only the client can answer,
+   * so it is resolved here to `light` or `dark` from
+   * prefers-color-scheme and `data-theme` always names a palette
+   * that tokens.css actually declares. That keeps everything
+   * downstream — the `[data-theme]` blocks, PrimeVue's
+   * darkModeSelector in main.ts, useTextScale's MutationObserver,
+   * useChartTheme's token reads — working on concrete themes with no
+   * knowledge of Auto at all.
+   *
+   * The media query is also watched, so a user who flips their OS
+   * between light and dark sees the interface follow immediately
+   * rather than at the next reload. The listener stays attached for
+   * the life of the store and re-reads the current wire value each
+   * time, so it is inert while a concrete theme is selected.
    *
    * Pre-Comet (before the first accessUpdate lands), no `data-theme`
    * attribute is set and the document falls through to the `:root`
    * defaults in tokens.css — the Light theme. Brief light flash on
-   * cold load for users on a dark theme; same UX as
+   * cold load for users on a dark theme, Auto included; same UX as
    * quicktips/uilevel/etc. which all wait for the same first
    * message.
    */
-  watch(
-    () => data.value?.theme,
-    (t) => {
-      if (t) document.documentElement.dataset.theme = t
-    }
-  )
+  const prefersDark =
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia('(prefers-color-scheme: dark)')
+      : null
+
+  function applyTheme(t: string | undefined): void {
+    if (!t) return
+    document.documentElement.dataset.theme =
+      t === 'auto' ? (prefersDark?.matches ? 'dark' : 'light') : t
+  }
+
+  watch(() => data.value?.theme, applyTheme)
+  prefersDark?.addEventListener('change', () => applyTheme(data.value?.theme))
 
   function has(key: PermissionKey): boolean {
     return !!data.value?.[key]

--- a/src/webui/static-vue/src/stores/access.ts
+++ b/src/webui/static-vue/src/stores/access.ts
@@ -200,7 +200,7 @@ export const useAccessStore = defineStore('access', () => {
 
   /*
    * Server-driven theme application. The wire value of `theme` (per
-   * access.c:1499-1508 — "blue", "gray", "access") drives the
+   * theme_get_ui_list() — "light", "dark", "access") drives the
    * `[data-theme=<value>]` selector in tokens.css and primevue.css.
    * Configuration → General → Theme writes to `config.theme_ui`,
    * the server resolves it via `access_get_theme()`, and the next
@@ -212,9 +212,10 @@ export const useAccessStore = defineStore('access', () => {
    *
    * Pre-Comet (before the first accessUpdate lands), no `data-theme`
    * attribute is set and the document falls through to the `:root`
-   * defaults in tokens.css — the blue theme. Brief blue flash on
-   * cold load for non-blue users; same UX as quicktips/uilevel/etc.
-   * which all wait for the same first message.
+   * defaults in tokens.css — the Light theme. Brief light flash on
+   * cold load for users on a dark theme; same UX as
+   * quicktips/uilevel/etc. which all wait for the same first
+   * message.
    */
   watch(
     () => data.value?.theme,

--- a/src/webui/static-vue/src/styles/__tests__/themeScale.test.ts
+++ b/src/webui/static-vue/src/styles/__tests__/themeScale.test.ts
@@ -91,29 +91,26 @@ describe('--tvh-text-scale per theme (desktop)', () => {
     /* Dark is a colour-only theme — it deliberately does NOT touch
      * --tvh-text-scale, unlike Access. Asserting absence keeps a
      * future edit from quietly giving the night palette a different
-     * text size from Blue/Gray. */
+     * text size from Light. */
     const dark = findTopLevelRule("[data-theme='dark']")
     expect(() => getDecl(dark, '--tvh-text-scale')).toThrow()
   })
 
-  it("[data-theme='gray'] inherits the :root scale of 1", () => {
-    /* Gray intentionally does NOT override --tvh-text-scale on
-     * desktop — the cascade from :root delivers scale=1. Asserting
-     * absence is part of the contract: if a future edit accidentally
-     * declares the variable on the Gray block, the test catches it. */
-    const gray = findTopLevelRule("[data-theme='gray']")
-    expect(() => getDecl(gray, '--tvh-text-scale')).toThrow()
+  it('Light is the :root palette and declares no selector of its own', () => {
+    /* Light is the default: its tokens live in :root rather than in a
+     * [data-theme='light'] block, so `data-theme` can be absent (pre-
+     * Comet) or "light" and render identically. */
+    expect(() => findTopLevelRule("[data-theme='light']")).toThrow()
   })
 })
 
 describe('--tvh-text-scale per theme (phone @media max-width: 767px)', () => {
-  it('Blue, Gray and Dark have no phone override — inherit desktop scale 1', () => {
+  it('Light and Dark have no phone override — inherit desktop scale 1', () => {
     /* Asserting absence: if a future edit accidentally adds a phone
      * override for any default-scale theme, the test fails. The
      * architecture supports the override (just add the selector to
      * the @media block); we deliberately don't apply one today. */
     expect(() => findMediaRule('max-width: 767px', ':root')).toThrow()
-    expect(() => findMediaRule('max-width: 767px', "[data-theme='gray']")).toThrow()
     expect(() => findMediaRule('max-width: 767px', "[data-theme='dark']")).toThrow()
   })
 

--- a/src/webui/static-vue/src/styles/__tests__/themeScale.test.ts
+++ b/src/webui/static-vue/src/styles/__tests__/themeScale.test.ts
@@ -99,8 +99,11 @@ describe('--tvh-text-scale per theme (desktop)', () => {
   it('Light is the :root palette and declares no selector of its own', () => {
     /* Light is the default: its tokens live in :root rather than in a
      * [data-theme='light'] block, so `data-theme` can be absent (pre-
-     * Comet) or "light" and render identically. */
+     * Comet) or "light" and render identically. Auto has no block
+     * either — the access store resolves it to light or dark before it
+     * reaches the DOM. */
     expect(() => findTopLevelRule("[data-theme='light']")).toThrow()
+    expect(() => findTopLevelRule("[data-theme='auto']")).toThrow()
   })
 })
 

--- a/src/webui/static-vue/src/styles/primevue.css
+++ b/src/webui/static-vue/src/styles/primevue.css
@@ -12,7 +12,8 @@
  * for DataTable et al. is large; here we map the ones that visibly
  * affect the grid + the small set of common controls (buttons,
  * paginator, headers). Theme name spelling matches the server's enum in
- * theme_get_ui_list() — "light", "dark", "access".
+ * theme_get_ui_list() — "light", "dark", "access"; "auto" resolves to
+ * one of those before it reaches the DOM.
  */
 
 :root,

--- a/src/webui/static-vue/src/styles/primevue.css
+++ b/src/webui/static-vue/src/styles/primevue.css
@@ -8,16 +8,15 @@
  * automatically pick up the active theme.
  *
  * The base block applies to all themes via the cascade. Per-theme blocks
- * (gray, dark, access) inherit and only override what differs. PrimeVue's
- * variable surface for DataTable et al. is large; here we map the ones
- * that visibly affect the grid + the small set of common controls
- * (buttons, paginator, headers). Theme name spelling matches the
- * server's enum in theme_get_ui_list() — "blue", "gray", "dark",
- * "access".
+ * inherit and only override what differs. PrimeVue's variable surface
+ * for DataTable et al. is large; here we map the ones that visibly
+ * affect the grid + the small set of common controls (buttons,
+ * paginator, headers). Theme name spelling matches the server's enum in
+ * theme_get_ui_list() — "light", "dark", "access".
  */
 
 :root,
-[data-theme='gray'],
+[data-theme='light'],
 [data-theme='dark'],
 [data-theme='access'] {
   /* Core content tokens */
@@ -80,7 +79,7 @@
    * primary color (which is what Aura's default `selectedColor:
    * '{highlight.color}'` falls through to). On a primary-tinted
    * background, primary-colored text has near-zero contrast — a
-   * highlighted row becomes unreadable in the Blue and Grey themes.
+   * highlighted row becomes unreadable in the Light theme.
    * ExtJS's xtheme-blue solves this the same way: light tint +
    * explicit black text (xtheme-blue.css:676 — `color: #000`).
    *
@@ -155,7 +154,7 @@
  * (emerald green) because we only override `--p-primary-color` — we
  * don't redefine the full palette. Without this rule, a "selected"
  * row gets emerald green background with dark green text regardless
- * of the user's Blue or Grey theme; PrimeVue's CSS lives in
+ * of the user's theme; PrimeVue's CSS lives in
  * `@layer primevue`, and while unlayered overrides should win, in
  * practice a direct rule with the same selector is the most reliable
  * way to guarantee the visual matches the surrounding theme.
@@ -180,7 +179,7 @@
  * above. PrimeVue's hover style applies when the user's mouse is
  * over a row; Aura's defaults give it a primary-tinted background
  * AND a primary-tinted text color via `{content.hover.color}`. The
- * combo is "almost impossible to read" in the Blue and Grey themes
+ * combo is "almost impossible to read" in the Light theme
  * (verified — the contrast is real). We override the background
  * via `--p-datatable-row-hover-background` above, but the text
  * color falls through to Aura's default unless we pin it directly.
@@ -203,8 +202,8 @@
  * resolves the highlight tokens to `{primary.50}` / `{primary.700}`
  * shade aliases that we don't override (we set `--p-primary-color`,
  * not the per-shade palette). Without these direct rules, a selected
- * tree node renders Aura's emerald-on-emerald-dark in our Blue and
- * Grey themes, and a hovered node renders dark-emerald text on our
+ * tree node renders Aura's emerald-on-emerald-dark in our Light
+ * theme, and a hovered node renders dark-emerald text on our
  * primary-tinted hover background — both unreadable.
  *
  * Same selectors PrimeVue uses internally (see

--- a/src/webui/static-vue/src/styles/tokens.css
+++ b/src/webui/static-vue/src/styles/tokens.css
@@ -4,19 +4,19 @@
 /*
  * Tvheadend Vue UI — design tokens
  *
- * Four themes via [data-theme] selectors: Blue (the default in
- * :root), Gray, Dark and Access. Dark is the low-glare night
+ * Three themes via [data-theme] selectors: Light (the default,
+ * declared in :root), Dark and Access. Dark is the low-glare night
  * palette and Access the high-contrast white-on-dark variant; both
- * need stronger interaction tints than the subtle Blue/Gray
- * defaults, and both opt back in to `color-scheme: dark`.
+ * need stronger interaction tints than the subtle Light defaults,
+ * and both opt back in to `color-scheme: dark`.
  */
 
 :root {
   /*
    * Force native widgets (checkboxes, radios, scrollbars, date
    * pickers, etc.) to render in light-mode style regardless of the
-   * OS-level `prefers-color-scheme` — Blue and Gray are both light
-   * variants and iOS Safari (and other browsers) would otherwise
+   * OS-level `prefers-color-scheme` — Light is, as the name says, a
+   * light variant and iOS Safari (and other browsers) would otherwise
    * draw native form controls in dark style at night while our own
    * surfaces stay light, producing the "checkbox painted as a dark
    * filled rectangle" effect. The Access theme below opts back in
@@ -25,7 +25,7 @@
    */
   color-scheme: light;
 
-  /* Blue — default theme */
+  /* Light — default theme */
   --tvh-primary: #2563eb;
   --tvh-bg-page: #f8fafc;
   --tvh-bg-surface: #ffffff;
@@ -110,19 +110,6 @@
   --tvh-scroll-fade: rgba(0, 0, 0, 0.18);
 }
 
-[data-theme='gray'] {
-  --tvh-primary: #475569;
-  --tvh-bg-page: #f6f7f8;
-  --tvh-bg-surface: #ffffff;
-  --tvh-border: #e4e6e9;
-  --tvh-border-strong: #c8ccd1;
-  --tvh-text: #1f2937;
-  --tvh-text-muted: #6b7280;
-
-  --tvh-hover-strength: 10%;
-  --tvh-active-strength: 18%;
-}
-
 [data-theme='dark'] {
   /*
    * Night-use dark theme.
@@ -134,8 +121,8 @@
    *
    * Pure white on pure black haloes on OLED panels and is tiring to
    * read at night, so text stops short of #fff and the page short of
-   * #000. Surface stays LIGHTER than page, mirroring the light
-   * themes' raised-surface relationship (page #f8fafc < surface
+   * #000. Surface stays LIGHTER than page, mirroring the Light
+   * theme's raised-surface relationship (page #f8fafc < surface
    * #ffffff), so elevation reads the same way in every theme.
    *
    * Opt native widgets (checkboxes, radios, scrollbars, date
@@ -163,8 +150,8 @@
   /*
    * Text/icon colour for elements filled with --tvh-primary.
    *
-   * The light themes leave this undefined and consuming sites fall
-   * back to #fff, which is right over their #2563eb (5.2:1). Here
+   * The Light theme leaves this undefined and consuming sites fall
+   * back to #fff, which is right over its #2563eb (5.2:1). Here
    * the primary has to be light so it stays legible AS text on the
    * dark page (7.3:1), and #fff over it would be 2.5:1. A near-black
    * on-colour restores 7.5:1, so both directions pass AAA.
@@ -173,7 +160,7 @@
 
   /*
    * Subtle interaction tints wash out over a dark surface, so both
-   * strengths sit above the light themes' 8%/14% — but well below
+   * strengths sit above the Light theme's 8%/14% — but well below
    * Access's 30%/50%, which is assertive by design.
    */
   --tvh-hover-strength: 16%;
@@ -239,8 +226,8 @@
 /*
  * Phone-mode text-scale overrides.
  *
- * Blue, Gray and Dark keep their desktop scale of 1 on phone —
- * same text size as desktop, deliberate. Access scales smaller on phone
+ * Light and Dark keep their desktop scale of 1 on phone — same
+ * text size as desktop, deliberate. Access scales smaller on phone
  * than on desktop (1.15 vs 1.5) because desktop's 1.5× would push
  * grid headers and toolbar action labels past the visual viewport.
  * To add a phone override for a future theme, add that theme's

--- a/src/webui/static-vue/src/styles/tokens.css
+++ b/src/webui/static-vue/src/styles/tokens.css
@@ -4,11 +4,16 @@
 /*
  * Tvheadend Vue UI — design tokens
  *
- * Three themes via [data-theme] selectors: Light (the default,
+ * Three palettes via [data-theme] selectors: Light (the default,
  * declared in :root), Dark and Access. Dark is the low-glare night
  * palette and Access the high-contrast white-on-dark variant; both
  * need stronger interaction tints than the subtle Light defaults,
  * and both opt back in to `color-scheme: dark`.
+ *
+ * The Auto theme has no palette of its own: the access store
+ * resolves it to `light` or `dark` from the host's
+ * prefers-color-scheme, so `data-theme` always names one of the
+ * three declared here.
  */
 
 :root {

--- a/src/webui/static-vue/src/views/configuration/ConfigGeneralBaseView.vue
+++ b/src/webui/static-vue/src/views/configuration/ConfigGeneralBaseView.vue
@@ -91,7 +91,7 @@ const ACCESS_REFETCH_FIELDS: readonly string[] = [
  *
  * Currently just the two:
  *   - language_ui   defaulted at startup; UI breaks if cleared.
- *   - theme_ui      defaulted "blue" at startup; same constraint.
+ *   - theme_ui      defaulted "light" at startup; same constraint.
  *
  * Numeric-keyed enums on this page (`page_size_ui`, `uilevel`,
  * `default_tab`, `chiconscheme`, `piconscheme`, `digest`,

--- a/src/webui/static-vue/src/views/epg/EpgMagazine.vue
+++ b/src/webui/static-vue/src/views/epg/EpgMagazine.vue
@@ -1164,7 +1164,7 @@ defineExpose({
  *
  * Colour: 18 % of the theme's text colour (`--tvh-text`) mixed
  * with transparent. `--tvh-text` is already theme-aware — dark
- * on Blue / Gray, white on Access — so the fade reads
+ * on Light, white on Dark and Access — so the fade reads
  * as a soft shadow on light surfaces and a soft glow on dark
  * surfaces, same visual affordance in either polarity. Mirrors
  * the scroll-shadow gradients on `IdnodeGrid` and `PageTabs`.

--- a/src/webui/static-vue/src/views/epg/EpgTimeline.vue
+++ b/src/webui/static-vue/src/views/epg/EpgTimeline.vue
@@ -933,7 +933,7 @@ defineExpose({
    * transparency — a non-transparent background here would show
    * through as a coloured rectangle behind the logo (very visible
    * under Access's #000/#1a1a1a surface, faintly visible on
-   * Blue / Gray too where bg-page and the cell's bg-surface
+   * Light too where bg-page and the cell's bg-surface
    * don't quite match). Border-radius stays so opaque logos
    * (some skin packs ship square JPGs) still get rounded
    * corners. */
@@ -1220,7 +1220,7 @@ defineExpose({
  *
  * Colour: 18 % of the theme's text colour (`--tvh-text`) mixed
  * with transparent. `--tvh-text` is already theme-aware — dark
- * on Blue / Gray, white on Access — so the fade reads
+ * on Light, white on Dark and Access — so the fade reads
  * as a soft shadow on light surfaces and a soft glow on dark
  * surfaces, same visual affordance in either polarity. Mirrors
  * the scroll-shadow gradients on `IdnodeGrid` and `PageTabs`.

--- a/src/webui/webui.c
+++ b/src/webui/webui.c
@@ -2705,13 +2705,20 @@ static int http_file_test(const char *path)
   return -1;
 }
 
-#define WEBUI_THEME_DEFAULT "blue"
+/*
+ * The legacy interface ships ExtJS widget themes under these names,
+ * and "blue" is the one every Vue theme without an ExtJS counterpart
+ * falls back to. It is deliberately not the Vue default (that is
+ * "light", see theme_get_ui_list()): this names a stylesheet on
+ * disk, not a theme a user can pick.
+ */
+#define WEBUI_THEME_EXTJS_FALLBACK "blue"
 
 /*
  * Serve a per-theme stylesheet as a CSS import, falling back to the
- * default theme when the active one has no legacy ExtJS variant.
+ * ExtJS fallback theme when the active one has no legacy variant.
  *
- * Themes added for the Vue interface (currently "dark") ship no
+ * The Vue interface's own themes ("light", "dark") ship no
  * xtheme-<name>.css / ext-<name>.css of their own, because those are
  * full ExtJS widget themes rather than a token palette. Without this
  * fallback the legacy interface would answer its own theme.css
@@ -2726,7 +2733,7 @@ static int
 http_theme_css(http_connection_t *hc, const char *prefix,
                const char *suffix, const char *theme)
 {
-  const char *names[2] = { theme, WEBUI_THEME_DEFAULT };
+  const char *names[2] = { theme, WEBUI_THEME_EXTJS_FALLBACK };
   char rel[128];
   char buf[256];
   int i;

--- a/src/webui/webui.c
+++ b/src/webui/webui.c
@@ -2718,7 +2718,7 @@ static int http_file_test(const char *path)
  * Serve a per-theme stylesheet as a CSS import, falling back to the
  * ExtJS fallback theme when the active one has no legacy variant.
  *
- * The Vue interface's own themes ("light", "dark") ship no
+ * The Vue interface's own themes ("light", "dark", "auto") ship no
  * xtheme-<name>.css / ext-<name>.css of their own, because those are
  * full ExtJS widget themes rather than a token palette. Without this
  * fallback the legacy interface would answer its own theme.css


### PR DESCRIPTION
Reduces the Vue interface to three themes and adds a fourth option that follows the host.

### Drop Gray, rename Blue to Light

Blue and Gray were both light palettes differing only in how much blue was in the neutrals. Now that Dark exists, the axis users pick along is light versus dark, and a theme called "Blue" on that axis reads as a colour rather than a polarity.

Gray is removed and Blue becomes **Light**, keeping Blue's exact palette — a rename, not a retune, so nobody's interface changes appearance apart from Gray users landing on Light. Light is the default.

Stored values are migrated by a new `config_migrate_v25`: `config.theme_ui` is retuned in memory (`config_boot()` has already loaded it by the time migrations run, and `config_migrate()` saves the idnode when it finishes), and each access entry's `themeui` is rewritten on disk the way `config_migrate_v24()` rewrites its `streaming` and `dvr` fields. Existing Blue and Gray users therefore land on Light rather than on a theme name nothing declares.

### Add Auto

<img width="436" height="283" alt="image" src="https://github.com/user-attachments/assets/de33347f-4444-4321-989e-f0b8e4a85d5e" />

**Auto** answers with whatever the host is set to, so a system that switches itself in the evening no longer leaves the interface on the theme that was picked by hand.

It is the only theme value that never reaches the DOM: the access store resolves it to `light` or `dark` from `prefers-color-scheme` before setting `data-theme`, so the attribute always names a palette `tokens.css` actually declares.

Resolving on the client rather than in CSS is what keeps the rest of the interface unaware of it — the `[data-theme]` token blocks, PrimeVue's `darkModeSelector`, `useTextScale`'s MutationObserver and `useChartTheme`'s token reads all keep working on concrete themes, and neither the palettes nor the PrimeVue mapping gain an Auto branch. In CSS that branch would have meant restating the whole Dark palette inside a `prefers-color-scheme` media query, with the two copies free to drift apart.

The media query is watched as well as read, so flipping the host setting switches the interface immediately rather than at the next reload. The listener re-reads the current wire value each time, so it is inert unless Auto is selected.

The cold-load flash is unchanged: pre-Comet there is no `data-theme` yet and the document renders Light until the first `accessUpdate` arrives, as it already does for Dark and Access.

### Testing

- Full C build clean, no new warnings, on both commits.
- Theme-related suites pass: 88 tests across the access store, both style suites, `useChartTheme` and `IdnodeConfigForm`.
- Five new access-store tests cover Auto: resolution in each direction, the live follow when the host flips, inertness while a concrete theme is selected, and that `auto` never lands in the DOM.

### Notes

The legacy ExtJS interface is deliberately untouched. It keeps serving `xtheme-blue.css` to Light, Dark and Auto users through the existing fallback; only the macro is renamed to `WEBUI_THEME_EXTJS_FALLBACK` so it reads as the name of a stylesheet on disk rather than the interface default. `xtheme-gray.css` and `ext-gray.css` are now unreachable but are left in place, on the assumption they go with the rest of ExtJS.

Unrelated to this branch: 16 test files fail in the working tree with `Hook timed out in 10000ms` on `vi.useRealTimers()` in fake-timer suites. Verified pre-existing by re-running at the parent commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
