### PR TITLE
tcp: do not call the status callback with a NULL opaque pointer

### DIFF
--- a/src/webui/webui.c
+++ b/src/webui/webui.c
@@ -1456,8 +1456,10 @@ http_stream_mux(http_connection_t *hc, mpegts_mux_t *mm, int weight)
         pids.all = 1;
       } else {
         i = atoi(p);
-        if (i < 0 || i > 8192)
+        if (i < 0 || i > 8192) {
+          http_stream_postop(tcp_id);
           return HTTP_STATUS_BAD_REQUEST;
+        }
         if (i == 8192)
           pids.all = 1;
         else
@@ -1465,8 +1467,10 @@ http_stream_mux(http_connection_t *hc, mpegts_mux_t *mm, int weight)
       }
       p = strtok_r(NULL, ",", &saveptr);
     }
-    if (!pids.all && pids.count <= 0)
+    if (!pids.all && pids.count <= 0) {
+      http_stream_postop(tcp_id);
       return HTTP_STATUS_BAD_REQUEST;
+    }
   } else {
     pids.all = 1;
   }


### PR DESCRIPTION
### Version

`4.3-2746~gfd531a452` (Debian trixie, self-built). The same code is present in current master (`4ffbc07e6`).

### Symptom

Tvheadend dies with SIGSEGV and the web interface becomes unavailable until the service is restarted. It has happened three times over roughly seven weeks on a busy server:

```
[Tue Jul 21 23:07:07 2026] traps: tvh:tcp-start[2181832] general protection fault ip:558aa94df8f8
[Fri Sep  4 17:19:27 2026] tvh:tcp-start[1810628]: segfault at 38 ip 000055ac7ba35654 error 4
[Mon Sep  7 18:26:05 2026] tvh:tcp-start[2069654]: segfault at 28 ip 000055695476fef4 error 4
```

The built-in crash handler reports:

```
CRASH: Signal: 11 in PRG: /usr/bin/tvheadend (4.3-2746~gfd531a452)
CRASH: Fault address 0x28 (Address not mapped)
```

### Backtrace

Resolved with `addr2line` against the matching `-dbg` build:

```
traphandler              src/trap.c:184
http_stream_status       src/webui/webui.c:347
tcp_server_connections   src/tcp.c:1149
webui_api_handler        src/webui/webui_api.c:50
http_exec                src/http.c:1263
http_cmd_get             src/http.c:1337
process_request          src/http.c:1559
http_serve_requests      src/http.c:2040
http_serve               src/http.c:2091
tcp_server_start         src/tcp.c:727
thread_wrapper           src/tvh_thread.c:92
```

So the crash is triggered by a request to `/api/status/connections`, i.e. by the Status → Connections page of the web interface.

### Analysis

`tcp_server_connections()` walks `tcp_server_launches` and invokes the per-connection status callback:

```c
LIST_FOREACH(tsl, &tcp_server_launches, link) {
  if (!tsl->status) continue;
  ...
  tsl->status(tsl->opaque, e);
```

It guards `tsl->status` but not `tsl->opaque`. When an HTTP connection finishes, `http_serve()` deliberately invalidates the pointer:

```c
tvh_mutex_lock(&global_lock);
*opaque = NULL;
```

If the launch entry is still linked at that moment, `http_stream_status(NULL, m)` is called and dereferences `hc` on its first field access:

```c
htsmsg_add_str(m, "type", "HTTP");
if (hc->hc_proxy_ip) {          /* webui.c:347 */
```

The fault address matches exactly — `hc_proxy_ip` sits at offset 0x28 of `http_connection_t`:

```
0x00 hc_subsys      0x18 hc_self
0x04 hc_fd          0x20 hc_representative
0x08 hc_peer        0x28 hc_proxy_ip
0x10 hc_peer_ipstr  0x30 hc_local_ip
```

`htsp_server_status()` and `rtsp_stream_status()` dereference their `opaque` the same way, so the HTSP and SAT>IP paths have the same exposure.

### Fix

Skip entries whose `opaque` has already been invalidated in `tcp_server_connections()` and `tcp_server_connections_count()`, and return early on a NULL `opaque` in `http_stream_status()`, `htsp_server_status()` and `rtsp_stream_status()` so those callbacks cannot be crashed through another path.

Running this patch in production on two servers; I will report back after a couple of weeks.

### Open question

The guard stops the crash, but it does not explain why a launch entry with a NULL `opaque` is still linked in `tcp_server_launches` at all — `tcp_connection_land()` should have removed it before the connection thread nulls the pointer. That may point at a missing or skipped `tcp_connection_land()` on one of the HTTP paths.