### PR TITLE
ci: stop building armhf against the rolling Ubuntu tag

### DIFF
--- a/.github/workflows/build-cloudsmith.yml
+++ b/.github/workflows/build-cloudsmith.yml
@@ -84,7 +84,7 @@ jobs:
        # aarch64 is not emulated here: it builds natively on arm64
        # runners in build-deb-native below.
        arch: [ armv7 ]
-       distro: [ stretch, buster, bullseye, bookworm, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04, ubuntu24.04, ubuntu_latest ]
+       distro: [ stretch, buster, bullseye, bookworm, ubuntu16.04, ubuntu18.04, ubuntu20.04, ubuntu22.04, ubuntu24.04 ]
        include:
          - arch: armv6
            distro: stretch


### PR DESCRIPTION
`Build on ubuntu_latest armv7` is the only red job in the master push runs, and has been since `ubuntu:latest` rolled to 26.04 (resolute). It dies ~50 minutes in, at the very end of the Debian build:

```
chmod: Value too large for defined data type
dh_installdocs: error: chmod -R u\+rw,go=rX debian/tvheadend/usr/share/doc returned exit code 1
make: *** [debian/rules:11: binary] Error 255
```

Example: [run 34232513034, job 102082192339](https://github.com/tvheadend/tvheadend/actions/runs/34232513034/job/102082192339) — 1 failure, 62 successes.

### Cause

That is `EOVERFLOW` out of a 32-bit stat. The armv7 jobs run under QEMU on an amd64 host with the workspace bind-mounted from it, and resolute's armhf coreutils cannot represent the inode numbers the host filesystem hands back when it walks a directory.

Nothing in the tree is involved. The same `dh_installdocs` invocation, on the same runner, under the same emulator and the same mount, succeeds for every other armv7 target in the matrix — noble included. Only the container release differs. Naming files works throughout (the two `cp` calls that populate that directory both succeed); it is the *traversal* that overflows, which is also why the `find ... -name .git` a few lines earlier is written to swallow its own failure.

### Fix

There is nothing here to fix in tvheadend, and nothing to wait for either — the ceiling is Ubuntu's armhf toolchain under emulation. So the newest armv7 target is pinned at 24.04 and the rolling tag is dropped.

This repairs drift rather than making a new call: 97f80b835 already dropped `ubuntu_latest` from `build-ci.yml`'s armv7 list when resolute was added, and `build-cloudsmith.yml` kept it. The two armv7 matrices now match again.

### No coverage is lost that we had

The job has never produced a deb for resolute armhf — it fails before `dh_builddeb`, so what this removes is a red X and 50 minutes of emulated build, not a published package. Rolling-release coverage stays with the aarch64 `ubuntu_latest` job, which builds natively on an arm64 runner and passes.

`Autobuild/resolute-armv7l.sh` and `cloudsmith.sh`'s `resolute` case are left in place, so restoring the target is a one-word change once the toolchain can carry it.
