### PR TITLE
webui: let the Vue config forms follow a live view-level change

### DIFF
--- a/src/webui/static-vue/src/components/IdnodeConfigForm.vue
+++ b/src/webui/static-vue/src/components/IdnodeConfigForm.vue
@@ -259,33 +259,38 @@ const access = useAccessStore()
 
 /* ---- View-level override (per-view, session-scoped) ---- */
 
-/* Local view level — defaults to the user's effective
+/* Local view level — follows the user's effective
  * `access.uilevel`, but the LevelMenu in the toolbar lets the
  * user widen / narrow it for this page only without touching the
- * global preference. Mirrors the IdnodeEditor drawer's per-session
- * level picker. Honours `access.locked` (config.uilevel_nochange):
- * if the admin pinned the level, the menu's radio is disabled and
- * any active local override gets clamped down to the cap.
+ * global preference. Same three-tier resolution IdnodeGrid's
+ * `effectiveLevel` uses, so grids, drawers and config forms all
+ * answer "what level am I at?" the same way:
  *
- * When `props.lockLevel` is set the page commits to that level —
- * `currentLevel` is initialised to it and a watcher keeps it
- * pinned across access-store mutations. The LevelMenu is `v-if`'d
- * out in the template. */
-const currentLevel = ref<UiLevel>(props.lockLevel ?? access.uilevel)
+ *   1. `props.lockLevel` — the page committed to one level and
+ *      hid the chooser (`v-if`'d out in the template).
+ *   2. `access.locked` (config.uilevel_nochange) — the admin
+ *      pinned the level; the menu's radio is disabled and a local
+ *      override is ignored.
+ *   3. the local override, else the store's level.
+ *
+ * The store is read through on every access rather than
+ * snapshotted, because the level can move under a mounted form:
+ * saving Default View Level re-pulls `access/whoami` instead of
+ * reloading the page (ConfigGeneralBaseView's
+ * ACCESS_REFETCH_FIELDS). */
+const levelOverride = ref<UiLevel | null>(null)
 
-watch([() => access.locked, () => access.uilevel], ([locked, cap]) => {
-  if (props.lockLevel) return
-  if (locked && currentLevel.value !== cap) {
-    currentLevel.value = cap
-  }
+const currentLevel = computed<UiLevel>({
+  get() {
+    if (props.lockLevel) return props.lockLevel
+    if (access.locked) return access.uilevel
+    return levelOverride.value ?? access.uilevel
+  },
+  set(v) {
+    if (props.lockLevel || access.locked) return
+    levelOverride.value = v
+  },
 })
-
-watch(
-  () => props.lockLevel,
-  (lock) => {
-    if (lock) currentLevel.value = lock
-  }
-)
 
 /* ---- Load ---- */
 
@@ -810,9 +815,12 @@ defineExpose({ save, reload: load, loading, saving, currentValues })
  * doesn't change the persisted preference because we never
  * called the LevelMenu's pick.
  *
- * `currentLevel` is the local override ref established earlier in
- * setup; assigning to it triggers `displayedGroups` to recompute
- * and the row to appear (or stay) in the DOM before we scroll.
+ * `currentLevel` is the writable computed established earlier in
+ * setup; assigning to it records a local override and triggers
+ * `displayedGroups` to recompute, so the row is in the DOM before
+ * we scroll. The write is a no-op when the admin pinned the level
+ * (`access.locked`), which is the same answer the LevelMenu's
+ * disabled radio gives.
  *
  * `targetedField` drives the `.ifld-row--targeted` class binding
  * in the template; the keyframe pulse on that class is the visual

--- a/src/webui/static-vue/src/components/__tests__/IdnodeConfigForm.test.ts
+++ b/src/webui/static-vue/src/components/__tests__/IdnodeConfigForm.test.ts
@@ -253,6 +253,78 @@ describe('IdnodeConfigForm — lockLevel', () => {
   })
 })
 
+/*
+ * The store's level can move under a form that is already mounted:
+ * ConfigGeneralBaseView lists `uilevel` in ACCESS_REFETCH_FIELDS, so
+ * saving Default View Level re-pulls `access/whoami` rather than
+ * reloading the page. A form that reads the level once at setup
+ * never sees that, so these cases drive the store after mount.
+ */
+describe('IdnodeConfigForm — access.uilevel reactivity', () => {
+  it('reveals expert fields when access.uilevel rises after mount', async () => {
+    const access = useAccessStore()
+    access.data = { admin: true, dvr: true, uilevel: 'basic' }
+
+    const wrapper = await mountWithParams(MIXED_PARAMS)
+    expect(wrapper.html()).not.toContain('Expert')
+
+    access.data = { admin: true, dvr: true, uilevel: 'expert' }
+    await flushPromises()
+
+    expect(wrapper.html()).toContain('Expert')
+  })
+
+  it('hides expert fields again when access.uilevel drops after mount', async () => {
+    const access = useAccessStore()
+    access.data = { admin: true, dvr: true, uilevel: 'expert' }
+
+    const wrapper = await mountWithParams(MIXED_PARAMS)
+    expect(wrapper.html()).toContain('Expert')
+
+    access.data = { admin: true, dvr: true, uilevel: 'basic' }
+    await flushPromises()
+
+    expect(wrapper.html()).not.toContain('Expert')
+  })
+
+  it('keeps a user-picked level across an access.uilevel change', async () => {
+    /* The LevelMenu pick is a per-page override and outranks the
+     * store — otherwise a stray accessUpdate would yank the page
+     * back under the user mid-edit. */
+    const access = useAccessStore()
+    access.data = { admin: true, dvr: true, uilevel: 'basic' }
+
+    const wrapper = await mountWithParams(MIXED_PARAMS)
+    wrapper.findComponent({ name: 'LevelMenu' }).vm.$emit('set-level', 'expert')
+    await flushPromises()
+    expect(wrapper.html()).toContain('Expert')
+
+    access.data = { admin: true, dvr: true, uilevel: 'advanced' }
+    await flushPromises()
+
+    expect(wrapper.html()).toContain('Expert')
+  })
+
+  it('ignores a local override while the admin has pinned the level', async () => {
+    /* config.uilevel_nochange — the LevelMenu's radio renders
+     * disabled, and a pick that slips through must not widen the
+     * page past the server-set cap. */
+    const access = useAccessStore()
+    access.data = {
+      admin: true,
+      dvr: true,
+      uilevel: 'basic',
+      uilevel_nochange: 1,
+    }
+
+    const wrapper = await mountWithParams(MIXED_PARAMS)
+    wrapper.findComponent({ name: 'LevelMenu' }).vm.$emit('set-level', 'expert')
+    await flushPromises()
+
+    expect(wrapper.html()).not.toContain('Expert')
+  })
+})
+
 describe('IdnodeConfigForm — mandatoryFields', () => {
   /* IdnodeConfigForm synthesises `prop.mandatory: true` on the
    * listed field ids inside effectiveProp. IdnodeFieldEnum reads


### PR DESCRIPTION
Partially addresses #2244.

Saving **Default View Level** no longer reloads the page — `uilevel` is in `ConfigGeneralBaseView`'s `ACCESS_REFETCH_FIELDS`, so the save re-pulls `api/access/whoami` and the reactive consumers of the access store are expected to catch up on their own.

`IdnodeGrid` does: `effectiveLevel` is a computed over `access.uilevel`, and the `IdnodeEditor` drawer inherits it through `useEditorMode()`'s `editorLevel`.

`IdnodeConfigForm` did not. It seeded a plain `ref` from `access.uilevel` at setup, and its only watcher acted when `config.uilevel_nochange` moved — so an unlocked level change never reached it. The form stayed frozen at whatever level was in force when it mounted: the General → Base page you just changed the setting on, plus every config form already on screen for the rest of the session (the right-hand panes of Stream Profiles, DVR Profiles, Codec Profiles and CAs, which bind `:uuid` and are never re-keyed per selection, and the Service Mapper dialog). Only a browser reload cleared it.

The level is now resolved on every read, through the same three tiers `IdnodeGrid` uses: the page's `lockLevel` pin → the admin's `uilevel_nochange` cap → the LevelMenu override → the store. Both watchers drop out.

### Testing

- Four new cases in `IdnodeConfigForm.test.ts`: the store level rising, falling, losing to a user-picked override, and outranking one while the admin has pinned the level. Three fail without the change.
- Full Vue suite unchanged against `master` (the same 16 files / 159 cases fail before and after in my environment — timer-hook timeouts, unrelated).
- `vue-tsc --noEmit`, `eslint` and `stylelint` clean on the touched files.

### Not covered here

Server side checks out — with `config.uilevel = 2`, both `api/access/whoami` and the comet `accessUpdate` return `"uilevel":"expert"`, under `--noacl` and for an ACL user over digest auth.

#2244 reports "any modal for specific settings shows with Basic". The `IdnodeEditor` drawer takes its level from the grid and does honour the setting on a fresh desktop load, so this change may not be the whole story; I've asked the reporter for the specific page and viewport. One other candidate, left alone for now because it may well be deliberate: `IdnodeGrid.effectiveLevel` clamps to `basic` below 768px and the drawer inherits that clamp, so on a narrow viewport every editor opens at Basic regardless of the configured level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
