### PR TITLE
capmt: read the OSCam revision out of the version token only

### DIFF
--- a/src/descrambler/capmt.c
+++ b/src/descrambler/capmt.c
@@ -1351,6 +1351,62 @@ capmt_peek_str(sbuf_t *sb, int *offset)
   return str;
 }
 
+/*
+ * Extract the OSCam SVN revision from a DVBAPI_SERVER_INFO string.
+ * Returns 0 when no revision can be read.
+ *
+ * Two formats are in the wild:
+ *
+ *   "OSCam v1.30, build r11772@631abab8"          pre-r11773
+ *                       rev^
+ *
+ *   "OSCam 2.26.07-11966 (x86_64-linux-gnu); ..."  r11773+
+ *           p^    rev^    ^end
+ *
+ * In the second the revision closes the version token, which runs
+ * from the first space to the next. The build target after it
+ * carries hyphens of its own ("x86_64-linux-gnu",
+ * "mips-linux-uclibc-libusb"), so the scan has to stop at `end`
+ * rather than walk the rest of the string.
+ *
+ * The product name is not checked, so OSCam forks that keep the
+ * layout parse too. A server that puts something else entirely in
+ * that position yields either 0 or a small number, and only a
+ * revision at or above the r11396 feature gate changes what we send.
+ */
+static int
+capmt_oscam_revision(const char *info)
+{
+  const char *rev, *p, *end;
+
+  /* Legacy: the revision follows "build r", wherever that sits. */
+  if ((rev = strstr(info, "build r")) != NULL)
+    return strtol(rev + 7, NULL, 10);
+
+  /* Step over the product name to the version token. */
+  if ((p = strchr(info, ' ')) == NULL)
+    return 0;
+  p++;
+
+  /* Stop at the build target, which is hyphen-rich. */
+  if ((end = strchr(p, ' ')) == NULL)
+    end = p + strlen(p);
+
+  /* Revision is whatever follows the token's last hyphen. */
+  for (rev = NULL; p < end; p++)
+    if (*p == '-')
+      rev = p + 1;
+  if (rev == NULL || rev == end)
+    return 0;
+
+  /* Digits only: "v1.20-unstable_svn" has no revision to report. */
+  for (p = rev; p < end; p++)
+    if (!isdigit((unsigned char)*p))
+      return 0;
+
+  return strtol(rev, NULL, 10);
+}
+
 static void
 capmt_analyze_cmd(capmt_t *capmt, uint32_t cmd, int adapter, sbuf_t *sb, int offset)
 {
@@ -1511,19 +1567,10 @@ capmt_analyze_cmd(capmt_t *capmt, uint32_t cmd, int adapter, sbuf_t *sb, int off
     uint16_t protover = sbuf_peek_u16(sb, offset);
     int offset2       = offset + 2;
     char *info        = capmt_peek_str(sb, &offset2);
-    char *rev         = strstr(info, "build r");
 
-    tvhinfo(LS_CAPMT, "%s: Connected to server '%s' (protocol version %d)", capmt_name(capmt), info, protover);
-    if (rev) {
-      /* Old format: "OSCam v1.30, build r11772@631abab8" */
-      capmt->capmt_oscam_rev = strtol(rev + 7, NULL, 10);
-    } else if (strncmp(info, "OSCam ", 6) == 0) {
-      /* New format: "OSCam 2.25.11-11905" - revision after last hyphen */
-      char *last_hyphen = strrchr(info, '-');
-      if (last_hyphen && isdigit(last_hyphen[1])) {
-        capmt->capmt_oscam_rev = strtol(last_hyphen + 1, NULL, 10);
-      }
-    }
+    capmt->capmt_oscam_rev = capmt_oscam_revision(info);
+    tvhinfo(LS_CAPMT, "%s: Connected to server '%s' (protocol version %d, revision %d)",
+            capmt_name(capmt), info, protover, capmt->capmt_oscam_rev);
 
     free(info);
 


### PR DESCRIPTION
Fixes #1942, which #2017 was meant to close but did not.

## Why #2017 doesn't work

Since r11773 OSCam reports itself as `OSCam <version>-<rev> (<target>); <capabilities>`. #2017 looks for the revision with `strrchr(info, '-')` over the whole string, but the build target carries hyphens of its own, so the last hyphen never belongs to the version:

| server info (verbatim from the issue) | last `-` lands on | `capmt_oscam_rev` |
|---|---|---|
| `OSCam 2.26.07-11966 (x86_64-linux-gnu); ` | `-gnu); ` | **0** |
| `OSCam 2.25.11-11905 (mips-linux-uclibc-libusb); ` | `-libusb); ` | **0** |

`isdigit()` rejects both and the revision stays 0, exactly as before the PR. It only parses when the target happens to contain no hyphen, which is not a shape anyone has reported.

## Why that breaks descrambling

A zero revision fails the `rev >= 11396` test in `capmt_send_request()`, so the `CAPMT_DESC_DEMUX` tag carrying the adapter number is left out of the PMT. OSCam has to guess the demux, and two services whose elementary PIDs coincide — RTL HD on 10832.25H and SAT.1 HD on 11464.25H, both video 255 / audio 259 / teletext 32 — both land on index 0. Whichever is subscribed second never gets a `CA_SET_PID` or `CA_SET_DESCR` for its own adapter and cannot be decoded. Reverse the start order and the other one breaks. @jacotec's traces show `adapter 1` commands appearing only once OSCam is patched to re-emit the legacy `build r` token.

## The change

Scan for the revision inside the version token only, ending at the first space so the target is never reached, and require the tail after the last hyphen in that token to be digits. Both formats stay supported, and the legacy `build r` token still wins when present — which also covers servers patched to emit both.

Two smaller things ride along:

- the parsed value is now assigned unconditionally, so reconnecting to a server that reports no revision clears the previous server's value instead of leaving it in place;
- the connect line logs the parsed revision. That is the fact you need when descrambling misbehaves, and the one thing the old log did not show.

## Testing

The parse function, extracted verbatim from the patched tree, against the exact strings from the issue:

```
ok   11966   OSCam 2.26.07-11966 (x86_64-linux-gnu);
ok   11905   OSCam 2.25.11-11905 (mips-linux-uclibc-libusb);
ok   11773   OSCam 2.24.04-11773 (x86_64-linux-gnu);
ok   11772   OSCam v1.30, build r11772@631abab8
ok   11396   OSCam v1.20-unstable_svn, build r11396
ok   11966   OSCam 2.26.07-11966 (x86_64-linux-gnu); ; build r11966
ok   11905   OSCam 2.25.11-11905 (unknown);
ok   11905   OSCam 2.25.11-11905
ok   0       gbox
ok   0       OSCam
ok   0       OSCam 2.25.11 (x86_64-linux-gnu);
ok   0       OSCam -x (a-b);
ok   0       <unknown>
```

The first three return 0 on current master. `capmt.c` compiles clean with `ENABLE_CAPMT=1` under the project's own flags (`-Werror -Wall -Wmissing-prototypes`).

And on the wire, driving a real CAPMT session (`--enable-capmt`) against a fake DVBAPI server that serves a different `DVBAPI_SERVER_INFO` per reconnect:

```
Connected to server 'OSCam 2.26.07-11966 (x86_64-linux-gnu); ' (protocol version 3, revision 11966)
Connected to server 'OSCam 2.25.11-11905 (mips-linux-uclibc-libusb); ' (protocol version 3, revision 11905)
Connected to server 'OSCam v1.30, build r11772@631abab8' (protocol version 3, revision 11772)
Connected to server 'NCam 1.20.11-11905 (x86_64-linux-gnu); ' (protocol version 3, revision 11905)
Connected to server 'OSCam 2.25.11 (x86_64-linux-gnu); ' (protocol version 3, revision 0)
Connected to server 'gbox' (protocol version 3, revision 0)
```

The first two are @jacotec's and @p4r4s0n1c's exact strings (info length 0x28, matching the trace in the issue). The last two also show the unconditional assignment doing its job: coming off a server that reported 11905, a server that reports nothing now reads 0 instead of inheriting the previous value.

No card here, so the descrambling itself is still unproven end to end — @jacotec and @p4r4s0n1c can drop their local OSCam-side and capmt.c workarounds and confirm on real hardware.

## Not done

Defaulting to a modern revision when the server reports none (the original suggestion in the issue) would change behaviour for genuinely pre-r11396 OSCam and for non-OSCam CAPMT servers. Anyone on a server this can't parse already has a manual override: **PMT Mode → "Universal tag order"** forces the demux tag on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

