### PR TITLE
mpegts: arm the scan timeout where the mux becomes active

### DIFF
--- a/src/input/mpegts.h
+++ b/src/input/mpegts.h
@@ -973,6 +973,7 @@ th_subscription_t *mpegts_mux_find_subscription_by_name(mpegts_mux_t *mm, const 
 void mpegts_mux_unsubscribe_linked(mpegts_input_t *mi, service_t *t);
 
 void mpegts_mux_scan_done ( mpegts_mux_t *mm, const char *buf, int res );
+void mpegts_mux_scan_timeout_arm ( mpegts_mux_t *mm, mpegts_input_t *mi );
 
 void mpegts_mux_bouquet_rescan ( const char *src, const char *extra );
 

--- a/src/input/mpegts/mpegts_mux.c
+++ b/src/input/mpegts/mpegts_mux.c
@@ -88,7 +88,18 @@ mpegts_mux_instance_create0
   return mmi;
 }
 
-static void
+/*
+ * Arm the scan timeout. Nothing else can take a mux out of
+ * MM_SCAN_STATE_ACTIVE on its own: mpegts_mux_scan_done() is reached
+ * either from here or from mpegts_table_fastswitch() once every
+ * MT_QUICKREQ table is complete, and the latter needs the mux to keep
+ * delivering data. Every transition into the active scan queue must
+ * therefore arm this, or the mux stays active for good.
+ *
+ * `mi` may be NULL - mpegts_input_grace() then falls back to its
+ * lower bound.
+ */
+void
 mpegts_mux_scan_timeout_arm ( mpegts_mux_t *mm, mpegts_input_t *mi )
 {
   mtimer_arm_rel(&mm->mm_scan_timeout, mpegts_mux_scan_timeout, mm,
@@ -1356,8 +1367,7 @@ mpegts_mux_set_tsid ( mpegts_mux_t *mm, uint32_t tsid, int force )
   mm->mm_tsid = tsid;
   tvhtrace(LS_MPEGTS, "%s - set tsid %04X (%d)", mm->mm_nicename, tsid, tsid);
   idnode_changed(&mm->mm_id);
-  if (mpegts_network_scan_mux_reactivate(mm))
-    mpegts_mux_scan_timeout_arm(mm, mm->mm_active->mmi_input);
+  mpegts_network_scan_mux_reactivate(mm);
   return 1;
 }
 

--- a/src/input/mpegts/mpegts_network_scan.c
+++ b/src/input/mpegts/mpegts_network_scan.c
@@ -313,26 +313,33 @@ mpegts_network_scan_mux_active ( mpegts_mux_t *mm )
   TAILQ_INSERT_TAIL(&mn->mn_scan_active, mm, mm_scan_link);
 }
 
-/* Mux has been reactivated */
-int
+/*
+ * Mux has been reactivated - its TSID changed, so re-run the scan to pick
+ * up the new identity.
+ *
+ * Only a tuned mux may go to the active queue, and it must leave here with
+ * a scan timeout armed. An entry in mn_scan_active is not visited by
+ * mpegts_network_scan_timer_cb(), so nothing tunes it again, and the only
+ * two routes to mpegts_mux_scan_done() - the timeout, and
+ * mpegts_table_fastswitch() on a mux that is delivering data - are both
+ * closed for a mux that is neither tuned nor on a timer. Such a mux never
+ * returns to the idle state and blocks the network scan for good.
+ */
+void
 mpegts_network_scan_mux_reactivate ( mpegts_mux_t *mm )
 {
   mpegts_network_t *mn = mm->mm_network;
   if (mm->mm_scan_state == MM_SCAN_STATE_ACTIVE)
-    return 0;
-  /* Only a tuned mux may be moved to the active queue. Otherwise, the mux
-   * is orphaned - it is taken out of the scan queues, but nothing is able
-   * to finish the scan for it, so it never returns to the idle state.
-   */
+    return;
   if (mm->mm_active == NULL) {
     tvhtrace(LS_MPEGTS, "%s - scan not reactivated, mux is not tuned", mm->mm_nicename);
-    return 0;
+    return;
   }
   mpegts_network_scan_queue_del0(mm);
   mm->mm_scan_init  = 0;
   mm->mm_scan_state = MM_SCAN_STATE_ACTIVE;
   TAILQ_INSERT_TAIL(&mn->mn_scan_active, mm, mm_scan_link);
-  return 1;
+  mpegts_mux_scan_timeout_arm(mm, mm->mm_active->mmi_input);
 }
 
 /******************************************************************************

--- a/src/input/mpegts/mpegts_network_scan.h
+++ b/src/input/mpegts/mpegts_network_scan.h
@@ -45,7 +45,7 @@ void mpegts_network_scan_mux_done    ( mpegts_mux_t *mm );
 void mpegts_network_scan_mux_partial ( mpegts_mux_t *mm );
 void mpegts_network_scan_mux_cancel  ( mpegts_mux_t *mm, int reinsert );
 void mpegts_network_scan_mux_active  ( mpegts_mux_t *mm );
-int  mpegts_network_scan_mux_reactivate ( mpegts_mux_t *mm );
+void mpegts_network_scan_mux_reactivate ( mpegts_mux_t *mm );
 
 /*
  * Init / Teardown


### PR DESCRIPTION
Follow-up to #2233, addressing @Flole998's review comment there. Structural only — no behavioural change.

## The invariant

`mm_scan_state` and queue membership are kept in lockstep by `queue_del0()`. `mpegts_network_scan_timer_cb()` walks **only** `mn_scan_pend` and `mn_scan_ipend`, so nothing ever re-tunes an entry in `mn_scan_active`, and the only two routes out of ACTIVE are:

1. `mm_scan_timeout` → `mpegts_mux_scan_timeout()` → `mpegts_mux_scan_done()`
2. `mpegts_table_fastswitch()` → `mpegts_mux_scan_done()`, which needs the mux to be delivering data

So: **a mux put into `mn_scan_active` must be tuned, or on a timer, or it is stuck for good.**

## What's wrong with how #2233 left it

aee318393 made `mpegts_network_scan_mux_reactivate()` return whether it promoted the mux and left the arming to its caller in `mpegts_mux_set_tsid()`:

```c
if (mpegts_network_scan_mux_reactivate(mm))
  mpegts_mux_scan_timeout_arm(mm, mm->mm_active->mmi_input);
```

That splits one invariant across two files. A second caller that ignored the return value would reintroduce exactly the orphaned mux aee318393 set out to prevent, and nothing would flag it.

## The change

Arm the timeout inside `reactivate()`, next to the state change and queue insert it belongs to, and give the function its `void` return back. `mpegts_mux_scan_timeout_arm()` leaves static scope for that, carrying a comment that states the invariant so the next transition into the active queue has something to be measured against.

`mpegts_network_scan_mux_active()` deliberately keeps arming from its caller in `mpegts_mux_scan_active()` — there the transition and the arm are adjacent lines of one function, where the pairing is hard to miss.

## Equivalence

The same guard promotes the same muxes and arms the same timeout with the same grace period, computed from the same `mm_active->mmi_input`. Only the call site moves, and there is no code between it and the return it replaces. So the uk-Oxford DVB-T result in #2233 and @dave-p's DVB-S confirmation both still apply.

## On the Copilot review comment in #2233

It suggested folding `mm_active->mmi_input != NULL` into the guard. Not needed: `mpegts_input_grace()` is explicitly NULL-tolerant (`if (mi && mi->mi_get_grace)`) and falls back to its 5 s lower bound, and `mm_active` itself is already guaranteed non-NULL on that path. Documented on the helper rather than guarded twice.

## Testing

Builds clean. No tuner on this machine, so the scan itself is not re-tested here — the argument for this PR is the equivalence above rather than a fresh hardware run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
