### PR TITLE
tsfix: fix DTS normalisation across the 33 bit timestamp wrap

### DIFF
--- a/src/plumbing/tsfix.c
+++ b/src/plumbing/tsfix.c
@@ -99,6 +99,18 @@ tsfix_ts_diff(int64_t ts1, int64_t ts2)
 }
 
 /**
+ * Offset of a timestamp from the 33 bit reference clock, folded into
+ * [0, PTS_MASK]. The wrap of the result is compensated by the
+ * tfs_dts_epoch handling in normalize_ts().
+ */
+static int64_t
+tsfix_ts_offset(int64_t ref, int64_t ts)
+{
+  return (ts - ref) & PTS_MASK;
+}
+
+
+/**
  *
  */
 static void
@@ -238,12 +250,13 @@ normalize_ts(tsfix_t *tf, tfstream_t *tfs, th_pkt_t *pkt, int backlog)
 
   /* Subtract the transport wide start offset */
   if (tf->dts_offset_apply)
-    dts = pts_diff(ref, pkt->pkt_dts + tf->dts_offset);
+    dts = tsfix_ts_offset(ref, pkt->pkt_dts + tf->dts_offset);
   else
-    dts = pts_diff(ref, pkt->pkt_dts);
+    dts = tsfix_ts_offset(ref, pkt->pkt_dts);
 
   if (tfs->tfs_last_dts_norm == PTS_UNSET) {
-    if (dts < 0 || pkt->pkt_err) {
+    /* Timestamps before the reference clock fold to the top of the range */
+    if (dts > PTS_MASK / 2 || pkt->pkt_err) {
       /* Early packet with negative time stamp, drop those */
       tsfix_packet_drop(tfs, pkt, "negative/error");
       return;


### PR DESCRIPTION
`normalize_ts()` derives each packet's normalised DTS as an offset from a reference clock latched once when the subscription starts:

```c
dts = pts_diff(ref, pkt->pkt_dts);
```

`pts_diff()` returns `PTS_UNSET` (`INT64_MIN`) whenever `b < a`, unless its wrap heuristic `b < PTS_MASK/4 && a > PTS_MASK/2` fires — and that heuristic only recognises a 33 bit wrap when the *reference* sits in the top half of the range.

So once the input DTS wraps, which it must every 26.5 hours, any reference below `2^32` yields `PTS_UNSET`, and it is used unchecked as the normalised DTS. That is the value in the reported logs. It also poisons `tfs_last_dts_norm`, so every subsequent packet fails the negative timestamp test further down and is dropped for the remaining life of the subscription — which is why the stream stays dead until a retune.

The `tfs_dts_epoch` machinery in `normalize_ts()` already exists to compensate for exactly this wrap, but it expects the offset to step backwards by `2^33`. `pts_diff()` never produces that. The plain subtraction that preceded 433bcd2e5 did, so that commit left the epoch handling dead for this path.

## Change

Compute the offset modulo `2^33`. A sweep of ~2.9M `(ref, offset)` pairs confirms this returns **bit-identical values wherever `pts_diff()` returned anything at all**, and additionally hands the epoch code the backwards step it looks for. Since a timestamp preceding the reference now folds to the top of the range instead of going negative, the first-packet test becomes `dts > PTS_MASK / 2`.

`pts_diff()` itself is deliberately untouched. All eight other callers (`iptv.c`, `parsers/message.c`, `parsers/parsers.c`, `muxer_mkv.c`) compare timestamps that lie close together and every one checks the result against `PTS_UNSET` before use. `normalize_ts()` was the only caller using the result unchecked against a fixed reference across a full 26.5 hour span.

The `#5252` case that motivated 433bcd2e5 still works: a stream starting across the wrap gets continuous positive offsets, and packets preceding the reference are still dropped. The only first-packet decisions that differ require the reference clock itself to land within a fraction of a second of the wrap point, where dropping the pre-reference packet is the intended behaviour anyway.

## Verification

The arithmetic of `normalize_ts()` was replicated offline and swept across reference-clock values, simulating 40 hours of stream at 40ms packets:

```
reference clock       current pts_diff()   modular offset
           0             ok                     ok
  1000000000   broken after    23.43h           ok
  2200000000   broken after    19.72h           ok
  3597119165   broken after    15.41h           ok
  4294967296   broken after    19.88h           ok
  6000000000   broken after    14.62h           ok
  8000000000   broken after     8.45h           ok
  8589000000   broken after     6.63h           ok

trace for ref=3597119165:
  current: t= 15.41h DTS discontinuity. DTS = -9223372036854775808, last = 4992814800
  modular: t= 26.51h wrap detected, epoch -> 8589934592
```

The reported log line is `DTS = -9223372036854775808, last = 4992815426`; the simulated `last` differs only by the packet granularity used. @DeltaMikeCharlie's `last = 3461472442` is 10.7 hours, matching his "chase-played for the next 10+ hours".

Time to failure is `(2^33 - reference) / 90000`, i.e. **6.6 to 26.5 hours** depending on where the reference clock happens to land. That is why this reproduces reliably but never at a predictable time, and never in a short session.

Not actually timeshift-specific: `tsfix` sits upstream of timeshift in the pipeline, so timeshift is only what keeps a single subscription alive long enough. Long recordings are affected identically.

This is also a regression rather than a long-standing bug: 433bcd2e5 (2018-10-12) was cherry-picked to the 4.2 branch as 6590060c3 and shipped in v4.2.8; v4.2.7 and earlier are unaffected.

Builds clean. A live end-to-end confirmation needs 6.6+ hours of continuous streaming, so that has not been done — testers welcome.

Supersedes #1931, which was reverted in #2049. That approach patched the `PTS_UNSET` at the output and substituted `dts = 0`, which trades the stall for a corrupted timeline; this fixes the ambiguous input instead.

Fixes: #1876

🤖 Generated with [Claude Code](https://claude.com/claude-code)
