### PR TITLE
timeshift: record from the cache of a tuned channel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -485,7 +485,8 @@ SRCS-TIMESHIFT = \
 	src/timeshift/timeshift_filemgr.c \
 	src/timeshift/timeshift_writer.c \
 	src/timeshift/timeshift_reader.c \
-	src/timeshift/timeshift_svcbuf.c
+	src/timeshift/timeshift_svcbuf.c \
+	src/timeshift/timeshift_svcts.c
 SRCS-${CONFIG_TIMESHIFT} += $(SRCS-TIMESHIFT)
 I18N-C += $(SRCS-TIMESHIFT)
 

--- a/Makefile
+++ b/Makefile
@@ -484,7 +484,8 @@ SRCS-TIMESHIFT = \
 	src/timeshift.c \
 	src/timeshift/timeshift_filemgr.c \
 	src/timeshift/timeshift_writer.c \
-	src/timeshift/timeshift_reader.c
+	src/timeshift/timeshift_reader.c \
+	src/timeshift/timeshift_svcbuf.c
 SRCS-${CONFIG_TIMESHIFT} += $(SRCS-TIMESHIFT)
 I18N-C += $(SRCS-TIMESHIFT)
 

--- a/docs/class/timeshift.md
+++ b/docs/class/timeshift.md
@@ -21,9 +21,13 @@ the moment it was requested. It works with every stream profile.
 
 The cache holds the channel's stream as received, in the *Storage path*
 (or in RAM with *RAM only*, bounded by *Maximum RAM size*), and is removed
-once nothing watches or records the channel any more. It is separate from
-a client's own timeshift buffer, so a Kodi client pausing live TV keeps
-using its own as before.
+once nothing watches or records the channel any more.
+
+HTSP clients (Kodi) pausing, rewinding or skipping through live TV then use
+that same cache instead of writing a buffer of their own: one cache per
+channel, however many clients and recordings share it. A client paused
+for longer than the cache holds goes on, when it resumes, from a little
+after the oldest data still there.
 
 ---
 

--- a/docs/class/timeshift.md
+++ b/docs/class/timeshift.md
@@ -10,6 +10,23 @@ This tab is used to configure timeshift properties.
 
 ---
 
+## Recording from cache
+
+With *Record from cache* enabled, every tuned channel keeps its own
+cache of the last *Maximum period*, from the moment it was tuned. A
+recording started after its programme began -- pressing record on what is
+playing, typically -- then begins at the programme's start (less the
+pre-recording padding), or as far back as the cache reaches, instead of
+the moment it was requested. It works with every stream profile.
+
+The cache holds the channel's stream as received, in the *Storage path*
+(or in RAM with *RAM only*, bounded by *Maximum RAM size*), and is removed
+once nothing watches or records the channel any more. It is separate from
+a client's own timeshift buffer, so a Kodi client pausing live TV keeps
+using its own as before.
+
+---
+
 ## Buttons
 
 <tvh_include>inc/buttons</tvh_include>

--- a/src/dvr/dvr_rec.c
+++ b/src/dvr/dvr_rec.c
@@ -177,6 +177,13 @@ dvr_rec_subscribe(dvr_entry_t *de)
     goto _return;
   }
 
+  /* Started after the programme began (Kodi's record button, typically):
+   * take what the channel's cache still holds, if it is cached -- for
+   * the first file only, a restarted recording already has that part.
+   * The subscription links later, from the reschedule timer. */
+  if (de->de_files == NULL && dvr_entry_get_start_time(de, 0) + 2 < gclk())
+    de->de_s->ths_backfill_from = dvr_entry_get_start_time(de, 0);
+
   de->de_chain = prch;
 
   atomic_set(&de->de_thread_shutdown, 0);
@@ -1370,6 +1377,7 @@ dvr_rec_start(dvr_entry_t *de, const streaming_start_t *ss)
   htsmsg_field_t *f;
   muxer_t *muxer;
   struct stat st;
+  time_t start;
   int i;
 
   if (!cfg) {
@@ -1526,11 +1534,19 @@ dvr_rec_start(dvr_entry_t *de, const streaming_start_t *ss)
 
   streaming_start_unref(ss_copy);
 
-  /* update the info field for a filename */
+  /* update the info field for a filename; backfilled from the channel
+   * cache, the file starts with what the cache held (once: a later file
+   * of the same recording starts when it does) */
   if ((f = htsmsg_field_last(de->de_files)) != NULL &&
       (e = htsmsg_field_get_map(f)) != NULL) {
     htsmsg_set_msg(e, "info", info);
-    htsmsg_set_s64(e, "start", gclk());
+    start = gclk();
+    if (de->de_s && de->de_s->ths_backfill_start &&
+        de->de_s->ths_backfill_start < start)
+      start = de->de_s->ths_backfill_start;
+    if (de->de_s)
+      de->de_s->ths_backfill_start = 0;
+    htsmsg_set_s64(e, "start", start);
   } else {
     htsmsg_destroy(info);
   }

--- a/src/parsers/message.c
+++ b/src/parsers/message.c
@@ -370,20 +370,38 @@ parser_output(streaming_target_t *pad)
 /**
  * Parser create
  */
-streaming_target_t *
-parser_create(streaming_target_t *output, th_subscription_t *ts)
+static parser_t *
+parser_create0(streaming_target_t *output, service_t *t)
 {
   parser_t *prs = calloc(1, sizeof(parser_t));
-  service_t *t = ts->ths_service;
 
   prs->prs_output = output;
-  prs->prs_subscription = ts;
   prs->prs_service = t;
   TAILQ_INIT(&prs->prs_rstlog);
   elementary_set_init(&prs->prs_components, LS_PARSER, service_nicename(t), t);
   streaming_target_init(&prs->prs_input, &parser_input_ops, prs, 0);
-  return &prs->prs_input;
+  return prs;
+}
 
+streaming_target_t *
+parser_create(streaming_target_t *output, th_subscription_t *ts)
+{
+  parser_t *prs = parser_create0(output, ts->ths_service);
+  prs->prs_subscription = ts;
+  return &prs->prs_input;
+}
+
+/**
+ * Parser for data replayed from the channel cache outside any
+ * subscription (a client timeshifting through it): like replayed data
+ * reaching a subscription, it must not reconfigure the running service
+ */
+streaming_target_t *
+parser_create_replay(streaming_target_t *output, service_t *t)
+{
+  parser_t *prs = parser_create0(output, t);
+  prs->prs_replay = 1;
+  return &prs->prs_input;
 }
 
 /*

--- a/src/parsers/parsers.c
+++ b/src/parsers/parsers.c
@@ -27,6 +27,7 @@
 #include "packet.h"
 #include "streaming.h"
 #include "config.h"
+#include "subscriptions.h"
 
 /* parser states */
 #define PARSER_APPEND 0
@@ -104,6 +105,30 @@ parser_rstlog(parser_t *t, th_pkt_t *pkt)
   streaming_message_t *clone = streaming_msg_clone(sm);
   streaming_msg_free(sm);
   TAILQ_INSERT_TAIL (&t->prs_rstlog, clone, sm_link);
+}
+
+/**
+ * Report new stream parameters to the service.  Data replayed from the
+ * channel cache is older than what the service carries now: it may fill
+ * in parameters the service does not know yet -- start messages need them
+ * -- but must not change known ones and restart the streams under every
+ * subscriber.
+ */
+static void
+parser_update_service(parser_es_t *st)
+{
+  const th_subscription_t *s = st->es_parser->prs_subscription;
+  const elementary_stream_t *es;
+
+  if (s && s->ths_replaying) {
+    es = elementary_stream_find(&st->es_service->s_components, st->es_pid);
+    if (es == NULL)
+      return;
+    if (SCT_ISVIDEO(es->es_type) ? es->es_width && es->es_height
+                                 : es->es_sri != 0)
+      return;
+  }
+  service_update_elementary_stream(st->es_service, (elementary_stream_t *)st);
 }
 
 /**
@@ -823,7 +848,7 @@ ok:
         tvhtrace(LS_PARSER, "mpeg audio version change %02d: val=%d (old=%d)",
                  st->es_index, layer, st->es_audio_version);
         st->es_audio_version = layer;
-        service_update_elementary_stream(st->es_service, (elementary_stream_t *)st);
+        parser_update_service(st);
       }
       makeapkt(t, st, buf + i, fsize, dts, duration,
                channels, mpa_sri[(buf[i+2] >> 2) & 3]);
@@ -1127,7 +1152,7 @@ parser_set_stream_vparam(parser_es_t *st, int width, int height,
     st->es_width = width;
     st->es_height = height;
     st->es_frame_duration = duration;
-    service_update_elementary_stream(st->es_service, (elementary_stream_t *)st);
+    parser_update_service(st);
   }
 }
 

--- a/src/parsers/parsers.c
+++ b/src/parsers/parsers.c
@@ -120,7 +120,7 @@ parser_update_service(parser_es_t *st)
   const th_subscription_t *s = st->es_parser->prs_subscription;
   const elementary_stream_t *es;
 
-  if (s && s->ths_replaying) {
+  if (st->es_parser->prs_replay || (s && s->ths_replaying)) {
     es = elementary_stream_find(&st->es_service->s_components, st->es_pid);
     if (es == NULL)
       return;
@@ -171,8 +171,9 @@ deliver:
     pkt->v.pkt_aspect_den = st->es_aspect_den;
   }
 
-  /* Forward packet */
-  if(atomic_get(&st->es_service->s_pending_restart) == 1) {
+  /* Forward packet -- a replay parser gets no restart start message to
+   * flush the restart log, so it never queues there */
+  if(!t->prs_replay && atomic_get(&st->es_service->s_pending_restart) == 1) {
     /* Queue pkt to prs_rstlog if pending restart */
     pkt_trace(LS_PARSER, pkt, "deliver to rstlog");
     parser_rstlog(t, pkt);

--- a/src/parsers/parsers.h
+++ b/src/parsers/parsers.h
@@ -82,6 +82,8 @@ struct parser {
 
   service_t *prs_service;
 
+  int prs_replay;   ///< Fed from the channel cache, outside any subscription
+
   /* Elementary streams */
   elementary_set_t prs_components;
 
@@ -124,6 +126,8 @@ getpts(const uint8_t *p)
 }
 
 streaming_target_t * parser_create(streaming_target_t *output, struct th_subscription *ts);
+
+streaming_target_t * parser_create_replay(streaming_target_t *output, service_t *t);
 
 void parser_destroy(streaming_target_t *pad);
 

--- a/src/profile.c
+++ b/src/profile.c
@@ -30,6 +30,7 @@
 #endif
 #if ENABLE_TIMESHIFT
 #include "timeshift.h"
+#include "timeshift/timeshift_svcts.h"
 #include "input/mpegts/iptv/iptv_private.h"
 #endif
 #include "dvr/dvr.h"
@@ -1162,6 +1163,10 @@ profile_chain_close(profile_chain_t *prch)
     timeshift_destroy(prch->prch_timeshift);
     prch->prch_timeshift = NULL;
   }
+  if (prch->prch_svcts) {
+    svcts_destroy(prch->prch_svcts);
+    prch->prch_svcts = NULL;
+  }
 #endif
   if (prch->prch_gh) {
     globalheaders_destroy(prch->prch_gh);
@@ -1226,7 +1231,10 @@ profile_htsp_work(profile_chain_t *prch,
   prch->prch_share = prsh->prsh_tsfix;
 
 #if ENABLE_TIMESHIFT
-  if (timeshift_period > 0)
+  /* one cache per channel: timeshift through it when there is one */
+  if (timeshift_period > 0 && svcts_enabled())
+    dst = prch->prch_svcts = svcts_create(dst, timeshift_period);
+  else if (timeshift_period > 0)
     dst = prch->prch_timeshift = timeshift_create(dst, timeshift_period);
 #endif
 

--- a/src/profile.h
+++ b/src/profile.h
@@ -96,6 +96,7 @@ typedef struct profile_chain {
   struct streaming_target  *prch_tsfix;
 #if ENABLE_TIMESHIFT
   struct streaming_target  *prch_timeshift;
+  struct streaming_target  *prch_svcts;   ///< Timeshift through the channel cache
 #endif
   struct streaming_target   prch_input;
   struct streaming_target  *prch_share;

--- a/src/service.c
+++ b/src/service.c
@@ -35,6 +35,9 @@
 #include "bouquet.h"
 #include "memoryinfo.h"
 #include "config.h"
+#if ENABLE_TIMESHIFT
+#include "timeshift/timeshift_svcbuf.h"
+#endif
 
 static void service_data_timeout(void *aux);
 static void service_class_delete(struct idnode *self);
@@ -255,6 +258,10 @@ const idclass_t service_raw_class = {
 void
 service_stop(service_t *t)
 {
+#if ENABLE_TIMESHIFT
+  svcbuf_t *sb;
+#endif
+
   mtimer_disarm(&t->s_receive_timer);
 
   t->s_stop_feed(t);
@@ -270,10 +277,18 @@ service_stop(service_t *t)
    */
   elementary_set_clean_streams(&t->s_components);
 
+#if ENABLE_TIMESHIFT
+  sb = svcbuf_service_stop(t);
+#endif
+
   t->s_status = SERVICE_IDLE;
   tvhlog_limit_reset(&t->s_tei_log);
 
   tvh_mutex_unlock(&t->s_stream_mutex);
+
+#if ENABLE_TIMESHIFT
+  svcbuf_release(sb);
+#endif
 }
 
 
@@ -342,6 +357,10 @@ service_start(service_t *t, int instance, int weight, int flags,
    * Initialize stream
    */
   elementary_set_init_filter_streams(&t->s_components);
+
+#if ENABLE_TIMESHIFT
+  svcbuf_service_start(t);
+#endif
 
   tvh_mutex_unlock(&t->s_stream_mutex);
 

--- a/src/service.h
+++ b/src/service.h
@@ -378,6 +378,11 @@ typedef struct service {
    */
   streaming_pad_t s_streaming_pad;
 
+  /**
+   * Channel cache of the running service (timeshift/timeshift_svcbuf.c)
+   */
+  struct svcbuf *s_svcbuf;
+
   tvhlog_limit_t s_tei_log;
 
   /*

--- a/src/subscriptions.c
+++ b/src/subscriptions.c
@@ -31,6 +31,7 @@
 #include "dbus.h"
 #if ENABLE_TIMESHIFT
 #include "timeshift/timeshift_svcbuf.h"
+#include "timeshift/timeshift_svcts.h"
 #endif
 
 struct th_subscription_list subscriptions;
@@ -106,6 +107,9 @@ subscription_link_service(th_subscription_t *s, service_t *t)
       s->ths_output = s->ths_gate = gate;
     s->ths_backfill_from = 0;
   }
+  /* a client timeshifting through the channel cache */
+  if (s->ths_prch && s->ths_prch->prch_svcts)
+    svcts_attach(s->ths_prch->prch_svcts, t);
 #endif
 
   if(elementary_set_has_streams(&t->s_components, 1) || t->s_type != STYPE_STD) {
@@ -165,6 +169,8 @@ subscription_unlink_service0(th_subscription_t *s, int reason, int resched)
 #if ENABLE_TIMESHIFT
   if (s->ths_gate)
     s->ths_output = svcbuf_gate_stop(s->ths_gate);
+  if (s->ths_prch && s->ths_prch->prch_svcts)
+    svcts_detach(s->ths_prch->prch_svcts);
 #endif
   if (s->ths_parser)
     s->ths_output = parser_output(s->ths_parser);

--- a/src/subscriptions.c
+++ b/src/subscriptions.c
@@ -29,6 +29,9 @@
 #include "input.h"
 #include "intlconv.h"
 #include "dbus.h"
+#if ENABLE_TIMESHIFT
+#include "timeshift/timeshift_svcbuf.h"
+#endif
 
 struct th_subscription_list subscriptions;
 struct th_subscription_list subscriptions_remove;
@@ -90,6 +93,21 @@ subscription_link_service(th_subscription_t *s, service_t *t)
 
   tvh_mutex_lock(&t->s_stream_mutex);
 
+#if ENABLE_TIMESHIFT
+  /* Joining late: start with what the channel cache still holds.  Only
+   * once -- after a reschedule the output already has that part. */
+  if (s->ths_backfill_from) {
+    streaming_target_t *gate =
+      svcbuf_gate_create(t, s->ths_backfill_from, s->ths_output,
+                         &s->ths_replaying, &s->ths_backfill_start,
+                         s->ths_prch && s->ths_prch->prch_sq_used ?
+                           &s->ths_prch->prch_sq : NULL);
+    if (gate)
+      s->ths_output = s->ths_gate = gate;
+    s->ths_backfill_from = 0;
+  }
+#endif
+
   if(elementary_set_has_streams(&t->s_components, 1) || t->s_type != STYPE_STD) {
     streaming_msg_free(s->ths_start_message);
     ss = service_build_streaming_start(t);
@@ -144,6 +162,10 @@ subscription_unlink_service0(th_subscription_t *s, int reason, int resched)
     t->s_running = 0;
   }
 
+#if ENABLE_TIMESHIFT
+  if (s->ths_gate)
+    s->ths_output = svcbuf_gate_stop(s->ths_gate);
+#endif
   if (s->ths_parser)
     s->ths_output = parser_output(s->ths_parser);
 
@@ -151,6 +173,12 @@ subscription_unlink_service0(th_subscription_t *s, int reason, int resched)
 
   LIST_REMOVE(s, ths_service_link);
 
+#if ENABLE_TIMESHIFT
+  if (s->ths_gate) {
+    svcbuf_gate_destroy(s->ths_gate);
+    s->ths_gate = NULL;
+  }
+#endif
   if (s->ths_parser) {
     parser_destroy(s->ths_parser);
     s->ths_parser = NULL;

--- a/src/subscriptions.h
+++ b/src/subscriptions.h
@@ -110,6 +110,10 @@ typedef struct th_subscription {
 
   streaming_target_t *ths_output;
   streaming_target_t *ths_parser;
+  streaming_target_t *ths_gate;      ///< Replays the channel cache first
+  time_t ths_backfill_from;          ///< Join from this time if cached
+  int ths_replaying;                 ///< Fed from the channel cache, not live
+  time_t ths_backfill_start;         ///< Where the replayed data begins
 
   int ths_flags;
   int ths_timeout;

--- a/src/timeshift.c
+++ b/src/timeshift.c
@@ -299,6 +299,18 @@ const idclass_t timeshift_conf_class = {
       .off    = offsetof(timeshift_conf_t, teletext),
       .opts   = PO_EXPERT,
     },
+    {
+      .type   = PT_BOOL,
+      .id     = "record_cache",
+      .name   = N_("Record from cache"),
+      .desc   = N_("Keep the last \"Maximum period\" of every tuned "
+                   "channel, so a recording started after its programme "
+                   "began also gets the part already broadcast, as far "
+                   "back as the cache reaches. Each tuned channel uses "
+                   "its own cache, within the storage path and the "
+                   "maximum size above."),
+      .off    = offsetof(timeshift_conf_t, record_cache),
+    },
     {}
   }
 };

--- a/src/timeshift.c
+++ b/src/timeshift.c
@@ -306,9 +306,10 @@ const idclass_t timeshift_conf_class = {
       .desc   = N_("Keep the last \"Maximum period\" of every tuned "
                    "channel, so a recording started after its programme "
                    "began also gets the part already broadcast, as far "
-                   "back as the cache reaches. Each tuned channel uses "
-                   "its own cache, within the storage path and the "
-                   "maximum size above."),
+                   "back as the cache reaches. HTSP clients timeshift "
+                   "through the same cache instead of a buffer of their "
+                   "own. Each tuned channel uses one cache, within the "
+                   "storage path and the maximum size above."),
       .off    = offsetof(timeshift_conf_t, record_cache),
     },
     {}

--- a/src/timeshift.h
+++ b/src/timeshift.h
@@ -39,6 +39,7 @@ typedef struct timeshift_conf {
   int       ram_only;
   int       ram_fit;
   int       teletext;
+  int       record_cache;
 } timeshift_conf_t;
 
 extern struct timeshift_conf timeshift_conf;

--- a/src/timeshift/private.h
+++ b/src/timeshift/private.h
@@ -179,6 +179,7 @@ void *timeshift_writer ( void *p );
  */
 void timeshift_filemgr_init     ( void );
 void timeshift_filemgr_term     ( void );
+int  timeshift_filemgr_get_root ( char *buf, size_t len );
 int  timeshift_filemgr_makedirs ( int ts_index, char *buf, size_t len );
 
 static inline void timeshift_file_get0 ( timeshift_file_t *tsf )

--- a/src/timeshift/timeshift_filemgr.c
+++ b/src/timeshift/timeshift_filemgr.c
@@ -136,7 +136,7 @@ timeshift_filemgr_dump0 ( timeshift_t *ts )
  *
  * TODO: should this be fixed on startup?
  */
-static int
+int
 timeshift_filemgr_get_root ( char *buf, size_t len )
 {
   const char *path = timeshift_conf.path;

--- a/src/timeshift/timeshift_reader.c
+++ b/src/timeshift/timeshift_reader.c
@@ -671,6 +671,7 @@ void *timeshift_reader ( void *p )
                 /* Release */
                 if (sm)
                   streaming_msg_free(sm);
+                sm = NULL;
 
                 /* Find end */
                 skip_time = 0x7fffffffffffffffLL;

--- a/src/timeshift/timeshift_svcbuf.c
+++ b/src/timeshift/timeshift_svcbuf.c
@@ -59,6 +59,8 @@ typedef struct svcbuf_seg {
   int       fd;
   off_t     size;
   int       nblocks;   ///< Blocks stored in it
+  int       readers;   ///< Readers in the middle of a read from it
+  int       dead;      ///< Close once the last reader is out
   char     *path;
 } svcbuf_seg_t;
 
@@ -123,6 +125,16 @@ struct svcbuf {
   int                       run;
   pthread_t                 writer;
   LIST_HEAD(, svcbuf_gate)  gates;
+  LIST_HEAD(, svcbuf_reader) readers;
+};
+
+struct svcbuf_reader {
+  svcbuf_t            *sb;
+  svcbuf_block_t      *blk;     ///< Position (sb->lock); NULL = unset
+  size_t               off;
+  int                  skipped; ///< Its block expired under it (this read)
+  int                  lost;    ///< ... since svcbuf_reader_lost() last asked
+  LIST_ENTRY(svcbuf_reader) link;
 };
 
 static int svcbuf_index;
@@ -208,12 +220,30 @@ svcbuf_read_all ( int fd, uint8_t *data, size_t size, off_t off )
   return 0;
 }
 
+/* Close a segment no block needs any more, once nobody reads from it */
+static void
+svcbuf_seg_release ( svcbuf_t *sb, svcbuf_seg_t *seg )
+{
+  if (seg->readers)
+    seg->dead = 1;
+  else
+    svcbuf_seg_close(sb, seg);
+}
+
 /* Remove a block (sb->lock held) */
 static void
 svcbuf_block_remove ( svcbuf_t *sb, svcbuf_block_t *b )
 {
   svcbuf_block_t *next = TAILQ_NEXT(b, link);
+  svcbuf_reader_t *r;
 
+  /* readers do not hold data back: one still there moves on */
+  LIST_FOREACH(r, &sb->readers, link)
+    if (r->blk == b) {
+      r->blk = next;
+      r->off = 0;
+      r->skipped = r->lost = 1;
+    }
   TAILQ_REMOVE(&sb->blocks, b, link);
   sb->size -= b->size;
   if (sb->cur == b)
@@ -223,7 +253,7 @@ svcbuf_block_remove ( svcbuf_t *sb, svcbuf_block_t *b )
   if (b->seg) {
     b->seg->nblocks--;
     if (b->seg->nblocks == 0 && b->seg != sb->wr_seg)
-      svcbuf_seg_close(sb, b->seg);
+      svcbuf_seg_release(sb, b->seg);
   }
   free(b->data);
   free(b);
@@ -283,7 +313,7 @@ svcbuf_writer ( void *aux )
         seg = sb->wr_seg;
         if (seg == NULL || seg->size + (off_t)b->size > SVCBUF_SEG_SIZE) {
           if (seg && seg->nblocks == 0)
-            svcbuf_seg_close(sb, seg);
+            svcbuf_seg_release(sb, seg);
           seg = sb->wr_seg = svcbuf_seg_open(sb);
         }
         if (seg) {
@@ -443,6 +473,7 @@ svcbuf_service_start ( service_t *t )
   TAILQ_INIT(&sb->blocks);
   TAILQ_INIT(&sb->segs);
   LIST_INIT(&sb->gates);
+  LIST_INIT(&sb->readers);
   streaming_target_init(&sb->input, &svcbuf_input_ops, sb,
                         ~SMT_TO_MASK(SMT_MPEGTS));
   tvh_thread_create(&sb->writer, NULL, svcbuf_writer, sb, "svcbuf-wr");
@@ -725,4 +756,162 @@ svcbuf_gate_destroy ( streaming_target_t *pad )
   tvh_mutex_unlock(&sb->lock);
   svcbuf_unref(sb);
   free(g);
+}
+
+/* **************************************************************************
+ * Readers (timeshift clients)
+ * *************************************************************************/
+
+/* A reference to the channel cache, NULL when it has none
+ * (s_stream_mutex held) */
+svcbuf_t *
+svcbuf_acquire ( service_t *t )
+{
+  svcbuf_t *sb = t->s_svcbuf;
+  if (sb)
+    atomic_add(&sb->refcount, 1);
+  return sb;
+}
+
+service_t *
+svcbuf_service ( svcbuf_t *sb )
+{
+  return sb->service;
+}
+
+/* Monotonic time of the oldest and newest data held, 0 when empty */
+int
+svcbuf_span ( svcbuf_t *sb, int64_t *oldest, int64_t *newest )
+{
+  const svcbuf_block_t *first;
+  const svcbuf_block_t *last;
+  int r = 0;
+
+  tvh_mutex_lock(&sb->lock);
+  first = TAILQ_FIRST(&sb->blocks);
+  last  = TAILQ_LAST(&sb->blocks, svcbuf_block_queue);
+  if (first) {
+    *oldest = first->mono;
+    *newest = last->mono;
+    r = 1;
+  }
+  tvh_mutex_unlock(&sb->lock);
+  return r;
+}
+
+svcbuf_reader_t *
+svcbuf_reader_create ( svcbuf_t *sb )
+{
+  svcbuf_reader_t *r = calloc(1, sizeof(*r));
+  r->sb = sb;
+  atomic_add(&sb->refcount, 1);
+  tvh_mutex_lock(&sb->lock);
+  LIST_INSERT_HEAD(&sb->readers, r, link);
+  tvh_mutex_unlock(&sb->lock);
+  return r;
+}
+
+void
+svcbuf_reader_destroy ( svcbuf_reader_t *r )
+{
+  svcbuf_t *sb = r->sb;
+  tvh_mutex_lock(&sb->lock);
+  LIST_REMOVE(r, link);
+  tvh_mutex_unlock(&sb->lock);
+  svcbuf_unref(sb);
+  free(r);
+}
+
+/* Position at the block holding monotonic time 'mono', or the oldest one
+ * when the cache does not reach back that far; returns the block's time */
+int64_t
+svcbuf_reader_seek ( svcbuf_reader_t *r, int64_t mono )
+{
+  svcbuf_t *sb = r->sb;
+  svcbuf_block_t *b, *pos;
+  int64_t ret = 0;
+
+  tvh_mutex_lock(&sb->lock);
+  pos = TAILQ_FIRST(&sb->blocks);
+  TAILQ_FOREACH(b, &sb->blocks, link) {
+    if (b->mono > mono)
+      break;
+    pos = b;
+  }
+  r->blk = pos;
+  r->off = 0;
+  r->lost = 0;
+  if (pos)
+    ret = pos->mono;
+  tvh_mutex_unlock(&sb->lock);
+  return ret;
+}
+
+/* Next chunk of whole TS packets: 1 with *pb set, 0 at the head (nothing
+ * more yet, or not positioned), -1 on a read error */
+int
+svcbuf_reader_read ( svcbuf_reader_t *r, pktbuf_t **pb )
+{
+  svcbuf_t *sb = r->sb;
+  svcbuf_block_t *b, *nb;
+  svcbuf_seg_t *seg;
+  size_t n;
+  off_t off;
+  int fd, e;
+
+  *pb = NULL;
+  tvh_mutex_lock(&sb->lock);
+  while ((b = r->blk) != NULL) {
+    if (r->off < b->size) {
+      r->skipped = 0;
+      n = MIN(b->size - r->off, SVCBUF_READ_SIZE);
+      *pb = pktbuf_alloc(NULL, n);
+      if (b->data) {
+        memcpy(pktbuf_ptr(*pb), b->data + r->off, n);
+      } else {
+        /* the block may expire meanwhile: hold its segment open */
+        seg = b->seg;
+        seg->readers++;
+        fd  = seg->fd;
+        off = b->off + r->off;
+        tvh_mutex_unlock(&sb->lock);
+        e = svcbuf_read_all(fd, pktbuf_ptr(*pb), n, off);
+        tvh_mutex_lock(&sb->lock);
+        if (--seg->readers == 0 && seg->dead)
+          svcbuf_seg_close(sb, seg);
+        if (e) {
+          tvherror(LS_TIMESHIFT, "svcbuf: read failed: %s", strerror(errno));
+          pktbuf_ref_dec(*pb);
+          *pb = NULL;
+          tvh_mutex_unlock(&sb->lock);
+          return -1;
+        }
+      }
+      if (!r->skipped)   /* not moved on by an expiry meanwhile */
+        r->off += n;
+      tvh_mutex_unlock(&sb->lock);
+      return 1;
+    }
+    if ((nb = TAILQ_NEXT(b, link)) == NULL)
+      break;
+    r->blk = nb;
+    r->off = 0;
+  }
+  tvh_mutex_unlock(&sb->lock);
+  return 0;
+}
+
+/* Whether data was lost under the reader -- its position expired -- since
+ * the last call: what it reads next does not follow on */
+int
+svcbuf_reader_lost ( svcbuf_reader_t *r )
+{
+  svcbuf_t *sb = r->sb;
+  int lost;
+
+  tvh_mutex_lock(&sb->lock);
+  lost = r->lost;
+  r->lost = 0;
+  tvh_mutex_unlock(&sb->lock);
+  return lost;
 }

--- a/src/timeshift/timeshift_svcbuf.c
+++ b/src/timeshift/timeshift_svcbuf.c
@@ -1,0 +1,728 @@
+/*
+ *  TV headend - Timeshift - channel cache, raw MPEG-TS of a running service
+ *  Copyright (C) 2026 Vincent Fortier
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * While a service runs, keep the last timeshift "Maximum period" of its
+ * MPEG-TS -- exactly what the service hands its subscribers, before any
+ * per-subscription parsing -- so a subscription joining late can be given
+ * what it missed.  A recording started after its programme began (Kodi's
+ * record button, typically) uses it to begin at the programme's start
+ * instead of the moment it was requested, whatever its stream profile:
+ * packet profiles parse the replayed TS exactly as they parse live TS.
+ *
+ * The data is kept in blocks, filled from the service pad and flushed by a
+ * writer thread into segment files (or kept in RAM with "RAM only").  A
+ * gate placed at the head of the joining subscription's chain replays the
+ * blocks from the requested time, drops the live data meanwhile -- the
+ * cache receives the very same data -- and hands over to live once it has
+ * caught up.  Appending to the cache and handing over both happen under
+ * the service's s_stream_mutex, so the join has neither a gap nor a
+ * duplicate.
+ */
+
+#include "tvheadend.h"
+#include "streaming.h"
+#include "service.h"
+#include "timeshift.h"
+#include "timeshift/private.h"
+#include "timeshift/timeshift_svcbuf.h"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+
+#define SVCBUF_BLOCK_SIZE (256 * 1024)        ///< Block allocation
+#define SVCBUF_BLOCK_AGE  sec2mono(1)         ///< Seal a block after this
+#define SVCBUF_SEG_SIZE   (64 * 1024 * 1024)  ///< Segment file size
+#define SVCBUF_READ_SIZE  (188 * 348)         ///< Replay chunk, whole TS packets
+#define SVCBUF_QUEUE_MAX  (32 * 1024 * 1024)  ///< Consumer backlog to wait on
+
+typedef struct svcbuf_seg {
+  TAILQ_ENTRY(svcbuf_seg) link;
+  int       fd;
+  off_t     size;
+  int       nblocks;   ///< Blocks stored in it
+  char     *path;
+} svcbuf_seg_t;
+
+typedef struct svcbuf_block {
+  TAILQ_ENTRY(svcbuf_block) link;
+  uint64_t      seq;
+  time_t        wall;     ///< Wall clock of the first byte
+  int64_t       mono;     ///< Monotonic clock of the first byte
+  uint8_t      *data;     ///< RAM copy, NULL once only on disk
+  size_t        alloc;
+  size_t        size;
+  int           sealed;   ///< Complete, no more appends
+  int           settled;  ///< Passed by the writer (on disk, or kept in RAM)
+  svcbuf_seg_t *seg;
+  off_t         off;      ///< Offset in seg
+} svcbuf_block_t;
+
+TAILQ_HEAD(svcbuf_block_queue, svcbuf_block);
+TAILQ_HEAD(svcbuf_seg_queue, svcbuf_seg);
+
+enum {
+  GATE_WAIT,     ///< Waiting for the start message
+  GATE_REPLAY,   ///< Replaying the cache, live data dropped
+  GATE_LIVE,     ///< Pass-through
+  GATE_STOPPED   ///< Being torn down
+};
+
+struct svcbuf_gate {
+  streaming_target_t   input;
+  streaming_target_t  *output;
+  svcbuf_t            *sb;
+  time_t               from;
+  int                  state;   ///< Changed under s_stream_mutex
+  int                 *replaying; ///< Mirrors state == GATE_REPLAY
+  time_t              *replay_start; ///< Set to where the replay begins
+  streaming_queue_t   *sq;      ///< Consumer queue to pace on, or NULL
+  svcbuf_block_t      *blk;     ///< Replay position, pins it (sb->lock)
+  size_t               off;
+  pthread_t            thread;
+  int                  thread_started;
+  LIST_ENTRY(svcbuf_gate) link;
+};
+
+struct svcbuf {
+  streaming_target_t        input;
+  service_t                *service;
+  int                       refcount;
+  int                       id;
+  tvh_mutex_t               lock;
+  tvh_cond_t                cond;
+  struct svcbuf_block_queue blocks;
+  struct svcbuf_seg_queue   segs;
+  svcbuf_block_t           *cur;       ///< Being filled
+  svcbuf_block_t           *wr_next;   ///< Next block for the writer
+  svcbuf_seg_t             *wr_seg;    ///< Segment being written
+  uint64_t                  next_seq;
+  uint64_t                  size;
+  char                     *dir;
+  int                       seg_index;
+  int                       ram_only;
+  int                       wr_error;
+  int                       run;
+  pthread_t                 writer;
+  LIST_HEAD(, svcbuf_gate)  gates;
+};
+
+static int svcbuf_index;
+
+/* **************************************************************************
+ * Storage
+ * *************************************************************************/
+
+static svcbuf_seg_t *
+svcbuf_seg_open ( svcbuf_t *sb )
+{
+  char path[PATH_MAX];
+  svcbuf_seg_t *seg;
+  int fd;
+
+  if (!sb->dir) {
+    if (timeshift_filemgr_get_root(path, sizeof(path)))
+      return NULL;
+    snprintf(path + strlen(path), sizeof(path) - strlen(path),
+             "/svcbuf-%d", sb->id);
+    if (makedirs(LS_TIMESHIFT, path, 0700, 0, -1, -1))
+      return NULL;
+    sb->dir = strdup(path);
+  }
+  snprintf(path, sizeof(path), "%s/%d.ts", sb->dir, sb->seg_index++);
+  fd = tvh_open(path, O_RDWR | O_CREAT | O_TRUNC, 0600);
+  if (fd < 0) {
+    tvherror(LS_TIMESHIFT, "svcbuf: unable to create '%s': %s",
+             path, strerror(errno));
+    return NULL;
+  }
+  seg = calloc(1, sizeof(*seg));
+  seg->fd   = fd;
+  seg->path = strdup(path);
+  TAILQ_INSERT_TAIL(&sb->segs, seg, link);
+  tvhdebug(LS_TIMESHIFT, "svcbuf: %s: new segment %s",
+           sb->service->s_nicename, path);
+  return seg;
+}
+
+static void
+svcbuf_seg_close ( svcbuf_t *sb, svcbuf_seg_t *seg )
+{
+  TAILQ_REMOVE(&sb->segs, seg, link);
+  close(seg->fd);
+  unlink(seg->path);
+  free(seg->path);
+  free(seg);
+}
+
+static int
+svcbuf_write_all ( int fd, const uint8_t *data, size_t size )
+{
+  ssize_t r;
+  while (size > 0) {
+    r = write(fd, data, size);
+    if (r < 0) {
+      if (ERRNO_AGAIN(errno)) continue;
+      return -1;
+    }
+    data += r;
+    size -= r;
+  }
+  return 0;
+}
+
+static int
+svcbuf_read_all ( int fd, uint8_t *data, size_t size, off_t off )
+{
+  ssize_t r;
+  while (size > 0) {
+    r = pread(fd, data, size, off);
+    if (r < 0) {
+      if (ERRNO_AGAIN(errno)) continue;
+      return -1;
+    }
+    if (r == 0)
+      return -1;
+    data += r;
+    size -= r;
+    off  += r;
+  }
+  return 0;
+}
+
+/* Remove a block (sb->lock held) */
+static void
+svcbuf_block_remove ( svcbuf_t *sb, svcbuf_block_t *b )
+{
+  svcbuf_block_t *next = TAILQ_NEXT(b, link);
+
+  TAILQ_REMOVE(&sb->blocks, b, link);
+  sb->size -= b->size;
+  if (sb->cur == b)
+    sb->cur = NULL;
+  if (sb->wr_next == b)
+    sb->wr_next = next;
+  if (b->seg) {
+    b->seg->nblocks--;
+    if (b->seg->nblocks == 0 && b->seg != sb->wr_seg)
+      svcbuf_seg_close(sb, b->seg);
+  }
+  free(b->data);
+  free(b);
+}
+
+/* Oldest block a gate still has to replay (sb->lock held) */
+static uint64_t
+svcbuf_pinned ( svcbuf_t *sb )
+{
+  svcbuf_gate_t *g;
+  uint64_t pin = UINT64_MAX;
+  LIST_FOREACH(g, &sb->gates, link)
+    if (g->blk && g->blk->seq < pin)
+      pin = g->blk->seq;
+  return pin;
+}
+
+/* Drop what is beyond the configured period or size (sb->lock held) */
+static void
+svcbuf_expire ( svcbuf_t *sb )
+{
+  svcbuf_block_t *b;
+  svcbuf_block_t *nb;
+  const time_t limit = timeshift_conf.unlimited_period ? 0 :
+                       gclk() - (time_t)timeshift_conf.max_period * 60;
+  const uint64_t pin = svcbuf_pinned(sb);
+  uint64_t max_size = timeshift_conf.unlimited_size ? 0 : timeshift_conf.max_size;
+
+  if (sb->ram_only)
+    max_size = timeshift_conf.ram_size;
+
+  for (b = TAILQ_FIRST(&sb->blocks); b != NULL && b->settled && b->seq < pin;
+       b = nb) {
+    if (!(limit && b->wall < limit) && !(max_size && sb->size > max_size))
+      break;
+    nb = TAILQ_NEXT(b, link);
+    svcbuf_block_remove(sb, b);
+  }
+}
+
+static void *
+svcbuf_writer ( void *aux )
+{
+  svcbuf_t *sb = aux;
+  svcbuf_block_t *b;
+  svcbuf_seg_t *seg;
+  const uint8_t *data;
+  size_t size;
+  off_t off;
+  int r;
+
+  tvh_mutex_lock(&sb->lock);
+  while (sb->run) {
+    while (sb->run && sb->wr_next != NULL && sb->wr_next->sealed) {
+      b = sb->wr_next;
+      if (!sb->ram_only && !sb->wr_error) {
+        seg = sb->wr_seg;
+        if (seg == NULL || seg->size + (off_t)b->size > SVCBUF_SEG_SIZE) {
+          if (seg && seg->nblocks == 0)
+            svcbuf_seg_close(sb, seg);
+          seg = sb->wr_seg = svcbuf_seg_open(sb);
+        }
+        if (seg) {
+          data = b->data;
+          size = b->size;
+          off  = seg->size;
+          seg->size += size;  /* reserved: nobody else writes this segment */
+          tvh_mutex_unlock(&sb->lock);
+          r = svcbuf_write_all(seg->fd, data, size);
+          tvh_mutex_lock(&sb->lock);
+          if (r == 0) {
+            b->seg  = seg;
+            b->off  = off;
+            seg->nblocks++;
+            free(b->data);
+            b->data = NULL;
+          } else {
+            tvherror(LS_TIMESHIFT, "svcbuf: write to '%s' failed: %s, "
+                     "keeping the cache in RAM", seg->path, strerror(errno));
+            sb->wr_error = 1;
+          }
+        } else {
+          sb->wr_error = 1;
+        }
+      }
+      b->settled = 1;
+      sb->wr_next = TAILQ_NEXT(b, link);
+    }
+    svcbuf_expire(sb);
+    tvh_cond_timedwait(&sb->cond, &sb->lock, mclk() + sec2mono(1));
+  }
+  tvh_mutex_unlock(&sb->lock);
+  return NULL;
+}
+
+/* **************************************************************************
+ * Input from the service pad (s_stream_mutex held)
+ * *************************************************************************/
+
+static svcbuf_block_t *
+svcbuf_block_new ( svcbuf_t *sb, size_t size )
+{
+  svcbuf_block_t *b = calloc(1, sizeof(*b));
+  b->data  = malloc(size);
+  b->alloc = size;
+  b->seq   = sb->next_seq++;
+  b->wall  = gclk();
+  b->mono  = mclk();
+  TAILQ_INSERT_TAIL(&sb->blocks, b, link);
+  if (sb->wr_next == NULL)
+    sb->wr_next = b;
+  return sb->cur = b;
+}
+
+static void
+svcbuf_input ( void *opaque, streaming_message_t *sm )
+{
+  svcbuf_t *sb = opaque;
+  svcbuf_block_t *b;
+  pktbuf_t *pb;
+  size_t len;
+
+  if (sm->sm_type == SMT_MPEGTS) {
+    pb  = sm->sm_data;
+    len = pktbuf_len(pb);
+    if (len > 0) {
+      tvh_mutex_lock(&sb->lock);
+      b = sb->cur;
+      if (b && (b->size + len > b->alloc || mclk() - b->mono >= SVCBUF_BLOCK_AGE)) {
+        b->sealed = 1;
+        sb->cur = b = NULL;
+        tvh_cond_signal(&sb->cond, 0);
+      }
+      if (b == NULL)
+        b = svcbuf_block_new(sb, MAX(len, SVCBUF_BLOCK_SIZE));
+      memcpy(b->data + b->size, pktbuf_ptr(pb), len);
+      b->size += len;
+      sb->size += len;
+      tvh_mutex_unlock(&sb->lock);
+    }
+  }
+  streaming_msg_free(sm);
+}
+
+static htsmsg_t *
+svcbuf_input_info ( void *opaque, htsmsg_t *list )
+{
+  htsmsg_add_str(list, NULL, "channel cache input");
+  return list;
+}
+
+static streaming_ops_t svcbuf_input_ops = {
+  .st_cb   = svcbuf_input,
+  .st_info = svcbuf_input_info
+};
+
+/* **************************************************************************
+ * Life cycle
+ * *************************************************************************/
+
+static void
+svcbuf_unref ( svcbuf_t *sb )
+{
+  svcbuf_block_t *b;
+  svcbuf_block_t *nb;
+  svcbuf_seg_t *seg;
+  svcbuf_seg_t *nseg;
+
+  if (atomic_dec(&sb->refcount, 1) > 1)
+    return;
+
+  tvh_mutex_lock(&sb->lock);
+  sb->run = 0;
+  tvh_cond_signal(&sb->cond, 0);
+  tvh_mutex_unlock(&sb->lock);
+  pthread_join(sb->writer, NULL);
+
+  sb->wr_seg = NULL;
+  for (b = TAILQ_FIRST(&sb->blocks); b != NULL; b = nb) {
+    nb = TAILQ_NEXT(b, link);
+    svcbuf_block_remove(sb, b);
+  }
+  for (seg = TAILQ_FIRST(&sb->segs); seg != NULL; seg = nseg) {
+    nseg = TAILQ_NEXT(seg, link);
+    svcbuf_seg_close(sb, seg);
+  }
+  if (sb->dir) {
+    rmdir(sb->dir);
+    free(sb->dir);
+  }
+  tvh_cond_destroy(&sb->cond);
+  tvh_mutex_destroy(&sb->lock);
+  free(sb);
+}
+
+/* Called when the service starts (s_stream_mutex held) */
+void
+svcbuf_service_start ( service_t *t )
+{
+  svcbuf_t *sb;
+
+  /* channels only: not the raw mux services used for scanning and EPG;
+   * and "RAM only" needs a RAM size to stay bounded */
+  if (!timeshift_conf.enabled || !timeshift_conf.record_cache ||
+      t->s_type != STYPE_STD || t->s_svcbuf != NULL ||
+      (timeshift_conf.ram_only && timeshift_conf.ram_size == 0))
+    return;
+
+  sb = calloc(1, sizeof(*sb));
+  sb->service  = t;
+  sb->refcount = 1;
+  sb->id       = svcbuf_index++;
+  sb->ram_only = timeshift_conf.ram_only;
+  sb->run      = 1;
+  tvh_mutex_init(&sb->lock, NULL);
+  tvh_cond_init(&sb->cond, 1);
+  TAILQ_INIT(&sb->blocks);
+  TAILQ_INIT(&sb->segs);
+  LIST_INIT(&sb->gates);
+  streaming_target_init(&sb->input, &svcbuf_input_ops, sb,
+                        ~SMT_TO_MASK(SMT_MPEGTS));
+  tvh_thread_create(&sb->writer, NULL, svcbuf_writer, sb, "svcbuf-wr");
+
+  t->s_svcbuf = sb;
+  streaming_target_connect(&t->s_streaming_pad, &sb->input);
+  tvhdebug(LS_TIMESHIFT, "svcbuf: caching %s", t->s_nicename);
+}
+
+/* Called when the service stops (s_stream_mutex held) */
+svcbuf_t *
+svcbuf_service_stop ( service_t *t )
+{
+  svcbuf_t *sb = t->s_svcbuf;
+
+  if (sb == NULL)
+    return NULL;
+  streaming_target_disconnect(&t->s_streaming_pad, &sb->input);
+  t->s_svcbuf = NULL;
+  return sb;
+}
+
+/* Release what svcbuf_service_stop() returned (s_stream_mutex not held) */
+void
+svcbuf_release ( svcbuf_t *sb )
+{
+  if (sb)
+    svcbuf_unref(sb);
+}
+
+/* **************************************************************************
+ * Gate
+ * *************************************************************************/
+
+/* Change the gate state (s_stream_mutex held) */
+static void
+svcbuf_gate_set_state ( svcbuf_gate_t *g, int state )
+{
+  g->state = state;
+  *g->replaying = state == GATE_REPLAY;
+}
+
+static void *
+svcbuf_gate_thread ( void *aux )
+{
+  svcbuf_gate_t *g = aux;
+  svcbuf_t *sb = g->sb;
+  service_t *t = sb->service;
+  svcbuf_block_t *b, *nb;
+  pktbuf_t *pb;
+  uint64_t bytes = 0;
+  size_t n;
+  off_t off;
+  int fd, r, live = 0;
+
+  tvh_mutex_lock(&sb->lock);
+  while (g->state == GATE_REPLAY) {
+    /* the cache reads far faster than a recording is written: do not
+     * pile the whole backfill up in the consumer's queue */
+    if (g->sq) {
+      tvh_mutex_lock(&g->sq->sq_mutex);
+      n = g->sq->sq_size;
+      tvh_mutex_unlock(&g->sq->sq_mutex);
+      if (n > SVCBUF_QUEUE_MAX) {
+        tvh_mutex_unlock(&sb->lock);
+        tvh_safe_usleep(20000);
+        tvh_mutex_lock(&sb->lock);
+        continue;
+      }
+    }
+    b = g->blk;
+    if (g->off < b->size) {
+      n  = MIN(b->size - g->off, SVCBUF_READ_SIZE);
+      pb = pktbuf_alloc(NULL, n);
+      if (b->data) {
+        memcpy(pktbuf_ptr(pb), b->data + g->off, n);
+      } else {
+        /* on disk; the segment stays open as this block is pinned */
+        fd  = b->seg->fd;
+        off = b->off + g->off;
+        tvh_mutex_unlock(&sb->lock);
+        r = svcbuf_read_all(fd, pktbuf_ptr(pb), n, off);
+        tvh_mutex_lock(&sb->lock);
+        if (r) {
+          tvherror(LS_TIMESHIFT, "svcbuf: read failed: %s, joining live",
+                   strerror(errno));
+          pktbuf_ref_dec(pb);
+          break;
+        }
+      }
+      g->off += n;
+      tvh_mutex_unlock(&sb->lock);
+      tvh_mutex_lock(&t->s_stream_mutex);
+      if (g->state == GATE_REPLAY) {
+        streaming_target_deliver2(g->output,
+                                  streaming_msg_create_data(SMT_MPEGTS, pb));
+        bytes += n;
+        /* Parameters the replay filled in restart the streams: do it
+         * now, at the start of the replay, as the service would do it for
+         * live data -- not at the join, where the next live data would. */
+        if (atomic_set(&t->s_pending_restart, 0))
+          service_restart_streams(t);
+      } else {
+        pktbuf_ref_dec(pb);
+      }
+      tvh_mutex_unlock(&t->s_stream_mutex);
+      tvh_mutex_lock(&sb->lock);
+      continue;
+    }
+    nb = TAILQ_NEXT(b, link);
+    if (nb) {
+      g->blk = nb;
+      g->off = 0;
+      continue;
+    }
+    /* Caught up: hand over to live.  The service appends to the cache
+     * under s_stream_mutex, so holding it the cache cannot grow and all
+     * the live data dropped so far has been replayed. */
+    tvh_mutex_unlock(&sb->lock);
+    tvh_mutex_lock(&t->s_stream_mutex);
+    tvh_mutex_lock(&sb->lock);
+    if (TAILQ_NEXT(g->blk, link) == NULL && g->off == g->blk->size) {
+      if (g->state == GATE_REPLAY) {
+        svcbuf_gate_set_state(g, GATE_LIVE);
+        live = 1;
+      }
+      tvh_mutex_unlock(&t->s_stream_mutex);
+      break;
+    }
+    tvh_mutex_unlock(&t->s_stream_mutex);
+  }
+  if (!live && g->state == GATE_REPLAY) {
+    /* read error: join live, the remaining backfill is lost */
+    tvh_mutex_unlock(&sb->lock);
+    tvh_mutex_lock(&t->s_stream_mutex);
+    if (g->state == GATE_REPLAY)
+      svcbuf_gate_set_state(g, GATE_LIVE);
+    tvh_mutex_unlock(&t->s_stream_mutex);
+    tvh_mutex_lock(&sb->lock);
+  }
+  g->blk = NULL;  /* unpin */
+  tvh_mutex_unlock(&sb->lock);
+
+  tvhinfo(LS_TIMESHIFT, "svcbuf: %s: replayed %"PRIu64" kB from the cache%s",
+          t->s_nicename, bytes / 1024, live ? ", now live" : "");
+  return NULL;
+}
+
+/* Position the replay at 'from' and start it (s_stream_mutex held) */
+static void
+svcbuf_gate_start ( svcbuf_gate_t *g )
+{
+  svcbuf_t *sb = g->sb;
+  svcbuf_block_t *b, *pos = NULL;
+
+  /* the block holding 'from', or the oldest one when the cache does not
+   * reach back that far */
+  tvh_mutex_lock(&sb->lock);
+  pos = TAILQ_FIRST(&sb->blocks);
+  TAILQ_FOREACH(b, &sb->blocks, link) {
+    if (b->wall > g->from)
+      break;
+    pos = b;
+  }
+  if (pos == NULL) {
+    tvh_mutex_unlock(&sb->lock);
+    svcbuf_gate_set_state(g, GATE_LIVE);
+    return;
+  }
+  tvhinfo(LS_TIMESHIFT, "svcbuf: %s: recording from %"PRItime_t"s ago",
+          sb->service->s_nicename, gclk() - pos->wall);
+  *g->replay_start = pos->wall;
+  g->blk = pos;
+  g->off = 0;
+  svcbuf_gate_set_state(g, GATE_REPLAY);
+  tvh_mutex_unlock(&sb->lock);
+
+  tvh_thread_create(&g->thread, NULL, svcbuf_gate_thread, g, "svcbuf-rd");
+  g->thread_started = 1;
+}
+
+static void
+svcbuf_gate_input ( void *opaque, streaming_message_t *sm )
+{
+  svcbuf_gate_t *g = opaque;
+
+  switch (g->state) {
+  case GATE_WAIT:
+  case GATE_REPLAY:
+    if (sm->sm_type == SMT_MPEGTS) {
+      /* also in the cache: replayed in order before going live */
+      streaming_msg_free(sm);
+      return;
+    }
+    if (sm->sm_type == SMT_START) {
+      /* the first one starts the replay -- before passing it on, so the
+       * consumer knows where the data begins; the replay thread waits
+       * for s_stream_mutex, so the start message still goes first.  A
+       * later one (the service restarting its streams) resets the output,
+       * which then goes on with the replayed data like with live data. */
+      if (g->state == GATE_WAIT)
+        svcbuf_gate_start(g);
+      streaming_target_deliver2(g->output, sm);
+      return;
+    }
+    break;
+  default:
+    break;
+  }
+  streaming_target_deliver2(g->output, sm);
+}
+
+static htsmsg_t *
+svcbuf_gate_info ( void *opaque, htsmsg_t *list )
+{
+  svcbuf_gate_t *g = opaque;
+  streaming_target_t *st = g->output;
+  htsmsg_add_str(list, NULL, "channel cache gate");
+  return st->st_ops.st_info(st->st_opaque, list);
+}
+
+static streaming_ops_t svcbuf_gate_ops = {
+  .st_cb   = svcbuf_gate_input,
+  .st_info = svcbuf_gate_info
+};
+
+/*
+ * Create a gate replaying the channel cache from 'from' before passing
+ * the live data to 'output'; *replaying is set while it replays and
+ * *replay_start to where the replayed data begins; the replay waits
+ * whenever 'sq' (the consumer's queue, if any) is backed up.  NULL when
+ * the service has no cache.  s_stream_mutex held.
+ */
+streaming_target_t *
+svcbuf_gate_create ( service_t *t, time_t from, streaming_target_t *output,
+                     int *replaying, time_t *replay_start,
+                     streaming_queue_t *sq )
+{
+  svcbuf_t *sb = t->s_svcbuf;
+  svcbuf_gate_t *g;
+
+  if (sb == NULL)
+    return NULL;
+  g = calloc(1, sizeof(*g));
+  g->output = output;
+  g->from   = from;
+  g->state  = GATE_WAIT;
+  g->replaying = replaying;
+  g->replay_start = replay_start;
+  g->sq     = sq;
+  g->sb     = sb;
+  atomic_add(&sb->refcount, 1);
+  tvh_mutex_lock(&sb->lock);
+  LIST_INSERT_HEAD(&sb->gates, g, link);
+  tvh_mutex_unlock(&sb->lock);
+  streaming_target_init(&g->input, &svcbuf_gate_ops, g, 0);
+  return &g->input;
+}
+
+/* Stop replaying, return the gate's output (s_stream_mutex held) */
+streaming_target_t *
+svcbuf_gate_stop ( streaming_target_t *pad )
+{
+  svcbuf_gate_t *g = (svcbuf_gate_t *)pad;
+  svcbuf_gate_set_state(g, GATE_STOPPED);
+  return g->output;
+}
+
+/* Free a stopped gate (s_stream_mutex not held) */
+void
+svcbuf_gate_destroy ( streaming_target_t *pad )
+{
+  svcbuf_gate_t *g = (svcbuf_gate_t *)pad;
+  svcbuf_t *sb = g->sb;
+
+  if (g->thread_started)
+    pthread_join(g->thread, NULL);
+  tvh_mutex_lock(&sb->lock);
+  LIST_REMOVE(g, link);
+  tvh_mutex_unlock(&sb->lock);
+  svcbuf_unref(sb);
+  free(g);
+}

--- a/src/timeshift/timeshift_svcbuf.h
+++ b/src/timeshift/timeshift_svcbuf.h
@@ -25,6 +25,7 @@ struct service;
 
 typedef struct svcbuf svcbuf_t;
 typedef struct svcbuf_gate svcbuf_gate_t;
+typedef struct svcbuf_reader svcbuf_reader_t;
 
 /* Service life cycle, s_stream_mutex held */
 void svcbuf_service_start ( struct service *t );
@@ -43,5 +44,16 @@ streaming_target_t *svcbuf_gate_create
 streaming_target_t *svcbuf_gate_stop ( streaming_target_t *pad );
 /* Free a stopped gate, s_stream_mutex not held */
 void svcbuf_gate_destroy ( streaming_target_t *pad );
+
+/* Readers, for clients timeshifting through the cache.  svcbuf_acquire()
+ * takes a reference (s_stream_mutex held), svcbuf_release() drops it. */
+svcbuf_t *svcbuf_acquire ( struct service *t );
+struct service *svcbuf_service ( svcbuf_t *sb );
+int svcbuf_span ( svcbuf_t *sb, int64_t *oldest, int64_t *newest );
+svcbuf_reader_t *svcbuf_reader_create ( svcbuf_t *sb );
+void svcbuf_reader_destroy ( svcbuf_reader_t *r );
+int64_t svcbuf_reader_seek ( svcbuf_reader_t *r, int64_t mono );
+int svcbuf_reader_read ( svcbuf_reader_t *r, pktbuf_t **pb );
+int svcbuf_reader_lost ( svcbuf_reader_t *r );
 
 #endif /* __TVH_TIMESHIFT_SVCBUF_H__ */

--- a/src/timeshift/timeshift_svcbuf.h
+++ b/src/timeshift/timeshift_svcbuf.h
@@ -1,0 +1,47 @@
+/*
+ *  TV headend - Timeshift - channel cache, raw MPEG-TS of a running service
+ *  Copyright (C) 2026 Vincent Fortier
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __TVH_TIMESHIFT_SVCBUF_H__
+#define __TVH_TIMESHIFT_SVCBUF_H__
+
+#include "streaming.h"
+
+struct service;
+
+typedef struct svcbuf svcbuf_t;
+typedef struct svcbuf_gate svcbuf_gate_t;
+
+/* Service life cycle, s_stream_mutex held */
+void svcbuf_service_start ( struct service *t );
+svcbuf_t *svcbuf_service_stop ( struct service *t );
+/* Release what svcbuf_service_stop() returned, s_stream_mutex not held */
+void svcbuf_release ( svcbuf_t *sb );
+
+/* Replay the channel cache from 'from', then pass live data on to
+ * 'output'; *replaying is set while replaying and *replay_start to where
+ * the replayed data begins, paced on the consumer's queue 'sq' when given.
+ * NULL when the service is not cached.  s_stream_mutex held. */
+streaming_target_t *svcbuf_gate_create
+  ( struct service *t, time_t from, streaming_target_t *output,
+    int *replaying, time_t *replay_start, streaming_queue_t *sq );
+/* Stop replaying, returns the gate's output.  s_stream_mutex held. */
+streaming_target_t *svcbuf_gate_stop ( streaming_target_t *pad );
+/* Free a stopped gate, s_stream_mutex not held */
+void svcbuf_gate_destroy ( streaming_target_t *pad );
+
+#endif /* __TVH_TIMESHIFT_SVCBUF_H__ */

--- a/src/timeshift/timeshift_svcts.c
+++ b/src/timeshift/timeshift_svcts.c
@@ -1,0 +1,1086 @@
+/*
+ *  TV headend - Timeshift - clients timeshifting through the channel cache
+ *  Copyright (C) 2026 Vincent Fortier
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * With "Record from cache" each tuned channel already keeps its last
+ * "Maximum period" of MPEG-TS (timeshift_svcbuf.c).  A client pausing or
+ * rewinding live TV is served from that cache here, instead of writing a
+ * buffer of its own -- one cache per channel, however many clients.
+ *
+ * This target takes the place of timeshift_create() in the client's chain,
+ * after tsfix and the global headers, and answers the same speed / skip
+ * requests with the same messages.  Live, it passes packets through.  Out
+ * of live, it reads the channel cache through a private parser and hands
+ * the client packets in the client's own time base: the offset between
+ * source and client timestamps is calibrated by matching replayed video
+ * frames against the recent live ones (the sharer and tsfix both move the
+ * client's time base).  Back to live, packets the client already has are
+ * dropped by their DTS, so the join has neither a gap nor a duplicate.
+ */
+
+#include "tvheadend.h"
+#include "streaming.h"
+#include "service.h"
+#include "packet.h"
+#include "timeshift.h"
+#include "timeshift/private.h"
+#include "timeshift/timeshift_svcbuf.h"
+#include "timeshift/timeshift_svcts.h"
+#include "parsers/parsers.h"
+
+#define SVCTS_RING        512       ///< Recent live video packets, to calibrate
+#define SVCTS_PREROLL     2000000   ///< us parsed before a target (keyframe)
+#define SVCTS_CALIB_BACK  4000000   ///< us back from live to replay on entry
+#define SVCTS_REWIND_STEP 1000000   ///< us stepped back for a keyframe
+#define SVCTS_EXPIRED_GAP 10000000  ///< us ahead of the oldest data after an
+                                    ///< expiry, as both then move at 1x
+#define SVCTS_NSTREAMS    256
+
+enum {
+  SVCTS_LIVE,
+  SVCTS_PAUSE,
+  SVCTS_PLAY
+};
+
+typedef struct svcts_key {
+  int64_t  dts;       ///< Client time base, 90 kHz
+  uint32_t crc;
+  uint32_t len;
+  uint8_t  index;
+  uint8_t  used;
+} svcts_key_t;
+
+typedef struct svcts_pkt {
+  TAILQ_ENTRY(svcts_pkt) link;
+  th_pkt_t *pkt;      ///< Timestamps in the client time base
+  int64_t   time;     ///< us
+} svcts_pkt_t;
+
+TAILQ_HEAD(svcts_pkt_queue, svcts_pkt);
+
+typedef struct svcts {
+  streaming_target_t   input;
+  streaming_target_t  *output;
+  int64_t              max_time;    ///< us the client may go back
+  tvh_mutex_t          lock;
+  tvh_cond_t           cond;
+  pthread_t            thread;
+  int                  run;
+
+  /* shared with the live side (lock) */
+  svcbuf_t            *sb;          ///< Buffer of the attached service
+  svcbuf_t            *sb_old;      ///< Detached, for the thread to release
+  int                  reset;       ///< The thread drops its replay
+  TAILQ_HEAD(, streaming_message) ctrl;
+  int                  state;
+  int                  speed;
+  int                  keyframe_mode;
+  int64_t              pause_time;  ///< us delivered at mono_play
+  int64_t              mono_play;
+  int64_t              last_time;   ///< us of the last packet out
+  int64_t              live_time;   ///< us of the newest live packet
+  int64_t              live_mono;
+  int64_t              out_dts[SVCTS_NSTREAMS];
+  uint8_t              is_video[SVCTS_NSTREAMS];
+  svcts_key_t          ring[SVCTS_RING];
+  int                  ring_pos;
+  int                  calibrated;
+  int64_t              off;         ///< Source minus client, 90 kHz
+  struct svcts_pkt_queue q;          ///< Replayed, client time base
+  int64_t              expect;      ///< 90 kHz, to unwrap source times
+
+  /* thread */
+  svcbuf_reader_t     *rd;
+  service_t           *rd_service;
+  streaming_target_t  *parser;
+  streaming_target_t   sink;
+  int                  at_head;
+  int                  reanchor;    ///< Restart the pacing on the next one
+  int64_t              skip_to;     ///< us: drop until a keyframe from here
+  int                  skip_back;   ///< ... or the last one before, going back
+  streaming_message_t *skip_reply;  ///< Answered with the first packet
+  svcts_pkt_t         *rw_pkt;      ///< Rewind: next keyframe to show
+  int64_t              mono_status;
+} svcts_t;
+
+int
+svcts_enabled ( void )
+{
+  return timeshift_conf.enabled && timeshift_conf.record_cache &&
+         !(timeshift_conf.ram_only && timeshift_conf.ram_size == 0);
+}
+
+/* **************************************************************************
+ * Helpers (lock held)
+ * *************************************************************************/
+
+static inline int
+svcts_is_keyframe ( const th_pkt_t *pkt )
+{
+  return SCT_ISVIDEO(pkt->pkt_type) && pkt->v.pkt_frametype == PKT_I_FRAME;
+}
+
+static inline int64_t
+svcts_pkt_time ( const th_pkt_t *pkt )
+{
+  return ts_rescale(pkt->pkt_pts != PTS_UNSET ? pkt->pkt_pts : pkt->pkt_dts,
+                    1000000);
+}
+
+static int
+svcts_key ( th_pkt_t *pkt, svcts_key_t *k )
+{
+  size_t len = pktbuf_len(pkt->pkt_payload);
+  if (!SCT_ISVIDEO(pkt->pkt_type) || len < 64 || pkt->pkt_dts == PTS_UNSET)
+    return 0;
+  k->index = pkt->pkt_componentindex;
+  k->len   = len;
+  k->crc   = tvh_crc32(pktbuf_ptr(pkt->pkt_payload), MIN(len, 188), 0);
+  k->used  = 1;
+  return 1;
+}
+
+/* Bring a source time (33 bits) next to where the client time base is */
+static int64_t
+svcts_unwrap ( int64_t v, int64_t expect )
+{
+  const int64_t wrap = PTS_MASK + 1;
+  if (expect == PTS_UNSET)
+    return v;
+  while (v < expect - wrap / 2) v += wrap;
+  while (v > expect + wrap / 2) v -= wrap;
+  return v;
+}
+
+static void
+svcts_out_reset ( svcts_t *st )
+{
+  int i;
+  for (i = 0; i < SVCTS_NSTREAMS; i++)
+    st->out_dts[i] = PTS_UNSET;
+}
+
+/* A packet the client does not have yet: remember its DTS */
+static int
+svcts_out_new ( svcts_t *st, const th_pkt_t *pkt )
+{
+  int64_t *last = &st->out_dts[pkt->pkt_componentindex];
+  if (pkt->pkt_dts == PTS_UNSET)
+    return 1;
+  if (*last != PTS_UNSET && pkt->pkt_dts <= *last)
+    return 0;
+  *last = pkt->pkt_dts;
+  return 1;
+}
+
+static void
+svcts_queue_clear ( svcts_t *st )
+{
+  svcts_pkt_t *p;
+  svcts_pkt_t *n;
+
+  for (p = TAILQ_FIRST(&st->q); p != NULL; p = n) {
+    n = TAILQ_NEXT(p, link);
+    TAILQ_REMOVE(&st->q, p, link);
+    pkt_ref_dec(p->pkt);
+    free(p);
+  }
+  if (st->rw_pkt) {
+    pkt_ref_dec(st->rw_pkt->pkt);
+    free(st->rw_pkt);
+    st->rw_pkt = NULL;
+  }
+}
+
+/* Oldest time (us, client base) the client may go back to, 0 if none */
+static int64_t
+svcts_oldest ( svcts_t *st )
+{
+  int64_t oldest, newest, t;
+  if (st->sb == NULL || st->live_time == 0 ||
+      !svcbuf_span(st->sb, &oldest, &newest))
+    return 0;
+  t = st->live_time - (st->live_mono - oldest) + SVCTS_PREROLL;
+  if (st->max_time && t < st->live_time - st->max_time)
+    t = st->live_time - st->max_time;
+  return MIN(t, st->live_time);
+}
+
+static void
+svcts_fill_status ( svcts_t *st, timeshift_status_t *status )
+{
+  int64_t cur = st->state == SVCTS_LIVE ? st->live_time : st->last_time;
+  int64_t start = svcts_oldest(st);
+
+  status->full = 0;
+  status->shift = ts_rescale_inv(MAX(0, st->live_time - cur), 1000000);
+  if (start) {
+    status->pts_start = ts_rescale_inv(start, 1000000);
+    status->pts_end   = ts_rescale_inv(st->live_time, 1000000);
+  } else {
+    status->pts_start = PTS_UNSET;
+    status->pts_end   = PTS_UNSET;
+  }
+}
+
+static void
+svcts_status ( svcts_t *st )
+{
+  timeshift_status_t *status = calloc(1, sizeof(*status));
+  svcts_fill_status(st, status);
+  streaming_target_deliver2(st->output,
+                            streaming_msg_create_data(SMT_TIMESHIFT_STATUS, status));
+}
+
+static void
+svcts_speed_notify ( svcts_t *st )
+{
+  streaming_target_deliver2(st->output,
+                            streaming_msg_create_code(SMT_SPEED, st->speed));
+}
+
+/* **************************************************************************
+ * Live side
+ * *************************************************************************/
+
+static void
+svcts_live_reset ( svcts_t *st )
+{
+  if (st->state != SVCTS_LIVE) {
+    st->state = SVCTS_LIVE;
+    st->speed = 100;
+    st->reset = 1;
+    svcts_speed_notify(st);
+    tvh_cond_signal(&st->cond, 0);
+  }
+  svcts_out_reset(st);
+  memset(st->ring, 0, sizeof(st->ring));
+  st->calibrated = 0;
+  st->live_time = 0;
+}
+
+static void
+svcts_live_seen ( svcts_t *st, th_pkt_t *pkt )
+{
+  svcts_key_t *k;
+  int64_t t;
+
+  if (pkt->pkt_type == SCT_TELETEXT)
+    return;
+  if (SCT_ISVIDEO(pkt->pkt_type))
+    st->is_video[pkt->pkt_componentindex] = 1;
+  if (pkt->pkt_pts != PTS_UNSET || pkt->pkt_dts != PTS_UNSET) {
+    t = svcts_pkt_time(pkt);
+    if (t > st->live_time) {
+      st->live_time = t;
+      st->live_mono = mclk();
+    }
+  }
+  k = &st->ring[st->ring_pos];
+  if (svcts_key(pkt, k)) {
+    k->dts = pkt->pkt_dts;
+    st->ring_pos = (st->ring_pos + 1) % SVCTS_RING;
+  }
+}
+
+static void
+svcts_input ( void *opaque, streaming_message_t *sm )
+{
+  svcts_t *st = opaque;
+  th_pkt_t *pkt;
+
+  tvh_mutex_lock(&st->lock);
+  switch (sm->sm_type) {
+  case SMT_PACKET:
+    pkt = sm->sm_data;
+    svcts_live_seen(st, pkt);
+    if (st->state == SVCTS_LIVE && svcts_out_new(st, pkt)) {
+      if (pkt->pkt_type != SCT_TELETEXT)
+        st->last_time = svcts_pkt_time(pkt);
+      streaming_target_deliver2(st->output, sm);
+    } else {
+      streaming_msg_free(sm);
+    }
+    break;
+  case SMT_SPEED:
+  case SMT_SKIP:
+    TAILQ_INSERT_TAIL(&st->ctrl, sm, sm_link);
+    tvh_cond_signal(&st->cond, 0);
+    break;
+  case SMT_START:
+  case SMT_STOP:
+    /* new streams, new time base */
+    svcts_live_reset(st);
+    streaming_target_deliver2(st->output, sm);
+    break;
+  default:
+    streaming_target_deliver2(st->output, sm);
+    break;
+  }
+  tvh_mutex_unlock(&st->lock);
+}
+
+static htsmsg_t *
+svcts_input_info ( void *opaque, htsmsg_t *list )
+{
+  svcts_t *st = opaque;
+  streaming_target_t *out = st->output;
+  htsmsg_add_str(list, NULL, "channel cache timeshift input");
+  return out->st_ops.st_info(out->st_opaque, list);
+}
+
+static streaming_ops_t svcts_input_ops = {
+  .st_cb   = svcts_input,
+  .st_info = svcts_input_info
+};
+
+/* **************************************************************************
+ * Replay: the private parser's output, in the client's time base
+ * *************************************************************************/
+
+/* Line a replayed video frame up with the same frame sent live.  Only a
+ * frame seen once counts: identical ones (black frames...) would mislead. */
+static void
+svcts_calibrate ( svcts_t *st, th_pkt_t *pkt )
+{
+  svcts_key_t k;
+  const svcts_key_t *match = NULL;
+  int i;
+
+  if (!svcts_key(pkt, &k))
+    return;
+  for (i = 0; i < SVCTS_RING; i++) {
+    const svcts_key_t *r = &st->ring[i];
+    if (r->used && r->index == k.index && r->len == k.len && r->crc == k.crc) {
+      if (match)
+        return;
+      match = r;
+    }
+  }
+  if (match == NULL)
+    return;
+  st->off = (pkt->pkt_dts & PTS_MASK) - match->dts;
+  st->expect = match->dts;
+  st->calibrated = 1;
+  tvhdebug(LS_TIMESHIFT, "svcts: calibrated, source - client = %"PRId64, st->off);
+}
+
+static void
+svcts_sink ( void *opaque, streaming_message_t *sm )
+{
+  svcts_t *st = opaque;
+  th_pkt_t *pkt, *n;
+  svcts_pkt_t *p;
+
+  if (sm->sm_type != SMT_PACKET) {
+    streaming_msg_free(sm);
+    return;
+  }
+  pkt = sm->sm_data;
+  tvh_mutex_lock(&st->lock);
+  if (!st->calibrated)
+    svcts_calibrate(st, pkt);
+  if (st->calibrated && pkt->pkt_dts != PTS_UNSET) {
+    n = pkt_copy_shallow(pkt);
+    n->pkt_dts = svcts_unwrap((pkt->pkt_dts & PTS_MASK) - st->off, st->expect);
+    st->expect = n->pkt_dts;
+    n->pkt_pts = pkt->pkt_pts == PTS_UNSET ? n->pkt_dts :
+                 svcts_unwrap((pkt->pkt_pts & PTS_MASK) - st->off, n->pkt_dts);
+    if (pkt->pkt_pcr != PTS_UNSET)
+      n->pkt_pcr = svcts_unwrap((pkt->pkt_pcr & PTS_MASK) - st->off, n->pkt_dts);
+    p = malloc(sizeof(*p));
+    p->pkt = n;
+    p->time = svcts_pkt_time(n);
+    TAILQ_INSERT_TAIL(&st->q, p, link);
+  }
+  tvh_mutex_unlock(&st->lock);
+  streaming_msg_free(sm);
+}
+
+static htsmsg_t *
+svcts_sink_info ( void *opaque, htsmsg_t *list )
+{
+  htsmsg_add_str(list, NULL, "channel cache timeshift replay");
+  return list;
+}
+
+static streaming_ops_t svcts_sink_ops = {
+  .st_cb   = svcts_sink,
+  .st_info = svcts_sink_info
+};
+
+/* Drop the replay pipeline (lock held, released meanwhile) */
+static void
+svcts_replay_drop ( svcts_t *st )
+{
+  streaming_target_t *parser = st->parser;
+  svcbuf_reader_t *rd = st->rd;
+  svcbuf_t *old = st->sb_old;
+
+  st->parser = NULL;
+  st->rd = NULL;
+  st->rd_service = NULL;
+  st->sb_old = NULL;
+  st->reset = 0;
+  svcts_queue_clear(st);
+  st->skip_to = 0;
+  st->skip_back = 0;
+  st->reanchor = 0;
+  if (st->skip_reply) {
+    ((streaming_skip_t *)st->skip_reply->sm_data)->type = SMT_SKIP_ERROR;
+    streaming_target_deliver2(st->output, st->skip_reply);
+    st->skip_reply = NULL;
+  }
+  tvh_mutex_unlock(&st->lock);
+  if (parser)
+    parser_destroy(parser);
+  if (rd)
+    svcbuf_reader_destroy(rd);
+  if (old)
+    svcbuf_release(old);
+  tvh_mutex_lock(&st->lock);
+}
+
+/* Replay from 'time' (us, client base): a fresh parser, as data restarts
+ * at an arbitrary point (lock held, released meanwhile).  0 on failure. */
+static int
+svcts_replay_open ( svcts_t *st, int64_t time )
+{
+  streaming_target_t *parser = st->parser;
+  svcbuf_t *sb = st->sb;
+  service_t *t;
+  streaming_start_t *ss;
+  int64_t mono;
+
+  if (sb == NULL || st->live_time == 0)
+    return 0;
+  mono = st->live_mono - (st->live_time - time) - SVCTS_PREROLL;
+  st->parser = NULL;
+  svcts_queue_clear(st);
+  st->at_head = 0;
+  st->expect = ts_rescale_inv(time, 1000000);
+  if (st->rd == NULL) {
+    st->rd = svcbuf_reader_create(sb);
+    st->rd_service = svcbuf_service(sb);
+  }
+  svcbuf_reader_seek(st->rd, mono);
+  t = st->rd_service;
+  tvh_mutex_unlock(&st->lock);
+  if (parser)
+    parser_destroy(parser);
+  tvh_mutex_lock(&t->s_stream_mutex);
+  parser = parser_create_replay(&st->sink, t);
+  ss = service_build_streaming_start(t);
+  streaming_target_deliver2(parser, streaming_msg_create_data(SMT_START, ss));
+  tvh_mutex_unlock(&t->s_stream_mutex);
+  tvh_mutex_lock(&st->lock);
+  st->parser = parser;
+  return 1;
+}
+
+/* Parse one more chunk of the cache (lock held, released meanwhile).
+ * 1 when data was parsed, 0 at the head, -1 on error, 2 when the position
+ * expired under the reader (nothing parsed: the data no longer follows) */
+static int
+svcts_fill ( svcts_t *st )
+{
+  svcbuf_reader_t *rd = st->rd;
+  streaming_target_t *parser = st->parser;
+  service_t *t = st->rd_service;
+  pktbuf_t *pb;
+  int r;
+
+  if (rd == NULL || parser == NULL)
+    return -1;
+  tvh_mutex_unlock(&st->lock);
+  r = svcbuf_reader_read(rd, &pb);
+  if (r > 0 && svcbuf_reader_lost(rd)) {
+    pktbuf_ref_dec(pb);
+    r = 2;
+  } else if (r > 0) {
+    tvh_mutex_lock(&t->s_stream_mutex);
+    streaming_target_deliver2(parser, streaming_msg_create_data(SMT_MPEGTS, pb));
+    tvh_mutex_unlock(&t->s_stream_mutex);
+  }
+  tvh_mutex_lock(&st->lock);
+  return r;
+}
+
+/* Going back, start from the last keyframe at or before skip_to, as the
+ * packet timeshift does: parse past the target, then drop what precedes
+ * that keyframe (lock held, released meanwhile) */
+static void
+svcts_skip_back_select ( svcts_t *st )
+{
+  svcts_pkt_t *p;
+  svcts_pkt_t *n;
+  svcts_pkt_t *kf = NULL;
+
+  st->skip_back = 0;
+  for (;;) {
+    p = TAILQ_LAST(&st->q, svcts_pkt_queue);
+    if ((p && p->time > st->skip_to) || st->reset)
+      break;
+    if (svcts_fill(st) != 1)
+      break;
+  }
+  TAILQ_FOREACH(p, &st->q, link)
+    if (p->time <= st->skip_to && svcts_is_keyframe(p->pkt))
+      kf = p;
+  if (kf == NULL)
+    return;   /* none in the preroll: the first one after it */
+  for (p = TAILQ_FIRST(&st->q); p != kf; p = n) {
+    n = TAILQ_NEXT(p, link);
+    TAILQ_REMOVE(&st->q, p, link);
+    pkt_ref_dec(p->pkt);
+    free(p);
+  }
+  st->skip_to = kf->time;
+}
+
+/* Drop from the head of the queue what is not to be shown -- what comes
+ * before the keyframe a skip lands on, or all but keyframes in keyframe
+ * mode -- and return the first packet to show, if any (lock held) */
+static svcts_pkt_t *
+svcts_head ( svcts_t *st )
+{
+  svcts_pkt_t *p = TAILQ_FIRST(&st->q);
+  svcts_pkt_t *n;
+
+  while (p != NULL &&
+         ((st->skip_to && !(svcts_is_keyframe(p->pkt) && p->time >= st->skip_to)) ||
+          (st->keyframe_mode && !svcts_is_keyframe(p->pkt)))) {
+    n = TAILQ_NEXT(p, link);
+    TAILQ_REMOVE(&st->q, p, link);
+    pkt_ref_dec(p->pkt);
+    free(p);
+    p = n;
+  }
+  if (p != NULL)
+    st->skip_to = 0;
+  return p;
+}
+
+/* Next packet to show, parsing as needed (lock held, released meanwhile);
+ * NULL at the head of the cache or on error */
+static svcts_pkt_t *
+svcts_next ( svcts_t *st )
+{
+  svcts_pkt_t *p;
+  int r;
+
+  if (st->skip_back && st->skip_to)
+    svcts_skip_back_select(st);
+  for (;;) {
+    if (st->reset)
+      return NULL;
+    if ((p = svcts_head(st)) != NULL)
+      return p;
+    r = svcts_fill(st);
+    if (r == 2) {
+      /* a pause longer than the cache: the position expired.  Go on a
+       * little ahead of the oldest data, as it keeps expiring at 1x. */
+      int64_t t = MIN(svcts_oldest(st) + SVCTS_EXPIRED_GAP, st->live_time);
+      tvhdebug(LS_TIMESHIFT, "svcts: position expired, going on from %"PRId64"s back",
+               (st->live_time - t) / 1000000);
+      if (!svcts_replay_open(st, t))
+        return NULL;
+      svcts_out_reset(st);
+      st->skip_to = t;
+      st->reanchor = 1;
+      continue;
+    }
+    if (r <= 0) {
+      st->at_head = 1;
+      return NULL;
+    }
+    st->at_head = 0;
+  }
+}
+
+/* Hand a packet to the client (lock held) */
+static void
+svcts_output ( svcts_t *st, svcts_pkt_t *p )
+{
+  if (svcts_out_new(st, p->pkt)) {
+    if (p->pkt->pkt_type != SCT_TELETEXT)
+      st->last_time = p->time;
+    streaming_target_deliver2(st->output, streaming_msg_create_pkt(p->pkt));
+  } else {
+    pkt_ref_dec(p->pkt);
+  }
+  free(p);
+}
+
+/* Answer a pending skip with the first packet found (lock held) */
+static void
+svcts_skip_answer ( svcts_t *st, const svcts_pkt_t *p )
+{
+  streaming_skip_t *skip = st->skip_reply->sm_data;
+
+  skip->type = SMT_SKIP_ABS_TIME;
+  skip->time = ts_rescale_inv(p->time, 1000000);
+  st->last_time = p->time;
+  svcts_fill_status(st, &skip->timeshift);
+  streaming_target_deliver2(st->output, st->skip_reply);
+  st->skip_reply = NULL;
+  st->pause_time = p->time;
+  st->mono_play = mclk();
+  st->mono_status = st->mono_play;
+}
+
+/* Back to live: what the client already has is dropped by its DTS */
+static void
+svcts_go_live ( svcts_t *st )
+{
+  tvhdebug(LS_TIMESHIFT, "svcts: back to live");
+  st->state = SVCTS_LIVE;
+  st->speed = 100;
+  st->keyframe_mode = 0;
+  st->reset = 1;
+  svcts_speed_notify(st);
+}
+
+/* Start of the cache reached going back: pause there */
+static void
+svcts_at_start ( svcts_t *st )
+{
+  tvhdebug(LS_TIMESHIFT, "svcts: start of the cache, pause");
+  st->state = SVCTS_PAUSE;
+  st->speed = 0;
+  st->keyframe_mode = 0;
+  st->pause_time = st->last_time;
+  svcts_speed_notify(st);
+}
+
+/* Rewind: find the last keyframe before last_time (lock held) */
+static svcts_pkt_t *
+svcts_rewind_find ( svcts_t *st )
+{
+  svcts_pkt_t *p;
+  svcts_pkt_t *n;
+  svcts_pkt_t *kf;
+  int64_t step = SVCTS_REWIND_STEP, from, oldest;
+  int at_start;
+
+  for (;;) {
+    oldest = svcts_oldest(st);
+    from = st->last_time - step;
+    at_start = from <= oldest;
+    if (at_start)
+      from = oldest;
+    if (!svcts_replay_open(st, from + SVCTS_PREROLL))
+      return NULL;
+    kf = NULL;
+    p = TAILQ_FIRST(&st->q);
+    for (;;) {
+      if (st->reset)
+        break;
+      if (p == NULL) {
+        /* all looked at: parse on */
+        if (svcts_fill(st) != 1)
+          break;
+        p = TAILQ_FIRST(&st->q);
+        continue;
+      }
+      if (p->time >= st->last_time)
+        break;
+      n = TAILQ_NEXT(p, link);
+      TAILQ_REMOVE(&st->q, p, link);
+      if (svcts_is_keyframe(p->pkt)) {
+        if (kf) {
+          pkt_ref_dec(kf->pkt);
+          free(kf);
+        }
+        kf = p;
+      } else {
+        pkt_ref_dec(p->pkt);
+        free(p);
+      }
+      p = n;
+    }
+    if (kf || at_start || st->reset)
+      return kf;
+    step *= 2;
+  }
+}
+
+/* PLAY: hand over what is due; returns how long to wait (lock held) */
+static int64_t
+svcts_play ( svcts_t *st )
+{
+  svcts_pkt_t *p;
+  int64_t now, deliver, w;
+
+  for (;;) {
+    now = mclk();
+
+    if (st->speed < 0) {
+      if (st->rw_pkt == NULL) {
+        st->rw_pkt = svcts_rewind_find(st);
+        if (st->reset)
+          return 0;
+        if (st->rw_pkt == NULL) {
+          svcts_at_start(st);
+          return 0;
+        }
+      }
+      p = st->rw_pkt;
+    } else {
+      p = svcts_next(st);
+      if (st->reset || st->state != SVCTS_PLAY)
+        return 0;
+      if (p == NULL) {
+        if (st->at_head && st->skip_reply == NULL) {
+          svcts_go_live(st);
+          return 0;
+        }
+        return ms2mono(100);
+      }
+    }
+
+    if (st->skip_reply)
+      svcts_skip_answer(st, p);
+    if (st->reanchor) {
+      st->reanchor = 0;
+      st->pause_time = p->time;
+      st->mono_play = now;
+      svcts_out_reset(st);
+      svcts_status(st);
+    }
+
+    deliver = st->pause_time +
+              ((now - st->mono_play) + TIMESHIFT_PLAY_BUF) * st->speed / 100;
+    if (st->speed > 0 ? p->time > deliver : p->time < deliver) {
+      w = llabs(p->time - deliver) * 100 / llabs(st->speed);
+      return MIN(MAX(w, ms2mono(1)), sec2mono(1));
+    }
+
+    if (p == st->rw_pkt) {
+      st->rw_pkt = NULL;
+      st->out_dts[p->pkt->pkt_componentindex] = PTS_UNSET;  /* going back */
+    } else {
+      TAILQ_REMOVE(&st->q, p, link);
+    }
+    svcts_output(st, p);
+    if (st->keyframe_mode)
+      svcts_status(st);   /* as the packet timeshift does in keyframe mode */
+  }
+}
+
+/* PAUSE after a skip: show the frame skipped to (lock held) */
+static void
+svcts_pause_skip ( svcts_t *st )
+{
+  svcts_pkt_t *p = svcts_next(st);
+  if (p == NULL || st->reset)
+    return;
+  svcts_skip_answer(st, p);
+  TAILQ_REMOVE(&st->q, p, link);
+  svcts_output(st, p);
+}
+
+/* **************************************************************************
+ * Requests
+ * *************************************************************************/
+
+/* Leave live: replay from just before the live point, calibrate against
+ * the packets the client got, and go on from the last one (lock held) */
+static int
+svcts_enter ( svcts_t *st )
+{
+  if (st->sb == NULL || st->live_time == 0)
+    return 0;
+  if (!svcts_replay_open(st, st->live_time - SVCTS_CALIB_BACK + SVCTS_PREROLL))
+    return 0;
+  while (!st->calibrated && !st->reset) {
+    if (svcts_fill(st) != 1)
+      break;
+  }
+  if (!st->calibrated) {
+    tvhwarn(LS_TIMESHIFT, "svcts: unable to line the cache up with the stream");
+    return 0;
+  }
+  /* what the client already has is dropped on the way out, by its DTS */
+  st->pause_time = st->last_time;
+  st->mono_play = mclk();
+  return 1;
+}
+
+/* Carry on from last_time again: after a change of direction or of
+ * keyframe mode, the queued packets do not follow on (lock held) */
+static void
+svcts_reposition ( svcts_t *st )
+{
+  int i;
+
+  if (svcts_replay_open(st, st->last_time)) {
+    /* the client has the frame on screen: carry on after it, with the
+     * other streams from there */
+    for (i = 0; i < SVCTS_NSTREAMS; i++)
+      if (!st->is_video[i])
+        st->out_dts[i] = PTS_UNSET;
+    st->skip_to = st->last_time;
+    st->skip_back = 0;
+  }
+}
+
+static void
+svcts_speed ( svcts_t *st, streaming_message_t *ctrl )
+{
+  int speed = ctrl->sm_code, kf;
+
+  if (speed > 3200)  speed = 3200;
+  if (speed < -3200) speed = -3200;
+
+  if (st->state == SVCTS_LIVE) {
+    if (speed >= 100 || !svcts_enter(st))
+      speed = 100;
+    else
+      tvhdebug(LS_TIMESHIFT, "svcts: enter timeshift mode");
+  }
+
+  if (st->state != SVCTS_LIVE || speed != 100) {
+    kf = speed < 0 || speed > 400;
+    /* leaving a rewind, or keyframes for every frame: the queue does not
+     * follow on from what was last shown */
+    if (st->state != SVCTS_LIVE &&
+        ((st->speed < 0 && speed >= 0) || (st->keyframe_mode && !kf)))
+      svcts_reposition(st);
+    if (speed != st->speed || st->state == SVCTS_LIVE) {
+      st->pause_time = st->last_time;
+      st->mono_play = mclk();
+    }
+    if (st->rw_pkt && speed >= 0) {
+      pkt_ref_dec(st->rw_pkt->pkt);
+      free(st->rw_pkt);
+      st->rw_pkt = NULL;
+    }
+    st->keyframe_mode = kf;
+    st->state = speed == 0 ? SVCTS_PAUSE : SVCTS_PLAY;
+    tvhdebug(LS_TIMESHIFT, "svcts: change speed %d", speed);
+  }
+  st->speed = speed;
+  ctrl->sm_code = speed;
+  streaming_target_deliver2(st->output, ctrl);
+}
+
+static void
+svcts_skip ( svcts_t *st, streaming_message_t *ctrl )
+{
+  streaming_skip_t *skip = ctrl->sm_data;
+  int64_t t, oldest, cur;
+
+  switch (skip->type) {
+  case SMT_SKIP_LIVE:
+    if (st->state != SVCTS_LIVE)
+      svcts_go_live(st);
+    skip->type = SMT_SKIP_ABS_TIME;
+    skip->time = ts_rescale_inv(st->live_time, 1000000);
+    svcts_fill_status(st, &skip->timeshift);
+    streaming_target_deliver2(st->output, ctrl);
+    return;
+  case SMT_SKIP_ABS_TIME:
+  case SMT_SKIP_REL_TIME:
+    break;
+  default:
+    goto error;
+  }
+
+  t = ts_rescale(skip->time, 1000000);
+  if (skip->type == SMT_SKIP_REL_TIME)
+    t += st->state == SVCTS_LIVE ? st->live_time : st->last_time;
+  tvhdebug(LS_TIMESHIFT, "svcts: skip to %"PRId64" (live %"PRId64")",
+           t, st->live_time);
+  if (st->sb == NULL || st->live_time == 0)
+    goto error;
+  if (st->state == SVCTS_LIVE && t >= st->live_time - TIMESHIFT_PLAY_BUF)
+    goto error;   /* already live */
+  if (t >= st->live_time) {
+    svcts_go_live(st);
+    skip->type = SMT_SKIP_ABS_TIME;
+    skip->time = ts_rescale_inv(st->live_time, 1000000);
+    svcts_fill_status(st, &skip->timeshift);
+    streaming_target_deliver2(st->output, ctrl);
+    return;
+  }
+  oldest = svcts_oldest(st);
+  if (t < oldest)
+    t = oldest;
+
+  if (!st->calibrated && !svcts_enter(st))
+    goto error;
+  cur = st->state == SVCTS_LIVE ? st->live_time : st->last_time;
+  if (!svcts_replay_open(st, t))
+    goto error;
+  svcts_out_reset(st);
+  st->skip_to = t;
+  st->skip_back = t < cur;
+  if (st->skip_reply)
+    streaming_msg_free(st->skip_reply);
+  st->skip_reply = ctrl;
+  if (st->rw_pkt) {
+    pkt_ref_dec(st->rw_pkt->pkt);
+    free(st->rw_pkt);
+    st->rw_pkt = NULL;
+  }
+  if (st->state == SVCTS_LIVE) {
+    st->state = SVCTS_PLAY;
+    st->speed = 100;
+    st->keyframe_mode = 0;
+  }
+  st->pause_time = t;
+  st->mono_play = mclk();
+  return;
+
+error:
+  skip->type = SMT_SKIP_ERROR;
+  streaming_target_deliver2(st->output, ctrl);
+}
+
+/* **************************************************************************
+ * Thread
+ * *************************************************************************/
+
+static void *
+svcts_thread ( void *aux )
+{
+  svcts_t *st = aux;
+  streaming_message_t *ctrl;
+  int64_t wait, now;
+
+  tvh_mutex_lock(&st->lock);
+  while (st->run) {
+    if (st->reset || st->sb_old)
+      svcts_replay_drop(st);
+
+    while ((ctrl = TAILQ_FIRST(&st->ctrl)) != NULL) {
+      TAILQ_REMOVE(&st->ctrl, ctrl, sm_link);
+      if (ctrl->sm_type == SMT_SPEED)
+        svcts_speed(st, ctrl);
+      else
+        svcts_skip(st, ctrl);
+      if (st->reset)
+        svcts_replay_drop(st);
+    }
+
+    wait = sec2mono(1);
+    if (st->state == SVCTS_PLAY)
+      wait = svcts_play(st);
+    else if (st->state == SVCTS_PAUSE && st->skip_reply)
+      svcts_pause_skip(st);
+
+    now = mclk();
+    if (now >= st->mono_status + sec2mono(1)) {
+      svcts_status(st);
+      st->mono_status = now;
+    }
+    if (wait > 0 && TAILQ_EMPTY(&st->ctrl) && !st->reset && !st->sb_old)
+      tvh_cond_timedwait(&st->cond, &st->lock, mclk() + wait);
+  }
+  svcts_replay_drop(st);
+  tvh_mutex_unlock(&st->lock);
+  return NULL;
+}
+
+/* **************************************************************************
+ * Life cycle
+ * *************************************************************************/
+
+streaming_target_t *
+svcts_create ( streaming_target_t *out, time_t max_period )
+{
+  svcts_t *st = calloc(1, sizeof(*st));
+
+  st->output   = out;
+  st->max_time = (int64_t)max_period * 1000000;
+  st->state    = SVCTS_LIVE;
+  st->speed    = 100;
+  st->run      = 1;
+  tvh_mutex_init(&st->lock, NULL);
+  tvh_cond_init(&st->cond, 1);
+  TAILQ_INIT(&st->ctrl);
+  TAILQ_INIT(&st->q);
+  svcts_out_reset(st);
+  streaming_target_init(&st->input, &svcts_input_ops, st, 0);
+  streaming_target_init(&st->sink, &svcts_sink_ops, st, 0);
+  tvh_thread_create(&st->thread, NULL, svcts_thread, st, "svcts");
+  return &st->input;
+}
+
+void
+svcts_destroy ( streaming_target_t *pad )
+{
+  svcts_t *st = (svcts_t *)pad;
+  streaming_message_t *sm;
+  streaming_message_t *next;
+
+  tvh_mutex_lock(&st->lock);
+  st->run = 0;
+  tvh_cond_signal(&st->cond, 0);
+  tvh_mutex_unlock(&st->lock);
+  pthread_join(st->thread, NULL);
+
+  for (sm = TAILQ_FIRST(&st->ctrl); sm != NULL; sm = next) {
+    next = TAILQ_NEXT(sm, sm_link);
+    TAILQ_REMOVE(&st->ctrl, sm, sm_link);
+    streaming_msg_free(sm);
+  }
+  if (st->sb)
+    svcbuf_release(st->sb);
+  tvh_cond_destroy(&st->cond);
+  tvh_mutex_destroy(&st->lock);
+  free(st);
+}
+
+void
+svcts_attach ( streaming_target_t *pad, service_t *t )
+{
+  svcts_t *st = (svcts_t *)pad;
+  svcbuf_t *sb = svcbuf_acquire(t);
+
+  tvh_mutex_lock(&st->lock);
+  if (st->sb) {
+    if (st->sb_old)
+      svcbuf_release(st->sb_old);   /* not the thread's: it only has sb_old */
+    st->sb_old = st->sb;
+  }
+  st->sb = sb;
+  svcts_live_reset(st);
+  st->reset = 1;
+  tvh_cond_signal(&st->cond, 0);
+  tvh_mutex_unlock(&st->lock);
+}
+
+void
+svcts_detach ( streaming_target_t *pad )
+{
+  svcts_t *st = (svcts_t *)pad;
+
+  tvh_mutex_lock(&st->lock);
+  if (st->sb) {
+    if (st->sb_old)
+      svcbuf_release(st->sb_old);
+    st->sb_old = st->sb;
+    st->sb = NULL;
+  }
+  svcts_live_reset(st);
+  st->reset = 1;
+  tvh_cond_signal(&st->cond, 0);
+  tvh_mutex_unlock(&st->lock);
+}

--- a/src/timeshift/timeshift_svcts.h
+++ b/src/timeshift/timeshift_svcts.h
@@ -1,0 +1,38 @@
+/*
+ *  TV headend - Timeshift - clients timeshifting through the channel cache
+ *  Copyright (C) 2026 Vincent Fortier
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __TVH_TIMESHIFT_SVCTS_H__
+#define __TVH_TIMESHIFT_SVCTS_H__
+
+#include "streaming.h"
+
+struct service;
+
+/* Clients timeshift through the channel's cache rather than their own */
+int svcts_enabled ( void );
+
+/* In a client chain, where timeshift_create() would go */
+streaming_target_t *svcts_create ( streaming_target_t *out, time_t max_period );
+void svcts_destroy ( streaming_target_t *pad );
+
+/* The client's subscription linked to / unlinked from a service
+ * (s_stream_mutex held) */
+void svcts_attach ( streaming_target_t *pad, struct service *t );
+void svcts_detach ( streaming_target_t *pad );
+
+#endif /* __TVH_TIMESHIFT_SVCTS_H__ */


### PR DESCRIPTION
### What

A recording started after its programme began — Kodi's record button on what is playing, typically — started at the moment it was requested, even when the channel had been watched for hours with timeshift on. It now starts at the programme's start, as far back as the channel's cache reaches. Kodi's timeshift is served from that same cache.

New timeshift option **Record from cache** (off by default, needs timeshift enabled). Three commits:

1. **Record from cache.** Each tuned channel keeps its last *Maximum period* of MPEG-TS, as the service hands it to its subscribers, before any per-subscription parsing. A recording whose start lies in the past replays it from `start − pre-padding`, then joins live. Appending to the cache and handing over both happen under `s_stream_mutex`, so the join has neither a gap nor a duplicate. Every profile works: packet profiles parse the replayed TS as they parse live TS.
2. **HTSP clients timeshift through the channel cache**, instead of each writing a buffer of its own: one cache per channel, however many clients and recordings. Same speed and skip requests and replies as the packet timeshift. It can be dropped without touching the first commit.
3. **A fix to the packet timeshift**, independent of the other two (below).

### Testing

Local bench: a real-time IPTV `pipe://` ffmpeg source, HTTP and HTSP clients, recordings created through the API.

- **Recording started 30 s late**, `pass` and Matroska: 49.8 s and 48.4 s instead of 19 s, video and audio continuous, 0 CC errors at the join. Also covered: capped by *Maximum period*, *RAM only*, 20 Mbit/s over four disk segments, two recordings at once, a recording stopped mid-replay.
- **Scripted HTSP client**: pause, resume, relative and absolute skip, 4×, −2× and back to live, compared with the packet timeshift on the same run. Skip replies and landing keyframes are identical, and DTS are continuous across pause/resume and back to live. Also covered: two clients on one channel (sharer), a pause longer than the cache holds, a disconnect while rewinding.
- Not yet run on DVB/ATSC hardware.

### The packet timeshift fix

On current master the packet timeshift aborts tvheadend when an HTSP client rewinds, then goes back to live. In `timeshift_reader()`, `SMT_SKIP_LIVE` frees the packet waiting to be delivered but keeps the pointer; the same message is then delivered, and freed a second time, further down the loop — `streaming_msg_free()` ends in `abort()` on the stale message type. Reproduced on `2e64ec02c` with a scripted client (speed −200, then `subscriptionLive`); with the fix the same scenario goes back to live:

```diff
                 /* Release */
                 if (sm)
                   streaming_msg_free(sm);
+                sm = NULL;
```

The packet timeshift stays in use whenever the new option is off — the default — and, with it on, for transcoding profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





